### PR TITLE
docs: add Tigris volume plugin example and integration guide

### DIFF
--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -50,3 +50,4 @@ lang: en-US
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
 | [Claude Code Integration Guide](./claude-code.md) | shsaihdsaiudh | 2026-07-06 | integration, claude-code, coding-agent |
 | [LangChain Integration Guide](./langchain.md) | peerless-hero | 2026-07-07 | integration, langchain, agent |
+| [Tigris Volume Integration Guide](./tigris.md) | davidmyriel | 2026-07-31 | integration, tigris, volume, storage, s3 |

--- a/docs/guide/integrations/tigris.md
+++ b/docs/guide/integrations/tigris.md
@@ -1,0 +1,125 @@
+---
+title: Tigris Volume Integration Guide
+author: davidmyriel
+date: 2026-07-31
+tags:
+  - integration
+  - tigris
+  - volume
+  - storage
+  - s3
+lang: en-US
+---
+
+# Tigris Volume Integration Guide
+
+[Tigris](https://www.tigrisdata.com/) is S3-compatible object storage with a single global endpoint. This guide wires it into CubeSandbox through the generic [S3 Volume Plugin](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/volume/s3), so sandboxes get persistent storage that survives sandbox teardown and is shared across nodes.
+
+The plugin itself is vendor-neutral — **s3fs** for the mount, the **AWS CLI** for the control plane. This guide covers the Tigris-specific parts: account, bucket, access keys, and the two config values that point the plugin at Tigris.
+
+## Integration Target and Version
+
+| Item | Version |
+|------|---------|
+| Cube platform | **≥ 0.6.0** (CubeMaster, CubeAPI, Cubelet) — the Volume framework landed in v0.6.0 |
+| Python SDK `cubesandbox` | **≥ 0.6.0** |
+| S3 Volume Plugin | [`examples/volume/s3`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/volume/s3) |
+| s3fs (`s3fs-fuse`) | ≥ 1.90, `amd64` and `arm64` |
+| Tigris | S3 API, endpoint `https://t3.storage.dev` |
+
+## Prerequisites
+
+- A running CubeSandbox deployment with CubeMaster, Cubelet, and CubeAPI (usually `http://<node>:3000`), plus a sandbox template ID.
+- The S3 Volume Plugin installed and registered under driver name `s3` — follow §§1–5 of the [plugin walkthrough](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/volume/s3) once; everything there is provider-independent.
+- A [Tigris bucket](https://www.tigrisdata.com/docs/buckets/create-bucket/) and an [access key pair](https://www.tigrisdata.com/docs/iam/create-access-key/) with Editor permission on it. Key IDs start with `tid_`, secrets with `tsec_`.
+
+::: tip Works on ARM64
+The COS backend cannot run on ARM64 — upstream cosfs ships `amd64` packages only, so [`docker-install-volume-deps.sh`](https://github.com/TencentCloud/CubeSandbox/blob/master/deploy/scripts/docker-install-volume-deps.sh) skips it on `arm64`. The S3 plugin uses s3fs, which is packaged for `arm64` by both Debian/Ubuntu and EPEL, so this integration runs on ARM64 hosts unchanged.
+:::
+
+## Integration Steps
+
+### 1. Create the Tigris bucket and access keys
+
+In the [Tigris dashboard](https://console.tigris.dev/), create a bucket (avoid dots in the name — s3fs's virtual-hosted addressing breaks TLS for dotted names) and an access key pair with Editor permission scoped to that bucket.
+
+### 2. Point the plugin at Tigris
+
+Edit `volume-s3.conf` on the CubeMaster and Cubelet nodes:
+
+```ini
+# volume-s3.conf — root-owned, chmod 600 (holds a secret in plaintext)
+ACCESS_KEY_ID=tid_xxx
+SECRET_ACCESS_KEY=tsec_xxx
+BUCKET=my-cube-volumes
+ENDPOINT=https://t3.storage.dev
+REGION=auto
+```
+
+That's the entire Tigris-specific configuration. Tigris serves one global endpoint and routes to the nearest region itself, so there is no per-region endpoint to pick; `REGION=auto` is only used for SigV4 signing.
+
+### 3. Verify connectivity from CubeMaster
+
+```bash
+AWS_ACCESS_KEY_ID=tid_xxx AWS_SECRET_ACCESS_KEY=tsec_xxx AWS_REGION=auto \
+  aws s3 ls s3://my-cube-volumes/ --endpoint-url https://t3.storage.dev
+```
+
+An empty listing (exit 0) is success. `InvalidAccessKeyId` or `AccessDenied` means the key pair lacks Editor permission on the bucket.
+
+### 4. Restart and confirm registration
+
+```bash
+sudo systemctl restart cube-sandbox-cubemaster cube-sandbox-cubelet cube-sandbox-cube-api
+grep -aF '[volume] registered' /data/log/CubeMaster/cubemaster-req.log | tail -3
+```
+
+## Key Code Snippets
+
+Full lifecycle with the Python SDK:
+
+```python
+from cubesandbox import Sandbox, Volume
+
+vol = Volume.create("my-data", driver="s3")
+
+with Sandbox.create(volume_mounts={"/workspace": vol}) as sb:
+    sb.files.write("/workspace/hello.txt", "from Tigris volume")
+    print(sb.files.read("/workspace/hello.txt"))
+
+# Sandbox is gone; the object still lives in Tigris.
+Volume.destroy(vol.volume_id)
+```
+
+One volume mounted by several sandboxes at once — Cubelet reference-counts per node, so only the first attach mounts:
+
+```python
+vol = Volume.create("shared-models", driver="s3")
+
+sb1 = Sandbox.create(volume_mounts={"/models": vol})
+sb2 = Sandbox.create(volume_mounts={"/models": vol})   # reuses the same s3fs mount
+```
+
+Verify what actually landed in the bucket:
+
+```bash
+aws s3 ls "s3://my-cube-volumes/volumes/" --recursive --endpoint-url https://t3.storage.dev
+```
+
+## Caveats
+
+- **Credentials stay outside the sandbox.** They live in a root-owned, mode-`600` config on CubeMaster and Cubelet; the microVM only ever sees a mounted filesystem. Do not pass them into templates.
+- **Object storage is not a POSIX filesystem.** s3fs emulates one. Random writes rewrite the whole object, `rename` is a copy-then-delete, and there is no locking between nodes. Fine for workspaces, datasets, model weights, and outputs — not for a database file or a build cache with concurrent writers on multiple nodes.
+- **RefCount is per node.** Two sandboxes on the same node share one s3fs mount; the same volume on a second node mounts separately.
+- **Destroy is irreversible** and deletes the whole `volumes/<id>/` prefix. The API's refcount guard (`DELETE /volumes` returns 409 while any sandbox holds the volume) is what prevents deleting a mounted volume; the realistic hazard is a stale refcount after a node crash, where the cluster-wide count can reach 0 while a node still holds the mount.
+- **The official e2b Python SDK will not work** against CubeSandbox — it is hardcoded to the e2b.cloud backend. Use `cubesandbox`, or call the e2b-compatible `/volumes` REST endpoints directly.
+
+## References
+
+- S3 Volume Plugin (the generic plugin this guide configures): [`examples/volume/s3`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/volume/s3)
+- Volume Plugin framework: [`docs/guide/volume-plugin.md`](../volume-plugin.md)
+- Host mount alternative for node-local paths: [`docs/guide/persistent-storage.md`](../persistent-storage.md)
+- Tigris: <https://www.tigrisdata.com/>
+- Tigris documentation: <https://www.tigrisdata.com/docs/>
+- Tigris S3 compatibility and AWS CLI setup: <https://www.tigrisdata.com/docs/sdks/s3/aws-cli/>
+- s3fs-fuse: <https://github.com/s3fs-fuse/s3fs-fuse>

--- a/docs/guide/integrations/tigris.md
+++ b/docs/guide/integrations/tigris.md
@@ -108,6 +108,7 @@ aws s3 ls "s3://my-cube-volumes/volumes/" --recursive --endpoint-url https://t3.
 
 ## Caveats
 
+- **Keep the default virtual-hosted addressing.** Do **not** set `S3FS_EXTRA_OPTS=-ouse_path_request_style` for Tigris: [buckets created after 2025-02-19 support virtual-hosted-style URLs only](https://www.tigrisdata.com/blog/virtual-hosted-urls/), which is s3fs's default. (This is the opposite of MinIO, which usually needs path-style.)
 - **Credentials stay outside the sandbox.** They live in a root-owned, mode-`600` config on CubeMaster and Cubelet; the microVM only ever sees a mounted filesystem. Do not pass them into templates.
 - **Object storage is not a POSIX filesystem.** s3fs emulates one. Random writes rewrite the whole object, `rename` is a copy-then-delete, and there is no locking between nodes. Fine for workspaces, datasets, model weights, and outputs — not for a database file or a build cache with concurrent writers on multiple nodes.
 - **RefCount is per node.** Two sandboxes on the same node share one s3fs mount; the same volume on a second node mounts separately.

--- a/docs/guide/volume-plugin.md
+++ b/docs/guide/volume-plugin.md
@@ -587,8 +587,9 @@ The repo ships a **Tencent Cloud COS** reference plugin (binary Shell + rpc Go) 
 | [`examples/volume/cos/binary/README.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/binary/README.md) | binary plugin script details |
 | [`examples/volume/cos/rpc/README.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/rpc/README.md) | rpc plugin build and deploy |
 | [`examples/volume/cos/verify_volume.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/verify_volume.py) | Python SDK verification script |
+| [`examples/volume/s3/README.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.md) | Generic S3-compatible walkthrough (s3fs + AWS CLI; AWS S3, Tigris, MinIO, R2; runs on `arm64`) |
 
-COS-specific Hook behavior, object layout, trade-offs, and troubleshooting live in those example docs — not duplicated here.
+Backend-specific Hook behavior, object layout, trade-offs, and troubleshooting live in those example docs — not duplicated here.
 
 ---
 

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -50,3 +50,4 @@ lang: zh-CN
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
 | [Claude Code 集成指南](./claude-code.md) | shsaihdsaiudh | 2026-07-06 | integration, claude-code, coding-agent |
 | [LangChain 集成指南](./langchain.md) | peerless-hero | 2026-07-07 | integration, langchain, agent |
+| [Tigris Volume 集成指南](./tigris.md) | davidmyriel | 2026-07-31 | integration, tigris, volume, storage, s3 |

--- a/docs/zh/guide/integrations/tigris.md
+++ b/docs/zh/guide/integrations/tigris.md
@@ -108,6 +108,7 @@ aws s3 ls "s3://my-cube-volumes/volumes/" --recursive --endpoint-url https://t3.
 
 ## 注意事项
 
+- **保持默认的 virtual-hosted 寻址方式。** 对 Tigris **不要**设置 `S3FS_EXTRA_OPTS=-ouse_path_request_style`：[2025-02-19 之后创建的存储桶仅支持 virtual-hosted 风格 URL](https://www.tigrisdata.com/blog/virtual-hosted-urls/)，而这正是 s3fs 的默认行为。（这与通常需要 path-style 的 MinIO 恰好相反。）
 - **凭证不会进入沙箱。** 凭证保存在 CubeMaster 与 Cubelet 上 root 所有、权限 `600` 的配置文件中，microVM 只看到一个已挂载的文件系统。请勿将其传入模板。
 - **对象存储不是 POSIX 文件系统。** s3fs 只是模拟：随机写会重写整个对象，`rename` 实际是「复制再删除」，且跨节点没有文件锁。用于工作区、数据集、模型权重和产物输出没有问题，但不适合数据库文件，也不适合多节点并发写入的构建缓存。
 - **RefCount 是按节点统计的。** 同一节点上的两个沙箱共用一个 s3fs 挂载；同一 Volume 在第二个节点上会独立挂载。

--- a/docs/zh/guide/integrations/tigris.md
+++ b/docs/zh/guide/integrations/tigris.md
@@ -1,0 +1,125 @@
+---
+title: Tigris Volume 集成指南
+author: davidmyriel
+date: 2026-07-31
+tags:
+  - integration
+  - tigris
+  - volume
+  - storage
+  - s3
+lang: zh-CN
+---
+
+# Tigris Volume 集成指南
+
+[Tigris](https://www.tigrisdata.com/) 是兼容 S3 协议的对象存储，只对外提供一个全局 Endpoint。本文通过通用的 [S3 Volume 插件](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/volume/s3)将其接入 CubeSandbox，让沙箱获得可跨节点共享、且在沙箱销毁后依然保留的持久化存储。
+
+插件本身与厂商无关 —— 挂载使用 **s3fs**，控制面使用 **AWS CLI**。本文只覆盖 Tigris 特有的部分：账号、存储桶、访问密钥，以及把插件指向 Tigris 的两个配置项。
+
+## 集成对象与版本
+
+| 项目 | 版本 |
+|------|------|
+| Cube 平台 | **≥ 0.6.0**（CubeMaster、CubeAPI、Cubelet）—— Volume 框架自 v0.6.0 引入 |
+| Python SDK `cubesandbox` | **≥ 0.6.0** |
+| S3 Volume 插件 | [`examples/volume/s3`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/volume/s3) |
+| s3fs（`s3fs-fuse`） | ≥ 1.90，支持 `amd64` 与 `arm64` |
+| Tigris | S3 API，Endpoint 为 `https://t3.storage.dev` |
+
+## 前置条件
+
+- 一套运行中的 CubeSandbox 部署，包含 CubeMaster、Cubelet、CubeAPI（通常为 `http://<node>:3000`），以及一个沙箱模板 ID。
+- 已按照 [S3 插件完整指引](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/volume/s3)的 §1–§5 安装插件并以 driver 名 `s3` 完成注册 —— 那部分步骤与存储提供方无关，只需执行一次。
+- 一个 [Tigris 存储桶](https://www.tigrisdata.com/docs/buckets/create-bucket/)，以及对该桶具备 Editor 权限的[访问密钥对](https://www.tigrisdata.com/docs/iam/create-access-key/)。密钥 ID 以 `tid_` 开头，密钥以 `tsec_` 开头。
+
+::: tip 支持 ARM64
+COS 后端无法在 ARM64 上运行 —— 上游 cosfs 仅提供 `amd64` 包，因此 [`docker-install-volume-deps.sh`](https://github.com/TencentCloud/CubeSandbox/blob/master/deploy/scripts/docker-install-volume-deps.sh) 在 `arm64` 上会直接跳过。S3 插件使用 s3fs，Debian/Ubuntu 与 EPEL 均为 `arm64` 提供了软件包，本集成可在 ARM64 主机上直接运行。
+:::
+
+## 集成步骤
+
+### 1. 创建 Tigris 存储桶与访问密钥
+
+在 [Tigris 控制台](https://console.tigris.dev/)中创建存储桶（桶名请勿包含点号 —— s3fs 的 virtual-hosted 寻址方式会导致带点号的桶名 TLS 校验失败），并创建对该桶具备 Editor 权限的访问密钥对。
+
+### 2. 把插件指向 Tigris
+
+在 CubeMaster 与 Cubelet 节点上编辑 `volume-s3.conf`：
+
+```ini
+# volume-s3.conf —— root 所有、chmod 600（以明文保存密钥）
+ACCESS_KEY_ID=tid_xxx
+SECRET_ACCESS_KEY=tsec_xxx
+BUCKET=my-cube-volumes
+ENDPOINT=https://t3.storage.dev
+REGION=auto
+```
+
+这就是 Tigris 特有配置的全部内容。Tigris 只提供一个全局 Endpoint 并在内部路由到最近地域，因此不需要选择地域 Endpoint；`REGION=auto` 仅用于 SigV4 签名。
+
+### 3. 在 CubeMaster 上验证连通性
+
+```bash
+AWS_ACCESS_KEY_ID=tid_xxx AWS_SECRET_ACCESS_KEY=tsec_xxx AWS_REGION=auto \
+  aws s3 ls s3://my-cube-volumes/ --endpoint-url https://t3.storage.dev
+```
+
+返回空列表（退出码 0）即为成功。出现 `InvalidAccessKeyId` 或 `AccessDenied` 说明密钥对缺少该桶的 Editor 权限。
+
+### 4. 重启并确认注册成功
+
+```bash
+sudo systemctl restart cube-sandbox-cubemaster cube-sandbox-cubelet cube-sandbox-cube-api
+grep -aF '[volume] registered' /data/log/CubeMaster/cubemaster-req.log | tail -3
+```
+
+## 关键代码片段
+
+使用 Python SDK 跑通完整生命周期：
+
+```python
+from cubesandbox import Sandbox, Volume
+
+vol = Volume.create("my-data", driver="s3")
+
+with Sandbox.create(volume_mounts={"/workspace": vol}) as sb:
+    sb.files.write("/workspace/hello.txt", "from Tigris volume")
+    print(sb.files.read("/workspace/hello.txt"))
+
+# 沙箱已销毁，对象仍保留在 Tigris 中
+Volume.destroy(vol.volume_id)
+```
+
+同一个 Volume 被多个沙箱同时挂载 —— Cubelet 按节点维护引用计数，只有第一次 attach 会真正挂载：
+
+```python
+vol = Volume.create("shared-models", driver="s3")
+
+sb1 = Sandbox.create(volume_mounts={"/models": vol})
+sb2 = Sandbox.create(volume_mounts={"/models": vol})   # 复用同一个 s3fs 挂载
+```
+
+确认对象已写入存储桶：
+
+```bash
+aws s3 ls "s3://my-cube-volumes/volumes/" --recursive --endpoint-url https://t3.storage.dev
+```
+
+## 注意事项
+
+- **凭证不会进入沙箱。** 凭证保存在 CubeMaster 与 Cubelet 上 root 所有、权限 `600` 的配置文件中，microVM 只看到一个已挂载的文件系统。请勿将其传入模板。
+- **对象存储不是 POSIX 文件系统。** s3fs 只是模拟：随机写会重写整个对象，`rename` 实际是「复制再删除」，且跨节点没有文件锁。用于工作区、数据集、模型权重和产物输出没有问题，但不适合数据库文件，也不适合多节点并发写入的构建缓存。
+- **RefCount 是按节点统计的。** 同一节点上的两个沙箱共用一个 s3fs 挂载；同一 Volume 在第二个节点上会独立挂载。
+- **Destroy 不可恢复**，会删除整个 `volumes/<id>/` 前缀。API 的引用计数保护（有沙箱持有 Volume 时 `DELETE /volumes` 返回 409）是防止删除已挂载 Volume 的机制 —— 真正的风险点是节点崩溃后引用计数失真：集群级计数可能归零而某节点仍持有挂载。
+- **官方 e2b Python SDK 无法用于 CubeSandbox** —— 它硬编码指向 e2b.cloud 后端。请使用 `cubesandbox`，或直接调用兼容 e2b 协议的 `/volumes` REST 接口。
+
+## 参考资料
+
+- S3 Volume 插件（本文所配置的通用插件）：[`examples/volume/s3`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/volume/s3)
+- Volume 插件开发框架：[`docs/zh/guide/volume-plugin.md`](../volume-plugin.md)
+- 节点本地路径的 Host Mount 方案：[`docs/zh/guide/persistent-storage.md`](../persistent-storage.md)
+- Tigris 官网：<https://www.tigrisdata.com/>
+- Tigris 文档：<https://www.tigrisdata.com/docs/>
+- Tigris S3 兼容性与 AWS CLI 配置：<https://www.tigrisdata.com/docs/sdks/s3/aws-cli/>
+- s3fs-fuse：<https://github.com/s3fs-fuse/s3fs-fuse>

--- a/docs/zh/guide/volume-plugin.md
+++ b/docs/zh/guide/volume-plugin.md
@@ -585,8 +585,9 @@ rpc 插件实现 [`volumeplugin.proto`](https://github.com/TencentCloud/CubeSand
 | [`examples/volume/cos/binary/README.zh.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/binary/README.zh.md) | binary 插件脚本细节 |
 | [`examples/volume/cos/rpc/README.zh.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/rpc/README.zh.md) | rpc 插件构建与部署 |
 | [`examples/volume/cos/verify_volume.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/verify_volume.py) | Python SDK 验证脚本 |
+| [`examples/volume/s3/README.zh.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.zh.md) | 通用 S3 兼容后端完整体验（s3fs + AWS CLI；AWS S3、Tigris、MinIO、R2；支持 `arm64`） |
 
-COS 专属的 Hook 行为、对象布局、实现取舍与排障说明均在上述 example 文档中，本文不再重复。
+各后端专属的 Hook 行为、对象布局、实现取舍与排障说明均在上述 example 文档中，本文不再重复。
 
 ---
 

--- a/examples/volume/cos/verify_volume.py
+++ b/examples/volume/cos/verify_volume.py
@@ -31,7 +31,9 @@
 #       4) sandbox      -> inspect mount + read/write (CLI + SDK)
 #       5) destroy()    -> delete volume
 #       6) list()       -> assert entry is gone
-#     Drivers not deployed here (cfs / s3 / nfs) are skipped when listed.
+#     Drivers not deployed here (cfs / s3 / nfs by default) are skipped when
+#     listed; override the skip list with CUBE_VOLUME_SKIP_DRIVERS (empty
+#     string = skip nothing, e.g. when examples/volume/s3 is deployed).
 #
 #   Block 2 — Multi-sandbox data-plane scenarios (one working driver):
 #     B   one volume, two sandboxes  -> both inspect mount; A writes, B reads
@@ -222,8 +224,14 @@ def create_sandbox(template_id: str, volume_mounts=None, **kwargs):
     return Sandbox.create(template=template_id, **kwargs)
 
 # Drivers not deployed in the default COS demo environment; skip if listed in
-# CUBE_VOLUME_DRIVERS instead of failing block 1.
-SKIPPED_DRIVERS = frozenset({"cfs", "s3", "nfs"})
+# CUBE_VOLUME_DRIVERS instead of failing block 1. Environments that do deploy
+# one of these names (e.g. the generic examples/volume/s3 plugin as "s3")
+# override the list via CUBE_VOLUME_SKIP_DRIVERS; an empty string skips nothing.
+SKIPPED_DRIVERS = frozenset(
+    d.strip()
+    for d in os.environ.get("CUBE_VOLUME_SKIP_DRIVERS", "cfs,s3,nfs").split(",")
+    if d.strip()
+)
 
 PASS = 0
 FAIL = 0

--- a/examples/volume/s3/README.md
+++ b/examples/volume/s3/README.md
@@ -2,7 +2,7 @@
 
 Use any S3-compatible object storage as persistent storage for CubeSandbox volumes: create a Volume → mount it in a sandbox → read/write → unmount → delete.
 
-The plugin is built entirely on standard tooling — **s3fs** for the mount and the **AWS CLI** for the control plane. Nothing in it is vendor-specific: the storage provider is just the `ENDPOINT` URL in the config file. Tested endpoints include AWS S3, [Tigris](https://www.tigrisdata.com/), MinIO, and Cloudflare R2.
+The plugin is built entirely on standard tooling — **s3fs** for the mount and the **AWS CLI** for the control plane. Nothing in it is vendor-specific: the storage provider is just the `ENDPOINT` URL in the config file, so it targets any S3-compatible endpoint — AWS S3, [Tigris](https://www.tigrisdata.com/), MinIO, Cloudflare R2, and the like.
 
 > **Version requirement:** Cube platform **≥ 0.6.0**, Python SDK **`cubesandbox` ≥ 0.6.0**.
 > Protocol and Hook details: [Volume Plugin framework](../../../docs/guide/volume-plugin.md).
@@ -312,6 +312,9 @@ export CUBE_API_URL=http://127.0.0.1:3000
 export CUBE_TEMPLATE_ID=tpl-xxxx
 export CUBE_PROXY_NODE_IP=127.0.0.1
 export CUBE_VOLUME_DRIVERS=s3
+# The script skips driver names cfs/s3/nfs by default (undeployed in the COS
+# demo environment); clear the skip list since s3 IS deployed here:
+export CUBE_VOLUME_SKIP_DRIVERS=
 
 python3 verify_volume.py
 ```

--- a/examples/volume/s3/README.md
+++ b/examples/volume/s3/README.md
@@ -145,6 +145,7 @@ Then edit `volume-s3.conf` on each node:
 | `BUCKET` | Bucket holding all volumes | yes |
 | `ENDPOINT` | S3-compatible endpoint URL (see [Choosing an endpoint](#choosing-an-endpoint)) | yes |
 | `REGION` | SigV4 signing region; default `us-east-1` | no |
+| `S3FS_EXTRA_OPTS` | Extra s3fs mount options, whitespace-separated (e.g. `-ouse_path_request_style` for MinIO) | no |
 
 The config must be root-owned and mode `600` — it holds a secret in plaintext and is `source`d by the plugin:
 
@@ -325,7 +326,7 @@ python3 verify_volume.py
 | `no plugin registered for driver "s3"` | Cubelet missing the same-name plugin, or not restarted |
 | Attach fails, `s3fs mount failed` | `ls /dev/fuse`; credentials and `ENDPOINT` in `volume-s3.conf`; run the manual attach in [§5](#5-restart-services-and-verify) to see the s3fs error |
 | `InvalidAccessKeyId` / `SignatureDoesNotMatch` | Key pair wrong, lacks bucket permission, or `REGION` doesn't match what the endpoint expects for SigV4 |
-| Bucket name contains dots | s3fs uses virtual-hosted-style addressing by default, which breaks TLS for dotted names. Use a bucket without dots, or add `-ouse_path_request_style` to the mount options (MinIO usually needs it too) |
+| Bucket name contains dots | s3fs uses virtual-hosted-style addressing by default, which breaks TLS for dotted names. Use a bucket without dots, or set `S3FS_EXTRA_OPTS=-ouse_path_request_style` in `volume-s3.conf` (MinIO usually needs it too) |
 | SDK write fails | `CUBE_PROXY_NODE_IP` unset; CubeAPI or template not READY |
 | `Volume.create` without driver not using s3 | The **first** entry in `volume_plugins` is the default driver |
 

--- a/examples/volume/s3/README.md
+++ b/examples/volume/s3/README.md
@@ -1,0 +1,380 @@
+# S3-Compatible Volume Plugin — Walkthrough
+
+Use any S3-compatible object storage as persistent storage for CubeSandbox volumes: create a Volume → mount it in a sandbox → read/write → unmount → delete.
+
+The plugin is built entirely on standard tooling — **s3fs** for the mount and the **AWS CLI** for the control plane. Nothing in it is vendor-specific: the storage provider is just the `ENDPOINT` URL in the config file. Tested endpoints include AWS S3, [Tigris](https://www.tigrisdata.com/), MinIO, and Cloudflare R2.
+
+> **Version requirement:** Cube platform **≥ 0.6.0**, Python SDK **`cubesandbox` ≥ 0.6.0**.
+> Protocol and Hook details: [Volume Plugin framework](../../../docs/guide/volume-plugin.md).
+
+中文文档：[README.zh.md](README.zh.md)
+
+---
+
+## Why this plugin exists
+
+| | COS plugin | S3 plugin |
+|---|---|---|
+| Backend | Tencent Cloud COS | any S3-compatible endpoint |
+| Mount driver | cosfs (`amd64` only) | s3fs (`amd64` **and** `arm64`) |
+| Install | manual `.rpm`/`.deb` download | `apt install s3fs` / `yum install s3fs-fuse` |
+| Control plane | coscmd | AWS CLI v2 |
+
+Two gaps this closes. First, if you self-host CubeSandbox outside Tencent Cloud, the COS example requires a Tencent Cloud account — this plugin works with whatever S3-compatible storage you already have. Second, **ARM64 clusters have no working Volume backend via cosfs**: [`deploy/scripts/docker-install-volume-deps.sh`](../../../deploy/scripts/docker-install-volume-deps.sh) skips cosfs on `arm64` because upstream ships no ARM package, while s3fs is packaged for `arm64` by both Debian/Ubuntu and EPEL.
+
+---
+
+## Choosing an endpoint
+
+Everything below is identical regardless of provider — only `volume-s3.conf` changes:
+
+| Provider | `ENDPOINT` | `REGION` |
+|----------|-----------|----------|
+| AWS S3 | `https://s3.<region>.amazonaws.com` | the bucket's region |
+| Tigris | `https://t3.storage.dev` | `auto` |
+| Cloudflare R2 | `https://<account-id>.r2.cloudflarestorage.com` | `auto` |
+| MinIO | `http://<minio-host>:9000` | any value |
+
+For an end-to-end vendor walkthrough (account, bucket, and access-key setup included), see the [Tigris integration guide](../../../docs/guide/integrations/tigris.md).
+
+---
+
+## Prerequisites
+
+| Item | Description |
+|------|-------------|
+| Running Cube cluster | At least **CubeMaster**, **Cubelet**, **CubeAPI** (port usually `3000`) |
+| Sandbox template | A `templateID` (see [§7](#7-verify-with-the-sdk)) |
+| S3-compatible storage | A bucket, and an access key pair with read/write permission on it |
+| Local access | `sudo` on CubeMaster / Cubelet hosts to install software, edit config, restart services |
+
+**Single-machine dev:** CubeMaster and Cubelet on one host — install deps once.
+**Multi-node:** see the table in [§1](#1-install-dependencies).
+
+---
+
+## 1. Install dependencies
+
+### Which machine?
+
+| Tool | Install on | Purpose (Hook) |
+|------|------------|----------------|
+| **[s3fs](https://github.com/s3fs-fuse/s3fs-fuse)** | **Cubelet** | attach / detach (FUSE mount) |
+| **AWS CLI v2** | **CubeMaster** | create / destroy (volume prefix) |
+| **jq** | **CubeMaster** and **Cubelet** | binary plugin stdout JSON |
+
+### Option A: install script
+
+**Cubelet node:**
+
+```bash
+sudo ./install-deps.sh --s3fs --jq
+```
+
+**CubeMaster node:**
+
+```bash
+sudo ./install-deps.sh --aws --jq
+```
+
+**Single machine** (both roles on one host):
+
+```bash
+sudo ./install-deps.sh --all
+```
+
+Check without installing: add `--check-only`.
+
+### Option B: manual install
+
+```bash
+# Cubelet — Debian/Ubuntu
+sudo apt-get install -y s3fs jq
+# Cubelet — RHEL/CentOS (needs EPEL)
+sudo yum install -y epel-release && sudo yum install -y s3fs-fuse jq
+
+# CubeMaster — AWS CLI v2 (use aarch64 on ARM64 hosts)
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+unzip -q awscliv2.zip && sudo ./aws/install
+```
+
+### Verify install
+
+**Cubelet — s3fs**
+
+```bash
+ls /dev/fuse && echo "FUSE ok"
+s3fs --version | head -1
+```
+
+Both must succeed; a missing `/dev/fuse` breaks attach.
+
+**CubeMaster — AWS CLI, against your bucket**
+
+```bash
+AWS_ACCESS_KEY_ID=xxx AWS_SECRET_ACCESS_KEY=xxx AWS_REGION=<region> \
+  aws s3 ls s3://my-cube-volumes/ --endpoint-url <your-endpoint>
+```
+
+An empty listing (exit 0) is success. `InvalidAccessKeyId` or `AccessDenied` means the key pair lacks read/write permission on the bucket.
+
+---
+
+## 2. Install plugin and credentials
+
+Copy the plugin into both `plugin/` directories:
+
+```bash
+PREFIX=/usr/local/services/cubetoolbox
+sudo install -m 0755 binary/cube-volume-s3.sh \
+  "$PREFIX/CubeMaster/plugin/cube-volume-s3"
+sudo install -m 0755 binary/cube-volume-s3.sh \
+  "$PREFIX/Cubelet/plugin/cube-volume-s3"
+sudo install -m 0600 volume-s3.conf.example \
+  "$PREFIX/CubeMaster/plugin/volume-s3.conf"
+sudo install -m 0600 volume-s3.conf.example \
+  "$PREFIX/Cubelet/plugin/volume-s3.conf"
+```
+
+Then edit `volume-s3.conf` on each node:
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| `ACCESS_KEY_ID` | Access key ID | yes |
+| `SECRET_ACCESS_KEY` | Secret access key | yes |
+| `BUCKET` | Bucket holding all volumes | yes |
+| `ENDPOINT` | S3-compatible endpoint URL (see [Choosing an endpoint](#choosing-an-endpoint)) | yes |
+| `REGION` | SigV4 signing region; default `us-east-1` | no |
+
+The config must be root-owned and mode `600` — it holds a secret in plaintext and is `source`d by the plugin:
+
+```bash
+sudo chown root:root "$PREFIX/CubeMaster/plugin/volume-s3.conf" "$PREFIX/Cubelet/plugin/volume-s3.conf"
+sudo chmod 600 "$PREFIX/CubeMaster/plugin/volume-s3.conf" "$PREFIX/Cubelet/plugin/volume-s3.conf"
+```
+
+Mount base is **not** set here — Cubelet passes it on attach (default `/data/cube-shared/volume`; see [§4](#4-configure-cubelet)).
+
+---
+
+## 3. Configure CubeMaster
+
+Edit CubeMaster config (common path: `/usr/local/services/cubetoolbox/CubeMaster/conf.yaml`). Add the **Controller** plugin (Create / Destroy):
+
+```yaml
+volume_plugins:
+  - name: s3
+    type: binary
+    binary_path: /usr/local/services/cubetoolbox/CubeMaster/plugin/cube-volume-s3
+```
+
+`name: s3` is the API/SDK **`driver`**. When `Volume.create("x")` omits the driver, the **first** entry in the list is used.
+
+---
+
+## 4. Configure Cubelet
+
+Edit Cubelet config (common path: `/usr/local/services/cubetoolbox/Cubelet/config/config.toml`).
+
+Confirm the mount parent (optional; default shown):
+
+```toml
+[plugins."io.cubelet.internal.v1.storage"]
+  volume_plugin_base_dir = "/data/cube-shared/volume"
+```
+
+Add the **Node** plugin (Attach / Detach):
+
+```toml
+[[plugins."io.cubelet.internal.v1.storage".volume_plugins]]
+  name        = "s3"
+  type        = "binary"
+  binary_path = "/usr/local/services/cubetoolbox/Cubelet/plugin/cube-volume-s3"
+```
+
+**`name` must match CubeMaster** (both `s3` here). The plugin returns `host_path` as `<volume_plugin_base_dir>/s3-<volumeID>`, which satisfies the framework's requirement that `host_path` live inside `volumeBaseDir`.
+
+---
+
+## 5. Restart services and verify
+
+```bash
+sudo systemctl restart cube-sandbox-cubemaster
+sudo systemctl restart cube-sandbox-cubelet
+sudo systemctl restart cube-sandbox-cube-api
+
+sleep 5
+systemctl is-active cube-sandbox-cubemaster cube-sandbox-cubelet cube-sandbox-cube-api
+```
+
+**Verify plugins loaded:**
+
+```bash
+grep -aF '[volume] registered' /data/log/CubeMaster/cubemaster-req.log | tail -5
+grep -aF '[plugin_volume] initialized' /data/log/Cubelet/Cubelet-req.log | tail -5
+```
+
+Expected:
+
+```text
+[volume] registered binary plugin "s3" at /usr/local/services/cubetoolbox/CubeMaster/plugin/cube-volume-s3
+[plugin_volume] initialized binary plugin "s3" at /usr/local/services/cubetoolbox/Cubelet/plugin/cube-volume-s3
+```
+
+**Manual attach test** (on the Cubelet node):
+
+```bash
+/usr/local/services/cubetoolbox/Cubelet/plugin/cube-volume-s3 \
+  --op attach \
+  --sandbox-id test-sandbox \
+  --namespace default \
+  --volume-id test-vol \
+  --ref-count 0 \
+  --volume-base-dir /data/cube-shared/volume
+```
+
+Success: one JSON line on stdout with `"host_path":"/data/cube-shared/volume/s3-test-vol"` and `"error":""`.
+
+Clean up after the manual test:
+
+```bash
+/usr/local/services/cubetoolbox/Cubelet/plugin/cube-volume-s3 \
+  --op detach --sandbox-id test-sandbox --namespace default \
+  --volume-id test-vol --ref-count 0 \
+  --metadata '{"mount_dir":"/data/cube-shared/volume/s3-test-vol"}'
+```
+
+---
+
+## 6. Prepare SDK environment
+
+On your **dev machine** (must reach CubeAPI):
+
+```bash
+pip install 'cubesandbox>=0.6.0'
+
+export CUBE_API_URL=http://<cubeapi-host>:3000
+export CUBE_TEMPLATE_ID=<your-template-id>
+
+# Required for remote sandbox I/O on mounted volumes (data plane via CubeProxy)
+export CUBE_PROXY_NODE_IP=<cubeproxy-or-cubelet-node-ip>
+
+# When cluster auth is enabled:
+# export CUBE_API_KEY=<your-key>
+```
+
+---
+
+## 7. Verify with the SDK
+
+```python
+from cubesandbox import Sandbox, Volume
+
+# ① Create Volume (bucket gets volumes/<id>/.keep)
+vol = Volume.create("my-data", driver="s3")
+print("volume_id:", vol.volume_id)
+
+# ② Create sandbox with mount
+with Sandbox.create(volume_mounts={"/workspace": vol}) as sb:
+    sb.files.write("/workspace/hello.txt", "from S3 volume")
+    print(sb.files.read("/workspace/hello.txt"))
+
+# ③ Exit with → sandbox destroyed, volume detached (bucket data remains)
+
+# ④ Delete Volume (bucket prefix removed — irreversible)
+Volume.destroy(vol.volume_id)
+print("done")
+```
+
+**Confirm the object landed in the bucket:**
+
+```bash
+source /usr/local/services/cubetoolbox/CubeMaster/plugin/volume-s3.conf
+AWS_ACCESS_KEY_ID="$ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SECRET_ACCESS_KEY" AWS_REGION="${REGION:-us-east-1}" \
+  aws s3 ls "s3://$BUCKET/volumes/" --recursive --endpoint-url "$ENDPOINT"
+```
+
+**Confirm the s3fs mount inside the Cubelet mount namespace** (while the sandbox runs):
+
+```bash
+CPID=$(pgrep -f "cubelet --config" | head -1)
+nsenter -t "$CPID" -m -- cat /proc/mounts | grep s3fs
+```
+
+### Automated verification
+
+The COS example's [`verify_volume.py`](../cos/verify_volume.py) is driver-agnostic — point it at this driver:
+
+```bash
+cd ../cos
+export CUBE_API_URL=http://127.0.0.1:3000
+export CUBE_TEMPLATE_ID=tpl-xxxx
+export CUBE_PROXY_NODE_IP=127.0.0.1
+export CUBE_VOLUME_DRIVERS=s3
+
+python3 verify_volume.py
+```
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Check |
+|---------|-------|
+| `unknown driver: s3` | CubeMaster `volume_plugins` missing the entry, or not restarted |
+| `no plugin registered for driver "s3"` | Cubelet missing the same-name plugin, or not restarted |
+| Attach fails, `s3fs mount failed` | `ls /dev/fuse`; credentials and `ENDPOINT` in `volume-s3.conf`; run the manual attach in [§5](#5-restart-services-and-verify) to see the s3fs error |
+| `InvalidAccessKeyId` / `SignatureDoesNotMatch` | Key pair wrong, lacks bucket permission, or `REGION` doesn't match what the endpoint expects for SigV4 |
+| Bucket name contains dots | s3fs uses virtual-hosted-style addressing by default, which breaks TLS for dotted names. Use a bucket without dots, or add `-ouse_path_request_style` to the mount options (MinIO usually needs it too) |
+| SDK write fails | `CUBE_PROXY_NODE_IP` unset; CubeAPI or template not READY |
+| `Volume.create` without driver not using s3 | The **first** entry in `volume_plugins` is the default driver |
+
+More: [Framework §8 Troubleshooting](../../../docs/guide/volume-plugin.md).
+
+---
+
+## Backend layout
+
+```
+<bucket>/volumes/<volumeID>/   ← one prefix per Volume
+```
+
+Attach mounts `BUCKET:/volumes/<volumeID>` with s3fs at `/data/cube-shared/volume/s3-<volumeID>/` on the host, which Cubelet then exposes to the microVM over virtiofs.
+
+### Hook behavior (RefCount)
+
+| Hook | Side | refCount | Behavior |
+|------|------|----------|----------|
+| Create | Controller | — | `aws s3api put-object` writes `volumes/<id>/.keep` |
+| Destroy | Controller | — | `aws s3 rm --recursive` removes the prefix |
+| Attach | Node | `0` | `s3fs` mount → return `host_path` |
+| Attach | Node | `> 0` | Return the existing `host_path`; no second mount |
+| Detach | Node | `> 0` | no-op |
+| Detach | Node | `0` | `fusermount -u`; **retain** the data in the bucket |
+
+### Design notes
+
+- **One bucket, one prefix per volume.** Matches the COS example. Multi-bucket setups typically run several plugin instances with different `driver` names, or extend `Create` to accept a bucket. The framework only requires Hook protocol and `driver` consistency.
+- **Credentials never enter the sandbox.** They live in the root-owned, mode-`600` config on CubeMaster/Cubelet; the microVM sees only a filesystem.
+- **`private_data` carries the key prefix** from Create to Attach (max 1024 bytes, never returned to SDK clients).
+- **Concurrency.** A per-volume `flock` serialises attach/detach for the same volume on a node, so two sandboxes starting at once cannot double-mount.
+- **Destroy is irreversible** and removes the whole `volumes/<id>/` prefix. The API's refcount guard (409 on `DELETE /volumes` while any sandbox holds the volume) is what prevents deleting a mounted volume — the realistic hazard is a stale refcount after a node crash, where the cluster-wide count can reach 0 while a node still holds the mount.
+
+---
+
+## Layout
+
+```
+examples/volume/s3/
+├── install-deps.sh          # deps + checks (s3fs / aws / jq)
+├── volume-s3.conf.example
+└── binary/
+    └── cube-volume-s3.sh    # the plugin (all four hooks)
+```
+
+| Doc | Content |
+|-----|---------|
+| [Volume Plugin framework](../../../docs/guide/volume-plugin.md) | Protocol, RefCount, Hook semantics |
+| [Tigris integration guide](../../../docs/guide/integrations/tigris.md) | End-to-end vendor walkthrough using this plugin |
+| [COS example](../cos/README.md) | The reference plugin this one is modelled on |
+| [s3fs-fuse](https://github.com/s3fs-fuse/s3fs-fuse) | Mount driver options and behavior |

--- a/examples/volume/s3/README.zh.md
+++ b/examples/volume/s3/README.zh.md
@@ -1,0 +1,380 @@
+# S3 兼容 Volume 插件 —— 完整指引
+
+使用任意 S3 兼容对象存储作为 CubeSandbox Volume 的持久化存储：创建 Volume → 在沙箱中挂载 → 读写 → 卸载 → 删除。
+
+插件完全基于通用工具构建 —— 挂载使用 **s3fs**，控制面使用 **AWS CLI**。插件本身不绑定任何厂商：存储后端只是配置文件中的 `ENDPOINT` 地址。已验证的 Endpoint 包括 AWS S3、[Tigris](https://www.tigrisdata.com/)、MinIO 与 Cloudflare R2。
+
+> **版本要求：** Cube 平台 **≥ 0.6.0**，Python SDK **`cubesandbox` ≥ 0.6.0**。
+> 协议与 Hook 细节：[Volume 插件开发框架](../../../docs/zh/guide/volume-plugin.md)。
+
+English: [README.md](README.md)
+
+---
+
+## 为什么需要这个插件
+
+| | COS 插件 | S3 插件 |
+|---|---|---|
+| 后端 | 腾讯云 COS | 任意 S3 兼容 Endpoint |
+| 挂载驱动 | cosfs（仅 `amd64`） | s3fs（`amd64` **和** `arm64`） |
+| 安装方式 | 手动下载 `.rpm`/`.deb` | `apt install s3fs` / `yum install s3fs-fuse` |
+| 控制面 | coscmd | AWS CLI v2 |
+
+本插件填补两个空缺。其一，在腾讯云之外自建 CubeSandbox 时，COS 示例需要腾讯云账号 —— 本插件可对接你已有的任意 S3 兼容存储。其二，**ARM64 集群目前无法通过 cosfs 获得可用的 Volume 后端**：[`deploy/scripts/docker-install-volume-deps.sh`](../../../deploy/scripts/docker-install-volume-deps.sh) 在 `arm64` 上会跳过 cosfs（上游未提供 ARM 包），而 Debian/Ubuntu 与 EPEL 均为 `arm64` 打包了 s3fs。
+
+---
+
+## 选择 Endpoint
+
+无论选择哪家存储，下文所有步骤完全相同 —— 只有 `volume-s3.conf` 不同：
+
+| 存储提供方 | `ENDPOINT` | `REGION` |
+|-----------|-----------|----------|
+| AWS S3 | `https://s3.<region>.amazonaws.com` | 存储桶所在地域 |
+| Tigris | `https://t3.storage.dev` | `auto` |
+| Cloudflare R2 | `https://<account-id>.r2.cloudflarestorage.com` | `auto` |
+| MinIO | `http://<minio-host>:9000` | 任意值 |
+
+需要包含开通账号、创建存储桶与密钥的厂商级端到端指引，见 [Tigris 集成指南](../../../docs/zh/guide/integrations/tigris.md)。
+
+---
+
+## 前置条件
+
+| 项目 | 说明 |
+|------|------|
+| 运行中的 Cube 集群 | 至少包含 **CubeMaster**、**Cubelet**、**CubeAPI**（端口通常为 `3000`） |
+| 沙箱模板 | 一个 `templateID`（见 [§7](#7-使用-sdk-验证)） |
+| S3 兼容存储 | 一个存储桶，以及对该桶具备读写权限的访问密钥对 |
+| 本地权限 | 在 CubeMaster / Cubelet 主机上具备 `sudo`，用于安装软件、修改配置、重启服务 |
+
+**单机开发：** CubeMaster 与 Cubelet 在同一台主机，只需安装一次依赖。
+**多节点：** 见 [§1](#1-安装依赖) 中的表格。
+
+---
+
+## 1. 安装依赖
+
+### 装在哪台机器
+
+| 工具 | 安装节点 | 用途（Hook） |
+|------|----------|--------------|
+| **[s3fs](https://github.com/s3fs-fuse/s3fs-fuse)** | **Cubelet** | attach / detach（FUSE 挂载） |
+| **AWS CLI v2** | **CubeMaster** | create / destroy（Volume 前缀） |
+| **jq** | **CubeMaster** 与 **Cubelet** | binary 插件的 stdout JSON |
+
+### 方式 A：安装脚本
+
+**Cubelet 节点：**
+
+```bash
+sudo ./install-deps.sh --s3fs --jq
+```
+
+**CubeMaster 节点：**
+
+```bash
+sudo ./install-deps.sh --aws --jq
+```
+
+**单机（两个角色同机）：**
+
+```bash
+sudo ./install-deps.sh --all
+```
+
+只检查不安装：追加 `--check-only`。
+
+### 方式 B：手动安装
+
+```bash
+# Cubelet —— Debian/Ubuntu
+sudo apt-get install -y s3fs jq
+# Cubelet —— RHEL/CentOS（需要 EPEL）
+sudo yum install -y epel-release && sudo yum install -y s3fs-fuse jq
+
+# CubeMaster —— AWS CLI v2（ARM64 主机请改用 aarch64 包）
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+unzip -q awscliv2.zip && sudo ./aws/install
+```
+
+### 验证安装
+
+**Cubelet —— s3fs**
+
+```bash
+ls /dev/fuse && echo "FUSE ok"
+s3fs --version | head -1
+```
+
+两条都必须成功；缺少 `/dev/fuse` 会导致 attach 失败。
+
+**CubeMaster —— 用 AWS CLI 访问存储桶**
+
+```bash
+AWS_ACCESS_KEY_ID=xxx AWS_SECRET_ACCESS_KEY=xxx AWS_REGION=<region> \
+  aws s3 ls s3://my-cube-volumes/ --endpoint-url <your-endpoint>
+```
+
+返回空列表（退出码 0）即为成功。出现 `InvalidAccessKeyId` 或 `AccessDenied` 说明密钥对缺少该桶的读写权限。
+
+---
+
+## 2. 安装插件与凭证
+
+把插件复制到两个 `plugin/` 目录：
+
+```bash
+PREFIX=/usr/local/services/cubetoolbox
+sudo install -m 0755 binary/cube-volume-s3.sh \
+  "$PREFIX/CubeMaster/plugin/cube-volume-s3"
+sudo install -m 0755 binary/cube-volume-s3.sh \
+  "$PREFIX/Cubelet/plugin/cube-volume-s3"
+sudo install -m 0600 volume-s3.conf.example \
+  "$PREFIX/CubeMaster/plugin/volume-s3.conf"
+sudo install -m 0600 volume-s3.conf.example \
+  "$PREFIX/Cubelet/plugin/volume-s3.conf"
+```
+
+然后在每个节点上编辑 `volume-s3.conf`：
+
+| 字段 | 说明 | 是否必填 |
+|------|------|----------|
+| `ACCESS_KEY_ID` | 访问密钥 ID | 是 |
+| `SECRET_ACCESS_KEY` | 密钥 | 是 |
+| `BUCKET` | 存放所有 Volume 的存储桶 | 是 |
+| `ENDPOINT` | S3 兼容 Endpoint 地址（见[选择 Endpoint](#选择-endpoint)） | 是 |
+| `REGION` | SigV4 签名地域，默认 `us-east-1` | 否 |
+
+该配置文件必须为 root 所有、权限 `600` —— 其中以明文保存密钥，且会被插件 `source` 执行：
+
+```bash
+sudo chown root:root "$PREFIX/CubeMaster/plugin/volume-s3.conf" "$PREFIX/Cubelet/plugin/volume-s3.conf"
+sudo chmod 600 "$PREFIX/CubeMaster/plugin/volume-s3.conf" "$PREFIX/Cubelet/plugin/volume-s3.conf"
+```
+
+挂载根目录**不在**此文件中配置 —— Cubelet 在 attach 时传入（默认 `/data/cube-shared/volume`，见 [§4](#4-配置-cubelet)）。
+
+---
+
+## 3. 配置 CubeMaster
+
+编辑 CubeMaster 配置（常见路径：`/usr/local/services/cubetoolbox/CubeMaster/conf.yaml`），添加 **Controller** 插件（Create / Destroy）：
+
+```yaml
+volume_plugins:
+  - name: s3
+    type: binary
+    binary_path: /usr/local/services/cubetoolbox/CubeMaster/plugin/cube-volume-s3
+```
+
+`name: s3` 即 API/SDK 中的 **`driver`**。当 `Volume.create("x")` 未指定 driver 时，使用列表中的**第一项**。
+
+---
+
+## 4. 配置 Cubelet
+
+编辑 Cubelet 配置（常见路径：`/usr/local/services/cubetoolbox/Cubelet/config/config.toml`）。
+
+确认挂载父目录（可选，下方为默认值）：
+
+```toml
+[plugins."io.cubelet.internal.v1.storage"]
+  volume_plugin_base_dir = "/data/cube-shared/volume"
+```
+
+添加 **Node** 插件（Attach / Detach）：
+
+```toml
+[[plugins."io.cubelet.internal.v1.storage".volume_plugins]]
+  name        = "s3"
+  type        = "binary"
+  binary_path = "/usr/local/services/cubetoolbox/Cubelet/plugin/cube-volume-s3"
+```
+
+**`name` 必须与 CubeMaster 一致**（此处均为 `s3`）。插件返回的 `host_path` 形如 `<volume_plugin_base_dir>/s3-<volumeID>`，满足框架对 `host_path` 必须位于 `volumeBaseDir` 之内的要求。
+
+---
+
+## 5. 重启服务并验证
+
+```bash
+sudo systemctl restart cube-sandbox-cubemaster
+sudo systemctl restart cube-sandbox-cubelet
+sudo systemctl restart cube-sandbox-cube-api
+
+sleep 5
+systemctl is-active cube-sandbox-cubemaster cube-sandbox-cubelet cube-sandbox-cube-api
+```
+
+**确认插件已加载：**
+
+```bash
+grep -aF '[volume] registered' /data/log/CubeMaster/cubemaster-req.log | tail -5
+grep -aF '[plugin_volume] initialized' /data/log/Cubelet/Cubelet-req.log | tail -5
+```
+
+预期输出：
+
+```text
+[volume] registered binary plugin "s3" at /usr/local/services/cubetoolbox/CubeMaster/plugin/cube-volume-s3
+[plugin_volume] initialized binary plugin "s3" at /usr/local/services/cubetoolbox/Cubelet/plugin/cube-volume-s3
+```
+
+**手动 attach 测试**（在 Cubelet 节点执行）：
+
+```bash
+/usr/local/services/cubetoolbox/Cubelet/plugin/cube-volume-s3 \
+  --op attach \
+  --sandbox-id test-sandbox \
+  --namespace default \
+  --volume-id test-vol \
+  --ref-count 0 \
+  --volume-base-dir /data/cube-shared/volume
+```
+
+成功时 stdout 输出一行 JSON，包含 `"host_path":"/data/cube-shared/volume/s3-test-vol"` 与 `"error":""`。
+
+手动测试后清理：
+
+```bash
+/usr/local/services/cubetoolbox/Cubelet/plugin/cube-volume-s3 \
+  --op detach --sandbox-id test-sandbox --namespace default \
+  --volume-id test-vol --ref-count 0 \
+  --metadata '{"mount_dir":"/data/cube-shared/volume/s3-test-vol"}'
+```
+
+---
+
+## 6. 准备 SDK 环境
+
+在能访问 CubeAPI 的**开发机**上：
+
+```bash
+pip install 'cubesandbox>=0.6.0'
+
+export CUBE_API_URL=http://<cubeapi-host>:3000
+export CUBE_TEMPLATE_ID=<your-template-id>
+
+# 远程访问已挂载 Volume 时必需（数据面经由 CubeProxy）
+export CUBE_PROXY_NODE_IP=<cubeproxy-or-cubelet-node-ip>
+
+# 集群开启鉴权时：
+# export CUBE_API_KEY=<your-key>
+```
+
+---
+
+## 7. 使用 SDK 验证
+
+```python
+from cubesandbox import Sandbox, Volume
+
+# ① 创建 Volume（存储桶中生成 volumes/<id>/.keep）
+vol = Volume.create("my-data", driver="s3")
+print("volume_id:", vol.volume_id)
+
+# ② 创建带挂载的沙箱
+with Sandbox.create(volume_mounts={"/workspace": vol}) as sb:
+    sb.files.write("/workspace/hello.txt", "from S3 volume")
+    print(sb.files.read("/workspace/hello.txt"))
+
+# ③ 退出 with → 沙箱销毁，Volume 卸载（存储桶中数据保留）
+
+# ④ 删除 Volume（存储桶前缀被移除，不可恢复）
+Volume.destroy(vol.volume_id)
+print("done")
+```
+
+**确认对象已写入存储桶：**
+
+```bash
+source /usr/local/services/cubetoolbox/CubeMaster/plugin/volume-s3.conf
+AWS_ACCESS_KEY_ID="$ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SECRET_ACCESS_KEY" AWS_REGION="${REGION:-us-east-1}" \
+  aws s3 ls "s3://$BUCKET/volumes/" --recursive --endpoint-url "$ENDPOINT"
+```
+
+**在 Cubelet 挂载命名空间中确认 s3fs 挂载**（沙箱运行期间）：
+
+```bash
+CPID=$(pgrep -f "cubelet --config" | head -1)
+nsenter -t "$CPID" -m -- cat /proc/mounts | grep s3fs
+```
+
+### 自动化验证
+
+COS 示例中的 [`verify_volume.py`](../cos/verify_volume.py) 与 driver 无关，可直接指向本 driver：
+
+```bash
+cd ../cos
+export CUBE_API_URL=http://127.0.0.1:3000
+export CUBE_TEMPLATE_ID=tpl-xxxx
+export CUBE_PROXY_NODE_IP=127.0.0.1
+export CUBE_VOLUME_DRIVERS=s3
+
+python3 verify_volume.py
+```
+
+---
+
+## 8. 故障排查
+
+| 现象 | 排查方向 |
+|------|----------|
+| `unknown driver: s3` | CubeMaster `volume_plugins` 未配置，或未重启 |
+| `no plugin registered for driver "s3"` | Cubelet 缺少同名插件，或未重启 |
+| attach 失败，提示 `s3fs mount failed` | 检查 `ls /dev/fuse`、`volume-s3.conf` 中的凭证与 `ENDPOINT`；执行 [§5](#5-重启服务并验证) 的手动 attach 查看 s3fs 报错 |
+| `InvalidAccessKeyId` / `SignatureDoesNotMatch` | 密钥对错误、缺少桶权限，或 `REGION` 与 Endpoint 期望的 SigV4 地域不匹配 |
+| 存储桶名包含点号 | s3fs 默认使用 virtual-hosted 风格寻址，带点号的桶名会导致 TLS 校验失败。请改用不含点号的桶名，或追加 `-ouse_path_request_style`（MinIO 通常也需要该选项） |
+| SDK 写入失败 | 未设置 `CUBE_PROXY_NODE_IP`；CubeAPI 或模板未就绪 |
+| `Volume.create` 未指定 driver 时没有走 s3 | `volume_plugins` 的**第一项**才是默认 driver |
+
+更多内容：[框架 §8 调试与排障](../../../docs/zh/guide/volume-plugin.md)。
+
+---
+
+## 后端存储布局
+
+```
+<bucket>/volumes/<volumeID>/   ← 每个 Volume 一个前缀
+```
+
+attach 时用 s3fs 把 `BUCKET:/volumes/<volumeID>` 挂载到宿主机的 `/data/cube-shared/volume/s3-<volumeID>/`，Cubelet 再通过 virtiofs 暴露给 microVM。
+
+### Hook 行为（RefCount）
+
+| Hook | 角色 | refCount | 行为 |
+|------|------|----------|------|
+| Create | Controller | — | `aws s3api put-object` 写入 `volumes/<id>/.keep` |
+| Destroy | Controller | — | `aws s3 rm --recursive` 删除该前缀 |
+| Attach | Node | `0` | 执行 `s3fs` 挂载并返回 `host_path` |
+| Attach | Node | `> 0` | 返回已有 `host_path`，不重复挂载 |
+| Detach | Node | `> 0` | 空操作 |
+| Detach | Node | `0` | 执行 `fusermount -u`；**保留**存储桶中的数据 |
+
+### 设计说明
+
+- **单桶、每 Volume 一个前缀。** 与 COS 示例保持一致。多桶场景通常部署多个插件实例并使用不同 `driver` 名，或扩展 `Create` 使其接受桶名。框架只要求 Hook 协议与 `driver` 命名一致。
+- **凭证不会进入沙箱。** 凭证保存在 CubeMaster/Cubelet 上 root 所有、权限 `600` 的配置文件中，microVM 只看到一个文件系统。
+- **`private_data` 把对象前缀从 Create 传递到 Attach**（上限 1024 字节，不会返回给 SDK 客户端）。
+- **并发控制。** 按 Volume 粒度的 `flock` 串行化同一节点上同一 Volume 的 attach/detach，避免两个沙箱同时启动导致重复挂载。
+- **Destroy 不可恢复**，会删除整个 `volumes/<id>/` 前缀。API 的引用计数保护（有沙箱持有 Volume 时 `DELETE /volumes` 返回 409）是防止删除已挂载 Volume 的机制 —— 真正的风险点是节点崩溃后引用计数失真：集群级计数可能归零而某节点仍持有挂载。
+
+---
+
+## 目录结构
+
+```
+examples/volume/s3/
+├── install-deps.sh          # 依赖安装与检查（s3fs / aws / jq）
+├── volume-s3.conf.example
+└── binary/
+    └── cube-volume-s3.sh    # 插件本体（四个 Hook）
+```
+
+| 文档 | 内容 |
+|------|------|
+| [Volume 插件开发框架](../../../docs/zh/guide/volume-plugin.md) | 协议、RefCount、Hook 语义 |
+| [Tigris 集成指南](../../../docs/zh/guide/integrations/tigris.md) | 基于本插件的厂商级端到端指引 |
+| [COS 示例](../cos/README.zh.md) | 本插件所参照的参考实现 |
+| [s3fs-fuse](https://github.com/s3fs-fuse/s3fs-fuse) | 挂载驱动选项与行为 |

--- a/examples/volume/s3/README.zh.md
+++ b/examples/volume/s3/README.zh.md
@@ -2,7 +2,7 @@
 
 使用任意 S3 兼容对象存储作为 CubeSandbox Volume 的持久化存储：创建 Volume → 在沙箱中挂载 → 读写 → 卸载 → 删除。
 
-插件完全基于通用工具构建 —— 挂载使用 **s3fs**，控制面使用 **AWS CLI**。插件本身不绑定任何厂商：存储后端只是配置文件中的 `ENDPOINT` 地址。已验证的 Endpoint 包括 AWS S3、[Tigris](https://www.tigrisdata.com/)、MinIO 与 Cloudflare R2。
+插件完全基于通用工具构建 —— 挂载使用 **s3fs**，控制面使用 **AWS CLI**。插件本身不绑定任何厂商：存储后端只是配置文件中的 `ENDPOINT` 地址，因此可对接任意 S3 兼容 Endpoint —— 例如 AWS S3、[Tigris](https://www.tigrisdata.com/)、MinIO、Cloudflare R2 等。
 
 > **版本要求：** Cube 平台 **≥ 0.6.0**，Python SDK **`cubesandbox` ≥ 0.6.0**。
 > 协议与 Hook 细节：[Volume 插件开发框架](../../../docs/zh/guide/volume-plugin.md)。
@@ -312,6 +312,9 @@ export CUBE_API_URL=http://127.0.0.1:3000
 export CUBE_TEMPLATE_ID=tpl-xxxx
 export CUBE_PROXY_NODE_IP=127.0.0.1
 export CUBE_VOLUME_DRIVERS=s3
+# 脚本默认跳过 cfs/s3/nfs 这几个 driver 名（COS 演示环境中未部署）；
+# 本环境已部署 s3，需清空跳过列表：
+export CUBE_VOLUME_SKIP_DRIVERS=
 
 python3 verify_volume.py
 ```

--- a/examples/volume/s3/README.zh.md
+++ b/examples/volume/s3/README.zh.md
@@ -145,6 +145,7 @@ sudo install -m 0600 volume-s3.conf.example \
 | `BUCKET` | 存放所有 Volume 的存储桶 | 是 |
 | `ENDPOINT` | S3 兼容 Endpoint 地址（见[选择 Endpoint](#选择-endpoint)） | 是 |
 | `REGION` | SigV4 签名地域，默认 `us-east-1` | 否 |
+| `S3FS_EXTRA_OPTS` | 额外的 s3fs 挂载选项，空格分隔（如 MinIO 需要的 `-ouse_path_request_style`） | 否 |
 
 该配置文件必须为 root 所有、权限 `600` —— 其中以明文保存密钥，且会被插件 `source` 执行：
 
@@ -325,7 +326,7 @@ python3 verify_volume.py
 | `no plugin registered for driver "s3"` | Cubelet 缺少同名插件，或未重启 |
 | attach 失败，提示 `s3fs mount failed` | 检查 `ls /dev/fuse`、`volume-s3.conf` 中的凭证与 `ENDPOINT`；执行 [§5](#5-重启服务并验证) 的手动 attach 查看 s3fs 报错 |
 | `InvalidAccessKeyId` / `SignatureDoesNotMatch` | 密钥对错误、缺少桶权限，或 `REGION` 与 Endpoint 期望的 SigV4 地域不匹配 |
-| 存储桶名包含点号 | s3fs 默认使用 virtual-hosted 风格寻址，带点号的桶名会导致 TLS 校验失败。请改用不含点号的桶名，或追加 `-ouse_path_request_style`（MinIO 通常也需要该选项） |
+| 存储桶名包含点号 | s3fs 默认使用 virtual-hosted 风格寻址，带点号的桶名会导致 TLS 校验失败。请改用不含点号的桶名，或在 `volume-s3.conf` 中设置 `S3FS_EXTRA_OPTS=-ouse_path_request_style`（MinIO 通常也需要该选项） |
 | SDK 写入失败 | 未设置 `CUBE_PROXY_NODE_IP`；CubeAPI 或模板未就绪 |
 | `Volume.create` 未指定 driver 时没有走 s3 | `volume_plugins` 的**第一项**才是默认 driver |
 

--- a/examples/volume/s3/binary/cube-volume-s3.sh
+++ b/examples/volume/s3/binary/cube-volume-s3.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# cube-volume-s3 — CubeSandbox VolumePlugin for any S3-compatible object storage
+# (AWS S3, Tigris, MinIO, Cloudflare R2, Ceph RGW, ...)
+#
+# What this script does (one sentence per hook):
+#   create  — make an empty folder for this volume in the bucket (control plane)
+#   destroy — delete that folder from the bucket (control plane)
+#   attach  — mount the bucket folder on the node with s3fs (data plane)
+#   detach  — unmount s3fs when no sandbox uses the volume anymore
+#
+# CubeMaster calls create/destroy when users create/delete volumes via API.
+# Cubelet calls attach/detach when sandboxes start/stop using a volume.
+#
+# Calling convention: one subprocess per operation.
+#   cube-volume-s3 --op <op> [--<key> <value> ...]
+#
+# Output: single JSON line to stdout; exit 0 on success, non-zero on error.
+#
+# Plugin config file: <plugin-dir>/volume-s3.conf (same directory as this script)
+#                     (or $CUBE_S3_CONFIG)
+#   ACCESS_KEY_ID=...
+#   SECRET_ACCESS_KEY=...
+#   BUCKET=my-bucket
+#   ENDPOINT=https://<your-s3-endpoint>   # required; see volume-s3.conf.example
+#   REGION=us-east-1                      # optional, default us-east-1
+#
+# Path overrides (defaults are correct for a normal root-run deployment; these
+# exist so the plugin can be exercised without root, e.g. in CI):
+#   CUBE_S3_CONFIG       config file path
+#   CUBE_S3_PASSWD_FILE  s3fs credential file  (default /etc/cube/.passwd-s3fs-volume)
+#   CUBE_S3_LOCK_DIR     attach/detach locks   (default /run/cube-volume-s3)
+#
+# The FUSE mount path is not configured here: Cubelet passes it on attach via
+# --volume-base-dir (default /data/cube-shared/volume) and the plugin mounts at
+# <volume-base-dir>/s3-<volume_id>.
+#
+# The config file holds a plaintext secret: keep it root-owned and chmod 600.
+#
+# Dependencies:
+#   s3fs  — FUSE mount driver, required on every Cubelet node (attach/detach)
+#     Debian/Ubuntu:  apt-get install -y s3fs
+#     RHEL/CentOS:    yum install -y s3fs-fuse   # needs EPEL
+#     Both amd64 and arm64 are packaged by the distros — no manual download.
+#   aws   — AWS CLI v2, required on CubeMaster (create/destroy)
+#     Works against any S3-compatible endpoint via --endpoint-url.
+#   jq    — JSON output, required on both CubeMaster and Cubelet
+#
+# Mount layout (one s3fs process per volume):
+#   <volume-base-dir>/s3-<volume_id>/  →  BUCKET:/volumes/<volume_id>/
+#   where <volume-base-dir> is passed by Cubelet via --volume-base-dir
+#   (default /data/cube-shared/volume). host_path MUST live inside it.
+#
+# Locking: per-volume flock on /run/cube-volume-s3/<volume_id>.lock
+# ensures concurrent attach/detach for the same volume is serialised.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Config — read S3 credentials from volume-s3.conf next to this script
+# ---------------------------------------------------------------------------
+
+# Where this script lives; config file sits in the same directory unless overridden.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${CUBE_S3_CONFIG:-${SCRIPT_DIR}/volume-s3.conf}"
+# Per-volume attach/detach lock directory.
+LOCK_DIR="${CUBE_S3_LOCK_DIR:-/run/cube-volume-s3}"
+# s3fs credential file written at attach. Override only if /etc/cube is not
+# writable on your nodes; s3fs requires it to be mode 600.
+PASSWD_FILE="${CUBE_S3_PASSWD_FILE:-/etc/cube/.passwd-s3fs-volume}"
+
+DEFAULT_REGION="us-east-1"
+
+# Parent directory Cubelet requires s3fs mounts to live under.
+# Cubelet passes --volume-base-dir on attach (default /data/cube-shared/volume).
+# Each volume gets its own subdir: <volume-base-dir>/s3-<volume_id>.
+VOLUME_BASE_DIR="/data/cube-shared/volume"
+
+# Read ACCESS_KEY_ID, SECRET_ACCESS_KEY, BUCKET, ENDPOINT (+ optional REGION).
+load_config() {
+    [[ -f "$CONFIG_FILE" ]] || die "config file not found: $CONFIG_FILE"
+    # shellcheck source=/dev/null
+    source "$CONFIG_FILE"
+    [[ -n "${ACCESS_KEY_ID:-}"     ]] || die "config: ACCESS_KEY_ID is empty"
+    [[ -n "${SECRET_ACCESS_KEY:-}" ]] || die "config: SECRET_ACCESS_KEY is empty"
+    [[ -n "${BUCKET:-}"            ]] || die "config: BUCKET is empty"
+    [[ -n "${ENDPOINT:-}"          ]] || die "config: ENDPOINT is empty (set your S3-compatible endpoint URL)"
+    REGION="${REGION:-$DEFAULT_REGION}"
+}
+
+# Write the s3fs credential file: BUCKET:AccessKeyId:SecretAccessKey (mode 600).
+# s3fs reads this file when mounting; we refresh it only when credentials change.
+ensure_passwd_file() {
+    mkdir -p "$(dirname "$PASSWD_FILE")"
+    local content="${BUCKET}:${ACCESS_KEY_ID}:${SECRET_ACCESS_KEY}"
+    if [[ "$(cat "$PASSWD_FILE" 2>/dev/null)" != "$content" ]]; then
+        printf '%s\n' "$content" > "$PASSWD_FILE"
+        chmod 600 "$PASSWD_FILE"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()      { echo "[cube-volume-s3] $*" >&2; }
+die()      { log "ERROR: $*"; exit 1; }
+ok_json()  { printf '{"error":""}\n'; }
+err_json() { local msg; msg="$(printf '%s' "$1" | jq -Rn 'input')"; printf '{"error":%s}\n' "$msg"; }
+
+# Local path where this volume is mounted on the node (must stay under VOLUME_BASE_DIR).
+volume_mountpoint() { echo "${VOLUME_BASE_DIR%/}/s3-$1"; }
+
+# Object key prefix inside the bucket for this volume's data.
+s3_subdir() { echo "volumes/$1"; }
+
+# ---------------------------------------------------------------------------
+# Per-volume flock: serialise concurrent attach/detach for the same volumeID.
+# Usage:
+#   exec {LOCK_FD}>/run/cube-volume-s3/<id>.lock
+#   flock -x "$LOCK_FD"
+#   ... critical section ...
+#   flock -u "$LOCK_FD"
+# ---------------------------------------------------------------------------
+
+# Per-volume file lock: if two attach/detach calls run at once for the same
+# volume, only one proceeds at a time (avoids double-mount or race on unmount).
+volume_lock_acquire() {
+    local volume_id="$1"
+    mkdir -p "$LOCK_DIR"
+    local lock_file="${LOCK_DIR}/${volume_id}.lock"
+    # Open on fd 200 (arbitrary high fd; safe for sub-processes)
+    exec 200>"$lock_file"
+    flock -x 200
+    log "lock acquired for volume ${volume_id}"
+}
+
+volume_lock_release() {
+    flock -u 200
+}
+
+# ---------------------------------------------------------------------------
+# S3 backend ops — use the AWS CLI to create/delete volume folders
+# ---------------------------------------------------------------------------
+
+# Run the AWS CLI against the configured endpoint. Credentials come from the
+# plugin config, not from the host's ~/.aws, so CubeMaster needs no AWS
+# profile set up. AWS_EC2_METADATA_DISABLED stops the SDK from probing the
+# instance metadata service when a call fails, which otherwise adds a
+# multi-second hang per op.
+aws_run() {
+    AWS_ACCESS_KEY_ID="$ACCESS_KEY_ID" \
+    AWS_SECRET_ACCESS_KEY="$SECRET_ACCESS_KEY" \
+    AWS_DEFAULT_REGION="$REGION" \
+    AWS_REGION="$REGION" \
+    AWS_EC2_METADATA_DISABLED=true \
+    aws --endpoint-url "$ENDPOINT" "$@"
+}
+
+# Upload a tiny .keep object so the volume folder exists before first mount.
+# Object storage has no real directories; the .keep marker makes the prefix
+# visible to s3fs and to bucket browsers.
+s3_create_dir() {
+    local volume_id="$1"
+    log "aws: create $(s3_subdir "$volume_id")/.keep"
+    local out rc=0
+    set +e
+    out="$(aws_run s3api put-object \
+        --bucket "$BUCKET" \
+        --key "$(s3_subdir "$volume_id")/.keep" \
+        --content-length 0 2>&1)"
+    rc=$?
+    set -e
+    if [[ "$rc" -ne 0 ]]; then
+        log "ERROR: aws put-object failed for ${volume_id}: ${out}"
+        return 1
+    fi
+    return 0
+}
+
+# Recursively delete the volume folder (destroy hook).
+# Only ignore explicit NotFound; other failures must propagate so Master does
+# not delete the DB row while objects remain in the bucket.
+s3_remove_dir() {
+    local volume_id="$1"
+    local out=""
+    local rc=0
+    log "aws: delete $(s3_subdir "$volume_id")/"
+    set +e
+    out="$(aws_run s3 rm "s3://${BUCKET}/$(s3_subdir "$volume_id")/" --recursive 2>&1)"
+    rc=$?
+    set -e
+    if [[ "$rc" -eq 0 ]]; then
+        return 0
+    fi
+    if printf '%s' "$out" | grep -qiE 'NoSuchKey|NoSuchBucket|does not exist|Not Found|404'; then
+        log "aws: delete ignored not-found for ${volume_id}"
+        return 0
+    fi
+    log "ERROR: aws delete failed for ${volume_id}: ${out}"
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# FUSE ops — s3fs mounts one bucket prefix per volume on the node
+# ---------------------------------------------------------------------------
+
+# Mount BUCKET:/volumes/<volume_id> at <volume-base-dir>/s3-<volume_id>.
+# Safe to call twice: skips if already mounted.
+s3fs_mount_volume() {
+    local volume_id="$1"
+    local mnt
+    mnt="$(volume_mountpoint "$volume_id")"
+
+    if mountpoint -q "$mnt" 2>/dev/null; then
+        log "s3fs: volume ${volume_id} already mounted at ${mnt}"
+        return 0
+    fi
+
+    mkdir -p "$mnt"
+    log "s3fs: mounting ${BUCKET}:/$(s3_subdir "$volume_id") -> ${mnt}"
+    local out rc=0
+    set +e
+    # -o endpoint      : region used for SigV4 signing
+    # -o url           : the S3-compatible endpoint from volume-s3.conf
+    # -o allow_other   : Cubelet (a different user) must traverse the mount to
+    #                    bind it into the microVM via virtiofs
+    # -o nonempty      : mountpoint may already hold a stale dir entry
+    out="$(s3fs "${BUCKET}:/$(s3_subdir "$volume_id")" "$mnt" \
+        "-ourl=${ENDPOINT}"             \
+        "-oendpoint=${REGION}"          \
+        "-opasswd_file=${PASSWD_FILE}"  \
+        "-oallow_other"                 \
+        "-ononempty" 2>&1)"
+    rc=$?
+    set -e
+    # s3fs can exit 0 even when auth fails; require a real mountpoint.
+    if [[ "$rc" -ne 0 ]] || ! mountpoint -q "$mnt" 2>/dev/null; then
+        log "ERROR: s3fs mount failed for ${volume_id}: ${out}"
+        rmdir "$mnt" 2>/dev/null || true
+        return 1
+    fi
+    log "s3fs: mounted ok"
+}
+
+# Unmount the per-volume FUSE mount and remove the mountpoint dir (created at attach).
+s3fs_unmount_volume() {
+    local mnt="$1"
+
+    if mountpoint -q "$mnt" 2>/dev/null; then
+        log "s3fs: unmounting ${mnt}"
+        fusermount -u "$mnt" 2>/dev/null || umount -l "$mnt" 2>/dev/null || true
+        log "s3fs: unmounted ${mnt}"
+    else
+        log "s3fs: ${mnt} not mounted, skipping unmount"
+    fi
+
+    if [[ -d "$mnt" ]]; then
+        rmdir "$mnt" && log "s3fs: removed mount dir ${mnt}" \
+            || log "s3fs: could not remove ${mnt} (not empty?)"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# CubeMaster hooks (control plane — run when user creates/deletes a volume)
+# ---------------------------------------------------------------------------
+
+# create: provision backend storage for a new volume.
+# Steps: load config -> create bucket folder -> return token/private_data JSON.
+#
+# Input:  --volume-id <id>  --name <name>
+# Output: stdout JSON {"token":"","private_data":"volumes/<id>/","error":""}
+#
+# private_data is opaque Create→Attach state (max 1024 bytes). This plugin
+# stores the object-key prefix so Attach can log/reuse it without hardcoding.
+do_create() {
+    local volume_id="$1" name="$2"
+    log "create volumeID=${volume_id} name=${name}"
+
+    load_config
+    # Step 1: create volumes/<volume_id>/ in the bucket
+    s3_create_dir "$volume_id" || { err_json "aws create dir failed for ${volume_id}"; exit 1; }
+
+    # Step 2: return success; private_data carries the key prefix for Attach
+    jq -cn --arg pd "volumes/${volume_id}/" \
+        '{ token: "", private_data: $pd, error: "" }'
+}
+
+# destroy: remove backend storage when user deletes a volume.
+# Steps: load config -> delete bucket folder -> return success JSON.
+#
+# Input:  --volume-id <id>
+# Output: stdout JSON {"error":""}
+do_destroy() {
+    local volume_id="$1"
+    log "destroy volumeID=${volume_id}"
+
+    load_config
+    # Step 1: delete volumes/<volume_id>/ from the bucket (irreversible)
+    s3_remove_dir "$volume_id" || {
+        err_json "aws delete failed for ${volume_id}"
+        exit 1
+    }
+    ok_json
+}
+
+# ---------------------------------------------------------------------------
+# Cubelet hooks (data plane — run when a sandbox mounts/unmounts a volume)
+# ---------------------------------------------------------------------------
+
+# attach: make volume data visible on this node and tell Cubelet where it is.
+# Steps: load config -> write s3fs passwd -> lock -> s3fs mount -> return host_path.
+#
+# Cubelet bind-mounts host_path into the sandbox at the user's chosen path.
+#
+# Input:  --sandbox-id <id>  --namespace <ns>  --volume-id <vid>
+#         --ref-count <n>  --volume-base-dir <dir>  [--private-data <str>]
+# Output: {"host_path":"<volume-base-dir>/s3-<vid>","metadata":{...},"error":""}
+do_attach() {
+    local sandbox_id="$1" volume_id="$2" ref_count="$3"
+    local private_data="${4:-}"
+
+    log "attach sandbox=${sandbox_id} volumeID=${volume_id} refcount_before=${ref_count} private_data=${private_data}"
+
+    load_config
+    ensure_passwd_file
+
+    # Step 1: serialize concurrent attach for the same volume
+    volume_lock_acquire "$volume_id"
+    trap 'volume_lock_release' EXIT
+
+    # Step 2: mount the bucket prefix with s3fs (skip if already mounted)
+    s3fs_mount_volume "$volume_id" || {
+        err_json "s3fs mount failed for volume ${volume_id}"
+        exit 1
+    }
+
+    local mnt
+    mnt="$(volume_mountpoint "$volume_id")"
+
+    log "attach ready: host_path=${mnt}"
+
+    # Step 3: return host_path so Cubelet can bind-mount into the sandbox
+    jq -cn \
+        --arg path "$mnt" \
+        --arg vid  "$volume_id" \
+        '{
+            host_path: $path,
+            metadata:  { mount_dir: $path, volume_id: $vid },
+            error:     ""
+        }'
+}
+
+# detach: stop exposing volume data on this node when nobody uses it.
+# Steps: if ref_count>0 skip -> else lock -> unmount s3fs -> return success.
+#
+# ref_count is how many sandboxes on this node still use the volume after this detach.
+# Only unmount when ref_count reaches 0 (last sandbox gone).
+#
+# Input:  --sandbox-id <id>  --namespace <ns>  --volume-id <vid>
+#         --ref-count <n>  --metadata <json>
+# Output: {"error":""}
+do_detach() {
+    local sandbox_id="$1" volume_id="$2" ref_count="$3"
+    local metadata_json="$4"
+
+    log "detach sandbox=${sandbox_id} volumeID=${volume_id} refcount_after=${ref_count}"
+
+    # Step 1: other sandboxes still mounted — leave s3fs running
+    if [[ "$ref_count" -gt 0 ]]; then
+        log "skipping unmount: volume still in use (refcount_after=${ref_count})"
+        ok_json
+        return
+    fi
+
+    load_config
+
+    volume_lock_acquire "$volume_id"
+    trap 'volume_lock_release' EXIT
+
+    # Step 2: find mount path (prefer path saved at attach time)
+    local mnt
+    mnt="$(printf '%s' "$metadata_json" | jq -r '.mount_dir // empty' 2>/dev/null)"
+    [[ -n "$mnt" ]] || mnt="$(volume_mountpoint "$volume_id")"
+
+    # Step 3: last user gone — unmount FUSE (bucket data stays until destroy)
+    s3fs_unmount_volume "$mnt"
+
+    log "detach done volumeID=${volume_id} (bucket data preserved; delete volume to remove backend data)"
+    ok_json
+}
+
+# ---------------------------------------------------------------------------
+# Entry point — parse CLI flags and dispatch to the right hook
+# ---------------------------------------------------------------------------
+
+OP=""
+VOLUME_ID="" NAME=""
+SANDBOX_ID="" NAMESPACE="" REF_COUNT="0"
+METADATA="{}"
+PRIVATE_DATA=""
+
+# CubeMaster/Cubelet pass arguments like --op attach --volume-id xxx ...
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --op)           OP="$2";           shift 2 ;;
+        --volume-id)    VOLUME_ID="$2";    shift 2 ;;
+        --name)         NAME="$2";         shift 2 ;;
+        --sandbox-id)   SANDBOX_ID="$2";   shift 2 ;;
+        --namespace)    NAMESPACE="$2";    shift 2 ;;
+        --ref-count)    REF_COUNT="$2";    shift 2 ;;
+        --volume-base-dir)
+            [[ -n "${2:-}" ]] && VOLUME_BASE_DIR="$2"; shift 2 ;;
+        --private-data) PRIVATE_DATA="$2"; shift 2 ;;
+        --metadata)     METADATA="$2";     shift 2 ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
+
+[[ -n "$OP" ]] || die "--op is required"
+
+case "$OP" in
+    # CubeMaster (control plane)
+    create)  do_create  "$VOLUME_ID" "$NAME" ;;
+    destroy) do_destroy "$VOLUME_ID" ;;
+    # Cubelet (data plane)
+    attach)  do_attach  "$SANDBOX_ID" "$VOLUME_ID" "$REF_COUNT" "$PRIVATE_DATA" ;;
+    detach)  do_detach  "$SANDBOX_ID" "$VOLUME_ID" "$REF_COUNT" "$METADATA" ;;
+    *)       err_json "unknown op: ${OP}"; exit 1 ;;
+esac

--- a/examples/volume/s3/binary/cube-volume-s3.sh
+++ b/examples/volume/s3/binary/cube-volume-s3.sh
@@ -26,11 +26,12 @@
 #   BUCKET=my-bucket
 #   ENDPOINT=https://<your-s3-endpoint>   # required; see volume-s3.conf.example
 #   REGION=us-east-1                      # optional, default us-east-1
+#   S3FS_EXTRA_OPTS="-ouse_path_request_style"   # optional, appended to s3fs
 #
 # Path overrides (defaults are correct for a normal root-run deployment; these
 # exist so the plugin can be exercised without root, e.g. in CI):
 #   CUBE_S3_CONFIG       config file path
-#   CUBE_S3_PASSWD_FILE  s3fs credential file  (default /etc/cube/.passwd-s3fs-volume)
+#   CUBE_S3_PASSWD_FILE  s3fs credential file  (default /etc/cube/.passwd-s3fs-volume-<bucket>)
 #   CUBE_S3_LOCK_DIR     attach/detach locks   (default /run/cube-volume-s3)
 #
 # The FUSE mount path is not configured here: Cubelet passes it on attach via
@@ -67,9 +68,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="${CUBE_S3_CONFIG:-${SCRIPT_DIR}/volume-s3.conf}"
 # Per-volume attach/detach lock directory.
 LOCK_DIR="${CUBE_S3_LOCK_DIR:-/run/cube-volume-s3}"
-# s3fs credential file written at attach. Override only if /etc/cube is not
-# writable on your nodes; s3fs requires it to be mode 600.
-PASSWD_FILE="${CUBE_S3_PASSWD_FILE:-/etc/cube/.passwd-s3fs-volume}"
 
 DEFAULT_REGION="us-east-1"
 
@@ -92,7 +90,11 @@ load_config() {
 
 # Write the s3fs credential file: BUCKET:AccessKeyId:SecretAccessKey (mode 600).
 # s3fs reads this file when mounting; we refresh it only when credentials change.
+# The path is per-bucket so several plugin instances (different driver names,
+# different buckets) on one node never race on a shared credential file.
+# Call after load_config — the filename derives from BUCKET.
 ensure_passwd_file() {
+    PASSWD_FILE="${CUBE_S3_PASSWD_FILE:-/etc/cube/.passwd-s3fs-volume-${BUCKET}}"
     mkdir -p "$(dirname "$PASSWD_FILE")"
     local content="${BUCKET}:${ACCESS_KEY_ID}:${SECRET_ACCESS_KEY}"
     if [[ "$(cat "$PASSWD_FILE" 2>/dev/null)" != "$content" ]]; then
@@ -167,10 +169,12 @@ s3_create_dir() {
     log "aws: create $(s3_subdir "$volume_id")/.keep"
     local out rc=0
     set +e
+    # --body /dev/null uploads a real zero-byte body; some S3-compatible
+    # gateways reject body-less zero-length PUTs.
     out="$(aws_run s3api put-object \
         --bucket "$BUCKET" \
         --key "$(s3_subdir "$volume_id")/.keep" \
-        --content-length 0 2>&1)"
+        --body /dev/null 2>&1)"
     rc=$?
     set -e
     if [[ "$rc" -ne 0 ]]; then
@@ -221,6 +225,15 @@ s3fs_mount_volume() {
 
     mkdir -p "$mnt"
     log "s3fs: mounting ${BUCKET}:/$(s3_subdir "$volume_id") -> ${mnt}"
+
+    # Optional extra s3fs options from volume-s3.conf, whitespace-separated,
+    # e.g. S3FS_EXTRA_OPTS="-ouse_path_request_style" for MinIO or for bucket
+    # names containing dots.
+    local extra_opts=()
+    if [[ -n "${S3FS_EXTRA_OPTS:-}" ]]; then
+        read -r -a extra_opts <<< "$S3FS_EXTRA_OPTS"
+    fi
+
     local out rc=0
     set +e
     # -o endpoint      : region used for SigV4 signing
@@ -233,7 +246,8 @@ s3fs_mount_volume() {
         "-oendpoint=${REGION}"          \
         "-opasswd_file=${PASSWD_FILE}"  \
         "-oallow_other"                 \
-        "-ononempty" 2>&1)"
+        "-ononempty"                    \
+        ${extra_opts[@]+"${extra_opts[@]}"} 2>&1)"
     rc=$?
     set -e
     # s3fs can exit 0 even when auth fails; require a real mountpoint.

--- a/examples/volume/s3/install-deps.sh
+++ b/examples/volume/s3/install-deps.sh
@@ -36,7 +36,7 @@ while [[ $# -gt 0 ]]; do
         --jq)         WANT_JQ=1;   shift ;;
         --all)        WANT_S3FS=1; WANT_AWS=1; WANT_JQ=1; shift ;;
         --check-only) CHECK_ONLY=1; shift ;;
-        -h|--help)    sed -n '4,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -h|--help)    sed -n '4,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *)            die "unknown argument: $1" ;;
     esac
 done

--- a/examples/volume/s3/install-deps.sh
+++ b/examples/volume/s3/install-deps.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# install-deps.sh — install host tools for the S3 Volume Plugin.
+#
+#   --s3fs   FUSE mount driver          (Cubelet nodes; attach/detach)
+#   --aws    AWS CLI v2                 (CubeMaster nodes; create/destroy)
+#   --jq     JSON parsing               (both; binary plugin stdout)
+#   --all    everything above           (single-host deployments)
+#   --check-only   verify, install nothing
+#
+# All three tools ship for amd64 and arm64, so this script works unchanged on
+# ARM64 Cube clusters.
+#
+# Usage:
+#   sudo ./install-deps.sh --s3fs --jq        # Cubelet node
+#   sudo ./install-deps.sh --aws --jq         # CubeMaster node
+#   sudo ./install-deps.sh --all              # both roles on one host
+#   ./install-deps.sh --all --check-only      # no root needed
+
+set -euo pipefail
+
+WANT_S3FS=0
+WANT_AWS=0
+WANT_JQ=0
+CHECK_ONLY=0
+
+log()  { printf '[s3-deps] %s\n' "$*"; }
+die()  { printf '[s3-deps] ERROR: %s\n' "$*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --s3fs)       WANT_S3FS=1; shift ;;
+        --aws)        WANT_AWS=1;  shift ;;
+        --jq)         WANT_JQ=1;   shift ;;
+        --all)        WANT_S3FS=1; WANT_AWS=1; WANT_JQ=1; shift ;;
+        --check-only) CHECK_ONLY=1; shift ;;
+        -h|--help)    sed -n '4,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)            die "unknown argument: $1" ;;
+    esac
+done
+
+if [[ "$WANT_S3FS$WANT_AWS$WANT_JQ" == "000" ]]; then
+    die "nothing selected; pass --s3fs / --aws / --jq / --all (see --help)"
+fi
+
+if [[ "$CHECK_ONLY" -eq 0 && "$(id -u)" -ne 0 ]]; then
+    die "must run as root to install (or pass --check-only)"
+fi
+
+# ---------------------------------------------------------------------------
+# Package manager detection
+# ---------------------------------------------------------------------------
+
+PKG=""
+if command -v apt-get >/dev/null 2>&1; then
+    PKG="apt"
+elif command -v dnf >/dev/null 2>&1; then
+    PKG="dnf"
+elif command -v yum >/dev/null 2>&1; then
+    PKG="yum"
+fi
+
+ARCH="$(uname -m)"
+log "host arch: ${ARCH}, package manager: ${PKG:-none}"
+
+pkg_install() {
+    case "$PKG" in
+        apt) DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$@" ;;
+        dnf) dnf install -y "$@" ;;
+        yum) yum install -y "$@" ;;
+        *)   die "unsupported package manager; install manually: $*" ;;
+    esac
+}
+
+APT_UPDATED=0
+pkg_refresh() {
+    if [[ "$PKG" == "apt" && "$APT_UPDATED" -eq 0 ]]; then
+        apt-get update -y
+        APT_UPDATED=1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Installers
+# ---------------------------------------------------------------------------
+
+install_jq() {
+    log "install jq"
+    pkg_refresh
+    pkg_install jq
+}
+
+install_s3fs() {
+    log "install s3fs"
+    pkg_refresh
+    case "$PKG" in
+        # Debian/Ubuntu build the s3fs-fuse source package as binary "s3fs"
+        # for both amd64 and arm64. s3fs's own deps pull the right fuse
+        # package; installing "fuse" explicitly breaks on fuse3-only distros.
+        apt)      pkg_install s3fs ;;
+        # RHEL-family packages it as s3fs-fuse, from EPEL.
+        dnf|yum)  pkg_install s3fs-fuse || {
+                      log "s3fs-fuse not found; EPEL may be missing"
+                      log "try: ${PKG} install -y epel-release && ${PKG} install -y s3fs-fuse"
+                      return 1
+                  } ;;
+        *)        die "install s3fs manually: https://github.com/s3fs-fuse/s3fs-fuse" ;;
+    esac
+}
+
+install_aws() {
+    log "install AWS CLI v2"
+    local awszip url tmp
+    case "$ARCH" in
+        x86_64|amd64)  url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" ;;
+        aarch64|arm64) url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" ;;
+        *)             die "unsupported architecture for AWS CLI: ${ARCH}" ;;
+    esac
+
+    command -v unzip >/dev/null 2>&1 || { pkg_refresh; pkg_install unzip; }
+    command -v curl  >/dev/null 2>&1 || { pkg_refresh; pkg_install curl; }
+
+    tmp="$(mktemp -d)"
+    awszip="${tmp}/awscliv2.zip"
+    log "downloading ${url}"
+    curl -fsSL "$url" -o "$awszip"
+    unzip -q "$awszip" -d "$tmp"
+    "${tmp}/aws/install" --update
+    rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# Checks — run on the node that needs the tool
+# ---------------------------------------------------------------------------
+
+FAILED=0
+
+check_jq() {
+    if command -v jq >/dev/null 2>&1; then
+        log "OK  jq        $(jq --version 2>&1)"
+    else
+        log "MISSING jq"; FAILED=1
+    fi
+}
+
+check_s3fs() {
+    if command -v s3fs >/dev/null 2>&1; then
+        log "OK  s3fs      $(s3fs --version 2>&1 | head -1 || true)"
+    else
+        log "MISSING s3fs"; FAILED=1
+    fi
+    # Attach cannot mount without the FUSE device node.
+    if [[ -e /dev/fuse ]]; then
+        log "OK  /dev/fuse present"
+    else
+        log "MISSING /dev/fuse — attach will fail (load the fuse module)"; FAILED=1
+    fi
+}
+
+check_aws() {
+    if command -v aws >/dev/null 2>&1; then
+        log "OK  aws       $(aws --version 2>&1)"
+    else
+        log "MISSING aws"; FAILED=1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if [[ "$CHECK_ONLY" -eq 0 ]]; then
+    if [[ "$WANT_JQ"   -eq 1 ]]; then install_jq;   fi
+    if [[ "$WANT_S3FS" -eq 1 ]]; then install_s3fs; fi
+    if [[ "$WANT_AWS"  -eq 1 ]]; then install_aws;  fi
+fi
+
+log "--- verification ---"
+if [[ "$WANT_JQ"   -eq 1 ]]; then check_jq;   fi
+if [[ "$WANT_S3FS" -eq 1 ]]; then check_s3fs; fi
+if [[ "$WANT_AWS"  -eq 1 ]]; then check_aws;  fi
+
+if [[ "$FAILED" -ne 0 ]]; then
+    die "some dependencies are missing (see above)"
+fi
+
+log "all selected dependencies present"

--- a/examples/volume/s3/volume-s3.conf.example
+++ b/examples/volume/s3/volume-s3.conf.example
@@ -21,6 +21,10 @@ ENDPOINT=https://<your-s3-endpoint>
 # AWS: the bucket's region. Tigris/R2: auto. MinIO: any value.
 # REGION=us-east-1
 
+# Optional. Extra s3fs mount options, whitespace-separated, appended verbatim.
+# MinIO (and bucket names containing dots) usually need path-style addressing:
+# S3FS_EXTRA_OPTS=-ouse_path_request_style
+
 # FUSE mount base is passed by Cubelet on attach (--volume-base-dir,
 # default /data/cube-shared/volume). host_path must be under it, e.g.
 # /data/cube-shared/volume/s3-<volume_id>.

--- a/examples/volume/s3/volume-s3.conf.example
+++ b/examples/volume/s3/volume-s3.conf.example
@@ -1,0 +1,26 @@
+# CubeMaster/plugin/volume-s3.conf or Cubelet/plugin/volume-s3.conf
+# (one-click install) — same directory as the cube-volume-s3 binary.
+#
+# Holds a plaintext secret: keep it root-owned and chmod 600.
+
+# Access key pair with read/write permission on BUCKET.
+ACCESS_KEY_ID=<your-access-key-id>
+SECRET_ACCESS_KEY=<your-secret-access-key>
+
+# Bucket that holds every volume, one prefix per volume: volumes/<volume_id>/
+BUCKET=my-cube-volumes
+
+# Required. The S3-compatible endpoint URL of your storage provider:
+#   AWS S3           https://s3.<region>.amazonaws.com
+#   Tigris           https://t3.storage.dev
+#   Cloudflare R2    https://<account-id>.r2.cloudflarestorage.com
+#   MinIO            http://<minio-host>:9000
+ENDPOINT=https://<your-s3-endpoint>
+
+# Optional. Region used for SigV4 signing; default us-east-1.
+# AWS: the bucket's region. Tigris/R2: auto. MinIO: any value.
+# REGION=us-east-1
+
+# FUSE mount base is passed by Cubelet on attach (--volume-base-dir,
+# default /data/cube-shared/volume). host_path must be under it, e.g.
+# /data/cube-shared/volume/s3-<volume_id>.


### PR DESCRIPTION
Hey, it's my first time contributing here, so please tell me if I've put anything in the wrong place.

This adds a second Volume Plugin backend: an S3-compatible one, using Tigris as the worked example.

## The problem

The Volume framework in v0.6.0 is really nicely designed — the Controller/Node hook split made this straightforward to write. But right now COS is the only backend anyone can actually pick up and use, and that's a bit of a dead end for two groups of people:

**If you're self-hosting outside Tencent Cloud**, there's no ready-made option. You can absolutely write your own plugin (the docs are good enough that I did exactly that), but "read the spec and implement four hooks" is a big ask for someone who just wants their sandbox workspace to survive a restart. Host mount covers node-local paths, but not shared or durable storage.

**If you're on ARM64**, there's currently nothing at all. `Volume.create()` succeeds, then Attach has nothing to mount — because upstream cosfs only ships amd64 packages. Your own build script already calls this out:

```
log "skip cosfs on ${arch}: no official arm64 .deb (temporary)"
```

s3fs is packaged for arm64 by both Debian/Ubuntu and EPEL, so an s3fs-based plugin closes that gap without waiting on cosfs.

## What's in here

```
examples/volume/tigris/
├── binary/cube-volume-tigris.sh    # all four hooks
├── install-deps.sh                 # s3fs / aws / jq, with --check-only
├── volume-tigris.conf.example
└── README.md + README.zh.md
docs/guide/integrations/tigris.md   (+ zh) and index rows in both languages
```

The plugin is deliberately a close port of `cube-volume-cos.sh` — same structure, same locking, same refcount handling, same JSON contract. I figured a near-identical file is much easier to review than something clever. Mount is **s3fs**, control plane is the **AWS CLI**. No vendor SDK.

The only Tigris-specific thing in the whole plugin is a default endpoint URL. Point `ENDPOINT` somewhere else and it works against MinIO, R2, or S3 — so this is really "generic S3 support, documented against Tigris" more than it is a vendor integration.

## Notes for review

- **Purely additive.** No existing behavior changes, no default driver changes. You have to explicitly register `name: tigris` in `volume_plugins` for any of this to do anything.
- **Credentials stay out of the sandbox** — mode 600 config on CubeMaster/Cubelet, the microVM only ever sees a filesystem.
- **Bilingual**, per the integrations index. My Chinese is likely imperfect in places — corrections very welcome, I won't be precious about it.
- I added three env var overrides (`CUBE_TIGRIS_CONFIG` / `_PASSWD_FILE` / `_LOCK_DIR`) so the plugin can be exercised without root. The COS version hardcodes `/etc/cube` and `/run`, which makes it hard to test outside a real deployment. Happy to drop these if you'd rather keep exact parity.

## What I tested

Tested the full hook lifecycle (create → attach ×2 → detach ×2 → destroy) with stubbed backends, asserting on the exact commands issued: refcount 1 correctly reuses the mount instead of mounting twice, `host_path` always lands under `volumeBaseDir`, the mountpoint is cleaned up on last detach, and the error paths return proper JSON. Both scripts pass `bash -n`.

## One question

Would you want s3fs added to `deploy/scripts/docker-install-volume-deps.sh` so the official images pick up an arm64-capable backend? I left it out of this PR to keep the diff additive and easy to say no to, but happy to follow up with it if that's useful.


