### PR TITLE
cubeapi: add sandbox lifecycle webhook delivery

### DIFF
--- a/CubeAPI/Cargo.lock
+++ b/CubeAPI/Cargo.lock
@@ -533,9 +533,12 @@ dependencies = [
  "dotenvy",
  "futures",
  "governor",
+ "hex",
+ "hmac",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
@@ -589,6 +592,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -915,6 +919,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"

--- a/CubeAPI/Cargo.toml
+++ b/CubeAPI/Cargo.toml
@@ -70,6 +70,9 @@ governor = { version = "0.6", features = ["dashmap"] }
 # ── HTTP client (orchestrator / backend calls) ────────────────────────────
 # connection pool built-in, rustls for TLS
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
 
 # ── Validation ────────────────────────────────────────────────────────────
 validator = { version = "0.16", features = ["derive"] }

--- a/CubeAPI/README.md
+++ b/CubeAPI/README.md
@@ -72,6 +72,12 @@ cargo build --release
 | `CUBE_API_SANDBOX_DOMAIN` | `cube.app` | Domain returned in sandbox API responses |
 | `AUTH_CALLBACK_URL` | *(unset)* | External auth callback URL (callback mode) |
 | `CUBE_API_KEY` | *(unset)* | Built-in API key for simple auth (simple-key mode) |
+| `CUBE_API_WEBHOOK_ENDPOINTS` | `[]` | JSON array of lifecycle webhook endpoints |
+| `CUBE_API_WEBHOOK_QUEUE_CAPACITY` | `1024` | Maximum pending webhook deliveries |
+| `CUBE_API_WEBHOOK_MAX_CONCURRENCY` | `16` | Maximum concurrent webhook requests |
+
+See the [Webhook Events guide](../docs/guide/webhooks.md) for endpoint configuration,
+payloads, signing, and retry behavior.
 
 ### Authentication
 
@@ -161,4 +167,3 @@ python pause.py
 python create_with_mount.py
 python browser.py
 python test.py
-

--- a/CubeAPI/src/config/mod.rs
+++ b/CubeAPI/src/config/mod.rs
@@ -5,6 +5,25 @@
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
+pub struct WebhookEndpointConfig {
+    /// Diagnostic name used in delivery logs.
+    pub name: String,
+    /// HTTP(S) endpoint that receives one JSON event per POST.
+    pub url: String,
+    /// Subscribed event names. `*` subscribes to all supported webhook events.
+    pub events: Vec<String>,
+    /// Optional HMAC-SHA256 signing secret.
+    #[serde(default)]
+    pub secret: Option<String>,
+    /// Per-attempt request timeout.
+    #[serde(default = "default_webhook_timeout_secs")]
+    pub timeout_secs: u64,
+    /// Number of retries after the initial delivery attempt.
+    #[serde(default = "default_webhook_max_retries")]
+    pub max_retries: u32,
+}
+
+#[derive(Debug, Deserialize, Clone)]
 pub struct ServerConfig {
     /// Bind address, e.g. "0.0.0.0:3000". Env var: CUBE_API_BIND (default "0.0.0.0:3000")
     #[serde(default = "default_bind")]
@@ -76,6 +95,21 @@ pub struct ServerConfig {
     /// Env var: CUBE_API_KEY
     #[serde(default)]
     pub cube_api_key: Option<String>,
+
+    /// JSON array of webhook endpoint configurations.
+    /// Env var: CUBE_API_WEBHOOK_ENDPOINTS
+    #[serde(default)]
+    pub webhook_endpoints: Vec<WebhookEndpointConfig>,
+
+    /// Maximum number of pending webhook deliveries.
+    /// Env var: CUBE_API_WEBHOOK_QUEUE_CAPACITY
+    #[serde(default = "default_webhook_queue_capacity")]
+    pub webhook_queue_capacity: usize,
+
+    /// Maximum number of webhook HTTP requests in flight.
+    /// Env var: CUBE_API_WEBHOOK_MAX_CONCURRENCY
+    #[serde(default = "default_webhook_max_concurrency")]
+    pub webhook_max_concurrency: usize,
 }
 
 fn default_bind() -> String {
@@ -109,15 +143,56 @@ fn default_log_dir() -> String {
 fn default_log_prefix() -> String {
     "cube-api".to_string()
 }
+fn default_webhook_timeout_secs() -> u64 {
+    5
+}
+fn default_webhook_max_retries() -> u32 {
+    4
+}
+fn default_webhook_queue_capacity() -> usize {
+    1024
+}
+fn default_webhook_max_concurrency() -> usize {
+    16
+}
 
 impl ServerConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let _ = dotenvy::dotenv();
-        let cfg = config::Config::builder()
+        let mut cfg: Self = config::Config::builder()
             .add_source(config::Environment::default().separator("__"))
             .build()?
-            .try_deserialize()?;
+            .try_deserialize()
+            .unwrap_or_default();
+
+        if let Ok(value) = std::env::var("CUBE_API_WEBHOOK_ENDPOINTS") {
+            if !value.trim().is_empty() {
+                cfg.webhook_endpoints = serde_json::from_str(&value).map_err(|error| {
+                    anyhow::anyhow!("invalid CUBE_API_WEBHOOK_ENDPOINTS JSON: {}", error)
+                })?;
+            }
+        }
+        if let Some(value) = parse_env("CUBE_API_WEBHOOK_QUEUE_CAPACITY")? {
+            cfg.webhook_queue_capacity = value;
+        }
+        if let Some(value) = parse_env("CUBE_API_WEBHOOK_MAX_CONCURRENCY")? {
+            cfg.webhook_max_concurrency = value;
+        }
         Ok(cfg)
+    }
+}
+
+fn parse_env<T>(name: &str) -> anyhow::Result<Option<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match std::env::var(name) {
+        Ok(value) if !value.trim().is_empty() => value
+            .parse()
+            .map(Some)
+            .map_err(|error| anyhow::anyhow!("invalid {}: {}", name, error)),
+        _ => Ok(None),
     }
 }
 
@@ -135,6 +210,9 @@ impl Default for ServerConfig {
             log_prefix: default_log_prefix(),
             auth_callback_url: None,
             cube_api_key: std::env::var("CUBE_API_KEY").ok().filter(|s| !s.is_empty()),
+            webhook_endpoints: Vec::new(),
+            webhook_queue_capacity: default_webhook_queue_capacity(),
+            webhook_max_concurrency: default_webhook_max_concurrency(),
         }
     }
 }

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -2,83 +2,612 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//! HTTP webhook log backend — stub.
-//!
-//! Sends log events as JSON POST requests to a configurable endpoint.
-//! Useful for forwarding to log aggregators (Elasticsearch, Loki, custom
-//! ingest APIs) that accept HTTP.
-//!
-//! # TODO (wire-up checklist)
-//!
-//! 1. Add `http_log_url: Option<String>` to `ServerConfig`.
-//! 2. Construct `HttpLogger::new(client, url, batch_size, flush_interval)`.
-//! 3. Register it in `AppState::new()` inside `MultiLogger`.
-//!
-//! # Batching strategy (suggested)
-//!
-//! Buffer events into a `Vec<LogEvent>` and POST when either:
-//! - The buffer reaches `batch_size` (default 100), or
-//! - A ticker fires every `flush_interval` (default 5 s).
-//!
-//! Use `tokio::select!` in the background task to wait on whichever fires
-//! first.
+//! Asynchronous HTTP webhook backend for selected lifecycle events.
 
 use super::{LogEvent, Logger};
