### PR TITLE
feat: 新增 WebUI 容器实例终端登录

### DIFF
--- a/CubeMaster/pkg/base/constants/constants.go
+++ b/CubeMaster/pkg/base/constants/constants.go
@@ -5,6 +5,11 @@
 // Package constants contains all of the application wide constant values used throughout Cube Master.
 package constants
 
+// LabelEnvdPort is written by Cubelet on each container and exposed by
+// CubeMaster so control-plane clients can route data-plane calls to a selected
+// container.
+const LabelEnvdPort = "cube.envd-port"
+
 const (
 	SelectorPreFilterID     = "PreFilter"
 	SelectorBackoffFilterID = "Backoff"

--- a/CubeMaster/pkg/service/sandbox/sandbox_info.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_info.go
@@ -6,6 +6,7 @@ package sandbox
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -171,6 +172,7 @@ func doget(ctx context.Context, calleep string, cubeletReq *cubebox.ListCubeSand
 				Mem:         container.GetResources().GetMem(),
 				Type:        container.GetType(),
 				PauseAt:     container.GetPausedAt(),
+				EnvdPort:    envdPortFromLabels(container.GetLabels(), container.GetId() == sandbox.GetId()),
 			}
 			one.Containers = append(one.Containers, containerInfo)
 		}
@@ -182,6 +184,20 @@ func doget(ctx context.Context, calleep string, cubeletReq *cubebox.ListCubeSand
 		rsp.Data = append(rsp.Data, one)
 	}
 	return nil
+}
+
+func envdPortFromLabels(labels map[string]string, primary bool) int32 {
+	if raw := labels[constants.LabelEnvdPort]; raw != "" {
+		if port, err := strconv.Atoi(raw); err == nil && port > 0 && port <= 65535 {
+			return int32(port)
+		}
+	}
+	// Sandboxes created before per-container endpoint metadata always expose
+	// the primary envd process on the historical default port.
+	if primary {
+		return 49983
+	}
+	return 0
 }
 
 func decorateSandboxInfo(ctx context.Context, req *types.GetCubeSandboxReq, rsp *types.GetCubeSandboxRes) error {

--- a/CubeMaster/pkg/service/sandbox/sandbox_info_terminal_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_info_terminal_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+)
+
+func TestEnvdPortFromLabels(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		primary bool
+		want    int32
+	}{
+		{name: "metadata", labels: map[string]string{constants.LabelEnvdPort: "55000"}, want: 55000},
+		{name: "legacy primary fallback", primary: true, want: 49983},
+		{name: "legacy sidecar unavailable", primary: false, want: 0},
+		{name: "invalid metadata", labels: map[string]string{constants.LabelEnvdPort: "70000"}, primary: true, want: 49983},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := envdPortFromLabels(test.labels, test.primary); got != test.want {
+				t.Fatalf("envdPortFromLabels() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -595,6 +595,7 @@ type ContainerInfo struct {
 	Mem         string `json:"mem,omitempty"`
 	Type        string `json:"type,omitempty"`
 	PauseAt     int64  `json:"pause_at,omitempty"`
+	EnvdPort    int32  `json:"envd_port,omitempty"`
 }
 
 type CreateImageReq struct {

--- a/CubeOps/cmd/cubeops/main.go
+++ b/CubeOps/cmd/cubeops/main.go
@@ -58,7 +58,11 @@ func main() {
 	}
 	cfg.JWTSecret = jwtSecret
 
-	srv := server.New(cfg, s)
+	srv, err := server.New(cfg, s)
+	if err != nil {
+		slog.Error("failed to initialise server", "error", err)
+		os.Exit(1)
+	}
 
 	// Graceful shutdown
 	go func() {

--- a/CubeOps/config.example.yaml
+++ b/CubeOps/config.example.yaml
@@ -47,3 +47,13 @@ redis_url: ""
 
 # --- Sandbox domain exposed to SDK clients via /config ---
 sandbox_domain: "cube.app"
+
+# --- Web Terminal ---
+# CubeOps reaches envd through CubeProxy while preserving the virtual Host
+# (<envd-port>-<sandbox-id>.<sandbox-domain>).
+sandbox_proxy_url: "http://127.0.0.1"
+terminal_ticket_ttl: "30s"
+terminal_idle_timeout: "15m"
+terminal_reconnect_grace: "30s"
+terminal_max_sessions: 128
+terminal_max_sessions_per_sandbox: 8

--- a/CubeOps/go.mod
+++ b/CubeOps/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/go-containerregistry v0.21.6
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/tencentcloud/CubeSandbox/CubeDB v0.1.0
 	github.com/tencentcloud/CubeSandbox/cubelog v0.1.1-0.20260113105508-a996703fa42f
+	github.com/tencentcloud/CubeSandbox/sdk/go v0.0.0
 	golang.org/x/crypto v0.50.0
 	gorm.io/gorm v1.25.10
 )
@@ -101,3 +103,5 @@ require (
 )
 
 replace github.com/tencentcloud/CubeSandbox/CubeDB => ../CubeDB
+
+replace github.com/tencentcloud/CubeSandbox/sdk/go => ../sdk/go

--- a/CubeOps/go.sum
+++ b/CubeOps/go.sum
@@ -84,6 +84,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/CubeOps/internal/config/config.go
+++ b/CubeOps/internal/config/config.go
@@ -65,6 +65,14 @@ type Config struct {
 	// Sandbox domain exposed to SDK clients; matches SDK handler's
 	// CUBE_API_SANDBOX_DOMAIN env so the /config endpoint stays in sync.
 	SandboxDomain string `yaml:"sandbox_domain"`
+
+	// Web Terminal data-plane and session settings.
+	SandboxProxyURL           string        `yaml:"sandbox_proxy_url"`
+	TerminalTicketTTL         time.Duration `yaml:"terminal_ticket_ttl"`
+	TerminalIdleTimeout       time.Duration `yaml:"terminal_idle_timeout"`
+	TerminalReconnectGrace    time.Duration `yaml:"terminal_reconnect_grace"`
+	TerminalMaxSessions       int           `yaml:"terminal_max_sessions"`
+	TerminalMaxSessionsPerBox int           `yaml:"terminal_max_sessions_per_sandbox"`
 }
 
 // Load reads configuration from YAML + environment variables (env wins).
@@ -112,6 +120,24 @@ func Load() (*Config, error) {
 	}
 	if cfg.SandboxDomain == "" {
 		cfg.SandboxDomain = "cube.app"
+	}
+	if cfg.SandboxProxyURL == "" {
+		cfg.SandboxProxyURL = "http://127.0.0.1"
+	}
+	if cfg.TerminalTicketTTL <= 0 {
+		cfg.TerminalTicketTTL = 30 * time.Second
+	}
+	if cfg.TerminalIdleTimeout <= 0 {
+		cfg.TerminalIdleTimeout = 15 * time.Minute
+	}
+	if cfg.TerminalReconnectGrace <= 0 {
+		cfg.TerminalReconnectGrace = 30 * time.Second
+	}
+	if cfg.TerminalMaxSessions <= 0 {
+		cfg.TerminalMaxSessions = 128
+	}
+	if cfg.TerminalMaxSessionsPerBox <= 0 {
+		cfg.TerminalMaxSessionsPerBox = 8
 	}
 
 	// JWT_SECRET is optional — if not set, it will be auto-generated and
@@ -313,6 +339,36 @@ func overrideFromEnv(cfg *Config) {
 	}
 	if v := os.Getenv("CUBE_API_SANDBOX_DOMAIN"); v != "" {
 		cfg.SandboxDomain = v
+	}
+	if v := os.Getenv("CUBE_SANDBOX_PROXY_URL"); v != "" {
+		cfg.SandboxProxyURL = v
+	} else if v := os.Getenv("AGENTHUB_SANDBOX_PROXY_URL"); v != "" {
+		cfg.SandboxProxyURL = v
+	}
+	if v := os.Getenv("CUBE_OPS_TERMINAL_TICKET_TTL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.TerminalTicketTTL = d
+		}
+	}
+	if v := os.Getenv("CUBE_OPS_TERMINAL_IDLE_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.TerminalIdleTimeout = d
+		}
+	}
+	if v := os.Getenv("CUBE_OPS_TERMINAL_RECONNECT_GRACE"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.TerminalReconnectGrace = d
+		}
+	}
+	if v := os.Getenv("CUBE_OPS_TERMINAL_MAX_SESSIONS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.TerminalMaxSessions = n
+		}
+	}
+	if v := os.Getenv("CUBE_OPS_TERMINAL_MAX_SESSIONS_PER_SANDBOX"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.TerminalMaxSessionsPerBox = n
+		}
 	}
 	if v := os.Getenv("JWT_ACCESS_TTL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {

--- a/CubeOps/internal/config/config_test.go
+++ b/CubeOps/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestLoad_FromYAML proves that config.Load() reads values from the YAML
@@ -20,6 +21,12 @@ func TestLoad_FromYAML(t *testing.T) {
 log_level: "debug"
 cubemaster_addr: "http://1.2.3.4:8089"
 sandbox_domain: "test.example.com"
+sandbox_proxy_url: "https://proxy.example.com:8443"
+terminal_ticket_ttl: "45s"
+terminal_idle_timeout: "20m"
+terminal_reconnect_grace: "1m"
+terminal_max_sessions: 64
+terminal_max_sessions_per_sandbox: 6
 database_url: "mysql://root:pass@127.0.0.1:3306/testdb"
 jwt_secret: "yaml-secret"
 access_ttl: "30m"
@@ -48,6 +55,14 @@ refresh_ttl: "336h"
 	}
 	if cfg.JWTSecret != "yaml-secret" {
 		t.Errorf("JWTSecret = %q, want yaml-secret", cfg.JWTSecret)
+	}
+	if cfg.SandboxProxyURL != "https://proxy.example.com:8443" ||
+		cfg.TerminalTicketTTL != 45*time.Second ||
+		cfg.TerminalIdleTimeout != 20*time.Minute ||
+		cfg.TerminalReconnectGrace != time.Minute ||
+		cfg.TerminalMaxSessions != 64 ||
+		cfg.TerminalMaxSessionsPerBox != 6 {
+		t.Errorf("terminal config was not loaded from YAML: %#v", cfg)
 	}
 }
 

