### PR TITLE
feat(kubernetes): inject Pod search/options into guests under followNodeDns

### DIFF
--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -1470,6 +1470,22 @@ fn normalize_dns_for_agent(entry: &str) -> CResult<String> {
         return Ok(format!("nameserver {}", ip));
     }
 
+    // Pass through resolv.conf search/options lines from followNodeDns.
+    if let Some(rest) = trimmed.strip_prefix("search ") {
+        let domains: Vec<&str> = rest.split_whitespace().collect();
+        if domains.is_empty() {
+            return Err(format!("invalid dns search entry {}", entry));
+        }
+        return Ok(format!("search {}", domains.join(" ")));
+    }
+    if let Some(rest) = trimmed.strip_prefix("options ") {
+        let opts: Vec<&str> = rest.split_whitespace().collect();
+        if opts.is_empty() {
+            return Err(format!("invalid dns options entry {}", entry));
+        }
+        return Ok(format!("options {}", opts.join(" ")));
+    }
+
     let ip = trimmed
         .parse::<IpAddr>()
         .map_err(|_| format!("invalid dns ip {}", entry))?;
@@ -1603,5 +1619,16 @@ mod tests {
             sandbox.guest_container_id("real-task").await.unwrap(),
             "guest-container"
         );
+    }
+
+    #[test]
+    fn test_normalize_dns_for_agent_accepts_search_and_options() {
+        let got =
+            normalize_dns_for_agent(" search  default.svc.cluster.local   svc.cluster.local ")
+                .unwrap();
+        assert_eq!(got, "search default.svc.cluster.local svc.cluster.local");
+
+        let got = normalize_dns_for_agent(" options  ndots:5  timeout:2 ").unwrap();
+        assert_eq!(got, "options ndots:5 timeout:2");
     }
 }

--- a/Cubelet/dynamicconf/conf.yaml
+++ b/Cubelet/dynamicconf/conf.yaml
@@ -10,9 +10,16 @@ common:
   disable_host_cgroup: true
   # Disable the legacy netfile.
   disable_host_netfile: true
-  # Default DNS servers for guest containers. dns_config.servers in a template or request takes precedence.
+  # Default DNS servers for guest containers.
+  # When a template/request sets dns_config.servers, the whole guest DNS config
+  # comes from the request (servers plus any request searches/options); defaults
+  # for searches/options are not mixed in. With no request servers, empty
+  # dns_config.searches / dns_config.options fall back to the defaults below.
   default_dns_servers:
     - 119.29.29.29
+  # Default search domains / options for guest resolv.conf (e.g. followNodeDns).
+  default_dns_searches: []
+  default_dns_options: []
 
 host:
   scheduler_label: "default-cluster"

--- a/Cubelet/pkg/config/config.go
+++ b/Cubelet/pkg/config/config.go
@@ -104,8 +104,10 @@ type CommonConf struct {
 
 	DisableHostNetfile bool `yaml:"disable_host_netfile"`
 
-	DefaultDNSServers []string      `yaml:"default_dns_servers"`
-	ReconcileInterval time.Duration `yaml:"reconcile_interval"`
+	DefaultDNSServers  []string      `yaml:"default_dns_servers"`
+	DefaultDNSSearches []string      `yaml:"default_dns_searches"`
+	DefaultDNSOptions  []string      `yaml:"default_dns_options"`
+	ReconcileInterval  time.Duration `yaml:"reconcile_interval"`
 
 	DisableCubeBoxTemplateBaseFormatPoolOfNumberVer bool `yaml:"disable_cube_box_template_base_format_pool_of_number_ver"`
 }
@@ -172,8 +174,28 @@ func validate(cfg *Config) error {
 				return fmt.Errorf("invalid common.default_dns_servers entry: %q", dns)
 			}
 		}
+		for _, search := range cfg.Common.DefaultDNSSearches {
+			if !validDNSConfigToken(search) {
+				return fmt.Errorf("invalid common.default_dns_searches entry: %q", search)
+			}
+		}
+		for _, option := range cfg.Common.DefaultDNSOptions {
+			if !validDNSConfigToken(option) {
+				return fmt.Errorf("invalid common.default_dns_options entry: %q", option)
+			}
+		}
 	}
 	return nil