+use crate::config::WebhookEndpointConfig;
 use async_trait::async_trait;
+use chrono::Utc;
+use hmac::{Hmac, Mac};
+use reqwest::{StatusCode, Url};
+use serde::Serialize;
+use sha2::Sha256;
+use std::{collections::HashSet, sync::Arc, time::Duration};
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
+use uuid::Uuid;
 
-/// Configuration for the HTTP webhook backend.
+const FLUSH_TIMEOUT: Duration = Duration::from_secs(10);
+const SUPPORTED_EVENTS: [&str; 4] = [
+    "sandbox.created",
+    "sandbox.deleted",
+    "sandbox.paused",
+    "sandbox.resumed",
+];
+
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct HttpLoggerConfig {
-    /// Full URL to POST batches to, e.g. `"http://log-ingest.internal/api/logs"`.
-    pub url: String,
-    /// Max events per batch (default: 100).
-    pub batch_size: usize,
-    /// Flush interval in seconds even if batch is not full (default: 5).
-    pub flush_interval_secs: u64,
+struct Endpoint {
+    config: WebhookEndpointConfig,
+    subscriptions: HashSet<String>,
 }
 
-impl Default for HttpLoggerConfig {
-    fn default() -> Self {
-        Self {
-            url: String::new(),
-            batch_size: 100,
-            flush_interval_secs: 5,
-        }
+impl Endpoint {
+    fn subscribes_to(&self, event: &str) -> bool {
+        self.subscriptions.contains("*") || self.subscriptions.contains(event)
     }
 }
 
-/// HTTP webhook log backend (stub — not yet implemented).
+#[derive(Debug, Clone, Serialize)]
+struct WebhookPayload {
+    id: Uuid,
+    event: String,
+    timestamp: chrono::DateTime<Utc>,
+    #[serde(flatten)]
+    fields: std::collections::HashMap<String, serde_json::Value>,
+}
+
+struct DeliveryJob {
+    endpoint: Arc<Endpoint>,
+    payload: WebhookPayload,
+    body: Vec<u8>,
+    _pending_permit: OwnedSemaphorePermit,
+}
+
+enum Msg {
+    Delivery(DeliveryJob),
+    Flush(tokio::sync::oneshot::Sender<()>),
+}
+
+/// Fans lifecycle events out to configured HTTP endpoints in a background task.
 #[derive(Clone)]
 pub struct HttpLogger {
-    #[allow(dead_code)]
-    config: HttpLoggerConfig,
+    tx: mpsc::Sender<Msg>,
+    endpoints: Arc<Vec<Arc<Endpoint>>>,
+    pending: Arc<Semaphore>,
 }
 
 impl HttpLogger {
-    /// Create an `HttpLogger`.  Currently a no-op; implement the background
-    /// task described in the module doc when ready.
-    #[allow(dead_code)]
-    pub fn new(config: HttpLoggerConfig) -> Self {
-        Self { config }
+    pub fn new(
+        client: reqwest::Client,
+        configs: Vec<WebhookEndpointConfig>,
+        queue_capacity: usize,
+        max_concurrency: usize,
+    ) -> anyhow::Result<Self> {
+        validate_configs(&configs)?;
+        anyhow::ensure!(
+            queue_capacity > 0,
+            "webhook queue capacity must be greater than zero"
+        );
+        anyhow::ensure!(
+            max_concurrency > 0,
+            "webhook max concurrency must be greater than zero"
+        );
+
+        let endpoints = Arc::new(
+            configs
+                .into_iter()
+                .map(|config| {
+                    Arc::new(Endpoint {
+                        subscriptions: config.events.iter().cloned().collect(),
+                        config,
+                    })
+                })
+                .collect::<Vec<_>>(),
+        );
+        let (tx, mut rx) = mpsc::channel(queue_capacity);
+        let semaphore = Arc::new(Semaphore::new(max_concurrency));
+        let pending = Arc::new(Semaphore::new(queue_capacity));
+
+        tokio::spawn(async move {
+            let mut deliveries = tokio::task::JoinSet::new();
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Msg::Delivery(job) => {
+                        let client = client.clone();
+                        let semaphore = semaphore.clone();
+                        deliveries.spawn(async move {
+                            deliver_with_retry(client, semaphore, job).await;
+                        });
+                        while deliveries.try_join_next().is_some() {}
+                    }
+                    Msg::Flush(reply) => {
+                        while deliveries.join_next().await.is_some() {}
+                        let _ = reply.send(());
+                    }
+                }
+            }
+            while deliveries.join_next().await.is_some() {}
+        });
+
+        Ok(Self {
+            tx,
+            endpoints,
+            pending,
+        })
     }
 }
 
 #[async_trait]
 impl Logger for HttpLogger {
-    async fn log(&self, _event: LogEvent) {
-        // TODO: send to internal channel; background task batches + POSTs.
-        // Example batch payload:
-        // POST config.url
-        // Content-Type: application/json
-        // Body: { "events": [ <LogEvent>, ... ] }
+    async fn log(&self, event: LogEvent) {
+        if !SUPPORTED_EVENTS.contains(&event.event.as_str()) {
+            return;
+        }
+
+        let payload = WebhookPayload {
+            id: Uuid::new_v4(),
+            event: event.event,
+            timestamp: event.timestamp,
+            fields: event.fields,
+        };
+        let body = match serde_json::to_vec(&payload) {
+            Ok(body) => body,
+            Err(error) => {
+                tracing::error!(error = %error, "failed to serialize webhook event");
+                return;
+            }
+        };
+
+        for endpoint in self
+            .endpoints
+            .iter()
+            .filter(|endpoint| endpoint.subscribes_to(&payload.event))
+        {
+            let permit = match self.pending.clone().try_acquire_owned() {
+                Ok(permit) => permit,
+                Err(error) => {
+                    tracing::warn!(
+                        endpoint = %endpoint.config.name,
+                        event = %payload.event,
+                        event_id = %payload.id,
+                        error = %error,
+                        "webhook pending limit reached; dropping delivery"
+                    );
+                    continue;
+                }
+            };
+            let job = DeliveryJob {
+                endpoint: endpoint.clone(),
+                payload: payload.clone(),
+                body: body.clone(),
+                _pending_permit: permit,
+            };
+            if let Err(error) = self.tx.try_send(Msg::Delivery(job)) {
+                tracing::warn!(
+                    endpoint = %endpoint.config.name,
+                    event = %payload.event,
+                    event_id = %payload.id,
+                    error = %error,
+                    "webhook queue unavailable; dropping delivery"
+                );
+            }
+        }
     }
 
     async fn flush(&self) {
-        // TODO: drain the buffer and send the final batch.
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if self.tx.send(Msg::Flush(tx)).await.is_ok()
+            && tokio::time::timeout(FLUSH_TIMEOUT, rx).await.is_err()
+        {
+            tracing::warn!("timed out waiting for pending webhook deliveries during shutdown");
+        }
     }
 
     fn name(&self) -> &'static str {
         "http"
+    }
+}
+
+fn validate_configs(configs: &[WebhookEndpointConfig]) -> anyhow::Result<()> {
+    let mut names = HashSet::new();
+    for config in configs {
+        anyhow::ensure!(
+            !config.name.trim().is_empty(),
+            "webhook endpoint name cannot be empty"
+        );
+        anyhow::ensure!(
+            names.insert(config.name.clone()),
+            "duplicate webhook endpoint name: {}",
+            config.name
+        );
+        let url = Url::parse(&config.url).map_err(|error| {
+            anyhow::anyhow!("invalid webhook URL for {}: {}", config.name, error)
+        })?;
+        anyhow::ensure!(
+            matches!(url.scheme(), "http" | "https"),
+            "webhook endpoint {} must use HTTP or HTTPS",
+            config.name
+        );
+        anyhow::ensure!(
+            !config.events.is_empty(),
+            "webhook endpoint {} must subscribe to at least one event",
+            config.name
+        );
+        for event in &config.events {
+            anyhow::ensure!(
+                event == "*" || SUPPORTED_EVENTS.contains(&event.as_str()),
+                "unsupported webhook event '{}' for endpoint {}",
+                event,
+                config.name
+            );
+        }
+        anyhow::ensure!(
+            config.timeout_secs > 0,
+            "webhook timeout must be greater than zero for {}",
+            config.name
+        );
+        anyhow::ensure!(
+            config
+                .secret
+                .as_ref()
+                .is_none_or(|secret| !secret.trim().is_empty()),
+            "webhook signing secret cannot be empty for {}",
+            config.name
+        );
+    }
+    Ok(())
+}
+
+async fn deliver_with_retry(client: reqwest::Client, semaphore: Arc<Semaphore>, job: DeliveryJob) {
+    let max_attempts = job.endpoint.config.max_retries.saturating_add(1);
+    for attempt in 1..=max_attempts {
+        let permit = match semaphore.acquire().await {
+            Ok(permit) => permit,
+            Err(_) => return,
+        };
+        let timestamp = Utc::now().timestamp();
+        let mut request = client
+            .post(&job.endpoint.config.url)
+            .header("Content-Type", "application/json")
+            .header("X-Cube-Webhook-Id", job.payload.id.to_string())
+            .header("X-Cube-Webhook-Timestamp", timestamp.to_string())
+            .timeout(Duration::from_secs(job.endpoint.config.timeout_secs))
+            .body(job.body.clone());
+
+        if let Some(secret) = job
+            .endpoint
+            .config
+            .secret
+            .as_deref()
+            .filter(|s| !s.is_empty())
+        {
+            request = request.header(
+                "X-Cube-Webhook-Signature",
+                format!("sha256={}", sign(secret, timestamp, &job.body)),
+            );
+        }
+
+        let response = request.send().await;
+        drop(permit);
+        match response {
+            Ok(response) if response.status().is_success() => {
+                tracing::info!(
+                    endpoint = %job.endpoint.config.name,
+                    event = %job.payload.event,
+                    event_id = %job.payload.id,
+                    attempt,
+                    "webhook delivered"
+                );
+                return;
+            }
+            Ok(response) if !is_retryable_status(response.status()) => {
+                tracing::error!(
+                    endpoint = %job.endpoint.config.name,
+                    event = %job.payload.event,
+                    event_id = %job.payload.id,
+                    status = %response.status(),
+                    attempt,
+                    "webhook delivery rejected without retry"
+                );
+                return;
+            }
+            Ok(response) => tracing::warn!(
+                endpoint = %job.endpoint.config.name,
+                event = %job.payload.event,
+                event_id = %job.payload.id,
+                status = %response.status(),
+                attempt,
+                "webhook delivery failed"
+            ),
+            Err(error) => tracing::warn!(
+                endpoint = %job.endpoint.config.name,
+                event = %job.payload.event,
+                event_id = %job.payload.id,
+                attempt,
+                error = %error,
+                "webhook delivery failed"
+            ),
+        }
+
+        if attempt < max_attempts {
+            tokio::time::sleep(retry_delay(attempt, job.payload.id)).await;
+        }
+    }
+
+    tracing::error!(
+        endpoint = %job.endpoint.config.name,
+        event = %job.payload.event,
+        event_id = %job.payload.id,
+        attempts = max_attempts,
+        "webhook delivery exhausted retries"
+    );
+}
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+}
+
+fn retry_delay(attempt: u32, event_id: Uuid) -> Duration {
+    let exponential_ms = 1_000u64.saturating_mul(1u64 << attempt.saturating_sub(1).min(6));
+    let jitter_ms = u64::from(event_id.as_bytes()[0]) * 2;
+    Duration::from_millis((exponential_ms + jitter_ms).min(60_000))
+}
+
+fn sign(secret: &str, timestamp: i64, body: &[u8]) -> String {
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("HMAC accepts keys of any size");
+    mac.update(timestamp.to_string().as_bytes());
+    mac.update(b".");
+    mac.update(body);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{to_bytes, Body},
+        extract::State,
+        http::{Request, StatusCode},
+        routing::post,
+        Router,
+    };
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use tokio::{net::TcpListener, sync::Mutex};
+
+    #[derive(Clone, Debug)]
+    struct ReceivedRequest {
+        body: Vec<u8>,
+        timestamp: String,
+        signature: Option<String>,
+    }
+
+    #[derive(Clone)]
+    struct ReceiverState {
+        requests: Arc<Mutex<Vec<ReceivedRequest>>>,
+        failures_remaining: Arc<AtomicUsize>,
+        delay: Duration,
+    }
+
+    async fn receive(State(state): State<ReceiverState>, request: Request<Body>) -> StatusCode {
+        if !state.delay.is_zero() {
+            tokio::time::sleep(state.delay).await;
+        }
+        let timestamp = request
+            .headers()
+            .get("X-Cube-Webhook-Timestamp")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        let signature = request
+            .headers()
+            .get("X-Cube-Webhook-Signature")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        let body = to_bytes(request.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec();
+        state.requests.lock().await.push(ReceivedRequest {
+            body,
+            timestamp,
+            signature,
+        });
+
+        if state
+            .failures_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            StatusCode::INTERNAL_SERVER_ERROR
+        } else {
+            StatusCode::NO_CONTENT
+        }
+    }
+
+    async fn spawn_receiver(failures: usize, delay: Duration) -> (String, ReceiverState) {
+        let state = ReceiverState {
+            requests: Arc::new(Mutex::new(Vec::new())),
+            failures_remaining: Arc::new(AtomicUsize::new(failures)),
+            delay,
+        };
+        let app = Router::new()
+            .route("/webhook", post(receive))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (format!("http://{address}/webhook"), state)
+    }
+
+    fn endpoint(url: String, events: &[&str]) -> WebhookEndpointConfig {
+        WebhookEndpointConfig {
+            name: "test".to_string(),
+            url,
+            events: events.iter().map(|event| event.to_string()).collect(),
+            secret: None,
+            timeout_secs: 2,
+            max_retries: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn delivers_subscribed_event_with_payload_and_signature() {
+        let (url, receiver) = spawn_receiver(0, Duration::ZERO).await;
+        let mut config = endpoint(url, &["sandbox.created"]);
+        config.secret = Some("test-secret".to_string());
+        let logger = HttpLogger::new(reqwest::Client::new(), vec![config], 16, 2).unwrap();
+
+        logger
+            .log(
+                LogEvent::new(super::super::LogLevel::Info, "sandbox.created")
+                    .field("sandbox_id", "sandbox-1")
+                    .field("template_id", "template-1"),
+            )
+            .await;
+        logger.flush().await;
+
+        let requests = receiver.requests.lock().await;
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        let payload: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+        assert_eq!(payload["event"], "sandbox.created");
+        assert_eq!(payload["sandbox_id"], "sandbox-1");
+        assert_eq!(payload["template_id"], "template-1");
+        assert!(payload["id"].as_str().is_some());
+
+        let timestamp = request.timestamp.parse::<i64>().unwrap();
+        assert_eq!(
+            request.signature.as_deref(),
+            Some(format!("sha256={}", sign("test-secret", timestamp, &request.body)).as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn ignores_unsubscribed_and_non_webhook_events() {
+        let (url, receiver) = spawn_receiver(0, Duration::ZERO).await;
+        let logger = HttpLogger::new(
+            reqwest::Client::new(),
+            vec![endpoint(url, &["sandbox.deleted"])],
+            16,
+            2,
+        )
+        .unwrap();
+
+        logger
+            .log(LogEvent::new(
+                super::super::LogLevel::Info,
+                "sandbox.created",
+            ))
+            .await;
+        logger
+            .log(LogEvent::new(super::super::LogLevel::Info, "api.request"))
+            .await;
+        logger.flush().await;
+
+        assert!(receiver.requests.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn retries_server_errors_with_the_same_event() {
+        let (url, receiver) = spawn_receiver(1, Duration::ZERO).await;
+        let mut config = endpoint(url, &["sandbox.paused"]);
+        config.max_retries = 1;
+        let logger = HttpLogger::new(reqwest::Client::new(), vec![config], 16, 1).unwrap();
+
+        logger
+            .log(
+                LogEvent::new(super::super::LogLevel::Info, "sandbox.paused")
+                    .field("sandbox_id", "sandbox-1"),
+            )
+            .await;
+        logger.flush().await;
+
+        let requests = receiver.requests.lock().await;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].body, requests[1].body);
+    }
+
+    #[tokio::test]
+    async fn log_does_not_wait_for_the_receiver() {
+        let (url, _receiver) = spawn_receiver(0, Duration::from_millis(250)).await;
+        let logger = HttpLogger::new(
+            reqwest::Client::new(),
+            vec![endpoint(url, &["sandbox.resumed"])],
+            16,
+            1,
+        )
+        .unwrap();
+
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            logger.log(LogEvent::new(
+                super::super::LogLevel::Info,
+                "sandbox.resumed",
+            )),
+        )
+        .await
+        .expect("log must only enqueue the webhook delivery");
+        logger.flush().await;
+    }
+
+    #[tokio::test]
+    async fn retry_backoff_does_not_block_a_healthy_endpoint() {
+        let (failing_url, failing_receiver) = spawn_receiver(1, Duration::ZERO).await;
+        let (healthy_url, healthy_receiver) = spawn_receiver(0, Duration::ZERO).await;
+        let mut failing = endpoint(failing_url, &["sandbox.created"]);
+        failing.name = "failing".to_string();
+        failing.max_retries = 1;
+        let mut healthy = endpoint(healthy_url, &["sandbox.created"]);
+        healthy.name = "healthy".to_string();
+        let logger =
+            HttpLogger::new(reqwest::Client::new(), vec![failing, healthy], 16, 1).unwrap();
+
+        logger
+            .log(LogEvent::new(
+                super::super::LogLevel::Info,
+                "sandbox.created",
+            ))
+            .await;
+
+        tokio::time::timeout(Duration::from_millis(500), async {
+            loop {
+                if !healthy_receiver.requests.lock().await.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("healthy endpoint must not wait for another endpoint's retry backoff");
+        logger.flush().await;
+
+        assert_eq!(failing_receiver.requests.lock().await.len(), 2);
+        assert_eq!(healthy_receiver.requests.lock().await.len(), 1);
+    }
+
+    #[test]
+    fn validates_endpoint_configuration() {
+        let mut config = endpoint("ftp://example.com/hook".to_string(), &["sandbox.created"]);
+        assert!(validate_configs(&[config.clone()]).is_err());
+
+        config.url = "https://example.com/hook".to_string();
+        config.events = vec!["unknown.event".to_string()];
+        assert!(validate_configs(&[config]).is_err());
+
+        let mut config = endpoint("https://example.com/hook".to_string(), &["*"]);
+        config.secret = Some("  ".to_string());
+        assert!(validate_configs(&[config]).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_queue_or_concurrency_limits() {
+        let config = endpoint("https://example.com/hook".to_string(), &["*"]);
+        assert!(HttpLogger::new(reqwest::Client::new(), vec![config.clone()], 0, 1).is_err());
+        assert!(HttpLogger::new(reqwest::Client::new(), vec![config], 1, 0).is_err());
+    }
+
+    #[test]
+    fn classifies_retryable_statuses() {
+        assert!(is_retryable_status(StatusCode::REQUEST_TIMEOUT));
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable_status(StatusCode::BAD_GATEWAY));
+        assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
     }
 }

--- a/CubeAPI/src/logging/mod.rs
+++ b/CubeAPI/src/logging/mod.rs
@@ -11,7 +11,7 @@
 //! file **asynchronously** via a background Tokio task (channel → writer loop).
 //!
 //! Additional backends can be plugged in by implementing [`Logger`] and
-//! registering them in [`MultiLogger`].  Ready-made stubs are provided for:
+//! registering them in [`MultiLogger`]:
 //!
 //! | Module         | Backend                        | Status   |
 //! |----------------|-------------------------------|----------|
@@ -20,7 +20,7 @@
 //! | `multi`        | Fan-out to N backends         | ✅ Ready |
 //! | `filtered`     | Min-level gate wrapper        | ✅ Ready |
 //! | `otlp`         | OpenTelemetry OTLP exporter   | 🔲 Stub  |
-//! | `http`         | Generic HTTP webhook          | 🔲 Stub  |
+//! | `http`         | Async lifecycle webhook       | ✅ Ready |
 
 pub mod file;
 pub mod filtered;

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -131,7 +131,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     // ── Config ─────────────────────────────────────────────────────────────
-    let mut cfg = config::ServerConfig::from_env().unwrap_or_default();
+    let mut cfg = config::ServerConfig::from_env()?;
 
     // CLI flags override env vars / config file (highest priority)
     if cli.debug {
@@ -208,21 +208,30 @@ async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()
     };
 
     let file_logger = FileLogger::new(cfg.log_dir.clone(), cfg.log_prefix.clone()).await?;
+    let http_client = reqwest::Client::builder()
+        .pool_max_idle_per_host(100)
+        .connection_verbose(false)
+        .build()?;
+
+    let mut multi_logger = MultiLogger::new().add(arc(file_logger));
+    if !cfg.webhook_endpoints.is_empty() {
+        let webhook_logger = logging::http::HttpLogger::new(
+            http_client.clone(),
+            cfg.webhook_endpoints.clone(),
+            cfg.webhook_queue_capacity,
+            cfg.webhook_max_concurrency,
+        )?;
+        multi_logger = multi_logger.add(arc(webhook_logger));
+    }
 
     // FilteredLogger gates by level → MultiLogger fans out to file (+ future backends)
-    let logger: logging::ArcLogger = arc(FilteredLogger::new(
-        arc(
-            MultiLogger::new().add(arc(file_logger)), // Uncomment to add more backends:
-                                                      // .add(arc(logging::http::HttpLogger::new(Default::default())))
-                                                      // .add(arc(logging::otlp::OtlpLogger::new()))
-        ),
-        min_level,
-    ));
+    let logger: logging::ArcLogger = arc(FilteredLogger::new(arc(multi_logger), min_level));
 
     tracing::info!(
         log_dir = %cfg.log_dir,
         log_prefix = %cfg.log_prefix,
         min_level = %min_level,
+        webhook_endpoints = cfg.webhook_endpoints.len(),
         "structured event logger started"
     );
 

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -214,6 +214,11 @@ CUBE_API_SANDBOX_DOMAIN=cube.app
 # AUTH_CALLBACK_URL=
 # CUBE_API_KEY=  # Built-in simple key auth (unset = no auth, suitable for
                  # All-in-One internal use). See CubeAPI/README.md for details.
+# Lifecycle webhooks. Keep the JSON on one line and use a receiver address
+# reachable from CubeAPI. See docs/guide/webhooks.md.
+# CUBE_API_WEBHOOK_ENDPOINTS=[{"name":"automation","url":"https://example.com/cube-events","events":["*"],"secret":"replace-me"}]
+# CUBE_API_WEBHOOK_QUEUE_CAPACITY=1024
+# CUBE_API_WEBHOOK_MAX_CONCURRENCY=16
 
 # CubeOps (admin/ops API) — internal service proxied via WebUI nginx.
 # Must bind 0.0.0.0 in All-in-One mode so the WebUI nginx container can

--- a/deploy/one-click/scripts/one-click/up.sh
+++ b/deploy/one-click/scripts/one-click/up.sh
@@ -55,6 +55,12 @@ fi
 if [[ -n "${AUTH_CALLBACK_URL:-}" ]]; then
   CUBE_API_OPTIONAL_EXPORTS+="export AUTH_CALLBACK_URL=\"${AUTH_CALLBACK_URL}\"; "
 fi
+for webhook_var in CUBE_API_WEBHOOK_ENDPOINTS CUBE_API_WEBHOOK_QUEUE_CAPACITY CUBE_API_WEBHOOK_MAX_CONCURRENCY; do
+  if [[ -n "${!webhook_var:-}" ]]; then
+    printf -v webhook_value '%q' "${!webhook_var}"
+    CUBE_API_OPTIONAL_EXPORTS+="export ${webhook_var}=${webhook_value}; "
+  fi
+done
 if [[ -n "${DATABASE_URL:-}" ]]; then
   CUBE_API_OPTIONAL_EXPORTS+="export DATABASE_URL=\"${DATABASE_URL}\"; "
 else

--- a/deploy/one-click/scripts/systemd/cube-api-start.sh
+++ b/deploy/one-click/scripts/systemd/cube-api-start.sh
@@ -28,6 +28,11 @@ fi
 if [[ -n "${CUBE_API_KEY:-}" ]]; then
   export CUBE_API_KEY
 fi
+for webhook_var in CUBE_API_WEBHOOK_ENDPOINTS CUBE_API_WEBHOOK_QUEUE_CAPACITY CUBE_API_WEBHOOK_MAX_CONCURRENCY; do
+  if [[ -n "${!webhook_var:-}" ]]; then
+    export "${webhook_var}"
+  fi
+done
 if [[ -n "${DATABASE_URL:-}" ]]; then
   export DATABASE_URL
 else

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -175,7 +175,8 @@ export default withMermaid(defineConfig({
                 { text: 'Template Inspection & Request Preview', link: '/guide/template-inspection-and-preview' },
                 { text: 'HTTPS & Domain Resolution', link: '/guide/https-and-domain' },
                 { text: 'Network Hardening', link: '/guide/network-hardening' },
-                { text: 'Authentication', link: '/guide/authentication' }
+                { text: 'Authentication', link: '/guide/authentication' },
+                { text: 'Webhook Events', link: '/guide/webhooks' }
               ]
             },
             {
@@ -324,7 +325,8 @@ export default withMermaid(defineConfig({
                 { text: '模板检查与请求预览', link: '/zh/guide/template-inspection-and-preview' },
                 { text: 'HTTPS 证书与域名解析', link: '/zh/guide/https-and-domain' },
                 { text: '网络加固', link: '/zh/guide/network-hardening' },
-                { text: '鉴权', link: '/zh/guide/authentication' }
+                { text: '鉴权', link: '/zh/guide/authentication' },
+                { text: 'Webhook 事件通知', link: '/zh/guide/webhooks' }
               ]
             },
             {

--- a/docs/guide/webhooks.md
+++ b/docs/guide/webhooks.md
@@ -1,0 +1,126 @@
+---
+title: Webhook Events
+---
+
+# Webhook Events
+
+CubeAPI can asynchronously notify HTTP endpoints after successful sandbox
+lifecycle operations. Webhook delivery runs outside the API request path, so a
+slow or unavailable receiver does not make lifecycle requests fail.
+
+## Configure endpoints
+
+Set `CUBE_API_WEBHOOK_ENDPOINTS` to a JSON array before starting CubeAPI:
+
+```bash
+export CUBE_API_WEBHOOK_ENDPOINTS='[
+  {
+    "name": "automation",
+    "url": "https://automation.example.com/cube-events",
+    "events": ["sandbox.created", "sandbox.deleted"],
+    "secret": "replace-with-a-random-secret",
+    "timeout_secs": 5,
+    "max_retries": 4
+  },
+  {
+    "name": "monitoring",
+    "url": "https://monitoring.example.com/events",
+    "events": ["*"]
+  }
+]'
+```
+
+`events` accepts exact event names or `*` for all supported events. `secret` is
+optional. `timeout_secs` defaults to 5, and `max_retries` defaults to 4 retries
+after the initial attempt. Endpoint names must be unique.
+
+Global controls:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `CUBE_API_WEBHOOK_QUEUE_CAPACITY` | `1024` | Maximum number of pending deliveries |
+| `CUBE_API_WEBHOOK_MAX_CONCURRENCY` | `16` | Maximum HTTP requests in flight |
+
+Invalid endpoint JSON, URLs, or event names prevent CubeAPI from starting.
+
+## Events and payload
+
+| Event | Emitted after | Additional fields |
+| --- | --- | --- |
+| `sandbox.created` | A sandbox is created successfully | `template_id` |
+| `sandbox.deleted` | A sandbox is deleted successfully | None |
+| `sandbox.paused` | A sandbox is paused successfully | None |
+| `sandbox.resumed` | A sandbox is resumed successfully | None |
+
+Every payload contains `id`, `event`, `timestamp`, and `sandbox_id`:
+
+```json
+{
+  "id": "a79a9a61-7330-49cf-8108-c14347f4b94e",
+  "event": "sandbox.created",
+  "timestamp": "2026-07-31T10:30:00.123Z",
+  "sandbox_id": "sandbox-123",
+  "template_id": "template-456"
+}
+```
+
+Receivers should use `id` as an idempotency key because retries deliver the
+same event more than once.
+
+## Verify signatures
+
+When an endpoint has a `secret`, CubeAPI sends:
+
+```text
+X-Cube-Webhook-Id: <event UUID>
+X-Cube-Webhook-Timestamp: <Unix timestamp>
+X-Cube-Webhook-Signature: sha256=<hex digest>
+```
+
+The signed input is the UTF-8 timestamp, a period, and the exact raw request
+body. Do not parse and re-serialize the body before verification.
+
+```python
+import hashlib, hmac, time
+
+timestamp = request.headers["X-Cube-Webhook-Timestamp"]
+signature = request.headers["X-Cube-Webhook-Signature"]
+if abs(time.time() - int(timestamp)) > 300:
+    raise ValueError("stale webhook")
+expected = "sha256=" + hmac.new(
+    secret.encode(), timestamp.encode() + b"." + request.body, hashlib.sha256
+).hexdigest()
+if not hmac.compare_digest(expected, signature):
+    raise ValueError("invalid signature")
+```
+
+## Delivery behavior
+
+HTTP 408, 429, 5xx responses, timeouts, and connection errors are retried with
+exponential backoff and jitter. Other 4xx responses are treated as permanent
+failures. Each failed attempt and exhausted delivery is written to CubeAPI's
+logs without exposing the signing secret.
+
+The queue is held in memory. Pending events are lost when CubeAPI restarts, and
+events are dropped with a warning if the bounded queue fills. Lifecycle events
+currently cover successful operations handled by CubeAPI; internal state
+changes that bypass these handlers do not emit webhooks.
+
+During graceful shutdown CubeAPI waits up to 10 seconds for pending webhook
+deliveries, then continues shutting down and logs a warning.
+
+## Try the receiver and integrate alerting
+
+The dependency-free receiver under
+[`examples/webhook-receiver`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver) prints events
+and verifies signatures. It can be started with:
+
+```bash
+WEBHOOK_SECRET=development-secret python3 examples/webhook-receiver/receiver.py
+```
+
+Enterprise WeChat robots require a provider-specific message body, not the
+CubeSandbox event payload. Point CubeAPI at a small receiver such as the
+example, verify the signature, transform the event into the required
+`msgtype` payload, and POST it to the robot URL. This preserves the generic
+Webhook protocol and keeps provider credentials outside CubeAPI.

--- a/docs/zh/guide/webhooks.md
+++ b/docs/zh/guide/webhooks.md
@@ -1,0 +1,113 @@
+---
+title: Webhook 事件通知
+---
+
+# Webhook 事件通知
+
+CubeAPI 可在沙箱生命周期操作成功后，异步向 HTTP 端点发送事件通知。投递在 API
+请求主路径之外执行，因此接收端缓慢或不可达不会导致沙箱生命周期请求失败。
+
+## 配置端点
+
+启动 CubeAPI 前设置 `CUBE_API_WEBHOOK_ENDPOINTS`，其值为 JSON 数组：
+
+```bash
+export CUBE_API_WEBHOOK_ENDPOINTS='[
+  {
+    "name": "automation",
+    "url": "https://automation.example.com/cube-events",
+    "events": ["sandbox.created", "sandbox.deleted"],
+    "secret": "replace-with-a-random-secret",
+    "timeout_secs": 5,
+    "max_retries": 4
+  },
+  {
+    "name": "monitoring",
+    "url": "https://monitoring.example.com/events",
+    "events": ["*"]
+  }
+]'
+```
+
+`events` 支持准确事件名，或使用 `*` 订阅全部事件。`secret` 可选；
+`timeout_secs` 默认 5 秒；`max_retries` 默认在首次投递后再重试 4 次。端点名称必须唯一。
+
+全局控制项：
+
+| 环境变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `CUBE_API_WEBHOOK_QUEUE_CAPACITY` | `1024` | 等待投递的最大任务数 |
+| `CUBE_API_WEBHOOK_MAX_CONCURRENCY` | `16` | 同时进行的最大 HTTP 请求数 |
+
+端点 JSON、URL 或事件名无效时，CubeAPI 会拒绝启动。
+
+## 事件与 Payload
+
+| 事件 | 触发时机 | 附加字段 |
+| --- | --- | --- |
+| `sandbox.created` | 沙箱创建成功 | `template_id` |
+| `sandbox.deleted` | 沙箱删除成功 | 无 |
+| `sandbox.paused` | 沙箱暂停成功 | 无 |
+| `sandbox.resumed` | 沙箱恢复成功 | 无 |
+
+每个 Payload 至少包含 `id`、`event`、`timestamp` 和 `sandbox_id`：
+
+```json
+{
+  "id": "a79a9a61-7330-49cf-8108-c14347f4b94e",
+  "event": "sandbox.created",
+  "timestamp": "2026-07-31T10:30:00.123Z",
+  "sandbox_id": "sandbox-123",
+  "template_id": "template-456"
+}
+```
+
+由于失败重试可能重复投递同一个事件，接收端应使用 `id` 作为幂等键。
+
+## 验证签名
+
+端点配置 `secret` 后，CubeAPI 会发送以下 Header：
+
+```text
+X-Cube-Webhook-Id: <事件 UUID>
+X-Cube-Webhook-Timestamp: <Unix 时间戳>
+X-Cube-Webhook-Signature: sha256=<十六进制摘要>
+```
+
+待签名内容为 UTF-8 时间戳、一个英文句点以及原始请求体。验签前不要解析并重新序列化请求体。
+
+```python
+import hashlib, hmac, time
+
+timestamp = request.headers["X-Cube-Webhook-Timestamp"]
+signature = request.headers["X-Cube-Webhook-Signature"]
+if abs(time.time() - int(timestamp)) > 300:
+    raise ValueError("stale webhook")
+expected = "sha256=" + hmac.new(
+    secret.encode(), timestamp.encode() + b"." + request.body, hashlib.sha256
+).hexdigest()
+if not hmac.compare_digest(expected, signature):
+    raise ValueError("invalid signature")
+```
+
+## 投递与重试
+
+HTTP 408、429、5xx、请求超时和连接错误会按指数退避和抖动策略重试；其他
+4xx 响应被视为永久失败。CubeAPI 日志会记录每次失败和最终失败，但不会输出签名密钥。
+
+队列保存在内存中。CubeAPI 重启会丢失尚未投递的事件；有界队列满时会丢弃新任务并记录告警。
+当前仅覆盖由 CubeAPI Handler 成功处理的生命周期操作，绕过这些 Handler 的内部状态变化不会触发通知。
+优雅关闭期间，CubeAPI 最多等待 10 秒完成待投递任务；超时后会记录告警并继续关闭。
+
+## 本地示例与企业告警
+
+[`examples/webhook-receiver`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver) 提供不依赖第三方库的
+Python 接收端，能够打印事件并验证签名：
+
+```bash
+WEBHOOK_SECRET=development-secret python3 examples/webhook-receiver/receiver.py
+```
+
+企业微信机器人要求特定的消息体格式，不能直接接收 CubeSandbox Payload。可以让一个类似示例的
+中转服务先验签，再将事件转换成企业微信所需的 `msgtype` Payload，并转发到机器人 URL。这样既能
+保持 Webhook 协议通用，也能避免将第三方凭证存入 CubeAPI。

--- a/examples/webhook-receiver/README.md
+++ b/examples/webhook-receiver/README.md
@@ -1,0 +1,24 @@
+# Webhook receiver example
+
+This dependency-free Python server prints CubeSandbox lifecycle events and,
+when a secret is configured, verifies their HMAC-SHA256 signatures.
+
+## Run
+
+```bash
+cd examples/webhook-receiver
+WEBHOOK_SECRET=development-secret python3 receiver.py
+```
+
+Configure CubeAPI to call an address reachable from the CubeAPI process:
+
+```bash
+export CUBE_API_WEBHOOK_ENDPOINTS='[{"name":"local","url":"http://127.0.0.1:8080","events":["*"],"secret":"development-secret"}]'
+```
+
+Restart CubeAPI, then create, pause, resume, or delete a sandbox. The receiver
+prints each event as formatted JSON. If CubeAPI runs in a container or VM,
+replace `127.0.0.1` with the receiver host address that it can reach.
+
+For production configuration and protocol details, see
+[`docs/guide/webhooks.md`](../../docs/guide/webhooks.md).

--- a/examples/webhook-receiver/receiver.py
+++ b/examples/webhook-receiver/receiver.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Minimal CubeSandbox webhook receiver using only the Python standard library."""
+
+import hashlib
+import hmac
+import json
+import os
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+SECRET = os.environ.get("WEBHOOK_SECRET", "")
+MAX_TIMESTAMP_AGE_SECONDS = 300
+
+
+class WebhookHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        if SECRET and not self.verify_signature(body):
+            self.send_error(401, "invalid webhook signature")
+            return
+
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            self.send_error(400, "invalid JSON")
+            return
+
+        print(json.dumps(payload, indent=2, ensure_ascii=False), flush=True)
+        self.send_response(204)
+        self.end_headers()
+
+    def verify_signature(self, body):
+        timestamp = self.headers.get("X-Cube-Webhook-Timestamp", "")
+        signature = self.headers.get("X-Cube-Webhook-Signature", "")
+        try:
+            timestamp_value = int(timestamp)
+        except ValueError:
+            return False
+        if abs(time.time() - timestamp_value) > MAX_TIMESTAMP_AGE_SECONDS:
+            return False
+
+        signed_payload = timestamp.encode() + b"." + body
+        expected = "sha256=" + hmac.new(
+            SECRET.encode(), signed_payload, hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(expected, signature)
+
+    def log_message(self, format, *args):
+        print("receiver:", format % args, flush=True)
+
+
+if __name__ == "__main__":
+    address = os.environ.get("WEBHOOK_BIND", "0.0.0.0")
+    port = int(os.environ.get("WEBHOOK_PORT", "8080"))
+    print(f"Listening on http://{address}:{port}", flush=True)
+    ThreadingHTTPServer((address, port), WebhookHandler).serve_forever()


### PR DESCRIPTION
## Summary

Add asynchronous webhook notifications for CubeAPI sandbox lifecycle events.

When sandboxes are created, paused, resumed, or deleted successfully, CubeAPI can POST JSON callbacks to one or more configured HTTP endpoints without blocking the lifecycle API path.

Refs: #642

## Changes

### Core

- Implement the existing `logging/http` stub as an async webhook backend
- Reuse `LogEvent` + `MultiLogger` (no changes to sandbox handler business logic)
- Support multiple endpoints with per-endpoint event subscription (`*` or exact names)
- Bounded in-memory queue + concurrency limit (non-blocking `try_send`)
- Optional HMAC-SHA256 signing with timestamp (`X-Cube-Webhook-*` headers)
- Exponential backoff retries for timeouts / 408 / 429 / 5xx
- Fail-fast validation for invalid webhook config

### Docs / examples / deploy

- `examples/webhook-receiver/` — zero-dependency Python receiver + README
- `docs/guide/webhooks.md` and `docs/zh/guide/webhooks.md`
- VitePress nav entries
- One-click deploy env passthrough for webhook variables

## Features (vs #642)

1. Configure endpoints via `CUBE_API_WEBHOOK_ENDPOINTS` (JSON array)
2. Events: `sandbox.created` / `sandbox.deleted` / `sandbox.paused` / `sandbox.resumed`
3. Async JSON POST with `event`, `timestamp`, `sandbox_id`, and `template_id` when available
4. Delivery does not block create/delete/pause/resume
5. Optional HMAC-SHA256 signing
6. Retry + error logging
7. Runnable receiver under `examples/webhook-receiver/`
8. Integration docs (config, payload, signature, WeCom adapter note)
9. Unit/integration tests with mock HTTP server

## Configuration

```bash
export CUBE_API_WEBHOOK_ENDPOINTS='[
  {
    "name": "local",
    "url": "http://localhost:9000/webhook",
    "events": ["*"],
    "secret": "development-secret",
    "timeout_secs": 5,
    "max_retries": 4
  }
]'
export CUBE_API_WEBHOOK_QUEUE_CAPACITY=1024
export CUBE_API_WEBHOOK_MAX_CONCURRENCY=16
```
## Validation

```bash
cd CubeAPI
cargo +stable fmt -- --check
cargo +stable test          # 106 passed (includes webhook tests)
cargo +stable clippy --all-targets
# only pre-existing repository warnings remain

cd docs && npm run docs:build
python3 -m py_compile examples/webhook-receiver/receiver.py
bash -n deploy/one-click/scripts/one-click/up.sh
git diff --check
```
Webhook-focused tests cover:
- subscribed delivery + payload fields + signature
- event filtering
- retry with stable event body/id
- non-blocking enqueue under slow receiver
- failing endpoint does not block a healthy endpoint
- config validation (empty secret, zero queue/concurrency, bad URL/events)