--- a/CubeOps/internal/handler/sdk_test.go
+++ b/CubeOps/internal/handler/sdk_test.go
@@ -94,7 +94,7 @@ func TestSDK_GetSandbox_Success(t *testing.T) {
 				"data": [{
 					"sandbox_id": "sb-42", "host_id": "node-a", "status": 1,
 					"template_id": "tpl-1", "namespace": "default",
-					"containers": [{"container_id": "c-1", "cpu": "2000m", "mem": "2048Mi", "create_at": 1700000000000000000, "type": "sandbox"}],
+					"containers": [{"name": "main", "container_id": "c-1", "cpu": "2000m", "mem": "2048Mi", "create_at": 1700000000000000000, "type": "sandbox", "status": 1, "envd_port": 49983}],
 					"annotations": {}, "labels": {}
 				}]
 			}`), nil
@@ -119,6 +119,15 @@ func TestSDK_GetSandbox_Success(t *testing.T) {
 	}
 	if detail["state"] != "running" {
 		t.Errorf("state = %v, want running (status 1 → running)", detail["state"])
+	}
+	containers, ok := detail["containers"].([]interface{})
+	if !ok || len(containers) != 1 {
+		t.Fatalf("containers = %#v", detail["containers"])
+	}
+	container, ok := containers[0].(map[string]interface{})
+	if !ok || container["name"] != "main" || container["containerID"] != "c-1" ||
+		container["state"] != "running" || container["envdPort"] != float64(49983) {
+		t.Errorf("container detail = %#v", containers[0])
 	}
 }
 

--- a/CubeOps/internal/handler/terminal.go
+++ b/CubeOps/internal/handler/terminal.go
@@ -1,0 +1,507 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/httputil"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/service"
+	cubesandbox "github.com/tencentcloud/CubeSandbox/sdk/go"
+)
+
+const (
+	terminalMinRows    = 2
+	terminalMaxRows    = 200
+	terminalMinCols    = 2
+	terminalMaxCols    = 500
+	terminalReadLimit  = 64 << 10
+	terminalInputLimit = 32 << 10
+	terminalWriteChunk = 64 << 10
+	terminalWriteWait  = 10 * time.Second
+	terminalPongWait   = 60 * time.Second
+	terminalPingEvery  = 20 * time.Second
+	terminalRateWindow = time.Second
+	terminalRateEvents = 200
+	terminalRateBytes  = 256 << 10
+)
+
+type terminalCubeMaster interface {
+	GetSandbox(ctx context.Context, sandboxID, instanceType string) (json.RawMessage, error)
+}
+
+type TerminalHandler struct {
+	cm          terminalCubeMaster
+	terminals   *service.TerminalService
+	idleTimeout time.Duration
+	upgrader    websocket.Upgrader
+}
+
+func NewTerminalHandler(cm terminalCubeMaster, terminals *service.TerminalService, idleTimeout time.Duration) *TerminalHandler {
+	return &TerminalHandler{
+		cm:          cm,
+		terminals:   terminals,
+		idleTimeout: idleTimeout,
+		upgrader: websocket.Upgrader{
+			HandshakeTimeout: 10 * time.Second,
+			CheckOrigin:      terminalSameOrigin,
+		},
+	}
+}
+
+func (h *TerminalHandler) RegisterAuthed(r *gin.RouterGroup) {
+	r.POST("/sandboxes/:id/terminal/tickets", h.CreateTicket)
+}
+
+func (h *TerminalHandler) RegisterPublic(r *gin.RouterGroup) {
+	r.GET("/sandboxes/:id/terminal/ws", h.Connect)
+}
+
+type createTerminalTicketRequest struct {
+	ContainerID string `json:"containerID"`
+	SessionID   string `json:"sessionID"`
+	Rows        int    `json:"rows"`
+	Cols        int    `json:"cols"`
+}
+
+type terminalContainer struct {
+	Name        string `json:"name"`
+	ContainerID string `json:"container_id"`
+	Status      int    `json:"status"`
+	Type        string `json:"type"`
+	EnvdPort    int    `json:"envd_port"`
+}
+
+func (h *TerminalHandler) CreateTicket(c *gin.Context) {
+	var req createTerminalTicketRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.WriteError(c, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Rows == 0 {
+		req.Rows = 24
+	}
+	if req.Cols == 0 {
+		req.Cols = 80
+	}
+	if !validTerminalSize(req.Rows, req.Cols) {
+		httputil.WriteError(c, http.StatusBadRequest, "terminal size is outside the supported range")
+		return
+	}
+
+	sandboxID := c.Param("id")
+	container, err := h.validateTarget(c.Request.Context(), sandboxID, req.ContainerID)
+	if err != nil {
+		h.writeTargetError(c, err)
+		return
+	}
+
+	ticket, err := h.terminals.IssueTicket(service.TerminalTicket{
+		Username:    c.GetString("username"),
+		SandboxID:   sandboxID,
+		ContainerID: container.ContainerID,
+		EnvdPort:    container.EnvdPort,
+		SessionID:   req.SessionID,
+		Rows:        req.Rows,
+		Cols:        req.Cols,
+	})
+	if err != nil {
+		if errors.Is(err, service.ErrTerminalSessionGone) {
+			httputil.WriteError(c, http.StatusGone, "terminal session can no longer be reconnected")
+			return
+		}
+		if errors.Is(err, service.ErrTerminalSessionLimit) {
+			httputil.WriteError(c, http.StatusTooManyRequests, "too many pending terminal sessions")
+			return
+		}
+		httputil.WriteError(c, http.StatusInternalServerError, "failed to create terminal ticket")
+		return
+	}
+
+	slog.Info("terminal audit",
+		"event", "terminal.ticket.issued",
+		"operator", ticket.Username,
+		"time", time.Now().UTC().Format(time.RFC3339Nano),
+		"sandbox_id", ticket.SandboxID,
+		"container_id", ticket.ContainerID,
+		"reconnect", ticket.SessionID != "",
+	)
+	httputil.WriteJSON(c, http.StatusCreated, gin.H{
+		"ticket":      ticket.Token,
+		"expiresAt":   ticket.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		"containerID": ticket.ContainerID,
+		"wsPath":      "/cubeapi/v1/sandboxes/" + url.PathEscape(ticket.SandboxID) + "/terminal/ws",
+	})
+}
+
+var (
+	errTerminalSandboxNotFound = errors.New("sandbox not found")
+	errTerminalSandboxStopped  = errors.New("sandbox is not running")
+	errTerminalContainerGone   = errors.New("container not found")
+	errTerminalContainerStop   = errors.New("container is not running")
+	errTerminalUnavailable     = errors.New("container does not expose an envd terminal endpoint")
+)
+
+func (h *TerminalHandler) validateTarget(ctx context.Context, sandboxID, containerID string) (terminalContainer, error) {
+	raw, err := h.cm.GetSandbox(ctx, sandboxID, sdkInstanceType)
+	if err != nil {
+		var cmErr interface{ IsNotFound() bool }
+		if errors.As(err, &cmErr) && cmErr.IsNotFound() {
+			return terminalContainer{}, errTerminalSandboxNotFound
+		}
+		return terminalContainer{}, err
+	}
+	var envelope struct {
+		Ret  *cmRet `json:"ret"`
+		Data []struct {
+			SandboxID  string              `json:"sandbox_id"`
+			Status     int                 `json:"status"`
+			Containers []terminalContainer `json:"containers"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return terminalContainer{}, err
+	}
+	if envelope.Ret != nil && envelope.Ret.RetCode != 0 && envelope.Ret.RetCode != 200 {
+		if envelope.Ret.RetCode == 130404 || envelope.Ret.RetCode == 404 {
+			return terminalContainer{}, errTerminalSandboxNotFound
+		}
+		return terminalContainer{}, errors.New(envelope.Ret.RetMsg)
+	}
+	if len(envelope.Data) == 0 {
+		return terminalContainer{}, errTerminalSandboxNotFound
+	}
+	sandbox := envelope.Data[0]
+	if sandbox.Status != 1 {
+		return terminalContainer{}, errTerminalSandboxStopped
+	}
+
+	var selected *terminalContainer
+	for i := range sandbox.Containers {
+		container := &sandbox.Containers[i]
+		if containerID != "" {
+			if container.ContainerID == containerID {
+				selected = container
+				break
+			}
+			continue
+		}
+		if container.Type == "sandbox" || container.ContainerID == sandboxID {
+			selected = container
+			break
+		}
+	}
+	if selected == nil && containerID == "" && len(sandbox.Containers) > 0 {
+		selected = &sandbox.Containers[0]
+	}
+	if selected == nil {
+		return terminalContainer{}, errTerminalContainerGone
+	}
+	if selected.Status != 1 {
+		return terminalContainer{}, errTerminalContainerStop
+	}
+	if selected.EnvdPort == 0 && (selected.Type == "sandbox" || selected.ContainerID == sandboxID) {
+		selected.EnvdPort = 49983
+	}
+	if selected.EnvdPort < 1 || selected.EnvdPort > 65535 {
+		return terminalContainer{}, errTerminalUnavailable
+	}
+	return *selected, nil
+}
+
+func (h *TerminalHandler) writeTargetError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, errTerminalSandboxNotFound), errors.Is(err, errTerminalContainerGone):
+		httputil.WriteError(c, http.StatusNotFound, err.Error())
+	case errors.Is(err, errTerminalSandboxStopped), errors.Is(err, errTerminalContainerStop),
+		errors.Is(err, errTerminalUnavailable):
+		httputil.WriteError(c, http.StatusConflict, err.Error())
+	default:
+		writeCMError(c, err)
+	}
+}
+
+type terminalClientMessage struct {
+	Type string `json:"type"`
+	Data string `json:"data,omitempty"`
+	Rows int    `json:"rows,omitempty"`
+	Cols int    `json:"cols,omitempty"`
+}
+
+type terminalReadResult struct {
+	message terminalClientMessage
+	err     error
+}
+
+type terminalInputLimiter struct {
+	windowStart time.Time
+	events      int
+	bytes       int
+}
+
+func (l *terminalInputLimiter) allow(size int, now time.Time) bool {
+	if l.windowStart.IsZero() || now.Sub(l.windowStart) >= terminalRateWindow {
+		l.windowStart = now
+		l.events = 0
+		l.bytes = 0
+	}
+	if size < 0 || l.events >= terminalRateEvents || l.bytes+size > terminalRateBytes {
+		return false
+	}
+	l.events++
+	l.bytes += size
+	return true
+}
+
+func (h *TerminalHandler) Connect(c *gin.Context) {
+	sandboxID := c.Param("id")
+	ticket, err := h.terminals.ConsumeTicket(c.Query("ticket"), sandboxID)
+	if err != nil {
+		httputil.WriteError(c, http.StatusUnauthorized, "invalid or expired terminal ticket")
+		return
+	}
+
+	conn, err := h.upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	conn.SetReadLimit(terminalReadLimit)
+	_ = conn.SetReadDeadline(time.Now().Add(terminalPongWait))
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(terminalPongWait))
+	})
+
+	session, reconnected, err := h.terminals.Open(c.Request.Context(), ticket)
+	if err != nil {
+		code := "terminal_start_failed"
+		if errors.Is(err, service.ErrTerminalSessionLimit) {
+			code = "session_limit"
+		}
+		_ = writeTerminalJSON(conn, gin.H{"type": "error", "code": code, "message": err.Error(), "recoverable": false})
+		return
+	}
+	process := session.Process()
+	slog.Info("terminal audit",
+		"event", "terminal.session.opened",
+		"operator", session.Username,
+		"time", time.Now().UTC().Format(time.RFC3339Nano),
+		"sandbox_id", session.SandboxID,
+		"container_id", session.ContainerID,
+		"session_id", session.ID,
+		"reconnected", reconnected,
+	)
+
+	if err := writeTerminalJSON(conn, gin.H{
+		"type":        "ready",
+		"sessionID":   session.ID,
+		"containerID": session.ContainerID,
+		"reconnected": reconnected,
+	}); err != nil {
+		h.terminals.Detach(session)
+		return
+	}
+
+	readResults := make(chan terminalReadResult, 1)
+	readerDone := make(chan struct{})
+	defer close(readerDone)
+	go readTerminalMessages(conn, readResults, readerDone)
+
+	ping := time.NewTicker(terminalPingEvery)
+	defer ping.Stop()
+	idle := time.NewTimer(h.idleTimeout)
+	defer idle.Stop()
+	resetIdle := func() {
+		if !idle.Stop() {
+			select {
+			case <-idle.C:
+			default:
+			}
+		}
+		idle.Reset(h.idleTimeout)
+	}
+
+	activeDisconnect := false
+	abnormalDisconnect := false
+	exitReason := "process_exit"
+	inputLimiter := terminalInputLimiter{}
+
+	for {
+		select {
+		case output, ok := <-process.Output():
+			if !ok {
+				exitCode, hasExitCode := process.ExitCode()
+				message := gin.H{"type": "exit", "reason": "process_exit"}
+				if hasExitCode {
+					message["exitCode"] = exitCode
+				}
+				if detail := process.ErrorMessage(); detail != "" {
+					message["message"] = detail
+				}
+				_ = writeTerminalJSON(conn, message)
+				h.terminals.Finish(session)
+				goto done
+			}
+			resetIdle()
+			for len(output) > 0 {
+				chunkSize := min(len(output), terminalWriteChunk)
+				_ = conn.SetWriteDeadline(time.Now().Add(terminalWriteWait))
+				if err := conn.WriteMessage(websocket.BinaryMessage, output[:chunkSize]); err != nil {
+					abnormalDisconnect = true
+					exitReason = "connection_lost"
+					h.terminals.Detach(session)
+					goto done
+				}
+				output = output[chunkSize:]
+			}
+
+		case result := <-readResults:
+			if result.err != nil {
+				abnormalDisconnect = true
+				exitReason = "connection_lost"
+				h.terminals.Detach(session)
+				goto done
+			}
+			message := result.message
+			switch message.Type {
+			case "input":
+				if len(message.Data) > terminalInputLimit {
+					_ = writeTerminalJSON(conn, gin.H{"type": "error", "code": "input_too_large", "message": "terminal input is too large", "recoverable": true})
+					continue
+				}
+				if !inputLimiter.allow(len(message.Data), time.Now()) {
+					_ = writeTerminalJSON(conn, gin.H{"type": "error", "code": "input_rate_limited", "message": "terminal input rate limit exceeded", "recoverable": true})
+					continue
+				}
+				resetIdle()
+				ctx, cancel := context.WithTimeout(c.Request.Context(), terminalWriteWait)
+				err := process.SendStdin(ctx, []byte(message.Data))
+				cancel()
+				if err != nil {
+					_ = writeTerminalJSON(conn, gin.H{"type": "error", "code": "input_failed", "message": err.Error(), "recoverable": false})
+					exitReason = "input_failed"
+					h.terminals.Terminate(session.ID)
+					goto done
+				}
+			case "resize":
+				if !validTerminalSize(message.Rows, message.Cols) {
+					_ = writeTerminalJSON(conn, gin.H{"type": "error", "code": "invalid_size", "message": "terminal size is outside the supported range", "recoverable": true})
+					continue
+				}
+				resetIdle()
+				ctx, cancel := context.WithTimeout(c.Request.Context(), terminalWriteWait)
+				err := process.Resize(ctx, cubesandbox.PtySize{Rows: message.Rows, Cols: message.Cols})
+				cancel()
+				if err != nil {
+					_ = writeTerminalJSON(conn, gin.H{"type": "error", "code": "resize_failed", "message": err.Error(), "recoverable": true})
+				}
+			case "ping":
+				_ = writeTerminalJSON(conn, gin.H{"type": "pong"})
+			case "disconnect":
+				activeDisconnect = true
+				exitReason = "client_disconnect"
+				h.terminals.Terminate(session.ID)
+				_ = writeTerminalJSON(conn, gin.H{"type": "exit", "reason": "client_disconnect"})
+				goto done
+			default:
+				_ = writeTerminalJSON(conn, gin.H{"type": "error", "code": "unknown_message", "message": "unknown terminal message type", "recoverable": true})
+			}
+
+		case <-idle.C:
+			exitReason = "idle_timeout"
+			_ = writeTerminalJSON(conn, gin.H{"type": "error", "code": "idle_timeout", "message": "terminal session closed after being idle", "recoverable": false})
+			h.terminals.Terminate(session.ID)
+			goto done
+
+		case <-ping.C:
+			_ = conn.SetWriteDeadline(time.Now().Add(terminalWriteWait))
+			if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(terminalWriteWait)); err != nil {
+				abnormalDisconnect = true
+				exitReason = "connection_lost"
+				h.terminals.Detach(session)
+				goto done
+			}
+
+		case <-c.Request.Context().Done():
+			abnormalDisconnect = true
+			exitReason = "request_cancelled"
+			h.terminals.Detach(session)
+			goto done
+		}
+	}
+
+done:
+	slog.Info("terminal audit",
+		"event", "terminal.session.closed",
+		"operator", session.Username,
+		"time", time.Now().UTC().Format(time.RFC3339Nano),
+		"sandbox_id", session.SandboxID,
+		"container_id", session.ContainerID,
+		"session_id", session.ID,
+		"reason", exitReason,
+		"active", activeDisconnect,
+		"abnormal", abnormalDisconnect,
+	)
+}
+
+func readTerminalMessages(conn *websocket.Conn, results chan<- terminalReadResult, done <-chan struct{}) {
+	publish := func(result terminalReadResult) bool {
+		select {
+		case results <- result:
+			return true
+		case <-done:
+			return false
+		}
+	}
+	for {
+		messageType, payload, err := conn.ReadMessage()
+		if err != nil {
+			publish(terminalReadResult{err: err})
+			return
+		}
+		if messageType != websocket.TextMessage {
+			publish(terminalReadResult{err: errors.New("terminal control messages must be JSON text")})
+			return
+		}
+		var message terminalClientMessage
+		if err := json.Unmarshal(payload, &message); err != nil {
+			publish(terminalReadResult{err: errors.New("invalid terminal control message")})
+			return
+		}
+		if !publish(terminalReadResult{message: message}) {
+			return
+		}
+	}
+}
+
+func writeTerminalJSON(conn *websocket.Conn, value interface{}) error {
+	_ = conn.SetWriteDeadline(time.Now().Add(terminalWriteWait))
+	return conn.WriteJSON(value)
+}
+
+func validTerminalSize(rows, cols int) bool {
+	return rows >= terminalMinRows && rows <= terminalMaxRows &&
+		cols >= terminalMinCols && cols <= terminalMaxCols
+}
+
+func terminalSameOrigin(r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return true
+	}
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Host, r.Host)
+}