+}
+
+// validDNSConfigToken mirrors netfile token rules for search/options config entries.
+func validDNSConfigToken(item string) bool {
+	for _, r := range item {
+		if r <= ' ' || r == 0x7f || r == '#' || r == ';' {
+			return false
+		}
+	}
+	return true
 }
 
 func preHandle(config *Config) (*Config, error) {
@@ -229,17 +251,9 @@ func preHandle(config *Config) (*Config, error) {
 	if config.Common.GetBDFByIfNameCmd == "" {
 		config.Common.GetBDFByIfNameCmd = "/usr/local/services/AdamPlugins-1.0/snhost_snic_sdk/cath/bm/tools/get_bdf_by_ifname"
 	}
-	if len(config.Common.DefaultDNSServers) > 0 {
-		normalized := make([]string, 0, len(config.Common.DefaultDNSServers))
-		for _, dns := range config.Common.DefaultDNSServers {
-			dns = strings.TrimSpace(dns)
-			if dns == "" {
-				continue
-			}
-			normalized = append(normalized, dns)
-		}
-		config.Common.DefaultDNSServers = normalized
-	}
+	config.Common.DefaultDNSServers = normalizeStringList(config.Common.DefaultDNSServers)
+	config.Common.DefaultDNSSearches = normalizeStringList(config.Common.DefaultDNSSearches)
+	config.Common.DefaultDNSOptions = normalizeStringList(config.Common.DefaultDNSOptions)
 
 	if config.Tenant == nil {
 		config.Tenant = &TenantManager{
@@ -278,6 +292,21 @@ func preHandle(config *Config) (*Config, error) {
 		config.Common.ReconcileInterval = time.Minute * 5
 	}
 	return config, nil
+}
+
+func normalizeStringList(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		normalized = append(normalized, value)
+	}
+	return normalized
 }
 
 //go:noinline

--- a/Cubelet/pkg/config/dns_config_test.go
+++ b/Cubelet/pkg/config/dns_config_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreHandleNormalizesDefaultDNSServers(t *testing.T) {
+	cfg, err := preHandle(&Config{
+		Common: &CommonConf{
+			DefaultDNSServers:  []string{" 119.29.29.29 ", "", "1.1.1.1"},
+			DefaultDNSSearches: []string{" default.svc.cluster.local ", "", "svc.cluster.local"},
+			DefaultDNSOptions:  []string{" ndots:5 ", ""},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "119.29.29.29,1.1.1.1", strings.Join(cfg.Common.DefaultDNSServers, ","))
+	assert.Equal(t, "default.svc.cluster.local,svc.cluster.local", strings.Join(cfg.Common.DefaultDNSSearches, ","))
+	assert.Equal(t, "ndots:5", strings.Join(cfg.Common.DefaultDNSOptions, ","))
+}
+
+func TestValidateRejectsInvalidDefaultDNSServers(t *testing.T) {
+	err := validate(&Config{
+		Common: &CommonConf{
+			DefaultDNSServers: []string{"invalid-ip"},
+		},
+		HostConf: defaultHostConf(),
+	})
+	require.Error(t, err)
+}
+
+func TestValidateRejectsInvalidDefaultDNSSearchesAndOptions(t *testing.T) {
+	err := validate(&Config{
+		Common: &CommonConf{
+			DefaultDNSSearches: []string{"bad domain"},
+		},
+		HostConf: defaultHostConf(),
+	})
+	require.Error(t, err)
+
+	err = validate(&Config{
+		Common: &CommonConf{
+			DefaultDNSOptions: []string{"ndots:5\nnameserver 1.1.1.1"},
+		},
+		HostConf: defaultHostConf(),
+	})
+	require.Error(t, err)
+}

--- a/Cubelet/pkg/container/netfile/netfile.go
+++ b/Cubelet/pkg/container/netfile/netfile.go
@@ -59,6 +59,30 @@ type CubeboxNetfile struct {
 	ContainerNetfiles map[string]ContainerNetfile
 }
 
+// EffectiveDNSConfig is the guest resolv.conf content after merging request
+// dns_config with Cubelet defaults. If the request sets any servers, the whole
+// config comes from the request (no default search/options mixed in); otherwise
+// empty request searches/options fall back to Cubelet defaults.
+type EffectiveDNSConfig struct {
+	Servers  []string
+	Searches []string
+	Options  []string
+}
+
+// AnnotationLines returns entries for the cube.sandbox.dns annotation.
+// Servers stay as bare IPs (shim prefixes nameserver); search/options are full lines.
+func (c EffectiveDNSConfig) AnnotationLines() []string {
+	lines := make([]string, 0, len(c.Servers)+2)
+	if len(c.Searches) > 0 {
+		lines = append(lines, "search "+strings.Join(c.Searches, " "))
+	}
+	lines = append(lines, c.Servers...)
+	if len(c.Options) > 0 {
+		lines = append(lines, "options "+strings.Join(c.Options, " "))
+	}
+	return lines
+}
+
 func (c *CubeboxNetfile) WriteToHost() error {
 	for key := range c.ContainerNetfiles {
 		cnf := c.ContainerNetfiles[key]
@@ -80,9 +104,9 @@ func (c *CubeboxNetfile) WriteToHost() error {
 }
 
 func (cn *CubeboxNetfile) CreateNetfiles(req *cubebox.RunCubeSandboxRequest) error {
-	dnsServers, err := ResolveEffectiveDNSServers(req)
+	dnsCfg, err := ResolveEffectiveDNSConfig(req)
 	if err != nil {
-		return fmt.Errorf("failed to resolve effective dns servers: %w", err)
+		return fmt.Errorf("failed to resolve effective dns config: %w", err)
 	}
 	var netfiles = make(map[string]ContainerNetfile)
 	for _, c := range req.GetContainers() {
@@ -90,7 +114,7 @@ func (cn *CubeboxNetfile) CreateNetfiles(req *cubebox.RunCubeSandboxRequest) err
 		if err != nil {
 			return fmt.Errorf("failed to gen hosts file for container %s", c.Name)
 		}
-		dns, err := genResolvContent(dnsServers)
+		dns, err := genResolvContent(dnsCfg)
 		if err != nil {
 			return fmt.Errorf("failed to gen resolv.conf for container %s", c.Name)
 		}
@@ -187,21 +211,61 @@ func (cn *CubeboxNetfile) OciContainerNetfileSpec(ctx context.Context, container
 	return nil
 }
 
+// ResolveEffectiveDNSConfig merges request dns_config with Cubelet defaults.
+//
+// If the request sets any dns_config.servers, the whole DNS config is taken from
+// the request (servers plus any request searches/options). Defaults for
+// searches/options are not mixed in — explicit nameservers mean the caller owns
+// DNS end-to-end.
+//
+// If the request does not set servers, Cubelet defaults apply: empty request
+// searches/options fall back to default_dns_searches / default_dns_options
+// (e.g. followNodeDns).
+func ResolveEffectiveDNSConfig(req *cubebox.RunCubeSandboxRequest) (EffectiveDNSConfig, error) {
+	requestServers, err := requestDNSServers(req)
+	if err != nil {
+		return EffectiveDNSConfig{}, err
+	}
+	searches, err := requestDNSSearches(req)
+	if err != nil {
+		return EffectiveDNSConfig{}, err
+	}
+	options, err := requestDNSOptions(req)
+	if err != nil {
+		return EffectiveDNSConfig{}, err
+	}
+
+	servers := requestServers
+	if len(servers) == 0 {
+		servers = defaultDNSServers()
+		if len(servers) == 0 {
+			servers = []string{defaultDNSIP}
+		}
+		if len(searches) == 0 {
+			searches = defaultDNSSearches()
+		}
+		if len(options) == 0 {
+			options = defaultDNSOptions()
+		}
+	}
+
+	sort.Slice(servers, func(i, j int) bool {
+		return servers[i] < servers[j]
+	})
+
+	return EffectiveDNSConfig{
+		Servers:  append([]string(nil), servers...),
+		Searches: append([]string(nil), searches...),
+		Options:  append([]string(nil), options...),
+	}, nil
+}
+
 func ResolveEffectiveDNSServers(req *cubebox.RunCubeSandboxRequest) ([]string, error) {
-	dns, err := requestDNSServers(req)
+	cfg, err := ResolveEffectiveDNSConfig(req)
 	if err != nil {
 		return nil, err
 	}
-	if len(dns) == 0 {
-		dns = defaultDNSServers()
-	}
-	if len(dns) == 0 {
-		dns = []string{defaultDNSIP}
-	}
-	sort.Slice(dns, func(i, j int) bool {
-		return dns[i] < dns[j]
-	})
-	return append([]string(nil), dns...), nil
+	return append([]string(nil), cfg.Servers...), nil
 }
 
 func genHostsFileWithHostName(hostname string, hosts []*cubebox.HostAlias) ([]byte, error) {
@@ -233,23 +297,42 @@ func genHostsFileWithHostName(hostname string, hosts []*cubebox.HostAlias) ([]by
 	return b.Bytes(), nil
 }
 
-func genResolvContent(dns []string) ([]byte, error) {
-	var err error
-	if len(dns) == 0 {
-		dns, err = ResolveEffectiveDNSServers(nil)
+func genResolvContent(cfg EffectiveDNSConfig) ([]byte, error) {
+	if len(cfg.Servers) == 0 {
+		resolved, err := ResolveEffectiveDNSConfig(nil)
 		if err != nil {
 			return nil, err
 		}
+		// Fill missing fields from Cubelet defaults; keep any caller-provided
+		// searches/options (e.g. when only servers were empty).
+		cfg.Servers = resolved.Servers
+		if len(cfg.Searches) == 0 {
+			cfg.Searches = resolved.Searches
+		}
+		if len(cfg.Options) == 0 {
+			cfg.Options = resolved.Options
+		}
 	}
-	sort.Slice(dns, func(i, j int) bool {
-		return dns[i] < dns[j]
+	servers := append([]string(nil), cfg.Servers...)
+	sort.Slice(servers, func(i, j int) bool {
+		return servers[i] < servers[j]
 	})
 	var b bytes.Buffer
-	for _, entry := range dns {
+	if len(cfg.Searches) > 0 {
+		if _, err := b.Write([]byte("search " + strings.Join(cfg.Searches, " ") + "\n")); err != nil {
+			return nil, err
+		}
+	}
+	for _, entry := range servers {
 		if net.ParseIP(entry) == nil {
 			return nil, fmt.Errorf("invalid dns %s", entry)
 		}
 		if _, err := b.Write([]byte("nameserver " + entry + "\n")); err != nil {
+			return nil, err
+		}
+	}
+	if len(cfg.Options) > 0 {
+		if _, err := b.Write([]byte("options " + strings.Join(cfg.Options, " ") + "\n")); err != nil {
 			return nil, err
 		}
 	}
@@ -282,12 +365,82 @@ func requestDNSServers(req *cubebox.RunCubeSandboxRequest) ([]string, error) {
 	return dnsServers, nil
 }
 
+func requestDNSSearches(req *cubebox.RunCubeSandboxRequest) ([]string, error) {
+	return requestDNSStringList(req, "search", func(cfg *cubebox.DNSConfig) []string {
+		if cfg == nil {
+			return nil
+		}
+		return cfg.GetSearches()
+	})
+}
+
+func requestDNSOptions(req *cubebox.RunCubeSandboxRequest) ([]string, error) {
+	return requestDNSStringList(req, "option", func(cfg *cubebox.DNSConfig) []string {
+		if cfg == nil {
+			return nil
+		}
+		return cfg.GetOptions()
+	})
+}
+
+// validDNSListToken rejects whitespace/control chars and resolv.conf comment
+// markers so a single request entry cannot inject extra nameserver lines.
+func validDNSListToken(item string) bool {
+	for _, r := range item {
+		if r <= ' ' || r == 0x7f || r == '#' || r == ';' {
+			return false
+		}
+	}
+	return true
+}
+
+func requestDNSStringList(req *cubebox.RunCubeSandboxRequest, kind string, get func(*cubebox.DNSConfig) []string) ([]string, error) {
+	if req == nil {
+		return nil, nil
+	}
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, ctr := range req.GetContainers() {
+		for _, item := range get(ctr.GetDnsConfig()) {
+			item = strings.TrimSpace(item)
+			if item == "" {
+				continue
+			}
+			if !validDNSListToken(item) {
+				return nil, fmt.Errorf("invalid dns %s %q", kind, item)
+			}
+			if _, ok := seen[item]; ok {
+				continue
+			}
+			seen[item] = struct{}{}
+			out = append(out, item)
+		}
+	}
+	return out, nil
+}
+
 func defaultDNSServers() []string {
 	cfg := config.GetConfig()
 	if cfg == nil || cfg.Common == nil || len(cfg.Common.DefaultDNSServers) == 0 {
 		return nil
 	}
 	return append([]string(nil), cfg.Common.DefaultDNSServers...)
+}
+
+func defaultDNSSearches() []string {
+	cfg := config.GetConfig()
+	if cfg == nil || cfg.Common == nil || len(cfg.Common.DefaultDNSSearches) == 0 {
+		return nil
+	}
+	return append([]string(nil), cfg.Common.DefaultDNSSearches...)
+}
+
+func defaultDNSOptions() []string {
+	cfg := config.GetConfig()
+	if cfg == nil || cfg.Common == nil || len(cfg.Common.DefaultDNSOptions) == 0 {
+		return nil
+	}
+	return append([]string(nil), cfg.Common.DefaultDNSOptions...)
 }
 
 func Clean(ctx context.Context, containerID string) error {

--- a/Cubelet/pkg/container/netfile/netfile_test.go
+++ b/Cubelet/pkg/container/netfile/netfile_test.go
@@ -301,23 +301,152 @@ func TestGenHostsFileWithHostName(t *testing.T) {
 func TestGenResolvContent(t *testing.T) {
 
 	loadNetfileTestConfig(t, "common:\n  default_dns_servers:\n    - 119.29.29.29\n")
-	dnsServers := []string{"8.8.8.8", "9.9.9.9"}
-	content, err := genResolvContent(dnsServers)
+	content, err := genResolvContent(EffectiveDNSConfig{Servers: []string{"8.8.8.8", "9.9.9.9"}})
 	assert.NoError(t, err)
 	assert.Equal(t, "nameserver 8.8.8.8\nnameserver 9.9.9.9\n", string(content))
 
 	loadNetfileTestConfig(t, "common:\n  default_dns_servers:\n    - 1.1.1.1\n    - 119.29.29.29\n")
-	content, err = genResolvContent(nil)
+	content, err = genResolvContent(EffectiveDNSConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, "nameserver 1.1.1.1\nnameserver 119.29.29.29\n", string(content))
 
 	loadNetfileTestConfig(t, "common: {}\n")
-	content, err = genResolvContent(nil)
+	content, err = genResolvContent(EffectiveDNSConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, "nameserver 119.29.29.29\n", string(content))
 
-	_, err = genResolvContent([]string{"invalid-ip"})
+	_, err = genResolvContent(EffectiveDNSConfig{Servers: []string{"invalid-ip"}})
 	assert.Error(t, err)
+
+	loadNetfileTestConfig(t, `common:
+  default_dns_servers:
+    - 10.96.0.10
+  default_dns_searches:
+    - default.svc.cluster.local
+    - svc.cluster.local
+  default_dns_options:
+    - ndots:5
+`)
+	content, err = genResolvContent(EffectiveDNSConfig{})
+	assert.NoError(t, err)
+	assert.Equal(t, "search default.svc.cluster.local svc.cluster.local\nnameserver 10.96.0.10\noptions ndots:5\n", string(content))
+
+	content, err = genResolvContent(EffectiveDNSConfig{
+		Servers:  []string{"8.8.8.8"},
+		Searches: []string{"example.com"},
+		Options:  []string{"timeout:2"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "search example.com\nnameserver 8.8.8.8\noptions timeout:2\n", string(content))
+
+	// Empty Servers falls back to defaults only for servers; caller searches/options kept.
+	content, err = genResolvContent(EffectiveDNSConfig{
+		Searches: []string{"keep.example"},
+		Options:  []string{"ndots:2"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "search keep.example\nnameserver 10.96.0.10\noptions ndots:2\n", string(content))
+}
+
+func TestResolveEffectiveDNSConfig(t *testing.T) {
+	loadNetfileTestConfig(t, `common:
+  default_dns_servers:
+    - 10.96.0.10
+  default_dns_searches:
+    - default.svc.cluster.local
+    - svc.cluster.local
+  default_dns_options:
+    - ndots:5
+`)
+
+	t.Run("follow-node defaults when request has no servers", func(t *testing.T) {
+		got, err := ResolveEffectiveDNSConfig(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{{}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"10.96.0.10"}, got.Servers)
+		assert.Equal(t, []string{"default.svc.cluster.local", "svc.cluster.local"}, got.Searches)
+		assert.Equal(t, []string{"ndots:5"}, got.Options)
+		assert.Equal(t, []string{
+			"search default.svc.cluster.local svc.cluster.local",
+			"10.96.0.10",
+			"options ndots:5",
+		}, got.AnnotationLines())
+	})
+
+	t.Run("explicit servers override whole DNS config without default search/options", func(t *testing.T) {
+		got, err := ResolveEffectiveDNSConfig(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{DnsConfig: &cubebox.DNSConfig{Servers: []string{"8.8.8.8"}}},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"8.8.8.8"}, got.Servers)
+		assert.Empty(t, got.Searches)
+		assert.Empty(t, got.Options)
+		assert.Equal(t, []string{"8.8.8.8"}, got.AnnotationLines())
+	})
+
+	t.Run("explicit servers with request search/options", func(t *testing.T) {
+		got, err := ResolveEffectiveDNSConfig(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{DnsConfig: &cubebox.DNSConfig{
+					Servers:  []string{"1.1.1.1"},
+					Searches: []string{"example.com"},
+					Options:  []string{"timeout:2"},
+				}},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"1.1.1.1"}, got.Servers)
+		assert.Equal(t, []string{"example.com"}, got.Searches)
+		assert.Equal(t, []string{"timeout:2"}, got.Options)
+	})
+
+	t.Run("request searches without servers still fall back to default servers", func(t *testing.T) {
+		got, err := ResolveEffectiveDNSConfig(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{DnsConfig: &cubebox.DNSConfig{Searches: []string{"custom.local"}}},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"10.96.0.10"}, got.Servers)
+		assert.Equal(t, []string{"custom.local"}, got.Searches)
+		assert.Equal(t, []string{"ndots:5"}, got.Options)
+	})
+
+	t.Run("reject option with embedded newline", func(t *testing.T) {
+		_, err := ResolveEffectiveDNSConfig(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{DnsConfig: &cubebox.DNSConfig{
+					Options: []string{"ndots:5\nnameserver 6.6.6.6"},
+				}},
+			},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("reject search with comment marker", func(t *testing.T) {
+		_, err := ResolveEffectiveDNSConfig(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{DnsConfig: &cubebox.DNSConfig{
+					Searches: []string{"example.com #evil"},
+				}},
+			},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("reject search with whitespace", func(t *testing.T) {
+		_, err := ResolveEffectiveDNSConfig(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{DnsConfig: &cubebox.DNSConfig{
+					Searches: []string{"bad domain"},
+				}},
+			},
+		})
+		assert.Error(t, err)
+	})
 }
 
 func TestResolveEffectiveDNSServers(t *testing.T) {

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -451,14 +451,14 @@ func (l *local) genSandboxOptions(ctx context.Context, realReq *cubebox.RunCubeS
 		return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "generate storage medium annotation failed: %v", err)
 	}
 	additionalSandboxOpt = append(additionalSandboxOpt, sOpts...)
-	dnsServers, err := sandboxDNSServersFromContainers(realReq)
+	dnsLines, err := sandboxDNSLinesFromContainers(realReq)
 	if err != nil {
 		return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "generate sandbox dns annotation failed: %v", err)
 	}
-	if len(dnsServers) > 0 {
-		data, err := jsoniter.Marshal(dnsServers)
+	if len(dnsLines) > 0 {
+		data, err := jsoniter.Marshal(dnsLines)
 		if err != nil {
-			return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "marshal dns servers failed: %v", err)
+			return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "marshal dns lines failed: %v", err)
 		}
 		additionalSandboxOpt = append(additionalSandboxOpt, oci.WithAnnotations(map[string]string{
 			constants.AnnotationsSandboxDNS: string(data),
@@ -471,8 +471,12 @@ func (l *local) genSandboxOptions(ctx context.Context, realReq *cubebox.RunCubeS
 	return additionalSandboxOpt, nil
 }
 
-func sandboxDNSServersFromContainers(realReq *cubebox.RunCubeSandboxRequest) ([]string, error) {
-	return localnetfile.ResolveEffectiveDNSServers(realReq)
+func sandboxDNSLinesFromContainers(realReq *cubebox.RunCubeSandboxRequest) ([]string, error) {
+	cfg, err := localnetfile.ResolveEffectiveDNSConfig(realReq)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.AnnotationLines(), nil
 }
 
 func (l *local) genImageReferenceForCubebox(ctx context.Context, flowOpts *workflow.CreateContext, sandBox *cubeboxstore.CubeBox) error {

--- a/Cubelet/services/cubebox/cube_container_create_test.go
+++ b/Cubelet/services/cubebox/cube_container_create_test.go
@@ -197,67 +197,54 @@ func TestStoreNumaQueues(t *testing.T) {
 	}
 }
 
-func TestSandboxDNSServersFromContainers(t *testing.T) {
-	tests := []struct {
-		name       string
-		defaultDNS []string
-		req        *cubebox.RunCubeSandboxRequest
-		want       []string
-		wantErr    bool
-	}{
-		{
-			name: "aggregate unique dns servers in order",
-			req: &cubebox.RunCubeSandboxRequest{
-				Containers: []*cubebox.ContainerConfig{
-					{DnsConfig: &cubebox.DNSConfig{Servers: []string{"8.8.8.8", " 1.1.1.1 "}}},
-					{DnsConfig: &cubebox.DNSConfig{Servers: []string{"1.1.1.1", "9.9.9.9"}}},
-				},
-			},
-			want: []string{"1.1.1.1", "8.8.8.8", "9.9.9.9"},
-		},
-		{
-			name:       "fallback to cubelet default dns entries",
-			defaultDNS: []string{"1.1.1.1", "9.9.9.9"},
-			req: &cubebox.RunCubeSandboxRequest{
-				Containers: []*cubebox.ContainerConfig{
-					{DnsConfig: &cubebox.DNSConfig{Servers: []string{"", " "}}},
-				},
-			},
-			want: []string{"1.1.1.1", "9.9.9.9"},
-		},
-		{
-			name: "fallback to hardcoded dns server when config empty",
-			req: &cubebox.RunCubeSandboxRequest{
-				Containers: []*cubebox.ContainerConfig{{}},
-			},
-			want: []string{"119.29.29.29"},
-		},
-		{
-			name: "reject invalid dns server",
-			req: &cubebox.RunCubeSandboxRequest{
-				Containers: []*cubebox.ContainerConfig{
-					{DnsConfig: &cubebox.DNSConfig{Servers: []string{"not-an-ip"}}},
-				},
-			},
-			wantErr: true,
-		},
-	}
+func TestSandboxDNSLinesFromContainers(t *testing.T) {
+	_, err := config.Init("", true)
+	require.NoError(t, err)
+	config.GetCommon().DefaultDNSServers = []string{"10.96.0.10"}
+	config.GetCommon().DefaultDNSSearches = []string{"default.svc.cluster.local", "svc.cluster.local"}
+	config.GetCommon().DefaultDNSOptions = []string{"ndots:5"}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := config.Init("", true)
-			require.NoError(t, err)
-			config.GetCommon().DefaultDNSServers = append([]string(nil), tt.defaultDNS...)
-			got, err := sandboxDNSServersFromContainers(tt.req)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+	t.Run("follow-node defaults", func(t *testing.T) {
+		got, err := sandboxDNSLinesFromContainers(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{{}},
 		})
-	}
+		require.NoError(t, err)
+		assert.Equal(t, []string{
+			"search default.svc.cluster.local svc.cluster.local",
+			"10.96.0.10",
+			"options ndots:5",
+		}, got)
+	})
+
+	t.Run("explicit servers do not inherit default search/options", func(t *testing.T) {
+		got, err := sandboxDNSLinesFromContainers(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{DnsConfig: &cubebox.DNSConfig{Servers: []string{"8.8.8.8"}}},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"8.8.8.8"}, got)
+	})
+
+	t.Run("aggregate unique servers", func(t *testing.T) {
+		got, err := sandboxDNSLinesFromContainers(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{DnsConfig: &cubebox.DNSConfig{Servers: []string{"8.8.8.8", " 1.1.1.1 "}}},
+				{DnsConfig: &cubebox.DNSConfig{Servers: []string{"1.1.1.1", "9.9.9.9"}}},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1.1.1.1", "8.8.8.8", "9.9.9.9"}, got)
+	})
+
+	t.Run("reject invalid server", func(t *testing.T) {
+		_, err := sandboxDNSLinesFromContainers(&cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{DnsConfig: &cubebox.DNSConfig{Servers: []string{"not-an-ip"}}},
+			},
+		})
+		require.Error(t, err)
+	})
 }
 
 func TestAppendExt4NetfileMounts(t *testing.T) {

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -487,7 +487,8 @@ cubeProxy:
 cubeNode:
   dns:
     sandbox:
-      followNodeDns: true          # guests use node/cluster DNS
+      followNodeDns: true          # guests use node/cluster DNS (nameservers+search+options)
+                                   # explicit nameservers[] overrides and disables follow-node
 ```
 
 ## WebUI and CubeOps

--- a/deploy/kubernetes/chart/templates/NOTES.txt
+++ b/deploy/kubernetes/chart/templates/NOTES.txt
@@ -56,7 +56,9 @@ External control plane:
 Cube Node DaemonSet:
   {{ include "cube.nodeName" . }}
 {{- if .Values.cubeNode.dns.sandbox.followNodeDns }}
-  Sandbox guest DNS: follow node / cluster DNS
+  Sandbox guest DNS: follow node / cluster DNS (nameservers + search + options)
+{{- else if .Values.cubeNode.dns.sandbox.nameservers }}
+  Sandbox guest DNS: explicit nameservers (follow-node search/options not applied)
 {{- end }}
 {{- if eq (include "cube.proxyEnabled" .) "true" }}
 

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -543,9 +543,10 @@ cubeNode:
   dns:
     clusterDomain: cluster.local
     sandbox:
-      # Guests inherit the cube-node Pod nameservers (cluster DNS) so they can
-      # resolve in-cluster Services and *.cubeProxy.domain.
-      # Set nameservers to an explicit list to override.
+      # Guests inherit the cube-node Pod DNS (nameservers + search + options,
+      # e.g. ndots:5) so they can resolve in-cluster Services and *.cubeProxy.domain.
+      # Set nameservers to an explicit list to override: that turns follow-node
+      # off for the whole guest DNS config (search/options are not copied either).
       followNodeDns: true
       nameservers: []
 

--- a/deploy/kubernetes/images/scripts/component-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/component-entrypoint.sh
@@ -388,8 +388,42 @@ configure_sandbox_dns() {
       ' /etc/resolv.conf
     )"
     log "sandbox DNS follow-node nameservers: ${CUBE_SANDBOX_DNS_SERVERS:-<empty>}"
+    if [[ -z "${CUBE_SANDBOX_DNS_SEARCHES:-}" ]]; then
+      CUBE_SANDBOX_DNS_SEARCHES="$(
+        awk '
+          $1 ~ /^#/ { next }
+          $1 == "search" {
+            for (i = 2; i <= NF; i++) {
+              if ($i ~ /^[#;]/) break
+              if (seen[$i]++) continue
+              if (n++) printf ","
+              printf "%s", $i
+            }
+          }
+        ' /etc/resolv.conf
+      )"
+      log "sandbox DNS follow-node searches: ${CUBE_SANDBOX_DNS_SEARCHES:-<empty>}"
+    fi
+    if [[ -z "${CUBE_SANDBOX_DNS_OPTIONS:-}" ]]; then
+      CUBE_SANDBOX_DNS_OPTIONS="$(
+        awk '
+          $1 ~ /^#/ { next }
+          $1 == "options" {
+            for (i = 2; i <= NF; i++) {
+              if ($i ~ /^[#;]/) break
+              if (seen[$i]++) continue
+              if (n++) printf ","
+              printf "%s", $i
+            }
+          }
+        ' /etc/resolv.conf
+      )"
+      log "sandbox DNS follow-node options: ${CUBE_SANDBOX_DNS_OPTIONS:-<empty>}"
+    fi
   fi
   patch_common_yaml_list default_dns_servers "${CUBE_SANDBOX_DNS_SERVERS:-}"
+  patch_common_yaml_list default_dns_searches "${CUBE_SANDBOX_DNS_SEARCHES:-}"
+  patch_common_yaml_list default_dns_options "${CUBE_SANDBOX_DNS_OPTIONS:-}"
 }
 
 write_pidfile() {

--- a/deploy/kubernetes/images/scripts/cube-node-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/cube-node-entrypoint.sh
@@ -148,8 +148,42 @@ configure_sandbox_dns() {
       ' /etc/resolv.conf
     )"
     log "sandbox DNS follow-node nameservers: ${CUBE_SANDBOX_DNS_SERVERS:-<empty>}"
+    if [[ -z "${CUBE_SANDBOX_DNS_SEARCHES:-}" ]]; then
+      CUBE_SANDBOX_DNS_SEARCHES="$(
+        awk '
+          /^[[:space:]]*#/ { next }
+          /^search[[:space:]]+/ {
+            for (i = 2; i <= NF; i++) {
+              if ($i ~ /^[#;]/) break
+              if (seen[$i]++) continue
+              if (n++) printf ","
+              printf "%s", $i
+            }
+          }
+        ' /etc/resolv.conf
+      )"
+      log "sandbox DNS follow-node searches: ${CUBE_SANDBOX_DNS_SEARCHES:-<empty>}"
+    fi
+    if [[ -z "${CUBE_SANDBOX_DNS_OPTIONS:-}" ]]; then
+      CUBE_SANDBOX_DNS_OPTIONS="$(
+        awk '
+          /^[[:space:]]*#/ { next }
+          /^options[[:space:]]+/ {
+            for (i = 2; i <= NF; i++) {
+              if ($i ~ /^[#;]/) break
+              if (seen[$i]++) continue
+              if (n++) printf ","
+              printf "%s", $i
+            }
+          }
+        ' /etc/resolv.conf
+      )"
+      log "sandbox DNS follow-node options: ${CUBE_SANDBOX_DNS_OPTIONS:-<empty>}"
+    fi
   fi
   patch_common_yaml_list default_dns_servers "${CUBE_SANDBOX_DNS_SERVERS:-}"
+  patch_common_yaml_list default_dns_searches "${CUBE_SANDBOX_DNS_SEARCHES:-}"
+  patch_common_yaml_list default_dns_options "${CUBE_SANDBOX_DNS_OPTIONS:-}"
 }
 
 [[ -x "${CUBELET_BIN}" ]] || fail "missing executable: ${CUBELET_BIN}"


### PR DESCRIPTION
## Summary

- With `followNodeDns=true`, guests previously only inherited kube-dns **nameserver** from the cube-node Pod `/etc/resolv.conf`. Pod `search` domains and `options` (e.g. `ndots:5`) were dropped, so short Service names did not resolve like in a normal Pod.
- Entrypoints now also patch `default_dns_searches` / `default_dns_options`. Cubelet writes a full guest `resolv.conf` and passes the same lines via `cube.sandbox.dns` (shim accepts `search` / `options` lines).
- Per-field override: non-empty request `dns_config.servers` / `searches` / `options` still fully replace the corresponding defaults. Explicit `dns_config.servers` does **not** append kube-dns (keeps current override semantics, as confirmed in #1236).

Closes #1236

## Test plan

- [x] `go test` (CGO_ENABLED=0) for `Cubelet/pkg/container/netfile` and `Cubelet/pkg/config` — passed
- [x] CubeShim unit: `normalize_dns_for_agent` accepts `search` / `options` lines
- [x] E2E on ubuntu22 K8s (swap `cubelet` + `cube-shim` images only):
  - Before: `cube.sandbox.dns=["10.43.0.10"]`, guest resolv only `nameserver 10.43.0.10`
  - After: conf.yaml got `default_dns_searches` / `default_dns_options` from Pod resolv; sandbox from `gateway-client:v3.3.5` template had:
    ```
    search cube-system.svc.cluster.local svc.cluster.local cluster.local
    nameserver 10.43.0.10
    options ndots:5
    ```