--- a/CubeOps/internal/handler/terminal_test.go
+++ b/CubeOps/internal/handler/terminal_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/service"
+)
+
+type terminalFakeCM struct {
+	status          int
+	containerStatus int
+	includeSidecar  bool
+}
+
+func (f terminalFakeCM) GetSandbox(context.Context, string, string) (json.RawMessage, error) {
+	containers := []interface{}{map[string]interface{}{
+		"name":         "main",
+		"container_id": "sandbox-1",
+		"status":       f.containerStatus,
+		"type":         "sandbox",
+		"envd_port":    49983,
+	}}
+	if f.includeSidecar {
+		containers = append(containers, map[string]interface{}{
+			"name":         "worker",
+			"container_id": "container-2",
+			"status":       1,
+			"type":         "container",
+			"envd_port":    49984,
+		})
+	}
+	payload := map[string]interface{}{
+		"ret": map[string]interface{}{"ret_code": 0, "ret_msg": "ok"},
+		"data": []interface{}{map[string]interface{}{
+			"sandbox_id": "sandbox-1",
+			"status":     f.status,
+			"containers": containers,
+		}},
+	}
+	raw, _ := json.Marshal(payload)
+	return raw, nil
+}
+
+func connectFrame(payload string) []byte {
+	frame := make([]byte, 5+len(payload))
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(payload)))
+	copy(frame[5:], payload)
+	return frame
+}
+
+func terminalTestEnvd(t *testing.T) (*httptest.Server, <-chan [2]int) {
+	t.Helper()
+	resizes := make(chan [2]int, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/process.Process/Start":
+			w.Header().Set("Content-Type", "application/connect+json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(connectFrame(`{"event":{"start":{"pid":321}}}`))
+			output := base64.StdEncoding.EncodeToString([]byte("\x1b[32mready\x1b[0m\r\n"))
+			_, _ = w.Write(connectFrame(`{"event":{"data":{"pty":"` + output + `"}}}`))
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+		case "/process.Process/Update":
+			var request struct {
+				PTY struct {
+					Size struct {
+						Rows int `json:"rows"`
+						Cols int `json:"cols"`
+					} `json:"size"`
+				} `json:"pty"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&request)
+			resizes <- [2]int{request.PTY.Size.Rows, request.PTY.Size.Cols}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{}`)
+		}
+	}))
+	return server, resizes
+}
+
+func terminalTestRouter(t *testing.T, cm terminalFakeCM, envdURL string, idle time.Duration) (*gin.Engine, *service.TerminalService) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	terminals, err := service.NewTerminalService(envdURL, "cube.test", time.Minute, time.Second, 8, 4)
+	if err != nil {
+		t.Fatalf("NewTerminalService: %v", err)
+	}
+	handler := NewTerminalHandler(cm, terminals, idle)
+	router := gin.New()
+	public := router.Group("/api/v1/sdk")
+	handler.RegisterPublic(public)
+	authed := router.Group("/api/v1/sdk", func(c *gin.Context) {
+		if c.GetHeader("Authorization") != "Bearer valid" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		c.Set("username", "alice")
+		c.Next()
+	})
+	handler.RegisterAuthed(authed)
+	return router, terminals
+}
+
+func requestTerminalTicket(t *testing.T, baseURL string, auth bool) (int, map[string]interface{}) {
+	t.Helper()
+	request, err := http.NewRequest(
+		http.MethodPost,
+		baseURL+"/api/v1/sdk/sandboxes/sandbox-1/terminal/tickets",
+		bytes.NewBufferString(`{"containerID":"sandbox-1","rows":24,"cols":80}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	if auth {
+		request.Header.Set("Authorization", "Bearer valid")
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	var body map[string]interface{}
+	_ = json.NewDecoder(response.Body).Decode(&body)
+	return response.StatusCode, body
+}
+
+func TestTerminalTicketRequiresAuthenticationAndRunningTarget(t *testing.T) {
+	envd, _ := terminalTestEnvd(t)
+	defer envd.Close()
+
+	router, terminals := terminalTestRouter(t, terminalFakeCM{status: 1, containerStatus: 1}, envd.URL, time.Minute)
+	defer terminals.Close()
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	if status, _ := requestTerminalTicket(t, server.URL, false); status != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated ticket status = %d", status)
+	}
+	if status, body := requestTerminalTicket(t, server.URL, true); status != http.StatusCreated || body["ticket"] == "" {
+		t.Fatalf("authenticated ticket status/body = %d %#v", status, body)
+	}
+
+	stoppedRouter, stoppedTerminals := terminalTestRouter(t, terminalFakeCM{status: 5, containerStatus: 5}, envd.URL, time.Minute)
+	defer stoppedTerminals.Close()
+	stoppedServer := httptest.NewServer(stoppedRouter)
+	defer stoppedServer.Close()
+	if status, _ := requestTerminalTicket(t, stoppedServer.URL, true); status != http.StatusConflict {
+		t.Fatalf("stopped sandbox ticket status = %d", status)
+	}
+}
+
+func TestTerminalTargetSelectsSidecarEndpoint(t *testing.T) {
+	handler := &TerminalHandler{
+		cm: terminalFakeCM{status: 1, containerStatus: 1, includeSidecar: true},
+	}
+	target, err := handler.validateTarget(context.Background(), "sandbox-1", "container-2")
+	if err != nil {
+		t.Fatalf("validateTarget: %v", err)
+	}
+	if target.ContainerID != "container-2" || target.Name != "worker" || target.EnvdPort != 49984 {
+		t.Fatalf("sidecar target = %#v", target)
+	}
+}
+
+func TestTerminalWebSocketEstablishResizeAndDisconnect(t *testing.T) {
+	envd, resizes := terminalTestEnvd(t)
+	defer envd.Close()
+	router, terminals := terminalTestRouter(t, terminalFakeCM{status: 1, containerStatus: 1}, envd.URL, time.Minute)
+	defer terminals.Close()
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	status, ticketBody := requestTerminalTicket(t, server.URL, true)
+	if status != http.StatusCreated {
+		t.Fatalf("ticket status = %d", status)
+	}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/api/v1/sdk/sandboxes/sandbox-1/terminal/ws?ticket=" + ticketBody["ticket"].(string)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close()
+
+	messageType, payload, err := conn.ReadMessage()
+	if err != nil || messageType != websocket.TextMessage || !bytes.Contains(payload, []byte(`"ready"`)) {
+		t.Fatalf("ready message = type %d payload %s err %v", messageType, payload, err)
+	}
+	messageType, payload, err = conn.ReadMessage()
+	if err != nil || messageType != websocket.BinaryMessage || !bytes.Contains(payload, []byte("ready")) {
+		t.Fatalf("PTY output = type %d payload %q err %v", messageType, payload, err)
+	}
+
+	if err := conn.WriteJSON(map[string]interface{}{"type": "resize", "rows": 40, "cols": 120}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case size := <-resizes:
+		if size != [2]int{40, 120} {
+			t.Fatalf("resize = %v", size)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resize was not forwarded to envd")
+	}
+
+	if err := conn.WriteJSON(map[string]interface{}{"type": "disconnect"}); err != nil {
+		t.Fatal(err)
+	}
+	_, payload, err = conn.ReadMessage()
+	if err != nil || !bytes.Contains(payload, []byte(`"client_disconnect"`)) {
+		t.Fatalf("disconnect response = %s err %v", payload, err)
+	}
+}
+
+func TestTerminalWebSocketClosesIdleSession(t *testing.T) {
+	envd, _ := terminalTestEnvd(t)
+	defer envd.Close()
+	router, terminals := terminalTestRouter(
+		t,
+		terminalFakeCM{status: 1, containerStatus: 1},
+		envd.URL,
+		30*time.Millisecond,
+	)
+	defer terminals.Close()
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	status, ticketBody := requestTerminalTicket(t, server.URL, true)
+	if status != http.StatusCreated {
+		t.Fatalf("ticket status = %d", status)
+	}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/api/v1/sdk/sandboxes/sandbox-1/terminal/ws?ticket=" + ticketBody["ticket"].(string)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+
+	// Consume the ready control frame and initial PTY output. With no further
+	// input or output, the server must actively terminate the session.
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read ready: %v", err)
+	}
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read PTY output: %v", err)
+	}
+	messageType, payload, err := conn.ReadMessage()
+	if err != nil || messageType != websocket.TextMessage ||
+		!bytes.Contains(payload, []byte(`"idle_timeout"`)) {
+		t.Fatalf("idle response = type %d payload %s err %v", messageType, payload, err)
+	}
+}
+
+func TestTerminalInputLimiterBoundsEventsAndBytes(t *testing.T) {
+	now := time.Now()
+	var events terminalInputLimiter
+	for i := 0; i < terminalRateEvents; i++ {
+		if !events.allow(1, now) {
+			t.Fatalf("event %d was rejected before the configured limit", i)
+		}
+	}
+	if events.allow(1, now) {
+		t.Fatal("event rate limit was not enforced")
+	}
+	if !events.allow(1, now.Add(terminalRateWindow)) {
+		t.Fatal("event rate limit did not reset after the window")
+	}
+
+	var bytes terminalInputLimiter
+	if !bytes.allow(terminalRateBytes, now) {
+		t.Fatal("byte limit rejected an input exactly at the limit")
+	}
+	if bytes.allow(1, now) {
+		t.Fatal("byte rate limit was not enforced")
+	}
+}

--- a/CubeOps/internal/server/server.go
+++ b/CubeOps/internal/server/server.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -20,23 +21,38 @@ import (
 
 // Server is the CubeOps HTTP server.
 type Server struct {
-	cfg     *config.Config
-	store   *store.Store
-	jm      *auth.JWTManager
-	httpSrv *http.Server
-	cm      *cubemaster.Client
+	cfg      *config.Config
+	store    *store.Store
+	jm       *auth.JWTManager
+	httpSrv  *http.Server
+	cm       *cubemaster.Client
+	terminal *service.TerminalService
 }
 
-// New creates a new CubeOps server.
-func New(cfg *config.Config, s *store.Store) *Server {
+// New creates a new CubeOps server. It fails when the Web Terminal data-plane
+// address (sandbox_proxy_url / CUBE_SANDBOX_PROXY_URL) is not a usable
+// http(s) URL, so a misconfiguration surfaces as a startup error.
+func New(cfg *config.Config, s *store.Store) (*Server, error) {
 	jm := auth.NewJWTManager(cfg.JWTSecret, cfg.AccessTTL, cfg.RefreshTTL)
 	cm := cubemaster.New(cfg.CubeMasterAddr)
-	return &Server{
-		cfg:   cfg,
-		store: s,
-		jm:    jm,
-		cm:    cm,
+	terminal, err := service.NewTerminalService(
+		cfg.SandboxProxyURL,
+		cfg.SandboxDomain,
+		cfg.TerminalTicketTTL,
+		cfg.TerminalReconnectGrace,
+		cfg.TerminalMaxSessions,
+		cfg.TerminalMaxSessionsPerBox,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("configure Web Terminal: %w", err)
 	}
+	return &Server{
+		cfg:      cfg,
+		store:    s,
+		jm:       jm,
+		cm:       cm,
+		terminal: terminal,
+	}, nil
 }
 
 // Start begins listening for HTTP requests.
@@ -63,10 +79,19 @@ func (s *Server) Start() error {
 // Shutdown gracefully stops the server.
 func (s *Server) Shutdown(ctx context.Context) error {
 	if s.httpSrv == nil {
+		if s.terminal != nil {
+			return s.terminal.Close()
+		}
 		return nil
 	}
 	slog.Info("CubeOps shutting down")
-	return s.httpSrv.Shutdown(ctx)
+	err := s.httpSrv.Shutdown(ctx)
+	if s.terminal != nil {
+		if terminalErr := s.terminal.Close(); err == nil {
+			err = terminalErr
+		}
+	}
+	return err
 }
 
 // buildRouter configures all routes on a gin engine.
@@ -96,10 +121,12 @@ func (s *Server) buildRouter() *gin.Engine {
 	// deletions can reverse-sync AgentHub registrations (matching the old
 	// Rust reverse_sync_agenthub_template that lived in CubeAPI).
 	sdkH := handler.NewSDKHandler(s.cm).WithAgentHubService(agenthubH.AgentHubService())
+	terminalH := handler.NewTerminalHandler(s.cm, s.terminal, s.cfg.TerminalIdleTimeout)
 
 	// Public (no auth) routes — login + refresh.
 	public := r.Group("/api/v1")
 	authH.RegisterPublic(public)
+	terminalH.RegisterPublic(public.Group("/sdk"))
 
 	// Authenticated routes. The session / logout / change-password endpoints
 	// are mounted here, behind the JWT middleware.
@@ -115,6 +142,7 @@ func (s *Server) buildRouter() *gin.Engine {
 	// the WebUI and the E2B-compatible clients hit different prefixes.
 	sdkGroup := authed.Group("/sdk")
 	sdkH.Register(sdkGroup)
+	terminalH.RegisterAuthed(sdkGroup)
 	sdkV2Group := authed.Group("/sdk/v2")
 	sdkV2Group.GET("/sandboxes", sdkH.ListSandboxes)
 	sdkV2Group.GET("/sandboxes/:id/logs", sdkH.GetSandboxLogs)

--- a/CubeOps/internal/service/terminal.go
+++ b/CubeOps/internal/service/terminal.go
@@ -1,0 +1,442 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	cubesandbox "github.com/tencentcloud/CubeSandbox/sdk/go"
+)
+
+var (
+	ErrTerminalTicketInvalid = errors.New("terminal ticket is invalid or expired")
+	ErrTerminalSessionBusy   = errors.New("terminal session is already attached")
+	ErrTerminalSessionGone   = errors.New("terminal session is no longer available")
+	ErrTerminalSessionLimit  = errors.New("terminal session limit reached")
+)
+
+// TerminalTicket is a short-lived, single-use authorization grant. It carries
+// only server-side state; the random token is the sole value sent in the
+// WebSocket URL.
+type TerminalTicket struct {
+	Token       string
+	Username    string
+	SandboxID   string
+	ContainerID string
+	EnvdPort    int
+	SessionID   string
+	Rows        int
+	Cols        int
+	ExpiresAt   time.Time
+}
+
+type terminalProcess interface {
+	PID() int
+	Output() <-chan []byte
+	ExitCode() (int, bool)
+	ErrorMessage() string
+	SendStdin(context.Context, []byte) error
+	Resize(context.Context, cubesandbox.PtySize) error
+	Disconnect() error
+	Kill(context.Context) (bool, error)
+}
+
+type terminalBackend interface {
+	Start(context.Context, string, int, int, int) (terminalProcess, error)
+	Connect(context.Context, string, int, int) (terminalProcess, error)
+	Close() error
+}
+
+type sdkTerminalBackend struct {
+	client *cubesandbox.Client
+}
+
+func newSDKTerminalBackend(proxyURL, sandboxDomain string) (*sdkTerminalBackend, error) {
+	parsed, err := url.Parse(proxyURL)
+	if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" {
+		return nil, fmt.Errorf("invalid sandbox proxy URL %q", proxyURL)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("sandbox proxy URL must use http or https")
+	}
+	port := 80
+	if parsed.Scheme == "https" {
+		port = 443
+	}
+	if parsed.Port() != "" {
+		port, err = strconv.Atoi(parsed.Port())
+		if err != nil || port < 1 || port > 65535 {
+			return nil, fmt.Errorf("invalid sandbox proxy URL port %q", parsed.Port())
+		}
+	}
+	client := cubesandbox.NewClient(cubesandbox.Config{
+		ProxyNodeIP:    parsed.Hostname(),
+		ProxyPortHTTP:  port,
+		ProxyScheme:    parsed.Scheme,
+		SandboxDomain:  sandboxDomain,
+		RequestTimeout: 10 * time.Second,
+	})
+	return &sdkTerminalBackend{client: client}, nil
+}
+
+func (b *sdkTerminalBackend) Start(ctx context.Context, sandboxID string, envdPort, rows, cols int) (terminalProcess, error) {
+	sandbox := b.client.AttachSandbox(sandboxID, envdPort)
+	return sandbox.Pty().Create(ctx, cubesandbox.PtySize{Rows: rows, Cols: cols}, cubesandbox.PtyCreateOptions{
+		Shell:   "/bin/sh",
+		Args:    []string{"-i"},
+		Timeout: 24 * time.Hour,
+	})
+}
+
+func (b *sdkTerminalBackend) Connect(ctx context.Context, sandboxID string, envdPort, pid int) (terminalProcess, error) {
+	sandbox := b.client.AttachSandbox(sandboxID, envdPort)
+	return sandbox.Pty().Connect(ctx, pid, cubesandbox.PtyConnectOptions{Timeout: 24 * time.Hour})
+}
+
+func (b *sdkTerminalBackend) Close() error { return b.client.Close() }
+
+type TerminalSession struct {
+	ID          string
+	Username    string
+	SandboxID   string
+	ContainerID string
+	EnvdPort    int
+	PID         int
+
+	process    terminalProcess
+	attachment uint64
+}
+
+func (s *TerminalSession) Process() terminalProcess { return s.process }
+
+type terminalSessionState struct {
+	session    *TerminalSession
+	process    terminalProcess
+	attached   bool
+	generation uint64
+	cleanup    *time.Timer
+	createdAt  time.Time
+}
+
+// TerminalService owns one-time tickets and resumable PTY session metadata.
+// The PTY itself remains inside the sandbox and is always controlled through
+// envd, the same mechanism used by the SDK.
+type TerminalService struct {
+	backend terminalBackend
+
+	ticketTTL      time.Duration
+	reconnectGrace time.Duration
+	maxSessions    int
+	maxPerSandbox  int
+
+	mu       sync.Mutex
+	tickets  map[string]TerminalTicket
+	sessions map[string]*terminalSessionState
+}
+
+func NewTerminalService(proxyURL, sandboxDomain string, ticketTTL, reconnectGrace time.Duration, maxSessions, maxPerSandbox int) (*TerminalService, error) {
+	backend, err := newSDKTerminalBackend(proxyURL, sandboxDomain)
+	if err != nil {
+		return nil, err
+	}
+	return newTerminalService(backend, ticketTTL, reconnectGrace, maxSessions, maxPerSandbox), nil
+}
+
+func newTerminalService(backend terminalBackend, ticketTTL, reconnectGrace time.Duration, maxSessions, maxPerSandbox int) *TerminalService {
+	return &TerminalService{
+		backend:        backend,
+		ticketTTL:      ticketTTL,
+		reconnectGrace: reconnectGrace,
+		maxSessions:    maxSessions,
+		maxPerSandbox:  maxPerSandbox,
+		tickets:        make(map[string]TerminalTicket),
+		sessions:       make(map[string]*terminalSessionState),
+	}
+}
+
+func (s *TerminalService) Close() error {
+	s.mu.Lock()
+	sessions := make([]*TerminalSession, 0, len(s.sessions))
+	for _, state := range s.sessions {
+		if state.cleanup != nil {
+			state.cleanup.Stop()
+		}
+		session := *state.session
+		session.process = state.process
+		sessions = append(sessions, &session)
+	}
+	s.sessions = make(map[string]*terminalSessionState)
+	s.tickets = make(map[string]TerminalTicket)
+	s.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, session := range sessions {
+		if session.process != nil {
+			_, _ = session.process.Kill(ctx)
+		}
+	}
+	return s.backend.Close()
+}
+
+func (s *TerminalService) IssueTicket(ticket TerminalTicket) (TerminalTicket, error) {
+	if ticket.SessionID != "" {
+		s.mu.Lock()
+		state := s.sessions[ticket.SessionID]
+		valid := state != nil && !state.attached &&
+			state.session.Username == ticket.Username &&
+			state.session.SandboxID == ticket.SandboxID &&
+			state.session.ContainerID == ticket.ContainerID
+		s.mu.Unlock()
+		if !valid {
+			return TerminalTicket{}, ErrTerminalSessionGone
+		}
+	}
+
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return TerminalTicket{}, fmt.Errorf("create terminal ticket: %w", err)
+	}
+	ticket.Token = base64.RawURLEncoding.EncodeToString(raw)
+	ticket.ExpiresAt = time.Now().Add(s.ticketTTL)
+
+	s.mu.Lock()
+	now := time.Now()
+	for token, existing := range s.tickets {
+		if !existing.ExpiresAt.After(now) {
+			delete(s.tickets, token)
+		}
+	}
+	maxTickets := max(1, s.maxSessions*2)
+	if len(s.tickets) >= maxTickets {
+		s.mu.Unlock()
+		return TerminalTicket{}, ErrTerminalSessionLimit
+	}
+	s.tickets[ticket.Token] = ticket
+	s.mu.Unlock()
+	return ticket, nil
+}
+
+func (s *TerminalService) ConsumeTicket(token, sandboxID string) (TerminalTicket, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ticket, ok := s.tickets[token]
+	delete(s.tickets, token)
+	if !ok || !ticket.ExpiresAt.After(time.Now()) || ticket.SandboxID != sandboxID {
+		return TerminalTicket{}, ErrTerminalTicketInvalid
+	}
+	return ticket, nil
+}
+
+func (s *TerminalService) Open(ctx context.Context, ticket TerminalTicket) (*TerminalSession, bool, error) {
+	if ticket.SessionID != "" {
+		return s.reconnect(ctx, ticket)
+	}
+
+	session := &TerminalSession{
+		ID:          uuid.NewString(),
+		Username:    ticket.Username,
+		SandboxID:   ticket.SandboxID,
+		ContainerID: ticket.ContainerID,
+		EnvdPort:    ticket.EnvdPort,
+	}
+	state := &terminalSessionState{
+		session:    session,
+		attached:   true,
+		generation: 1,
+		createdAt:  time.Now(),
+	}
+
+	s.mu.Lock()
+	if len(s.sessions) >= s.maxSessions || s.sessionsForSandboxLocked(ticket.SandboxID) >= s.maxPerSandbox {
+		s.mu.Unlock()
+		return nil, false, ErrTerminalSessionLimit
+	}
+	s.sessions[session.ID] = state
+	s.mu.Unlock()
+
+	process, err := s.backend.Start(ctx, ticket.SandboxID, ticket.EnvdPort, ticket.Rows, ticket.Cols)
+	if err != nil {
+		s.mu.Lock()
+		if s.sessions[session.ID] == state {
+			delete(s.sessions, session.ID)
+		}
+		s.mu.Unlock()
+		return nil, false, err
+	}
+
+	s.mu.Lock()
+	if s.sessions[session.ID] != state || !state.attached || state.generation != 1 {
+		s.mu.Unlock()
+		closeTerminalProcess(process, true)
+		return nil, false, ErrTerminalSessionGone
+	}
+	state.session.PID = process.PID()
+	state.process = process
+	attached := *state.session
+	attached.process = process
+	attached.attachment = state.generation
+	s.mu.Unlock()
+	return &attached, false, nil
+}
+
+func (s *TerminalService) reconnect(ctx context.Context, ticket TerminalTicket) (*TerminalSession, bool, error) {
+	s.mu.Lock()
+	state := s.sessions[ticket.SessionID]
+	if state == nil ||
+		state.session.Username != ticket.Username ||
+		state.session.SandboxID != ticket.SandboxID ||
+		state.session.ContainerID != ticket.ContainerID {
+		s.mu.Unlock()
+		return nil, false, ErrTerminalSessionGone
+	}
+	if state.attached {
+		s.mu.Unlock()
+		return nil, false, ErrTerminalSessionBusy
+	}
+	state.attached = true
+	state.generation++
+	generation := state.generation
+	if state.cleanup != nil {
+		state.cleanup.Stop()
+		state.cleanup = nil
+	}
+	session := *state.session
+	s.mu.Unlock()
+
+	process, err := s.backend.Connect(ctx, session.SandboxID, session.EnvdPort, session.PID)
+	if err != nil {
+		s.mu.Lock()
+		if s.sessions[session.ID] == state && state.generation == generation {
+			state.attached = false
+			s.scheduleCleanupLocked(session.ID, state, generation)
+		}
+		s.mu.Unlock()
+		return nil, false, err
+	}
+
+	s.mu.Lock()
+	if s.sessions[session.ID] != state || !state.attached || state.generation != generation {
+		s.mu.Unlock()
+		closeTerminalProcess(process, true)
+		return nil, false, ErrTerminalSessionGone
+	}
+	state.process = process
+	session.process = process
+	session.attachment = generation
+	s.mu.Unlock()
+	return &session, true, nil
+}
+
+// Detach releases one WebSocket attachment while retaining its PTY during the
+// reconnect grace period. The attachment generation prevents a late close
+// event from an old WebSocket from detaching a newer, reconnected stream.
+func (s *TerminalService) Detach(session *TerminalSession) {
+	if session == nil {
+		return
+	}
+	s.mu.Lock()
+	state := s.sessions[session.ID]
+	if state == nil || !state.attached || state.generation != session.attachment || state.process != session.process {
+		s.mu.Unlock()
+		return
+	}
+	state.attached = false
+	process := state.process
+	s.scheduleCleanupLocked(session.ID, state, state.generation)
+	s.mu.Unlock()
+	if process != nil {
+		_ = process.Disconnect()
+	}
+}
+
+func (s *TerminalService) scheduleCleanupLocked(sessionID string, state *terminalSessionState, generation uint64) {
+	if state.cleanup != nil {
+		state.cleanup.Stop()
+	}
+	state.cleanup = time.AfterFunc(s.reconnectGrace, func() {
+		s.cleanupDetached(sessionID, state, generation)
+	})
+}
+
+func (s *TerminalService) cleanupDetached(sessionID string, expected *terminalSessionState, generation uint64) {
+	s.mu.Lock()
+	state := s.sessions[sessionID]
+	if state != expected || state.attached || state.generation != generation {
+		s.mu.Unlock()
+		return
+	}
+	delete(s.sessions, sessionID)
+	process := state.process
+	s.mu.Unlock()
+	closeTerminalProcess(process, true)
+}
+
+// Finish removes a session only when the PTY belonging to the current
+// attachment has exited. Output closure from a superseded attachment must not
+// delete a successfully reconnected session.
+func (s *TerminalService) Finish(session *TerminalSession) {
+	if session == nil {
+		return
+	}
+	s.mu.Lock()
+	state := s.sessions[session.ID]
+	if state == nil || state.generation != session.attachment || state.process != session.process {
+		s.mu.Unlock()
+		return
+	}
+	if state.cleanup != nil {
+		state.cleanup.Stop()
+	}
+	delete(s.sessions, session.ID)
+	s.mu.Unlock()
+}
+
+func (s *TerminalService) Terminate(sessionID string) {
+	s.mu.Lock()
+	state := s.sessions[sessionID]
+	if state == nil {
+		s.mu.Unlock()
+		return
+	}
+	delete(s.sessions, sessionID)
+	if state.cleanup != nil {
+		state.cleanup.Stop()
+	}
+	process := state.process
+	s.mu.Unlock()
+
+	closeTerminalProcess(process, true)
+}
+
+func closeTerminalProcess(process terminalProcess, kill bool) {
+	if process == nil {
+		return
+	}
+	if kill {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_, _ = process.Kill(ctx)
+		cancel()
+	}
+	_ = process.Disconnect()
+}
+
+func (s *TerminalService) sessionsForSandboxLocked(sandboxID string) int {
+	total := 0
+	for _, state := range s.sessions {
+		if state.session.SandboxID == sandboxID {
+			total++
+		}
+	}
+	return total
+}

--- a/CubeOps/internal/service/terminal_test.go
+++ b/CubeOps/internal/service/terminal_test.go
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	cubesandbox "github.com/tencentcloud/CubeSandbox/sdk/go"
+)
+
+type fakeTerminalProcess struct {
+	pid        int
+	output     chan []byte
+	disconnect chan struct{}
+	kill       chan struct{}
+	once       sync.Once
+}
+
+func newFakeTerminalProcess(pid int) *fakeTerminalProcess {
+	return &fakeTerminalProcess{
+		pid:        pid,
+		output:     make(chan []byte),
+		disconnect: make(chan struct{}),
+		kill:       make(chan struct{}),
+	}
+}
+
+func (p *fakeTerminalProcess) PID() int                                { return p.pid }
+func (p *fakeTerminalProcess) Output() <-chan []byte                   { return p.output }
+func (p *fakeTerminalProcess) ExitCode() (int, bool)                   { return 0, false }
+func (p *fakeTerminalProcess) ErrorMessage() string                    { return "" }
+func (p *fakeTerminalProcess) SendStdin(context.Context, []byte) error { return nil }
+func (p *fakeTerminalProcess) Resize(context.Context, cubesandbox.PtySize) error {
+	return nil
+}
+func (p *fakeTerminalProcess) Disconnect() error {
+	p.once.Do(func() { close(p.disconnect) })
+	return nil
+}
+func (p *fakeTerminalProcess) Kill(context.Context) (bool, error) {
+	select {
+	case <-p.kill:
+	default:
+		close(p.kill)
+	}
+	return true, nil
+}
+
+type fakeTerminalBackend struct {
+	mu         sync.Mutex
+	nextPID    int
+	started    []*fakeTerminalProcess
+	reconnects int
+}
+
+func (b *fakeTerminalBackend) Start(context.Context, string, int, int, int) (terminalProcess, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.nextPID++
+	process := newFakeTerminalProcess(b.nextPID)
+	b.started = append(b.started, process)
+	return process, nil
+}
+
+func (b *fakeTerminalBackend) Connect(context.Context, string, int, int) (terminalProcess, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.reconnects++
+	process := newFakeTerminalProcess(b.started[0].pid)
+	b.started = append(b.started, process)
+	return process, nil
+}
+
+func (b *fakeTerminalBackend) Close() error { return nil }
+
+func testTicket() TerminalTicket {
+	return TerminalTicket{
+		Username:    "alice",
+		SandboxID:   "sandbox-1",
+		ContainerID: "container-1",
+		EnvdPort:    49983,
+		Rows:        24,
+		Cols:        80,
+	}
+}
+
+func TestTerminalTicketIsSingleUseAndBoundToSandbox(t *testing.T) {
+	service := newTerminalService(&fakeTerminalBackend{}, time.Minute, time.Second, 8, 4)
+	ticket, err := service.IssueTicket(testTicket())
+	if err != nil {
+		t.Fatalf("IssueTicket: %v", err)
+	}
+	if _, err := service.ConsumeTicket(ticket.Token, "other-sandbox"); err != ErrTerminalTicketInvalid {
+		t.Fatalf("ConsumeTicket wrong sandbox error = %v", err)
+	}
+	if _, err := service.ConsumeTicket(ticket.Token, "sandbox-1"); err != ErrTerminalTicketInvalid {
+		t.Fatalf("ticket was not consumed after failed binding check: %v", err)
+	}
+}
+
+func TestTerminalTicketLimitAndProxySchemeValidation(t *testing.T) {
+	service := newTerminalService(&fakeTerminalBackend{}, time.Minute, time.Second, 1, 1)
+	for i := 0; i < 2; i++ {
+		if _, err := service.IssueTicket(testTicket()); err != nil {
+			t.Fatalf("IssueTicket %d: %v", i, err)
+		}
+	}
+	if _, err := service.IssueTicket(testTicket()); err != ErrTerminalSessionLimit {
+		t.Fatalf("ticket limit error = %v", err)
+	}
+	if _, err := NewTerminalService("ftp://proxy.example", "cube.test", time.Minute, time.Second, 1, 1); err == nil {
+		t.Fatal("unsupported sandbox proxy scheme was accepted")
+	}
+}
+
+func TestTerminalSessionEstablishDetachReconnectAndTerminate(t *testing.T) {
+	backend := &fakeTerminalBackend{}
+	service := newTerminalService(backend, time.Minute, time.Hour, 8, 4)
+	ticket := testTicket()
+
+	session, reconnected, err := service.Open(context.Background(), ticket)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if reconnected || session.PID == 0 {
+		t.Fatalf("unexpected initial session: reconnected=%v pid=%d", reconnected, session.PID)
+	}
+
+	service.Detach(session)
+	reconnectTicket := ticket
+	reconnectTicket.SessionID = session.ID
+	issued, err := service.IssueTicket(reconnectTicket)
+	if err != nil {
+		t.Fatalf("IssueTicket reconnect: %v", err)
+	}
+	consumed, err := service.ConsumeTicket(issued.Token, ticket.SandboxID)
+	if err != nil {
+		t.Fatalf("ConsumeTicket reconnect: %v", err)
+	}
+	reconnectedSession, reconnected, err := service.Open(context.Background(), consumed)
+	if err != nil {
+		t.Fatalf("Reconnect: %v", err)
+	}
+	if !reconnected || reconnectedSession.ID != session.ID || backend.reconnects != 1 {
+		t.Fatalf("reconnect did not preserve session: %#v", reconnectedSession)
+	}
+
+	service.Terminate(session.ID)
+	select {
+	case <-reconnectedSession.process.(*fakeTerminalProcess).kill:
+	case <-time.After(time.Second):
+		t.Fatal("active termination did not kill the PTY")
+	}
+}
+
+func TestStaleAttachmentCannotDetachOrFinishReconnectedSession(t *testing.T) {
+	backend := &fakeTerminalBackend{}
+	service := newTerminalService(backend, time.Minute, time.Hour, 8, 4)
+	ticket := testTicket()
+
+	first, _, err := service.Open(context.Background(), ticket)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	service.Detach(first)
+
+	reconnectTicket := ticket
+	reconnectTicket.SessionID = first.ID
+	second, reconnected, err := service.Open(context.Background(), reconnectTicket)
+	if err != nil {
+		t.Fatalf("Reconnect: %v", err)
+	}
+	if !reconnected {
+		t.Fatal("expected a reconnected session")
+	}
+	secondProcess := second.process.(*fakeTerminalProcess)
+
+	// A delayed close/output event from the first WebSocket must not affect the
+	// process now owned by the reconnected attachment.
+	service.Detach(first)
+	service.Finish(first)
+	select {
+	case <-secondProcess.disconnect:
+		t.Fatal("stale attachment disconnected the reconnected process")
+	default:
+	}
+
+	service.Terminate(second.ID)
+	select {
+	case <-secondProcess.kill:
+	case <-time.After(time.Second):
+		t.Fatal("stale attachment removed the reconnected session")
+	}
+}
+
+func TestTerminalSessionAuthorizationAndLimits(t *testing.T) {
+	service := newTerminalService(&fakeTerminalBackend{}, time.Minute, time.Hour, 1, 1)
+	session, _, err := service.Open(context.Background(), testTicket())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	if _, _, err := service.Open(context.Background(), TerminalTicket{
+		Username: "bob", SandboxID: "sandbox-2", ContainerID: "container-2", EnvdPort: 49983, Rows: 24, Cols: 80,
+	}); err != ErrTerminalSessionLimit {
+		t.Fatalf("limit error = %v", err)
+	}
+
+	service.Detach(session)
+	unauthorized := testTicket()
+	unauthorized.Username = "mallory"
+	unauthorized.SessionID = session.ID
+	if _, err := service.IssueTicket(unauthorized); err != ErrTerminalSessionGone {
+		t.Fatalf("unauthorized reconnect error = %v", err)
+	}
+	service.Terminate(session.ID)
+}
+
+func TestTerminalAllowsIndependentSessionsInOneSandbox(t *testing.T) {
+	backend := &fakeTerminalBackend{}
+	service := newTerminalService(backend, time.Minute, time.Hour, 8, 4)
+	first, _, err := service.Open(context.Background(), testTicket())
+	if err != nil {
+		t.Fatalf("open first session: %v", err)
+	}
+	secondTicket := testTicket()
+	secondTicket.ContainerID = "container-2"
+	secondTicket.EnvdPort = 49984
+	second, _, err := service.Open(context.Background(), secondTicket)
+	if err != nil {
+		t.Fatalf("open second session: %v", err)
+	}
+	if first.ID == second.ID || first.PID == second.PID {
+		t.Fatalf("sessions are not independent: first=%#v second=%#v", first, second)
+	}
+	service.Terminate(first.ID)
+	service.Terminate(second.ID)
+}
+
+func TestTerminalReconnectGraceCleansDetachedSession(t *testing.T) {
+	backend := &fakeTerminalBackend{}
+	service := newTerminalService(backend, time.Minute, 10*time.Millisecond, 8, 4)
+	session, _, err := service.Open(context.Background(), testTicket())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	service.Detach(session)
+
+	select {
+	case <-session.process.(*fakeTerminalProcess).kill:
+	case <-time.After(time.Second):
+		t.Fatal("detached session was not reaped after reconnect grace")
+	}
+	reconnect := testTicket()
+	reconnect.SessionID = session.ID
+	if _, err := service.IssueTicket(reconnect); err != ErrTerminalSessionGone {
+		t.Fatalf("reaped session reconnect error = %v", err)
+	}
+}

--- a/CubeOps/internal/translator/translator.go
+++ b/CubeOps/internal/translator/translator.go
@@ -68,6 +68,7 @@ type CMSandboxDetailItem struct {
 
 // CMSandboxContainer describes one container inside a CubeMaster sandbox detail.
 type CMSandboxContainer struct {
+	Name        string `json:"name"`
 	ContainerID string `json:"container_id"`
 	Status      int    `json:"status"`
 	Image       string `json:"image"`
@@ -76,6 +77,7 @@ type CMSandboxContainer struct {
 	Mem         string `json:"mem"`       // e.g. "2048Mi"
 	Type        string `json:"type"`
 	PauseAt     int64  `json:"pause_at"`
+	EnvdPort    int    `json:"envd_port"`
 }
 
 // ── camelCase key conversion ────────────────────────────────────────────────
@@ -359,6 +361,18 @@ func TransformSandboxDetail(raw json.RawMessage) interface{} {
 		"hostID":      item.HostID,
 		"domain":      SandboxDomain(),
 	}
+	containers := make([]map[string]interface{}, 0, len(item.Containers))
+	for _, container := range item.Containers {
+		containers = append(containers, map[string]interface{}{
+			"name":        container.Name,
+			"containerID": container.ContainerID,
+			"state":       SandboxStateFromInt(container.Status),
+			"image":       container.Image,
+			"type":        container.Type,
+			"envdPort":    container.EnvdPort,
+		})
+	}
+	result["containers"] = containers
 	if item.Labels != nil {
 		result["metadata"] = item.Labels
 	}

--- a/Cubelet/pkg/constants/labels.go
+++ b/Cubelet/pkg/constants/labels.go
@@ -25,6 +25,10 @@ const (
 const (
 	LabelCriSandboxID     = "io.kubernetes.cri.sandbox-id"
 	LabelCriContainerType = "io.cri-containerd.kind"
+	// LabelEnvdPort identifies the per-container envd endpoint exposed through
+	// CubeProxy. The Web Terminal uses it to route a PTY to the selected
+	// container without crossing the sandbox's network boundary.
+	LabelEnvdPort = "cube.envd-port"
 
 	LabelSandboxFirstContainerID = "cube.sandbox.first.container.id"
 )

--- a/Cubelet/pkg/container/envdport/envd_port.go
+++ b/Cubelet/pkg/container/envdport/envd_port.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package envdport assigns the envd listener used to address each container
+// inside a sandbox network namespace.
+package envdport
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+)
+
+const (
+	// Default is the established envd port used by the primary container.
+	Default = 49983
+	// EnvironmentVariable is read by envd when it starts in a container.
+	EnvironmentVariable = "ENVD_PORT"
+)
+
+// Assign gives every container a distinct envd listener. Existing valid
+// ENVD_PORT values are preserved; missing sidecar values are allocated
+// sequentially after the primary container's established port.
+func Assign(containers []*cubebox.ContainerConfig) error {
+	used := make(map[int]string, len(containers))
+
+	// Reserve explicit values first so an earlier implicit container cannot
+	// accidentally claim a later container's configured port.
+	for index, container := range containers {
+		port, explicit, err := explicit(container)
+		if err != nil {
+			return err
+		}
+		if !explicit {
+			continue
+		}
+		if index == 0 && port != Default {
+			return fmt.Errorf("primary container %q must use ENVD_PORT %d", container.GetName(), Default)
+		}
+		if index > 0 && port == Default {
+			return fmt.Errorf("ENVD_PORT %d is reserved for the primary container", Default)
+		}
+		if owner, exists := used[port]; exists {
+			return fmt.Errorf("duplicate ENVD_PORT %d for containers %q and %q", port, owner, container.GetName())
+		}
+		used[port] = container.GetName()
+	}
+	if len(containers) > 0 {
+		used[Default] = containers[0].GetName()
+	}
+
+	next := Default + 1
+	for index, container := range containers {
+		port, configured, _ := explicit(container)
+		if configured {
+			continue
+		}
+		if index == 0 {
+			port = Default
+		} else {
+			for {
+				if next > 65535 {
+					return fmt.Errorf("no available TCP port for container %q envd endpoint", container.GetName())
+				}
+				if _, exists := used[next]; !exists {
+					port = next
+					used[port] = container.GetName()
+					next++
+					break
+				}
+				next++
+			}
+		}
+		container.Envs = append(container.Envs, &cubebox.KeyValue{
+			Key:   EnvironmentVariable,
+			Value: strconv.Itoa(port),
+		})
+	}
+	return nil
+}
+
+// PrepareRequest assigns per-container envd ports and ensures the sandbox
+// network exposes each one through CubeProxy. It must run before network
+// allocation so remote proxy nodes receive host-port mappings for sidecars.
+func PrepareRequest(req *cubebox.RunCubeSandboxRequest) error {
+	if req == nil {
+		return fmt.Errorf("sandbox request is nil")
+	}
+	if err := Assign(req.GetContainers()); err != nil {
+		return err
+	}
+
+	exposed := make(map[int64]struct{}, len(req.GetExposedPorts())+len(req.GetContainers()))
+	for _, port := range req.GetExposedPorts() {
+		exposed[port] = struct{}{}
+	}
+	for _, container := range req.GetContainers() {
+		port, ok := Get(container)
+		if !ok {
+			return fmt.Errorf("container %q has no assigned envd port", container.GetName())
+		}
+		value := int64(port)
+		if _, exists := exposed[value]; exists {
+			continue
+		}
+		req.ExposedPorts = append(req.ExposedPorts, value)
+		exposed[value] = struct{}{}
+	}
+	return nil
+}
+
+// Get returns the configured envd port after Assign has run.
+func Get(container *cubebox.ContainerConfig) (int, bool) {
+	port, configured, err := explicit(container)
+	return port, configured && err == nil
+}
+
+func explicit(container *cubebox.ContainerConfig) (int, bool, error) {
+	if container == nil {
+		return 0, false, fmt.Errorf("container configuration is nil")
+	}
+	for _, env := range container.GetEnvs() {
+		if env == nil || env.GetKey() != EnvironmentVariable {
+			continue
+		}
+		port, err := strconv.Atoi(strings.TrimSpace(env.GetValue()))
+		if err != nil || port < 1 || port > 65535 {
+			return 0, false, fmt.Errorf("container %q has invalid ENVD_PORT %q", container.GetName(), env.GetValue())
+		}
+		return port, true, nil
+	}
+	return 0, false, nil
+}

--- a/Cubelet/pkg/container/envdport/envd_port_test.go
+++ b/Cubelet/pkg/container/envdport/envd_port_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package envdport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+)
+
+func TestAssign(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []*cubebox.ContainerConfig
+		wantPorts  []int
+		wantErr    bool
+	}{
+		{
+			name: "allocates distinct ports",
+			containers: []*cubebox.ContainerConfig{
+				{Name: "main"},
+				{Name: "sidecar"},
+				{Name: "worker"},
+			},
+			wantPorts: []int{49983, 49984, 49985},
+		},
+		{
+			name: "preserves explicit sidecar port",
+			containers: []*cubebox.ContainerConfig{
+				{Name: "main"},
+				{Name: "sidecar", Envs: []*cubebox.KeyValue{{Key: "ENVD_PORT", Value: "55000"}}},
+			},
+			wantPorts: []int{49983, 55000},
+		},
+		{
+			name: "skips a reserved explicit sidecar port",
+			containers: []*cubebox.ContainerConfig{
+				{Name: "main"},
+				{Name: "sidecar"},
+				{Name: "worker", Envs: []*cubebox.KeyValue{{Key: "ENVD_PORT", Value: "49984"}}},
+			},
+			wantPorts: []int{49983, 49985, 49984},
+		},
+		{
+			name: "rejects a non-default primary port",
+			containers: []*cubebox.ContainerConfig{
+				{Name: "main", Envs: []*cubebox.KeyValue{{Key: "ENVD_PORT", Value: "50000"}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "rejects duplicate explicit ports",
+			containers: []*cubebox.ContainerConfig{
+				{Name: "main", Envs: []*cubebox.KeyValue{{Key: "ENVD_PORT", Value: "49983"}}},
+				{Name: "sidecar", Envs: []*cubebox.KeyValue{{Key: "ENVD_PORT", Value: "49983"}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "rejects invalid port",
+			containers: []*cubebox.ContainerConfig{
+				{Name: "main", Envs: []*cubebox.KeyValue{{Key: "ENVD_PORT", Value: "not-a-port"}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "rejects nil container",
+			containers: []*cubebox.ContainerConfig{
+				nil,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Assign(tt.containers)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, tt.containers, len(tt.wantPorts))
+			for i, container := range tt.containers {
+				port, ok := Get(container)
+				require.True(t, ok)
+				assert.Equal(t, tt.wantPorts[i], port)
+			}
+		})
+	}
+}
+
+func TestPrepareRequestAddsEveryEnvdPortOnce(t *testing.T) {
+	req := &cubebox.RunCubeSandboxRequest{
+		Containers: []*cubebox.ContainerConfig{
+			{Name: "main"},
+			{Name: "sidecar"},
+		},
+		ExposedPorts: []int64{8080, 49983},
+	}
+	require.NoError(t, PrepareRequest(req))
+	assert.Equal(t, []int64{8080, 49983, 49984}, req.ExposedPorts)
+
+	// Preparation is idempotent when request setup is repeated.
+	require.NoError(t, PrepareRequest(req))
+	assert.Equal(t, []int64{8080, 49983, 49984}, req.ExposedPorts)
+}

--- a/Cubelet/services/cubebox/check.go
+++ b/Cubelet/services/cubebox/check.go
@@ -54,6 +54,9 @@ func checkParam(ctx context.Context, realReq *cubebox.RunCubeSandboxRequest) err
 			return ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "invalid exposed port %d", p)
 		}
 	}
+	// The four-port quota covers caller-declared ports only. Create runs this
+	// check before envdport.PrepareRequest appends the internal per-container
+	// envd endpoints, so those never consume the caller's quota.
 	if len(realReq.GetExposedPorts()) > 4 {
 		return ret.Errorf(errorcode.ErrorCode_InvalidParamFormat,
 			"exposed ports should be at most 4")

--- a/Cubelet/services/cubebox/check_test.go
+++ b/Cubelet/services/cubebox/check_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/envdport"
 )
 
 func TestCheckReqVolumes(t *testing.T) {
@@ -310,5 +311,22 @@ func TestCheckParamExposedPorts(t *testing.T) {
 		})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "at most 4")
+	})
+
+	// Create validates the caller's request first and only then lets
+	// envdport.PrepareRequest publish the per-container envd endpoints the Web
+	// Terminal routes through. Those internal ports must not push a request
+	// that declared four ports of its own over the quota.
+	t.Run("internal envd ports do not consume the caller quota", func(t *testing.T) {
+		req := &cubebox.RunCubeSandboxRequest{
+			Containers: []*cubebox.ContainerConfig{
+				{Name: "main", Resources: &cubebox.Resource{Cpu: "2000m", Mem: "2048Mi"}},
+				{Name: "sidecar", Resources: &cubebox.Resource{Cpu: "1000m", Mem: "1024Mi"}},
+			},
+			ExposedPorts: []int64{80, 443, 8080, 9000},
+		}
+		assert.NoError(t, checkParam(ctx, req))
+		assert.NoError(t, envdport.PrepareRequest(req))
+		assert.Equal(t, []int64{80, 443, 8080, 9000, 49983, 49984}, req.ExposedPorts)
 	})
 }

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/cgroup"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/command"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/env"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/envdport"
 	localnetfile "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/netfile"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/pmem"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/rlimit"
@@ -838,6 +839,9 @@ func (l *local) containerSpec(ctx context.Context, sandBox *cubeboxstore.CubeBox
 	containerLabels[constants.ContainerType] = containerType
 	containerLabels[constants.LabelCriContainerType] = containerType
 	containerLabels[constants.LabelCriSandboxID] = sandBox.ID
+	if port, ok := envdport.Get(containerReq); ok {
+		containerLabels[constants.LabelEnvdPort] = strconv.Itoa(port)
+	}
 	ci.AddLabels(containerLabels)
 	cOpts = append(cOpts, containerd.WithContainerLabels(containerLabels))
 

--- a/Cubelet/services/cubebox/service.go
+++ b/Cubelet/services/cubebox/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/envdport"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/cubelet/resourcesource"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/recov"
@@ -230,6 +231,14 @@ func (s *service) Create(ctx context.Context, req *cubebox.RunCubeSandboxRequest
 		rerr, _ := ret.FromError(err)
 		rsp.Ret.RetMsg = rerr.Message()
 		rsp.Ret.RetCode = rerr.Code()
+		return rsp, nil
+	}
+	// Runs after checkParam so the internal envd endpoints it exposes are not
+	// counted against the caller's four-port quota, and before the create
+	// workflow so network allocation publishes a host-port mapping for each.
+	if err := envdport.PrepareRequest(req); err != nil {
+		rsp.Ret.RetMsg = err.Error()
+		rsp.Ret.RetCode = errorcode.ErrorCode_InvalidParamFormat
 		return rsp, nil
 	}
 	SetRunCubeSandboxRequestDefaultValue(req)

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -222,6 +222,8 @@ CUBE_OPS_BIND=0.0.0.0:3010
 CUBE_OPS_LOG_LEVEL=info
 CUBE_OPS_LOG_DIR=/data/log/CubeOps
 CUBE_OPS_UPSTREAM=http://host.docker.internal:3010
+# CubeOps Web Terminal data plane; defaults to the host CubeProxy HTTP port.
+# CUBE_SANDBOX_PROXY_URL=http://127.0.0.1:80
 # JWT_SECRET left unset → auto-generated and persisted to t_system_setting.
 # JWT_SECRET=
 JWT_ACCESS_TTL=15m

--- a/deploy/one-click/scripts/systemd/cubeops-start.sh
+++ b/deploy/one-click/scripts/systemd/cubeops-start.sh
@@ -24,6 +24,10 @@ export CUBE_OPS_LOG_LEVEL="${CUBE_OPS_LOG_LEVEL:-info}"
 # CubeMaster address (same host in All-in-One mode).
 export CUBE_MASTER_ADDR="${CUBE_MASTER_ADDR:-http://127.0.0.1:8089}"
 
+# Web Terminal data plane. CubeProxy publishes its HTTP listener on the host;
+# keep custom one-click proxy ports aligned automatically.
+export CUBE_SANDBOX_PROXY_URL="${CUBE_SANDBOX_PROXY_URL:-http://127.0.0.1:${CUBE_PROXY_HTTP_PORT:-80}}"
+
 # JWT configuration. JWT_SECRET left unset → CubeOps auto-generates and
 # persists it to t_system_setting on first boot (single-instance default).
 export JWT_ACCESS_TTL="${JWT_ACCESS_TTL:-15m}"

--- a/deploy/one-click/terraform/tencentcloud/tke-addons.tf
+++ b/deploy/one-click/terraform/tencentcloud/tke-addons.tf
@@ -55,6 +55,10 @@ locals {
       worker_processes auto;
       events { worker_connections 1024; }
       http {
+        map $http_upgrade $connection_upgrade {
+          default upgrade;
+          ''      '';
+        }
         server {
           listen 80;
           root /usr/share/nginx/html;
@@ -62,6 +66,12 @@ locals {
           location ^~ /sandbox/ { proxy_pass __SANDBOX_PROXY_UPSTREAM__; }
           location /opsapi/ { proxy_pass __CUBE_OPS_UPSTREAM__/api/; }
           location /cubeapi/v1/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
             rewrite ^/cubeapi/v1/(.*)$ /api/v1/sdk/$1 break;
             proxy_pass __CUBE_OPS_UPSTREAM__;
           }
@@ -691,6 +701,10 @@ resource "kubernetes_deployment" "cube_ops" {
           env {
             name  = "CUBE_API_SANDBOX_DOMAIN"
             value = "cube.app"
+          }
+          env {
+            name  = "CUBE_SANDBOX_PROXY_URL"
+            value = "http://cube-proxy:80"
           }
           env {
             name  = "CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK"

--- a/deploy/one-click/webui/nginx.conf
+++ b/deploy/one-click/webui/nginx.conf
@@ -74,12 +74,14 @@ http {
         # /api/v1/sdk/* which calls CubeMaster directly.
         location /cubeapi/v1/ {
             proxy_http_version 1.1;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_read_timeout 300s;
-            proxy_send_timeout 300s;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
 
             rewrite ^/cubeapi/v1/(.*)$ /api/v1/sdk/$1 break;
             proxy_pass __CUBE_OPS_UPSTREAM__;

--- a/docs/guide/webui.md
+++ b/docs/guide/webui.md
@@ -85,7 +85,86 @@ The Dashboard uses **JWT-based authentication** (since v0.6.0, replacing the old
 - Login is rate-limited: 5 failed attempts per minute per IP.
 :::
 
-## 4. Keyboard shortcuts
+## 4. Open a Web Terminal
+
+The Web Terminal gives an authenticated Dashboard user an interactive shell in
+a **running** sandbox container. It uses the same envd PTY data plane as the
+CubeSandbox SDK; it does not grant host access or bypass the sandbox's network
+and egress policy.
+
+### Before you start
+
+- Sign in to the Dashboard. Terminal ticket creation is protected by the same
+  CubeOps JWT authentication as other sandbox operations.
+- Start a sandbox and wait until its state is **Running**. The terminal button
+  is disabled for paused, pausing, stopped, or missing sandboxes.
+- The selected container image must include envd. New multi-container
+  sandboxes expose an independent envd endpoint for each container.
+- Use HTTPS for production deployments. The browser automatically changes the
+  terminal channel from `ws://` to encrypted `wss://`.
+
+### Start a shell
+
+1. Open **Sandboxes**.
+2. Select **Open terminal** in a running sandbox's action column, or open the
+   sandbox detail page and select **Open terminal** there.
+3. If the sandbox contains more than one terminal-capable container, select
+   the target from the **Container** menu.
+4. Wait for the green **Connected** status, then run:
+
+   ```sh
+   ls
+   top
+   ping -c 3 127.0.0.1
+   ```
+
+   Press `q` to exit `top`. ANSI color, cursor control, scrollback, resize, and
+   normal browser copy/paste shortcuts are supported.
+5. Select **Disconnect** to actively terminate the shell. Closing the panel
+   also terminates an active session.
+
+The toolbar can enter fullscreen and change the terminal font size. Each panel
+opens an independent PTY, so multiple users, browser tabs, sandboxes, and
+containers can be used concurrently within the configured session limits.
+
+### Disconnects, timeout, and audit
+
+CubeOps sends WebSocket keepalives. If the network drops unexpectedly, the
+panel shows **Connection lost** and offers **Reconnect**; the PTY is retained
+for 30 seconds by default. An inactive session is closed after 15 minutes by
+default. Operators can tune these values with:
+
+```sh
+CUBE_OPS_TERMINAL_IDLE_TIMEOUT=15m
+CUBE_OPS_TERMINAL_RECONNECT_GRACE=30s
+CUBE_OPS_TERMINAL_MAX_SESSIONS=128
+CUBE_OPS_TERMINAL_MAX_SESSIONS_PER_SANDBOX=8
+```
+
+For a non-default topology, also set `CUBE_SANDBOX_PROXY_URL` to the internal
+HTTP endpoint of CubeProxy (for example, `http://cube-proxy:80`). CubeOps keeps
+the virtual sandbox host name while dialing that endpoint.
+
+CubeOps writes structured `terminal audit` entries when a ticket is issued and
+when a session opens or closes. The log includes operator, timestamp, sandbox,
+container, session, and close reason.
+
+### Security and known limits
+
+- A WebSocket URL carries only a random, single-use ticket that expires after
+  30 seconds—not the user's JWT. Same-origin checks apply to browser upgrades.
+- Commands run with the container's existing envd identity and remain inside
+  its isolation, filesystem, Linux capabilities, and egress policy.
+- Sandboxes created before per-container envd metadata was introduced can use
+  the primary container on port `49983`; an older sidecar without endpoint
+  metadata is shown as unavailable.
+- The session starts `/bin/sh -i` for compatibility with minimal images.
+  Commands absent from the image (for example `ping`) must be installed in the
+  image using its normal package policy.
+- Reconnection is available only during the configured grace window and only
+  to the same authenticated operator, sandbox, and container.
+
+## 5. Keyboard shortcuts
 
 The Dashboard is keyboard-friendly. The big three:
 
@@ -96,7 +175,7 @@ The Dashboard is keyboard-friendly. The big three:
 | `R` | Refetch every visible data panel |
 | `Esc` | Close any open modal or the Command Palette |
 
-## 5. Personalize it
+## 6. Personalize it
 
 Open **Settings** in the left rail:
 
@@ -106,7 +185,7 @@ Open **Settings** in the left rail:
 
 The Command Palette's ⌘K input box and the topbar have quick toggles for the same.
 
-## 6. FAQ
+## 7. FAQ
 
 **Why a separate Dashboard, not just curl?**
 Most operations (create-from-image, version matrix, node triage) are easier to discover and visualize in a UI. For automation, the Dashboard is just a thin client — every page is a call to `/cubeapi/v1/*`, which is the same E2B-compatible REST API you can hit with `curl` or the E2B SDK.
@@ -123,7 +202,7 @@ Yes — set `WEB_UI_ENABLE=0` (or unset) in `.env`. The cluster keeps running; y
 **Is the Dashboard open source? Can I run my own build?**
 Yes — it lives in `web/` of the repo, built with Vite + React + TypeScript + Tailwind. See [Self-Build Deployment](./self-build-deploy.md) and the [`web/README.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/web/README.md) for details.
 
-## 7. Next steps
+## 8. Next steps
 
 - [Quick Start](./quickstart.md) — if you haven't installed yet, get to a running Dashboard in minutes
 - [Service Management](./service-management.md) — how to start/stop/restart the `cube-sandbox-webui.service` container

--- a/docs/zh/guide/webui.md
+++ b/docs/zh/guide/webui.md
@@ -79,7 +79,75 @@ Dashboard 是一个静态前端，由 **控制节点** 上的 nginx 容器托管
 开启鉴权的人会生成它。完整流程见 [鉴权](./authentication.md)。
 :::
 
-## 4. 键盘快捷键
+## 4. 打开网页终端
+
+网页终端允许已登录 Dashboard 的用户进入**运行中**沙箱容器的交互式
+Shell。它复用 CubeSandbox SDK 已有的 envd PTY 数据通道，不会获得宿主机
+权限，也不会绕过沙箱原有的网络和出站策略。
+
+### 使用前提
+
+- 先登录 Dashboard。终端票据与其他沙箱操作一样，受 CubeOps JWT 鉴权保护。
+- 启动沙箱并等待状态变为**运行中**。暂停中、已暂停、已停止或不存在的
+  沙箱会禁用“打开终端”按钮。
+- 目标容器镜像需要包含 envd。新建的多容器沙箱会为每个容器暴露独立的
+  envd 端点。
+- 生产环境应使用 HTTPS；浏览器会自动把终端通道从 `ws://` 切换为加密的
+  `wss://`。
+
+### 打开 Shell
+
+1. 进入**沙箱**页面。
+2. 在运行中沙箱的操作栏点击**打开终端**，也可以进入沙箱详情页后点击。
+3. 如果沙箱包含多个可登录容器，在**容器**菜单中选择目标容器。
+4. 等待状态变为绿色的**已连接**，然后可以执行：
+
+   ```sh
+   ls
+   top
+   ping -c 3 127.0.0.1
+   ```
+
+   按 `q` 退出 `top`。终端支持 ANSI 颜色、光标控制、滚动回溯、窗口尺寸
+   自适应以及浏览器常用的复制粘贴快捷键。
+5. 点击**断开**会主动终止 Shell；关闭面板也会终止仍在运行的会话。
+
+工具栏支持全屏和字号调整。每个面板都会创建独立 PTY，因此在配置的并发
+上限内，多用户、多浏览器标签、多沙箱和多容器可以同时使用，互不干扰。
+
+### 断线、超时和审计
+
+CubeOps 会发送 WebSocket 保活消息。网络异常中断时，面板会显示**连接已
+中断**并提供**重新连接**；默认短暂保留 PTY 30 秒。会话默认连续 15 分钟
+无活动后关闭。运维人员可以调整：
+
+```sh
+CUBE_OPS_TERMINAL_IDLE_TIMEOUT=15m
+CUBE_OPS_TERMINAL_RECONNECT_GRACE=30s
+CUBE_OPS_TERMINAL_MAX_SESSIONS=128
+CUBE_OPS_TERMINAL_MAX_SESSIONS_PER_SANDBOX=8
+```
+
+非默认拓扑还需要把 `CUBE_SANDBOX_PROXY_URL` 设为 CubeProxy 的内部 HTTP
+地址（例如 `http://cube-proxy:80`）。CubeOps 连接该地址时仍会保留沙箱
+虚拟 Host。
+
+CubeOps 会在签发票据、打开和关闭会话时写入结构化的 `terminal audit`
+日志，其中包含操作人、时间、沙箱、容器、会话编号和关闭原因。
+
+### 安全与已知限制
+
+- WebSocket URL 只携带 30 秒过期、使用一次即失效的随机票据，不携带用户
+  JWT；浏览器升级请求还会做同源校验。
+- 命令使用容器现有的 envd 身份执行，仍受容器隔离、文件系统、Linux
+  capabilities 和出站策略限制。
+- 在“每容器 envd 元数据”功能上线前创建的沙箱，可继续通过 `49983`
+  进入主容器；没有端点元数据的旧版附属容器会显示为不可登录。
+- 为兼容精简镜像，会话启动 `/bin/sh -i`。如果镜像没有 `ping` 等命令，
+  需要按镜像原有的软件安装策略补充。
+- 只有同一已认证操作人、同一沙箱和同一容器，才能在保留时间内重连。
+
+## 5. 键盘快捷键
 
 Dashboard 对键盘很友好。最常用的三个：
 
@@ -90,7 +158,7 @@ Dashboard 对键盘很友好。最常用的三个：
 | `R` | 刷新所有可见数据面板 |
 | `Esc` | 关闭弹窗或 Command Palette |
 
-## 5. 个性化
+## 6. 个性化
 
 打开左侧栏的 **Settings**：
 
@@ -100,7 +168,7 @@ Dashboard 对键盘很友好。最常用的三个：
 
 顶栏右上角和 ⌘K 输入框里也有同样的快捷开关。
 
-## 6. 常见问题
+## 7. 常见问题
 
 **为什么还要单独做个 Dashboard，不能直接用 curl 吗？**
 绝大多数操作（从镜像创建模板、看版本矩阵、排查节点）在 UI 里更容易发现和理解。Dashboard 本质上只是 CubeAPI 的一个轻量客户端——每个页面背后都是一次 `/cubeapi/v1/*` 请求，这跟 E2B SDK、`curl` 调的是同一个 E2B 兼容 REST API。
@@ -117,7 +185,7 @@ Dashboard 对键盘很友好。最常用的三个：
 **Dashboard 是开源的吗？我能自己构建吗？**
 可以——它在仓库的 `web/` 目录里，用 Vite + React + TypeScript + Tailwind 构建。详见 [本地构建部署](./self-build-deploy.md) 和 [`web/README.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/web/README.md)。
 
-## 7. 下一步
+## 8. 下一步
 
 - [快速开始](./quickstart.md) — 如果你还没安装，几分钟到能跑的 Dashboard
 - [服务管理与日志](./service-management.md) — 如何启停 / 重启 `cube-sandbox-webui.service` 容器

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -89,6 +89,21 @@ func (c *Client) Connect(ctx context.Context, sandboxID string) (*Sandbox, error
 	return &sandbox, nil
 }
 
+// AttachSandbox creates a local data-plane handle for an already validated
+// sandbox without issuing a control-plane request. Control-plane services use
+// it after checking sandbox ownership and lifecycle state themselves.
+//
+// envdPort selects the envd endpoint for a specific container. Values outside
+// the TCP port range fall back to the standard EnvdPort.
+func (c *Client) AttachSandbox(sandboxID string, envdPort int) *Sandbox {
+	sandbox := &Sandbox{
+		SandboxID: sandboxID,
+		EnvdPort:  envdPort,
+	}
+	c.attachSandbox(sandbox)
+	return sandbox
+}
+
 func (c *Client) List(ctx context.Context) ([]SandboxInfo, error) {
 	var sandboxes []SandboxInfo
 	if err := c.doJSON(ctx, http.MethodGet, "/sandboxes", nil, &sandboxes, http.StatusOK); err != nil {

--- a/sdk/go/envd.go
+++ b/sdk/go/envd.go
@@ -209,9 +209,13 @@ func multipartFileBody(path string, data []byte) (io.Reader, string, error) {
 }
 
 func (s *Sandbox) newEnvdRequest(ctx context.Context, method, path string, query url.Values, body io.Reader) (*http.Request, error) {
+	envdPort := s.EnvdPort
+	if envdPort <= 0 || envdPort > 65535 {
+		envdPort = EnvdPort
+	}
 	target := url.URL{
 		Scheme:   s.client.config.ProxyScheme,
-		Host:     s.GetHost(EnvdPort),
+		Host:     s.GetHost(envdPort),
 		Path:     path,
 		RawQuery: query.Encode(),
 	}

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -18,6 +18,11 @@ type Sandbox struct {
 	EnvdAccessToken    string `json:"envdAccessToken,omitempty"`
 	TrafficAccessToken string `json:"trafficAccessToken,omitempty"`
 	Domain             string `json:"domain,omitempty"`
+	// EnvdPort overrides the default envd data-plane port for this sandbox
+	// handle. It is intentionally not serialized: CubeAPI's public sandbox
+	// response remains backward compatible, while trusted control-plane
+	// callers can address envd instances in additional containers.
+	EnvdPort int `json:"-"`
 }
 
 // SandboxInfo is returned by list and get-info endpoints.

--- a/sdk/go/pty.go
+++ b/sdk/go/pty.go
@@ -47,6 +47,13 @@ type PtyCreateOptions struct {
 	// Timeout is the server-side deadline for the stream (Connect-Timeout-Ms).
 	// Zero uses defaultPtyTimeout.
 	Timeout time.Duration
+	// Shell is the interactive shell executable. Empty preserves the existing
+	// /bin/bash default. Callers targeting minimal images can select /bin/sh.
+	Shell string
+	// Args overrides the default interactive shell arguments. When Shell is
+	// set and Args is nil, "-i" is used; with an empty Shell the historical
+	// bash arguments "-i -l" are retained.
+	Args []string
 }
 
 // PtyConnectOptions configures Pty.Connect.
@@ -95,10 +102,21 @@ func (p *Pty) Create(ctx context.Context, size PtySize, opts PtyCreateOptions) (
 		timeout = defaultPtyTimeout
 	}
 
+	shell := opts.Shell
+	args := opts.Args
+	if shell == "" {
+		shell = "/bin/bash"
+		if args == nil {
+			args = []string{"-i", "-l"}
+		}
+	} else if args == nil {
+		args = []string{"-i"}
+	}
+
 	payload := ptyStartRequest{
 		Process: ptyProcessConfig{
-			Cmd:  "/bin/bash",
-			Args: []string{"-i", "-l"},
+			Cmd:  shell,
+			Args: args,
 			Envs: envs,
 			Cwd:  opts.Cwd,
 		},

--- a/sdk/go/pty_test.go
+++ b/sdk/go/pty_test.go
@@ -122,6 +122,51 @@ func TestPtyCreateStreamsAndWaits(t *testing.T) {
 	}
 }
 
+func TestAttachSandboxUsesSelectedEnvdPortAndShell(t *testing.T) {
+	var gotHost string
+	var gotProcess struct {
+		Process struct {
+			Cmd  string   `json:"cmd"`
+			Args []string `json:"args"`
+		} `json:"process"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		body, _ := io.ReadAll(r.Body)
+		decodeEnvelopeJSON(t, body, &gotProcess)
+		w.Header().Set("Content-Type", connectContentType)
+		w.Write(connectEnvelope(0, `{"event":{"start":{"pid":7}}}`))
+		w.Write(connectEnvelope(0, `{"event":{"end":{"exitCode":0,"exited":true}}}`))
+		w.Write(connectEnvelope(connectEndStreamFlag, `{}`))
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{
+		ProxyNodeIP:    host,
+		ProxyPortHTTP:  port,
+		SandboxDomain:  "cube.test",
+		RequestTimeout: 5 * time.Second,
+	})
+	sandbox := client.AttachSandbox("sandbox-selected", 55000)
+	handle, err := sandbox.Pty().Create(context.Background(), PtySize{Rows: 24, Cols: 80}, PtyCreateOptions{
+		Shell: "/bin/sh",
+		Args:  []string{"-i"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := handle.Wait(nil); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if gotHost != "55000-sandbox-selected.cube.test" {
+		t.Fatalf("Host = %q", gotHost)
+	}
+	if gotProcess.Process.Cmd != "/bin/sh" || len(gotProcess.Process.Args) != 1 || gotProcess.Process.Args[0] != "-i" {
+		t.Fatalf("process = %#v", gotProcess.Process)
+	}
+}
+
 func TestPtyCreateUserEnvsCwd(t *testing.T) {
 	var gotAuth string
 	var gotBody []byte

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,8 @@
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.3",
         "@tanstack/react-query": "^5.59.0",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -37,19 +39,30 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.9.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
         "autoprefixer": "^10.4.20",
+        "jsdom": "^26.1.0",
         "msw": "^2.13.5",
         "openapi-typescript": "^7.13.0",
         "postcss": "^8.4.47",
         "prettier": "^3.9.5",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",
-        "vite": "^6.4.2"
+        "vite": "^6.4.2",
+        "vitest": "^3.2.7"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -62,6 +75,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -94,6 +128,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -354,6 +389,123 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@dicebear/adventurer": {
       "version": "9.4.2",
       "resolved": "https://registry.npmjs.org/@dicebear/adventurer/-/adventurer-9.4.2.tgz",
@@ -512,6 +664,7 @@
       "resolved": "https://registry.npmjs.org/@dicebear/core/-/core-9.4.2.tgz",
       "integrity": "sha512-MF0042+Z3s8PGZKZLySfhft28bUa3B1iq0e5NSjCvY8gfMi5aIH/iRJGRJa1N9Jz1BNkxYb4yvJ/N9KO8Z6Y+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -2846,6 +2999,89 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2891,6 +3127,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2910,6 +3164,7 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2927,6 +3182,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2938,6 +3194,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2979,6 +3236,137 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -3068,6 +3456,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autoprefixer": {
@@ -3181,6 +3589,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3193,6 +3602,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/camelcase-css": {
@@ -3225,12 +3644,39 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/change-case": {
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -3387,6 +3833,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3399,12 +3852,40 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3422,6 +3903,33 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-node-es": {
@@ -3442,6 +3950,13 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
@@ -3456,6 +3971,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -3464,6 +3992,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -3515,6 +4050,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3711,6 +4266,19 @@
         "set-cookie-parser": "^3.0.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -3718,6 +4286,20 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -3753,6 +4335,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -3772,6 +4355,29 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/index-to-position": {
@@ -3861,11 +4467,19 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3897,6 +4511,80 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/jsesc": {
@@ -3962,6 +4650,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3979,6 +4674,26 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/merge2": {
@@ -4001,6 +4716,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4030,6 +4755,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -4123,6 +4849,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4200,6 +4933,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -4212,6 +4958,23 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4278,6 +5041,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4431,6 +5195,44 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4456,6 +5258,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4468,6 +5271,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4502,6 +5306,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4635,6 +5446,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4738,6 +5563,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4759,6 +5591,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4787,6 +5639,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4809,6 +5668,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4818,6 +5684,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
@@ -4853,6 +5726,39 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -4901,6 +5807,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -4929,6 +5842,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -4991,6 +5905,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -5029,11 +5957,42 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -5081,6 +6040,19 @@
         "node": ">=16"
       }
     },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -5115,6 +6087,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5242,6 +6215,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5311,6 +6285,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5335,6 +6332,93 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -5349,6 +6433,84 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -5368,6 +6530,45 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b --noEmit && vite build",
     "preview": "vite preview",
     "lint": "tsc -b --noEmit",
+    "test": "vitest run",
     "fmt": "prettier --write .",
     "api:export": "cargo run --manifest-path ../CubeAPI/Cargo.toml -- --export-openapi ../openapi.yml",
     "api:generate": "openapi-typescript ../openapi.yml -o src/api/generated/schema.ts",
@@ -28,6 +29,8 @@
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tanstack/react-query": "^5.59.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
@@ -43,18 +46,22 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.9.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^26.1.0",
     "msw": "^2.13.5",
     "openapi-typescript": "^7.13.0",
     "postcss": "^8.4.47",
     "prettier": "^3.9.5",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^3.2.7"
   },
   "msw": {
     "workerDirectory": [

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -19,7 +19,18 @@ export type ComponentVersionDto = components['schemas']['ComponentVersionView'];
 
 export interface RunningSandbox extends ListedSandboxDto {}
 
-export interface SandboxDetail extends SandboxDetailDto {}
+export interface SandboxContainer {
+  name?: string;
+  containerID: string;
+  state: string;
+  image?: string;
+  type?: string;
+  envdPort?: number;
+}
+
+export interface SandboxDetail extends SandboxDetailDto {
+  containers?: SandboxContainer[];
+}
 
 export interface TemplateSummary {
   templateID: string;
@@ -117,7 +128,7 @@ function mapSandbox(dto: ListedSandboxDto): RunningSandbox {
 }
 
 function mapSandboxDetail(dto: SandboxDetailDto): SandboxDetail {
-  return dto;
+  return dto as SandboxDetail;
 }
 
 function mapTemplateSummary(dto: TemplateSummaryDto): TemplateSummary {
@@ -224,6 +235,27 @@ export const sandboxApi = {
       method: 'POST',
       body: JSON.stringify(body),
     }),
+};
+
+export interface TerminalTicketResponse {
+  ticket: string;
+  expiresAt: string;
+  containerID: string;
+  wsPath: string;
+}
+
+export const terminalApi = {
+  ticket: (
+    sandboxID: string,
+    body: { containerID?: string; sessionID?: string; rows: number; cols: number },
+  ) =>
+    ops<TerminalTicketResponse>(
+      `/sdk/sandboxes/${encodeURIComponent(sandboxID)}/terminal/tickets`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+      },
+    ),
 };
 
 export const templateApi = {

--- a/web/src/components/terminal/TerminalDialog.tsx
+++ b/web/src/components/terminal/TerminalDialog.tsx
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+  Expand,
+  Minimize2,
+  Minus,
+  Plus,
+  PlugZap,
+  Power,
+  RefreshCw,
+  SquareTerminal,
+  X,
+} from 'lucide-react';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+
+import { terminalApi, type SandboxContainer } from '@/api/client';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { terminalWebSocketURL } from '@/lib/terminal';
+
+type TerminalStatus =
+  'idle' | 'connecting' | 'connected' | 'reconnected' | 'disconnected' | 'closed' | 'error';
+
+interface Props {
+  sandboxID: string;
+  containers?: SandboxContainer[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface ServerControlMessage {
+  type: 'ready' | 'error' | 'exit' | 'pong';
+  sessionID?: string;
+  containerID?: string;
+  reconnected?: boolean;
+  code?: string;
+  message?: string;
+  recoverable?: boolean;
+  exitCode?: number;
+  reason?: string;
+}
+
+const MIN_FONT_SIZE = 10;
+const MAX_FONT_SIZE = 22;
+
+function primaryContainer(sandboxID: string, containers: SandboxContainer[]): SandboxContainer {
+  return (
+    containers.find(
+      (container) => container.type === 'sandbox' || container.containerID === sandboxID,
+    ) ??
+    containers[0] ?? {
+      containerID: sandboxID,
+      name: '',
+      state: 'running',
+      type: 'sandbox',
+      envdPort: 49983,
+    }
+  );
+}
+
+export function TerminalDialog({ sandboxID, containers = [], open, onOpenChange }: Props) {
+  const { t } = useTranslation('terminal');
+  const availableContainers = useMemo(
+    () =>
+      containers.filter(
+        (container) => container.state === 'running' && (container.envdPort ?? 0) > 0,
+      ),
+    [containers],
+  );
+  const initialContainer = primaryContainer(sandboxID, availableContainers);
+  const [selectedContainerID, setSelectedContainerID] = useState(initialContainer.containerID);
+  const [status, setStatus] = useState<TerminalStatus>('idle');
+  const [notice, setNotice] = useState('');
+  const [fontSize, setFontSize] = useState(14);
+  const [fullscreen, setFullscreen] = useState(false);
+  const [sessionID, setSessionID] = useState('');
+
+  const mountRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const selectedRef = useRef(selectedContainerID);
+  const sessionRef = useRef('');
+  const manualCloseRef = useRef(false);
+  const connectionGeneration = useRef(0);
+  const startConnectionRef = useRef<(reconnect: boolean) => void>(() => undefined);
+
+  selectedRef.current = selectedContainerID;
+  sessionRef.current = sessionID;
+
+  const containerLabel = (containerID: string) => {
+    const container = availableContainers.find((item) => item.containerID === containerID);
+    return container?.name || (container?.type === 'sandbox' ? t('primaryContainer') : containerID);
+  };
+
+  useEffect(() => {
+    if (!open || !mountRef.current) return;
+
+    const terminal = new Terminal({
+      cursorBlink: true,
+      cursorStyle: 'block',
+      convertEol: false,
+      fontFamily: '"JetBrains Mono Variable", "SFMono-Regular", Consolas, monospace',
+      fontSize,
+      lineHeight: 1.15,
+      scrollback: 10_000,
+      allowProposedApi: false,
+      theme: {
+        background: '#080c12',
+        foreground: '#dce7f5',
+        cursor: '#7aa2f7',
+        selectionBackground: '#334a74',
+        black: '#151b26',
+        red: '#f7768e',
+        green: '#9ece6a',
+        yellow: '#e0af68',
+        blue: '#7aa2f7',
+        magenta: '#bb9af7',
+        cyan: '#7dcfff',
+        white: '#c0caf5',
+      },
+    });
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+    terminal.open(mountRef.current);
+    terminalRef.current = terminal;
+
+    terminal.attachCustomKeyEventHandler((event) => {
+      const modifier = event.ctrlKey || event.metaKey;
+      if (!modifier) return true;
+      if (event.key.toLowerCase() === 'c' && terminal.hasSelection()) {
+        void navigator.clipboard?.writeText(terminal.getSelection());
+        terminal.clearSelection();
+        return false;
+      }
+      if (event.key.toLowerCase() === 'v') {
+        void navigator.clipboard?.readText().then((text) => terminal.paste(text));
+        return false;
+      }
+      return true;
+    });
+
+    const dataDisposable = terminal.onData((data) => {
+      const socket = socketRef.current;
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ type: 'input', data }));
+      }
+    });
+    const resizeDisposable = terminal.onResize(({ rows, cols }) => {
+      const socket = socketRef.current;
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ type: 'resize', rows, cols }));
+      }
+    });
+
+    const fit = () => {
+      try {
+        fitAddon.fit();
+      } catch {
+        // The dialog may be between layout states; the next observer callback retries.
+      }
+    };
+    const resizeObserver = new ResizeObserver(fit);
+    resizeObserver.observe(mountRef.current);
+    requestAnimationFrame(() => {
+      fit();
+      terminal.focus();
+    });
+
+    const closeCurrentSocket = (active: boolean) => {
+      const socket = socketRef.current;
+      if (!socket) return;
+      if (active && socket.readyState === WebSocket.OPEN) {
+        manualCloseRef.current = true;
+        socket.send(JSON.stringify({ type: 'disconnect' }));
+      }
+      socket.close();
+      socketRef.current = null;
+    };
+
+    const startConnection = async (reconnect: boolean) => {
+      const generation = ++connectionGeneration.current;
+      manualCloseRef.current = false;
+      setStatus('connecting');
+      const selected = selectedRef.current;
+      setNotice(t('messages.connecting', { container: containerLabel(selected) }));
+      terminal.options.disableStdin = true;
+
+      try {
+        fit();
+        const ticket = await terminalApi.ticket(sandboxID, {
+          containerID: selected,
+          sessionID: reconnect ? sessionRef.current : undefined,
+          rows: terminal.rows || 24,
+          cols: terminal.cols || 80,
+        });
+        if (generation !== connectionGeneration.current) return;
+
+        const socket = new WebSocket(terminalWebSocketURL(ticket.wsPath, ticket.ticket));
+        socket.binaryType = 'arraybuffer';
+        socketRef.current = socket;
+
+        socket.onmessage = (event) => {
+          if (generation !== connectionGeneration.current) return;
+          if (event.data instanceof ArrayBuffer) {
+            terminal.write(new Uint8Array(event.data));
+            return;
+          }
+          if (event.data instanceof Blob) {
+            void event.data.arrayBuffer().then((data) => terminal.write(new Uint8Array(data)));
+            return;
+          }
+
+          let control: ServerControlMessage;
+          try {
+            control = JSON.parse(String(event.data)) as ServerControlMessage;
+          } catch {
+            return;
+          }
+          if (control.type === 'ready') {
+            const nextSessionID = control.sessionID ?? '';
+            setSessionID(nextSessionID);
+            sessionRef.current = nextSessionID;
+            setStatus(control.reconnected ? 'reconnected' : 'connected');
+            setNotice(
+              control.reconnected
+                ? t('messages.reconnected')
+                : t('messages.ready', { container: containerLabel(selected) }),
+            );
+            terminal.options.disableStdin = false;
+            terminal.focus();
+          } else if (control.type === 'error') {
+            setNotice(
+              control.code === 'idle_timeout'
+                ? t('messages.idleTimeout')
+                : control.message || t('status.error'),
+            );
+            if (!control.recoverable) {
+              manualCloseRef.current = true;
+              terminal.options.disableStdin = true;
+              setStatus(control.code === 'idle_timeout' ? 'closed' : 'error');
+            }
+          } else if (control.type === 'exit') {
+            manualCloseRef.current = true;
+            terminal.options.disableStdin = true;
+            setStatus('closed');
+            setNotice(t('messages.sessionClosed'));
+            setSessionID('');
+            sessionRef.current = '';
+          }
+        };
+        socket.onerror = () => {
+          // onclose supplies the user-facing reconnect state.
+        };
+        socket.onclose = () => {
+          if (generation !== connectionGeneration.current) return;
+          socketRef.current = null;
+          terminal.options.disableStdin = true;
+          if (!manualCloseRef.current) {
+            setStatus('disconnected');
+            setNotice(t('messages.disconnected'));
+          }
+        };
+      } catch (error) {
+        if (generation !== connectionGeneration.current) return;
+        terminal.options.disableStdin = true;
+        setStatus('error');
+        setNotice(error instanceof Error ? error.message : String(error));
+      }
+    };
+    startConnectionRef.current = (reconnect) => {
+      void startConnection(reconnect);
+    };
+    startConnectionRef.current(false);
+
+    return () => {
+      connectionGeneration.current++;
+      closeCurrentSocket(true);
+      resizeObserver.disconnect();
+      dataDisposable.dispose();
+      resizeDisposable.dispose();
+      terminal.dispose();
+      terminalRef.current = null;
+      startConnectionRef.current = () => undefined;
+      setFullscreen(false);
+      setStatus('idle');
+      setNotice('');
+      setSessionID('');
+      sessionRef.current = '';
+    };
+    // The terminal lifecycle follows the dialog. Mutable refs carry container
+    // and session changes without recreating xterm.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, sandboxID]);
+
+  useEffect(() => {
+    if (terminalRef.current) {
+      terminalRef.current.options.fontSize = fontSize;
+      requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
+    }
+  }, [fontSize]);
+
+  useEffect(() => {
+    if (open) {
+      requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
+    }
+  }, [fullscreen, open]);
+
+  const activelyDisconnect = () => {
+    const socket = socketRef.current;
+    manualCloseRef.current = true;
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: 'disconnect' }));
+    }
+    socket?.close();
+    socketRef.current = null;
+    if (terminalRef.current) {
+      terminalRef.current.options.disableStdin = true;
+    }
+    setStatus('closed');
+    setNotice(t('messages.sessionClosed'));
+    setSessionID('');
+    sessionRef.current = '';
+  };
+
+  const startNewSession = () => {
+    activelyDisconnect();
+    manualCloseRef.current = false;
+    startConnectionRef.current(false);
+  };
+
+  const switchContainer = (containerID: string) => {
+    activelyDisconnect();
+    selectedRef.current = containerID;
+    setSelectedContainerID(containerID);
+    setNotice(t('messages.switchContainer'));
+    manualCloseRef.current = false;
+    startConnectionRef.current(false);
+  };
+
+  const statusTone =
+    status === 'connected' || status === 'reconnected'
+      ? 'text-cube-ok'
+      : status === 'connecting'
+        ? 'text-cube-info'
+        : status === 'disconnected' || status === 'error'
+          ? 'text-cube-err'
+          : 'text-muted-foreground';
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-background/80 backdrop-blur-sm" />
+        <Dialog.Content
+          className={cn(
+            'fixed z-50 flex flex-col overflow-hidden border border-border/70 bg-card shadow-2xl outline-none',
+            fullscreen
+              ? 'inset-2 rounded-xl'
+              : 'left-1/2 top-1/2 h-[min(760px,calc(100vh-3rem))] w-[min(1100px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-2xl',
+          )}
+        >
+          <div className="flex flex-wrap items-center gap-2 border-b border-border/60 px-4 py-3">
+            <Dialog.Title className="mr-2 flex items-center gap-2 text-sm font-semibold">
+              <SquareTerminal size={16} className="text-primary" />
+              {t('title')}
+            </Dialog.Title>
+            <span className="max-w-[260px] truncate font-mono text-xs text-muted-foreground">
+              {sandboxID}
+            </span>
+            <span className={cn('ml-auto text-xs font-medium', statusTone)}>
+              {t(`status.${status}`)}
+            </span>
+
+            <label className="sr-only" htmlFor="terminal-container">
+              {t('container')}
+            </label>
+            <select
+              id="terminal-container"
+              value={selectedContainerID}
+              onChange={(event) => switchContainer(event.target.value)}
+              className="h-8 max-w-[240px] rounded-md border border-border/60 bg-background px-2 text-xs"
+              title={t('messages.switchContainer')}
+            >
+              {(availableContainers.length ? availableContainers : [initialContainer]).map(
+                (container) => (
+                  <option key={container.containerID} value={container.containerID}>
+                    {containerLabel(container.containerID)}
+                  </option>
+                ),
+              )}
+            </select>
+
+            <Button
+              size="icon"
+              variant="ghost"
+              title={t('actions.decreaseFont')}
+              aria-label={t('actions.decreaseFont')}
+              disabled={fontSize <= MIN_FONT_SIZE}
+              onClick={() => setFontSize((size) => Math.max(MIN_FONT_SIZE, size - 1))}
+            >
+              <Minus size={14} />
+            </Button>
+            <span className="w-8 text-center font-mono text-xs text-muted-foreground">
+              {fontSize}
+            </span>
+            <Button
+              size="icon"
+              variant="ghost"
+              title={t('actions.increaseFont')}
+              aria-label={t('actions.increaseFont')}
+              disabled={fontSize >= MAX_FONT_SIZE}
+              onClick={() => setFontSize((size) => Math.min(MAX_FONT_SIZE, size + 1))}
+            >
+              <Plus size={14} />
+            </Button>
+            <Button
+              size="icon"
+              variant="ghost"
+              title={fullscreen ? t('actions.exitFullscreen') : t('actions.fullscreen')}
+              aria-label={fullscreen ? t('actions.exitFullscreen') : t('actions.fullscreen')}
+              onClick={() => setFullscreen((value) => !value)}
+            >
+              {fullscreen ? <Minimize2 size={14} /> : <Expand size={14} />}
+            </Button>
+            <Dialog.Close asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                title={t('actions.close')}
+                aria-label={t('actions.close')}
+              >
+                <X size={15} />
+              </Button>
+            </Dialog.Close>
+          </div>
+
+          <div className="flex items-center gap-2 border-b border-border/50 bg-muted/30 px-4 py-2 text-xs">
+            {status === 'connecting' ? (
+              <PlugZap size={13} className="animate-pulse text-cube-info" />
+            ) : null}
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">{notice}</span>
+            {status === 'disconnected' && sessionID ? (
+              <Button size="sm" variant="outline" onClick={() => startConnectionRef.current(true)}>
+                <RefreshCw size={13} /> {t('actions.reconnect')}
+              </Button>
+            ) : null}
+            {status === 'connected' || status === 'reconnected' ? (
+              <Button size="sm" variant="outline" onClick={activelyDisconnect}>
+                <Power size={13} /> {t('actions.disconnect')}
+              </Button>
+            ) : null}
+            {status === 'closed' || status === 'error' ? (
+              <Button size="sm" variant="outline" onClick={startNewSession}>
+                <SquareTerminal size={13} /> {t('actions.newSession')}
+              </Button>
+            ) : null}
+          </div>
+
+          <div className="min-h-0 flex-1 bg-[#080c12] p-2">
+            <div ref={mountRef} className="h-full w-full" aria-label={t('title')} />
+          </div>
+          <p className="border-t border-border/50 px-4 py-2 text-[11px] text-muted-foreground">
+            {t('messages.secureTransport')}
+          </p>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/web/src/components/terminal/TerminalLauncher.test.tsx
+++ b/web/src/components/terminal/TerminalLauncher.test.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import i18n from '@/i18n';
+
+vi.mock('./TerminalDialog', () => ({
+  TerminalDialog: ({ open }: { open: boolean }) => (
+    <div data-testid="terminal-dialog" data-open={String(open)} />
+  ),
+}));
+
+import { TerminalLauncher } from './TerminalLauncher';
+
+describe('TerminalLauncher', () => {
+  beforeAll(async () => {
+    await i18n.changeLanguage('en');
+  });
+  afterEach(cleanup);
+
+  it('disables terminal access for a non-running sandbox with a clear hint', () => {
+    render(<TerminalLauncher sandboxID="sandbox-1" state="paused" />);
+    const button = screen.getByRole('button', {
+      name: 'Terminal is available only while the sandbox is running.',
+    });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Terminal is available only while the sandbox is running.',
+    );
+    expect(screen.queryByTestId('terminal-dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the terminal dialog for a running sandbox', async () => {
+    render(<TerminalLauncher sandboxID="sandbox-1" state="running" />);
+    expect(screen.queryByTestId('terminal-dialog')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Open terminal' }));
+    expect(await screen.findByTestId('terminal-dialog')).toHaveAttribute('data-open', 'true');
+  });
+
+  it('disables terminal access when detail metadata has no loggable container', () => {
+    render(<TerminalLauncher sandboxID="sandbox-1" state="running" containers={[]} />);
+    expect(
+      screen.getByRole('button', {
+        name: 'No running container exposes a terminal endpoint.',
+      }),
+    ).toBeDisabled();
+  });
+});

--- a/web/src/components/terminal/TerminalLauncher.tsx
+++ b/web/src/components/terminal/TerminalLauncher.tsx
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { lazy, Suspense, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SquareTerminal } from 'lucide-react';
+
+import type { SandboxContainer } from '@/api/client';
+import { Button, type ButtonProps } from '@/components/ui/button';
+import { terminalAvailable } from '@/lib/terminal';
+
+const TerminalDialog = lazy(() =>
+  import('./TerminalDialog').then((module) => ({ default: module.TerminalDialog })),
+);
+
+interface Props {
+  sandboxID: string;
+  state?: string;
+  containers?: SandboxContainer[];
+  size?: ButtonProps['size'];
+  variant?: ButtonProps['variant'];
+  iconOnly?: boolean;
+}
+
+export function TerminalLauncher({
+  sandboxID,
+  state,
+  containers,
+  size = 'default',
+  variant = 'outline',
+  iconOnly = false,
+}: Props) {
+  const { t } = useTranslation('terminal');
+  const [open, setOpen] = useState(false);
+  const sandboxRunning = terminalAvailable(state);
+  const available = terminalAvailable(state, containers);
+  const unavailableText = sandboxRunning ? t('containerUnavailable') : t('unavailable');
+
+  return (
+    <>
+      <Button
+        size={size}
+        variant={variant}
+        disabled={!available}
+        title={available ? t('open') : unavailableText}
+        aria-label={available ? t('open') : unavailableText}
+        onClick={() => setOpen(true)}
+      >
+        <SquareTerminal size={14} />
+        {!iconOnly ? t('open') : null}
+      </Button>
+      {open ? (
+        <Suspense fallback={null}>
+          <TerminalDialog
+            sandboxID={sandboxID}
+            containers={containers}
+            open={open}
+            onOpenChange={setOpen}
+          />
+        </Suspense>
+      ) : null}
+    </>
+  );
+}

--- a/web/src/i18n/resources.ts
+++ b/web/src/i18n/resources.ts
@@ -22,6 +22,7 @@ import enObservability from '@/locales/en/observability.json';
 import enStore from '@/locales/en/store.json';
 import enAgentHub from '@/locales/en/agentHub.json';
 import enAuth from '@/locales/en/auth.json';
+import enTerminal from '@/locales/en/terminal.json';
 
 import zhCommon from '@/locales/zh/common.json';
 import zhNav from '@/locales/zh/nav.json';
@@ -44,6 +45,7 @@ import zhObservability from '@/locales/zh/observability.json';
 import zhStore from '@/locales/zh/store.json';
 import zhAgentHub from '@/locales/zh/agentHub.json';
 import zhAuth from '@/locales/zh/auth.json';
+import zhTerminal from '@/locales/zh/terminal.json';
 
 export const resources = {
   en: {
@@ -68,6 +70,7 @@ export const resources = {
     store: enStore,
     agentHub: enAgentHub,
     auth: enAuth,
+    terminal: enTerminal,
   },
   zh: {
     common: zhCommon,
@@ -91,6 +94,7 @@ export const resources = {
     store: zhStore,
     agentHub: zhAgentHub,
     auth: zhAuth,
+    terminal: zhTerminal,
   },
 } as const;
 

--- a/web/src/lib/terminal.test.ts
+++ b/web/src/lib/terminal.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { describe, expect, it } from 'vitest';
+import { terminalAvailable, terminalWebSocketURL } from './terminal';
+
+describe('terminal transport helpers', () => {
+  it('uses WSS on an HTTPS dashboard and URL-encodes the one-time ticket', () => {
+    const url = terminalWebSocketURL(
+      '/cubeapi/v1/sandboxes/sandbox-1/terminal/ws',
+      'ticket with + symbols',
+      { protocol: 'https:', host: 'cube.example:12088' } as Location,
+    );
+    expect(url).toBe(
+      'wss://cube.example:12088/cubeapi/v1/sandboxes/sandbox-1/terminal/ws?ticket=ticket+with+%2B+symbols',
+    );
+  });
+
+  it('only enables terminal access for running sandboxes', () => {
+    expect(terminalAvailable('running')).toBe(true);
+    expect(terminalAvailable('paused')).toBe(false);
+    expect(terminalAvailable('exited')).toBe(false);
+    expect(terminalAvailable(undefined)).toBe(false);
+  });
+
+  it('disables a running detail target without a terminal-capable container', () => {
+    expect(terminalAvailable('running', [])).toBe(false);
+    expect(terminalAvailable('running', [{ state: 'running', envdPort: 0 }])).toBe(false);
+    expect(terminalAvailable('running', [{ state: 'running', envdPort: 49983 }])).toBe(true);
+  });
+});

--- a/web/src/lib/terminal.ts
+++ b/web/src/lib/terminal.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+export function terminalWebSocketURL(
+  path: string,
+  ticket: string,
+  location = window.location,
+): string {
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const url = new URL(path, `${protocol}//${location.host}`);
+  url.protocol = protocol;
+  url.searchParams.set('ticket', ticket);
+  return url.toString();
+}
+
+interface TerminalContainerAvailability {
+  state: string;
+  envdPort?: number;
+}
+
+export function terminalAvailable(
+  state: string | undefined,
+  containers?: TerminalContainerAvailability[],
+): boolean {
+  if (state !== 'running') return false;
+  // List responses do not contain per-container metadata; the authenticated
+  // ticket endpoint performs the authoritative target check in that view.
+  if (containers === undefined) return true;
+  return containers.some(
+    (container) => container.state === 'running' && (container.envdPort ?? 0) > 0,
+  );
+}

--- a/web/src/locales/en/terminal.json
+++ b/web/src/locales/en/terminal.json
@@ -1,0 +1,37 @@
+{
+  "open": "Open terminal",
+  "unavailable": "Terminal is available only while the sandbox is running.",
+  "containerUnavailable": "No running container exposes a terminal endpoint.",
+  "title": "Web Terminal",
+  "container": "Container",
+  "primaryContainer": "Primary container",
+  "status": {
+    "idle": "Not connected",
+    "connecting": "Connecting…",
+    "connected": "Connected",
+    "reconnected": "Reconnected",
+    "disconnected": "Connection lost",
+    "closed": "Session closed",
+    "error": "Connection failed"
+  },
+  "actions": {
+    "disconnect": "Disconnect",
+    "reconnect": "Reconnect",
+    "newSession": "New session",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "increaseFont": "Increase font size",
+    "decreaseFont": "Decrease font size",
+    "close": "Close"
+  },
+  "messages": {
+    "connecting": "Connecting to {{container}}…",
+    "ready": "Connected to {{container}}.",
+    "reconnected": "Terminal session restored.",
+    "disconnected": "The connection was interrupted. Your shell is retained briefly; select Reconnect to restore it.",
+    "idleTimeout": "The terminal was closed after being idle.",
+    "sessionClosed": "The terminal session has ended.",
+    "switchContainer": "Switching containers starts a new terminal session.",
+    "secureTransport": "The terminal uses the current HTTPS/WSS session and keeps the sandbox's existing permission and network boundaries."
+  }
+}

--- a/web/src/locales/zh/terminal.json
+++ b/web/src/locales/zh/terminal.json
@@ -1,0 +1,37 @@
+{
+  "open": "打开终端",
+  "unavailable": "仅运行中的沙箱可以打开终端。",
+  "containerUnavailable": "没有运行中的容器提供终端端点。",
+  "title": "网页终端",
+  "container": "容器",
+  "primaryContainer": "主容器",
+  "status": {
+    "idle": "未连接",
+    "connecting": "连接中…",
+    "connected": "已连接",
+    "reconnected": "已重新连接",
+    "disconnected": "连接已中断",
+    "closed": "会话已关闭",
+    "error": "连接失败"
+  },
+  "actions": {
+    "disconnect": "断开",
+    "reconnect": "重新连接",
+    "newSession": "新建会话",
+    "fullscreen": "全屏",
+    "exitFullscreen": "退出全屏",
+    "increaseFont": "增大字号",
+    "decreaseFont": "减小字号",
+    "close": "关闭"
+  },
+  "messages": {
+    "connecting": "正在连接 {{container}}…",
+    "ready": "已连接到 {{container}}。",
+    "reconnected": "终端会话已恢复。",
+    "disconnected": "连接异常中断。Shell 会短暂保留，请点击“重新连接”恢复会话。",
+    "idleTimeout": "终端因长时间无活动已关闭。",
+    "sessionClosed": "终端会话已结束。",
+    "switchContainer": "切换容器会启动一个新的终端会话。",
+    "secureTransport": "终端沿用当前 HTTPS/WSS 会话，并保持沙箱原有的权限与网络边界。"
+  }
+}

--- a/web/src/pages/SandboxDetail.tsx
+++ b/web/src/pages/SandboxDetail.tsx
@@ -16,6 +16,7 @@ import { ArrowLeft, Pause, Play, Trash2, RefreshCw } from 'lucide-react';
 import { cn, formatBytes, formatRelative } from '@/lib/utils';
 import { formatSandboxActionError } from '@/lib/sandboxActionError';
 import { SandboxActionErrorBanner } from '@/components/SandboxActionErrorBanner';
+import { TerminalLauncher } from '@/components/terminal/TerminalLauncher';
 
 // ── Log level colors ────────────────────────────────────────────────────────
 const LEVEL_CLASS: Record<string, string> = {
@@ -219,6 +220,7 @@ export default function SandboxDetailPage() {
         </div>
         {data ? (
           <div className="flex gap-2">
+            <TerminalLauncher sandboxID={sandboxID} state={state} containers={data.containers} />
             {state === 'paused' ? (
               <Button variant="outline" onClick={() => resume.mutate()} disabled={resume.isPending}>
                 <Play size={14} /> {t('actions.resume')}

--- a/web/src/pages/Sandboxes.tsx
+++ b/web/src/pages/Sandboxes.tsx
@@ -16,6 +16,7 @@ import { formatBytes, formatRelative, short } from '@/lib/utils';
 import { cn } from '@/lib/utils';
 import { formatSandboxActionError } from '@/lib/sandboxActionError';
 import { SandboxActionErrorBanner } from '@/components/SandboxActionErrorBanner';
+import { TerminalLauncher } from '@/components/terminal/TerminalLauncher';
 
 type StateFilter = 'all' | 'running' | 'paused';
 
@@ -236,6 +237,13 @@ function Row({
       <div className="text-xs text-muted-foreground/80 text-num">{sb.clientID || '—'}</div>
       <div className="text-xs text-muted-foreground">{formatRelative(sb.startedAt)}</div>
       <div className="flex justify-end gap-1">
+        <TerminalLauncher
+          sandboxID={sb.sandboxID}
+          state={state}
+          size="icon"
+          variant="ghost"
+          iconOnly
+        />
         {state === 'paused' ? (
           <Button
             size="icon"

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import '@testing-library/jest-dom/vitest';
+
+class TestResizeObserver implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+globalThis.ResizeObserver = TestResizeObserver;
+
+Object.defineProperty(globalThis.navigator, 'clipboard', {
+  configurable: true,
+  value: {
+    readText: async () => '',
+    writeText: async () => undefined,
+  },
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,7 +6,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, './package.json'), 'utf-8'));
 
@@ -36,6 +36,11 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(resolveAppVersion()),
   },
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    restoreMocks: true,
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
@@ -48,6 +53,13 @@ export default defineConfig({
       '/opsapi': {
         target: 'http://127.0.0.1:3010',
         rewrite: (path) => path.replace(/^\/opsapi/, '/api'),
+      },
+      // Web Terminal and SDK routes served by CubeOps. This entry must precede
+      // the legacy /cubeapi fallback so WebSocket upgrades reach CubeOps.
+      '/cubeapi/v1': {
+        target: 'http://127.0.0.1:3010',
+        ws: true,
+        rewrite: (path) => path.replace(/^\/cubeapi\/v1/, '/api/v1/sdk'),
       },
       // CubeAPI (SDK/E2B endpoints) — proxy specific API paths to avoid
       // conflicting with vite's own static file serving.


### PR DESCRIPTION
关联 Issue

Closes #643

主要改动

1. 在沙箱列表和详情页增加网页终端入口，仅允许运行中且具备终端端点的容器登录，并支持多容器选择。
2. 基于 xterm.js 实现交互式终端，支持 ANSI、光标控制、复制粘贴、滚动回溯、窗口自适应、全屏和字号调整。
3. 在 CubeOps 增加经过 JWT 鉴权和一次性票据保护的 WebSocket PTY 通道，支持输入输出、尺寸同步、保活、空闲超时、主动断开、异常重连和并发会话限制。
4. 复用现有 envd PTY 能力，补充每容器 envd 端点元数据、SDK 路由和 CubeProxy 部署配置，并记录终端访问审计日志。
5. 接入中英文国际化，补充使用说明、权限要求、已知限制以及前后端测试。

验证结果
1. CubeOps：go test ./... 通过
2. Go SDK：go test ./... 通过
3. CubeMaster 终端端点测试通过
4. Cubelet envdport 测试通过
5. WebUI：npm test 通过（6 项）
6. WebUI：npm run build 通过
7. go vet 与 git diff --check 通过