### PR TITLE
examples: snapshot/rollback plugin for Claude Code hooks (companion to #765)

### DIFF
--- a/examples/claude-code-integration/rollback/.env.example
+++ b/examples/claude-code-integration/rollback/.env.example
@@ -3,5 +3,10 @@
 CUBE_ROLLBACK_SAFE=echo,cat,ls,pwd,cd,export,env,which,whoami
 # Redirects to /dev/null and &1/&2 are automatically excluded from risk
 
-# Uses same API endpoint and template as #765 (from ../hooks/.env)
-# CUBE_API_URL and CUBE_TEMPLATE_ID are read from the parent hook's .env
+# Max auto snapshots kept per session (ring buffer; oldest evicted from the
+# backend when exceeded). Baseline and explicit checkpoints are never evicted.
+CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS=30
+
+# Uses the same API endpoint and template as cubesandbox-hook. CUBE_API_URL
+# and CUBE_TEMPLATE_ID are read from `~/.claude/hooks/cubesandbox.env` at hook
+# startup (cubesandbox-hook's env file), or from the shell environment

--- a/examples/claude-code-integration/rollback/.env.example
+++ b/examples/claude-code-integration/rollback/.env.example
@@ -1,0 +1,7 @@
+# Rollback plugin configuration
+# Safe command whitelist (comma-separated) — these are NEVER snapshotted
+CUBE_ROLLBACK_SAFE=echo,cat,ls,pwd,cd,export,env,which,whoami
+# Redirects to /dev/null and &1/&2 are automatically excluded from risk
+
+# Uses same API endpoint and template as #765 (from ../hooks/.env)
+# CUBE_API_URL and CUBE_TEMPLATE_ID are read from the parent hook's .env

--- a/examples/claude-code-integration/rollback/README.md
+++ b/examples/claude-code-integration/rollback/README.md
@@ -1,0 +1,150 @@
+# CubeSandbox Rollback for Claude Code
+
+Snapshot and rollback protection for Claude Code sessions that run inside
+CubeSandbox MicroVMs. Before risky commands a sandbox snapshot is taken
+automatically; if the command breaks the environment, the agent runs
+`cubesandbox-rollback last` to restore the previous filesystem state. This
+example is a companion layer to the CubeSandbox Claude Code hooks
+(`examples/claude-code-integration/hooks/`, below: **#765**), which redirect
+every Bash tool call into an isolated sandbox.
+
+## Why
+
+Claude Code's `/rewind` restores the conversation and file edits but not Bash
+side effects in a sandbox: a destructive `rm`, `git reset`, or `npm install`
+cannot be unwound. This plugin snapshots before risky commands and lets the
+agent roll back to the last good state on demand.
+
+## Architecture
+
+- **Companion layer to #765.** It never imports #765 modules and never writes
+  #765's state. It only *reads* `~/.cache/cubesandbox-hook/<sha256(session_id)>.json`
+  (fields `sandbox_id`, `mount`, `state_token`) to find the session's sandbox.
+  If #765 is absent or the sandbox does not exist yet, the hooks degrade
+  gracefully (skip / no-op). The digest function is duplicated to match #765
+  exactly, so both plugins address the same session.
+- **Parallel-hook safety.** Claude Code runs multiple PreToolUse hooks in
+  parallel; each receives the original tool input, `deny` has highest
+  precedence, and `updatedInput` is not seen by other hooks. Our hooks return
+  only `{}` (no opinion) or `deny` — never `updatedInput` — so they coexist
+  with #765's rewrite hook without fighting over the command.
+- **Deny channel.** Verified with live sessions: Claude Code renders
+  `permissionDecisionReason` to the agent but not `hookSpecificOutput.stdout`.
+  All user-facing output (rollback results, snapshot lists, errors) is carried
+  in `permissionDecisionReason`.
+- **Fail-open vs fail-closed.** The snapshot hook is fail-open (any error
+  returns `{}` and the command proceeds). The rollback hook is fail-closed
+  (errors deny the command with a message).
+
+## Files
+
+| File | Role |
+|---|---|
+| `cubesandbox_lib.py` | Shared utilities: session digest (must match #765), atomic state I/O with `flock`, sandbox client, config-hash staleness check, orphan cleanup |
+| `cubesandbox_risky.py` | Risk classifier. Strict: compound commands are split per segment (quote-aware, `&&`/`\|\|`/`;`/`\|`), `sudo`/`env`/`nohup`/`nice` stripped, destructive redirects detected (`/dev/null`, `/dev/*` and fd refs `&1`/`&2` excluded), `curl`/`wget` `-o`/`-O`/`--output` flagged |
+| `cubesandbox_snapshot.py` | PreToolUse/Bash: risky command → `create_snapshot()` → record it → return `{}` (fail-open) |
+| `cubesandbox_rollback.py` | PreToolUse/Bash: sentinel command → `deny` + rollback / list / drop (fail-closed) |
+| `cubesandbox_session.py` | SessionStart: injects rollback awareness into the agent's context |
+| `cubesandbox_poststart.py` | PostToolUse/Bash: `<initial>` baseline snapshot after the first command |
+| `install_rollback.sh` | Idempotent install/uninstall. Registers hooks in the project's `.claude/settings.json` and installs `SKILL.md` as a skill. Never touches user-level `~/.claude/settings.json` (#765's domain) |
+| `SKILL.md` | Agent-facing command reference (installed to `.claude/skills/cubesandbox-rollback/`) |
+| `.env.example` | Optional `CUBE_ROLLBACK_SAFE` whitelist; API/template config is shared from #765's `.env` |
+
+Own state lives in `~/.cache/cubesandbox-rollback/<sha256(session_id)>.json`
+(written atomically, serialized with `flock`); if #765's state file disappears,
+the rollback state is treated as orphaned and cleaned up.
+
+## Installation
+
+Prerequisites: a running CubeSandbox deployment, the #765 hooks installed, and
+`claude` launched **from the project root** (project-level `settings.json` and
+the skill only load there).
+
+```bash
+# from the project you want protected
+bash examples/claude-code-integration/rollback/install_rollback.sh
+
+# remove again
+bash examples/claude-code-integration/rollback/install_rollback.sh --uninstall
+```
+
+The installer copies the hook scripts to `~/.claude/hooks/rollback/`, registers
+them in `<project>/.claude/settings.json`, and creates the skill at
+`.claude/skills/cubesandbox-rollback/`. It is idempotent — re-running it does
+not duplicate hooks.
+
+## Agent commands
+
+Snapshots are taken automatically before risky commands. The agent (or you)
+can then use:
+
+| Command | Effect |
+|---|---|
+| `cubesandbox-rollback last` | Restore the sandbox to the most recent snapshot |
+| `cubesandbox-rollback list` | List available snapshots (index, id, time, command) |
+| `cubesandbox-rollback drop <snapshot-id>` | Delete a snapshot |
+
+### Risk classification
+
+Snapshot-triggering commands include `rm`, `rmdir`, `chmod`, `chown`, `mv`,
+`dd`, `shred`, `mkfs`, `fdisk`, `apt*`, `dnf`, `yum`, `brew`, `snap`; risky
+subcommands such as `git reset`/`git clean`, `npm install`/`uninstall`/`update`,
+`pip install`/`uninstall`, `yarn add`/`remove`, `cargo install`, `go install`,
+`make install`; `curl`/`wget` writing via `-o`/`-O`/`--output`; and any
+redirect to a real file. Redirects to `/dev/null` or file descriptors (`2>&1`)
+are excluded, and the `cubesandbox-rollback` sentinel itself is never
+snapshotted.
+
+To whitelist commands that must never trigger a snapshot, export
+`CUBE_ROLLBACK_SAFE` (comma-separated), e.g.:
+
+```bash
+export CUBE_ROLLBACK_SAFE=echo,cat,ls,pwd,cd,git,make
+```
+
+## Verified on real hardware
+
+Tested end-to-end on a bare-metal CubeSandbox v0.6.0 deployment (11 services,
+KVM) with real Claude Code 2.1.142 sessions:
+
+```
+1. touch /tmp/demo.txt            # file created
+2. rm /tmp/demo.txt               # deleted; pre-snapshot taken automatically
+3. cubesandbox-rollback last      # "Rollback complete. State restored to snapshot `snap-xxx`"
+4. ls /tmp/demo.txt               # file restored, confirmed inside the sandbox
+```
+
+Cross-verified via the CubeAPI: the snapshot id reported by Claude Code appears
+both in `GET /cubeapi/v1/snapshots` (status `READY`) and in the sandbox's
+`metadata.cube.master.runtime.restore.snapshot.id` — three-way alignment
+between the agent output, the backend snapshot, and the restored sandbox.
+
+## Known limitations
+
+1. **Host-mount and snapshot are mutually exclusive (platform constraint).**
+   Cubelet's `validateCommitSandboxTarget` rejects `CommitSandbox` for any
+   sandbox with host-path volume mounts (`has volume mounts without persisted
+   volume sources`). Adding the project dir to CubeMaster's
+   `allowed_host_mount_prefixes` gives the read-only host mount but breaks
+   snapshot/rollback with error 130400. Keep the default prefix list (only
+   `/data/shared/`) — no host mount, snapshots work.
+2. **Rollback on long-active sandboxes can hit a TAP `EBUSY` race.** Rollback
+   restarts the VM and rebuilds its virtio-net TAP devices; on sandboxes with
+   persistent exec connections this can fail with
+   `CreateVirtioNet → Device or resource busy`. Retry after a few seconds or
+   start a fresh session (known platform race; related fix in v0.3.1, #442).
+3. **The first Bash command of a session has no prior snapshot.** The
+   `<initial>` baseline is taken *after* the first command, so the very first
+   command cannot be rolled back.
+4. **PostToolUse is skipped for failed tool calls.** Claude Code does not fire
+   PostToolUse hooks when a Bash tool call returns an error, so the baseline is
+   only created when the first command succeeds. If it fails,
+   `cubesandbox-rollback last` reports "No snapshots available to roll back."
+5. **Project-level hooks only apply when `claude` runs from the project root.**
+   Run `claude` in the directory that contains `.claude/settings.json`.
+
+## Contributing
+
+This README documents the example itself. Per `CONTRIBUTING.md`, a community
+integration guide may also be submitted under `docs/guide/integrations/` (and
+`docs/zh/guide/integrations/`), following its frontmatter and bilingual rules.

--- a/examples/claude-code-integration/rollback/README.md
+++ b/examples/claude-code-integration/rollback/README.md
@@ -99,13 +99,14 @@ never auto-evicted).
 Auto snapshots are kept in a ring buffer of `CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS`
 (default 30, env-configurable); when the cap is exceeded, the oldest auto
 snapshot is deleted from the backend. Baseline snapshots and explicit
-checkpoints are never auto-evicted — drop them manually.
+checkpoints are never auto-evicted by the ring buffer — drop them manually.
 
-Rolling back to a checkpoint discards all snapshots after it (deleted from the
-backend; the discarded list is shown in the message) but keeps a hidden undo
-point: `cubesandbox-rollback undo` restores the pre-rollback state. The undo
-point is deleted as soon as a new snapshot is taken (either auto or
-checkpoint).
+Rolling back to an early snapshot deletes all later snapshots from the
+plugin's index AND the backend — including named checkpoints; only the
+immediately preceding state is preserved as the hidden undo point, so
+`cubesandbox-rollback undo` restores the pre-rollback state. The discarded
+list is shown in the rollback message. The undo point is deleted as soon as a
+new snapshot is taken (either auto or checkpoint).
 
 ### Risk classification
 

--- a/examples/claude-code-integration/rollback/README.md
+++ b/examples/claude-code-integration/rollback/README.md
@@ -5,8 +5,8 @@ CubeSandbox MicroVMs. Before risky commands a sandbox snapshot is taken
 automatically; if the command breaks the environment, the agent runs
 `cubesandbox-rollback last` to restore the previous filesystem state. This
 example is a companion layer to the CubeSandbox Claude Code hooks
-(`examples/claude-code-integration/hooks/`, below: **#765**), which redirect
-every Bash tool call into an isolated sandbox.
+(`examples/claude-code-integration/hooks/`, below: **cubesandbox-hook**
+(PR #765)), which redirect every Bash tool call into an isolated sandbox.
 
 ## Why
 
@@ -17,17 +17,18 @@ agent roll back to the last good state on demand.
 
 ## Architecture
 
-- **Companion layer to #765.** It never imports #765 modules and never writes
-  #765's state. It only *reads* `~/.cache/cubesandbox-hook/<sha256(session_id)>.json`
-  (fields `sandbox_id`, `mount`, `state_token`) to find the session's sandbox.
-  If #765 is absent or the sandbox does not exist yet, the hooks degrade
-  gracefully (skip / no-op). The digest function is duplicated to match #765
+- **Companion layer to cubesandbox-hook.** It never imports cubesandbox-hook
+  modules and never writes cubesandbox-hook's state. It only *reads*
+  `~/.cache/cubesandbox-hook/<sha256(session_id)>.json` (fields `sandbox_id`,
+  `mount`, `state_token`) to find the session's sandbox. If cubesandbox-hook
+  is absent or the sandbox does not exist yet, the hooks degrade gracefully
+  (skip / no-op). The digest function is duplicated to match cubesandbox-hook
   exactly, so both plugins address the same session.
 - **Parallel-hook safety.** Claude Code runs multiple PreToolUse hooks in
   parallel; each receives the original tool input, `deny` has highest
   precedence, and `updatedInput` is not seen by other hooks. Our hooks return
   only `{}` (no opinion) or `deny` — never `updatedInput` — so they coexist
-  with #765's rewrite hook without fighting over the command.
+  with cubesandbox-hook's rewrite hook without fighting over the command.
 - **Deny channel.** Verified with live sessions: Claude Code renders
   `permissionDecisionReason` to the agent but not `hookSpecificOutput.stdout`.
   All user-facing output (rollback results, snapshot lists, errors) is carried
@@ -40,25 +41,25 @@ agent roll back to the last good state on demand.
 
 | File | Role |
 |---|---|
-| `cubesandbox_lib.py` | Shared utilities: session digest (must match #765), atomic state I/O with `flock`, sandbox client, config-hash staleness check, orphan cleanup |
-| `cubesandbox_risky.py` | Risk classifier. Strict: compound commands are split per segment (quote-aware, `&&`/`\|\|`/`;`/`\|`), `sudo`/`env`/`nohup`/`nice` stripped, destructive redirects detected (`/dev/null`, `/dev/*` and fd refs `&1`/`&2` excluded), `curl`/`wget` `-o`/`-O`/`--output` flagged |
-| `cubesandbox_snapshot.py` | PreToolUse/Bash: risky command → `create_snapshot()` → record it → return `{}` (fail-open) |
-| `cubesandbox_rollback.py` | PreToolUse/Bash: sentinel command → `deny` + rollback / list / drop (fail-closed) |
+| `cubesandbox_lib.py` | Shared utilities: session digest (must match cubesandbox-hook), atomic state I/O with `flock`, sandbox client, loads `~/.claude/hooks/cubesandbox.env` into the hook process at startup (without overriding existing env vars), pure helpers for snapshot find/prune/evict, orphan cleanup |
+| `cubesandbox_risky.py` | Risk classifier. AST-based (bashlex): parses the whole command with bash's own grammar instead of regex. Unwraps `sudo`/`env`/`nohup`/`nice`/`timeout`/`exec` prefixes and leading `VAR=value` assignments, evaluates every pipeline/compound segment and nested `$()`/`<( )` substitution independently, detects destructive redirects (`/dev/null` and fd refs `&1`/`&2` excluded), flags `curl`/`wget` `-o`/`-O`/`--output`, `curl|bash`-style download-to-interpreter pipes, and fork bombs. Unparseable commands are treated as risky (fail-safe) |
+| `cubesandbox_snapshot.py` | PreToolUse/Bash: risky command → `create_snapshot()` → record it → ring-buffer eviction of auto snapshots and undo-point invalidation → return `{}` (fail-open) |
+| `cubesandbox_rollback.py` | PreToolUse/Bash: sentinel command → `deny` + multi-point rollback (`last` / index / snapshot id), `checkpoint`, `undo`, `list`, `drop` (fail-closed) |
 | `cubesandbox_session.py` | SessionStart: injects rollback awareness into the agent's context |
-| `cubesandbox_poststart.py` | PostToolUse/Bash: `<initial>` baseline snapshot after the first command |
-| `install_rollback.sh` | Idempotent install/uninstall. Registers hooks in the project's `.claude/settings.json` and installs `SKILL.md` as a skill. Never touches user-level `~/.claude/settings.json` (#765's domain) |
+| `cubesandbox_poststart.py` | PostToolUse/Bash: `<initial>` baseline snapshot (`kind: baseline`, never auto-evicted) after the first command |
+| `install_rollback.sh` | Idempotent install/uninstall. Registers hooks in the project's `.claude/settings.json` and installs `SKILL.md` as a skill. Never touches user-level `~/.claude/settings.json` (cubesandbox-hook's domain) |
 | `SKILL.md` | Agent-facing command reference (installed to `.claude/skills/cubesandbox-rollback/`) |
-| `.env.example` | Optional `CUBE_ROLLBACK_SAFE` whitelist; API/template config is shared from #765's `.env` |
+| `.env.example` | Optional `CUBE_ROLLBACK_SAFE` whitelist and `CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS` ring-buffer cap; API/template config is read from `~/.claude/hooks/cubesandbox.env` at hook startup (cubesandbox-hook's env file), or from the shell environment |
 
 Own state lives in `~/.cache/cubesandbox-rollback/<sha256(session_id)>.json`
-(written atomically, serialized with `flock`); if #765's state file disappears,
-the rollback state is treated as orphaned and cleaned up.
+(written atomically, serialized with `flock`); if cubesandbox-hook's state
+file disappears, the rollback state is treated as orphaned and cleaned up.
 
 ## Installation
 
-Prerequisites: a running CubeSandbox deployment, the #765 hooks installed, and
-`claude` launched **from the project root** (project-level `settings.json` and
-the skill only load there).
+Prerequisites: a running CubeSandbox deployment, the cubesandbox-hook hooks
+installed, and `claude` launched **from the project root** (project-level
+`settings.json` and the skill only load there).
 
 ```bash
 # from the project you want protected
@@ -80,20 +81,58 @@ can then use:
 
 | Command | Effect |
 |---|---|
-| `cubesandbox-rollback last` | Restore the sandbox to the most recent snapshot |
-| `cubesandbox-rollback list` | List available snapshots (index, id, time, command) |
-| `cubesandbox-rollback drop <snapshot-id>` | Delete a snapshot |
+| `cubesandbox-rollback last` | Roll back to the most recent snapshot (default) |
+| `cubesandbox-rollback <N>` | Roll back to the snapshot at list index N |
+| `cubesandbox-rollback <snapshot-id>` | Roll back to a specific snapshot |
+| `cubesandbox-rollback list` | List snapshots: `[N] id time [kind] command` |
+| `cubesandbox-rollback checkpoint <name>` | Explicit milestone snapshot, never auto-evicted |
+| `cubesandbox-rollback undo` | Undo the last rollback (invalidated once a new snapshot is taken) |
+| `cubesandbox-rollback drop <last\|N\|snapshot-id>` | Delete a snapshot (local + backend) |
+
+Snapshots come in three kinds: `baseline` (taken at session start, never
+auto-evicted), `auto` (taken before risky commands, kept in a ring buffer
+capped by `CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS`), and `checkpoint` (user-named,
+never auto-evicted).
+
+### Snapshot lifecycle
+
+Auto snapshots are kept in a ring buffer of `CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS`
+(default 30, env-configurable); when the cap is exceeded, the oldest auto
+snapshot is deleted from the backend. Baseline snapshots and explicit
+checkpoints are never auto-evicted — drop them manually.
+
+Rolling back to a checkpoint discards all snapshots after it (deleted from the
+backend; the discarded list is shown in the message) but keeps a hidden undo
+point: `cubesandbox-rollback undo` restores the pre-rollback state. The undo
+point is deleted as soon as a new snapshot is taken (either auto or
+checkpoint).
 
 ### Risk classification
+
+The classifier parses each command with [bashlex](https://pypi.org/project/bashlex/)
+(a Python port of bash's own parser) and evaluates every segment of the AST —
+this is the same approach as OpenHands SDK, toad, and connectonion. Regex
+parsing is deliberately not used: regex-based classifiers are trivially
+bypassed by prefixes, quoted targets, or unspaced operators.
 
 Snapshot-triggering commands include `rm`, `rmdir`, `chmod`, `chown`, `mv`,
 `dd`, `shred`, `mkfs`, `fdisk`, `apt*`, `dnf`, `yum`, `brew`, `snap`; risky
 subcommands such as `git reset`/`git clean`, `npm install`/`uninstall`/`update`,
 `pip install`/`uninstall`, `yarn add`/`remove`, `cargo install`, `go install`,
-`make install`; `curl`/`wget` writing via `-o`/`-O`/`--output`; and any
-redirect to a real file. Redirects to `/dev/null` or file descriptors (`2>&1`)
-are excluded, and the `cubesandbox-rollback` sentinel itself is never
-snapshotted.
+`make install`; `curl`/`wget` writing via `-o`/`-O`/`--output`; `curl|bash`-
+style download-to-interpreter pipes; and any redirect to a real file
+(including quoted and unspaced targets like `> "out file.txt"` or `echo x>f`).
+The following are *not* snapshot triggers:
+
+- wrapper prefixes (`sudo`/`env`/`nohup`/`nice`/`timeout`/`exec`/`setsid`)
+  and leading `VAR=value` assignments — the real command is extracted from
+  behind them, so `sudo git reset --hard` and `DEBUG=1 npm install` trigger;
+- redirects to `/dev/null` or file descriptors (`2>&1`, `>&1`, `>/dev/null`);
+- the `cubesandbox-rollback` sentinel itself.
+
+**Fail-safe**: commands bashlex cannot parse (arithmetic expansion
+`$((1 > 0))`, `[[ ]]` tests, fork bombs) are treated as risky rather than
+silently safe — an extra snapshot is harmless, a missed one is not.
 
 To whitelist commands that must never trigger a snapshot, export
 `CUBE_ROLLBACK_SAFE` (comma-separated), e.g.:

--- a/examples/claude-code-integration/rollback/SKILL.md
+++ b/examples/claude-code-integration/rollback/SKILL.md
@@ -4,17 +4,26 @@ This session has CubeSandbox rollback protection. Snapshots are taken
 automatically before risky commands.
 
 ## Available commands
-- `cubesandbox-rollback last` — Restore sandbox to the last snapshot
-- `cubesandbox-rollback list` — List all available snapshots
-- `cubesandbox-rollback drop <id>` — Delete a snapshot
+- `cubesandbox-rollback last` — Roll back to the most recent snapshot (default)
+- `cubesandbox-rollback <N>` — Roll back to the snapshot at list index N
+- `cubesandbox-rollback <snapshot-id>` — Roll back to a specific snapshot
+- `cubesandbox-rollback list` — List snapshots: `[N] id time [kind] command`
+- `cubesandbox-rollback checkpoint <name>` — Create a named milestone snapshot (never auto-evicted)
+- `cubesandbox-rollback undo` — Undo the last rollback (invalidated by the next snapshot)
+- `cubesandbox-rollback drop <last|N|snapshot-id>` — Delete a snapshot (local + backend)
 
 ## When to use
 If a command (e.g. npm install, rm, git reset) breaks the environment,
-use rollback to restore the previous state.
+use rollback to restore the previous state. To go back further, roll back
+to an arbitrary checkpoint by index (`cubesandbox-rollback <N>`) or by
+snapshot id. If you rolled back too far, `cubesandbox-rollback undo`
+restores the pre-rollback state.
 
 ## Limitations
 - The first Bash command of a session cannot be rolled back (no prior snapshot)
 - Rollback **only** restores the sandbox filesystem state,
   not process memory or the Claude Code transcript
-- This plugin must coexist with the #765 CubeSandbox hooks
+- Auto snapshots beyond the ring-buffer cap are evicted; use
+  `cubesandbox-rollback checkpoint <name>` for milestones you need to keep
+- This plugin must coexist with the cubesandbox-hook CubeSandbox hooks
   (`examples/claude-code-integration/hooks/`)

--- a/examples/claude-code-integration/rollback/SKILL.md
+++ b/examples/claude-code-integration/rollback/SKILL.md
@@ -1,0 +1,20 @@
+# CubeSandbox Rollback
+
+This session has CubeSandbox rollback protection. Snapshots are taken
+automatically before risky commands.
+
+## Available commands
+- `cubesandbox-rollback last` — Restore sandbox to the last snapshot
+- `cubesandbox-rollback list` — List all available snapshots
+- `cubesandbox-rollback drop <id>` — Delete a snapshot
+
+## When to use
+If a command (e.g. npm install, rm, git reset) breaks the environment,
+use rollback to restore the previous state.
+
+## Limitations
+- The first Bash command of a session cannot be rolled back (no prior snapshot)
+- Rollback **only** restores the sandbox filesystem state,
+  not process memory or the Claude Code transcript
+- This plugin must coexist with the #765 CubeSandbox hooks
+  (`examples/claude-code-integration/hooks/`)

--- a/examples/claude-code-integration/rollback/SKILL.md
+++ b/examples/claude-code-integration/rollback/SKILL.md
@@ -25,5 +25,8 @@ restores the pre-rollback state.
   not process memory or the Claude Code transcript
 - Auto snapshots beyond the ring-buffer cap are evicted; use
   `cubesandbox-rollback checkpoint <name>` for milestones you need to keep
+- Rolling back to an early snapshot deletes all later snapshots from the
+  plugin's index and the backend, including named checkpoints — only the
+  immediately preceding state is kept as the undo point
 - This plugin must coexist with the cubesandbox-hook CubeSandbox hooks
   (`examples/claude-code-integration/hooks/`)

--- a/examples/claude-code-integration/rollback/cubesandbox_lib.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_lib.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Shared utilities: digest, state I/O, sandbox connection, config hash."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+DEFAULT_SESSION = "default"
+STATE_DIR_765 = Path(os.path.expanduser(
+    os.getenv("CUBE_HOOK_STATE_DIR", "~/.cache/cubesandbox-hook")
+))
+MY_STATE_DIR = Path(os.path.expanduser("~/.cache/cubesandbox-rollback"))
+
+# #765's installed config file (written by #765's install.sh → CONFIG_PATH)
+_ENV_PATH_765 = Path(os.path.expanduser("~/.claude/hooks/cubesandbox.env"))
+
+
+# ---------------------------------------------------------------------------
+# Digest (must match #765's _session_digest *exactly*)
+# ---------------------------------------------------------------------------
+def session_digest(session_id: str) -> str:
+    key = session_id or DEFAULT_SESSION
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+def _ensure_dir(dirpath: Path) -> None:
+    dirpath.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if dirpath.is_symlink() or not dirpath.is_dir():
+        raise OSError(f"unsafe state directory: {dirpath}")
+    os.chmod(dirpath, 0o700)
+
+
+def _sandbox_state_path(session_id: str) -> Path:
+    """Path to #765's state file: ~/.cache/cubesandbox-hook/<digest>.json"""
+    return STATE_DIR_765 / f"{session_digest(session_id)}.json"
+
+
+def _my_state_path(session_id: str) -> Path:
+    """Path to our state file: ~/.cache/cubesandbox-rollback/<digest>.json"""
+    return MY_STATE_DIR / f"{session_digest(session_id)}.json"
+
+
+def _my_lock_path(session_id: str) -> Path:
+    return MY_STATE_DIR / f"{session_digest(session_id)}.lock"
+
+
+# ---------------------------------------------------------------------------
+# #765 state I/O
+# ---------------------------------------------------------------------------
+def read_sandbox_state(session_id: str) -> Optional[Dict[str, Any]]:
+    """Read #765's JSON state; return None if missing or unreadable."""
+    path = _sandbox_state_path(session_id)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Own state I/O (atomic + flock)
+# ---------------------------------------------------------------------------
+@contextlib.contextmanager
+def _locked_state(session_id: str):
+    """Open a lock file and yield when the exclusive lock is acquired."""
+    _ensure_dir(MY_STATE_DIR)
+    lock_path = _my_lock_path(session_id)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def read_my_state(session_id: str) -> Dict[str, Any]:
+    """Read our state, returning an empty dict if not found."""
+    path = _my_state_path(session_id)
+    if not path.exists():
+        return {"session_id": session_id, "snapshots": [], "config_hash": ""}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return {"session_id": session_id, "snapshots": [], "config_hash": ""}
+
+
+def write_my_state(session_id: str, state: Dict[str, Any]) -> None:
+    """Atomically write our state file with flock serialisation."""
+    _ensure_dir(MY_STATE_DIR)
+    path = _my_state_path(session_id)
+    with _locked_state(session_id):
+        fd, tmp = tempfile.mkstemp(dir=str(MY_STATE_DIR),
+                                   prefix=".tmp_state_",
+                                   suffix=".json")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(state, fh, indent=2, sort_keys=True)
+            os.chmod(tmp, 0o600)
+            os.rename(tmp, str(path))
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Sandbox connection
+# ---------------------------------------------------------------------------
+def get_sandbox_client(sandbox_id: str):
+    """Connect to a CubeSandbox; import on demand."""
+    from cubesandbox import Sandbox
+    return Sandbox.connect(sandbox_id=sandbox_id)
+
+
+# ---------------------------------------------------------------------------
+# Config hash (detect stale #765 env)
+# ---------------------------------------------------------------------------
+def get_config_hash() -> str:
+    """SHA-256 of #765's .env file content."""
+    if _ENV_PATH_765.exists():
+        content = _ENV_PATH_765.read_bytes()
+    else:
+        content = b""
+    return hashlib.sha256(content).hexdigest()
+
+
+def check_config_stale(session_id: str) -> bool:
+    """Return True if our stored config hash differs from #765's current env."""
+    stored = read_my_state(session_id).get("config_hash", "")
+    current = get_config_hash()
+    return stored and stored != current
+
+
+# ---------------------------------------------------------------------------
+# Orphan detection
+# ---------------------------------------------------------------------------
+def orphan_check(session_id: str) -> bool:
+    """Delete our state if #765's state is gone. Return True if orphaned."""
+    if not _sandbox_state_path(session_id).exists():
+        our = _my_state_path(session_id)
+        if our.exists():
+            with contextlib.suppress(OSError):
+                our.unlink()
+        return True
+    return False
+

--- a/examples/claude-code-integration/rollback/cubesandbox_lib.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_lib.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Shared utilities: digest, state I/O, sandbox connection, config hash."""
+"""Shared utilities: digest, state I/O, sandbox connection, hook env,
+snapshot helpers."""
 
 from __future__ import annotations
 
@@ -11,27 +12,50 @@ import os
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 DEFAULT_SESSION = "default"
-STATE_DIR_765 = Path(os.path.expanduser(
+HOOK_STATE_DIR = Path(os.path.expanduser(
     os.getenv("CUBE_HOOK_STATE_DIR", "~/.cache/cubesandbox-hook")
 ))
 MY_STATE_DIR = Path(os.path.expanduser("~/.cache/cubesandbox-rollback"))
 
-# #765's installed config file (written by #765's install.sh → CONFIG_PATH)
-_ENV_PATH_765 = Path(os.path.expanduser("~/.claude/hooks/cubesandbox.env"))
+# cubesandbox-hook's installed config file (written by cubesandbox-hook's
+# install.sh → CONFIG_PATH)
+_HOOK_ENV_PATH = Path(os.path.expanduser("~/.claude/hooks/cubesandbox.env"))
 
 
 # ---------------------------------------------------------------------------
-# Digest (must match #765's _session_digest *exactly*)
+# Digest (must match cubesandbox-hook's _session_digest *exactly*)
 # ---------------------------------------------------------------------------
 def session_digest(session_id: str) -> str:
     key = session_id or DEFAULT_SESSION
     return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Hook env (cubesandbox-hook's installed .env — never clobber)
+# ---------------------------------------------------------------------------
+def load_hook_env() -> None:
+    """Load KEY=VALUE entries from cubesandbox-hook's installed env file.
+
+    Missing or unreadable file → no-op.  Already-set environment variables
+    are NEVER clobbered (``os.environ.setdefault``).
+    """
+    path = _HOOK_ENV_PATH
+    if not path.exists():
+        return
+    try:
+        from dotenv import dotenv_values
+        values = dotenv_values(str(path))
+    except Exception:
+        return
+    for key, value in values.items():
+        if key and isinstance(value, str):
+            os.environ.setdefault(key, value)
 
 
 # ---------------------------------------------------------------------------
@@ -45,8 +69,9 @@ def _ensure_dir(dirpath: Path) -> None:
 
 
 def _sandbox_state_path(session_id: str) -> Path:
-    """Path to #765's state file: ~/.cache/cubesandbox-hook/<digest>.json"""
-    return STATE_DIR_765 / f"{session_digest(session_id)}.json"
+    """Path to cubesandbox-hook's state file:
+    ~/.cache/cubesandbox-hook/<digest>.json"""
+    return HOOK_STATE_DIR / f"{session_digest(session_id)}.json"
 
 
 def _my_state_path(session_id: str) -> Path:
@@ -59,10 +84,10 @@ def _my_lock_path(session_id: str) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# #765 state I/O
+# cubesandbox-hook state I/O
 # ---------------------------------------------------------------------------
-def read_sandbox_state(session_id: str) -> Optional[Dict[str, Any]]:
-    """Read #765's JSON state; return None if missing or unreadable."""
+def read_sandbox_state(session_id: str) -> Dict[str, Any] | None:
+    """Read cubesandbox-hook's JSON state; return None if missing/unreadable."""
     path = _sandbox_state_path(session_id)
     if not path.exists():
         return None
@@ -90,14 +115,14 @@ def _locked_state(session_id: str):
 
 
 def read_my_state(session_id: str) -> Dict[str, Any]:
-    """Read our state, returning an empty dict if not found."""
+    """Read our state, returning a fresh default if not found."""
     path = _my_state_path(session_id)
     if not path.exists():
-        return {"session_id": session_id, "snapshots": [], "config_hash": ""}
+        return {"session_id": session_id, "snapshots": [], "undo": None}
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError, OSError):
-        return {"session_id": session_id, "snapshots": [], "config_hash": ""}
+        return {"session_id": session_id, "snapshots": [], "undo": None}
 
 
 def write_my_state(session_id: str, state: Dict[str, Any]) -> None:
@@ -120,7 +145,61 @@ def write_my_state(session_id: str, state: Dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Sandbox connection
+# Snapshot helpers (pure, unit-testable — no I/O)
+# ---------------------------------------------------------------------------
+def find_snapshot_index(snaps: list, target: str) -> int | None:
+    """Locate a snapshot in the snapshots list.
+
+    ``target``:
+      - ``"last"``            → the final index (``len(snaps) - 1``)
+      - decimal int string    → that index (out-of-range → None)
+      - otherwise             → index of the entry whose ``snapshot_id``
+                                matches, else None (non-numeric non-id → None)
+    """
+    if not snaps:
+        return None
+    if target == "last":
+        return len(snaps) - 1
+    if target.isdigit():
+        idx = int(target)
+        return idx if 0 <= idx < len(snaps) else None
+    for i, s in enumerate(snaps):
+        if s.get("snapshot_id") == target:
+            return i
+    return None
+
+
+def prune_after(snaps: list, idx: int) -> tuple[list, list]:
+    """Return (kept, dropped) — kept = snaps[:idx+1], dropped = snaps[idx+1:].
+
+    Preserves order.
+    """
+    return snaps[:idx + 1], snaps[idx + 1:]
+
+
+def evict_auto(snaps: list, max_auto: int) -> tuple[list, list]:
+    """Ring eviction for ``kind == 'auto'`` snapshots only.
+
+    Baseline and checkpoint snapshots are NEVER evicted.  If the number of
+    auto snapshots exceeds ``max_auto``, the OLDEST auto (lowest index among
+    autos) is removed, repeated until count(auto) <= max_auto (usually one
+    iteration).  Snapshots missing a ``kind`` are treated as ``auto``
+    (backward compat with pre-``kind`` state).  ``max_auto`` is clamped to
+    >= 1.  Returns (new_list, evicted_list).
+    """
+    new = list(snaps)
+    evicted: list = []
+    limit = max(1, max_auto)
+    while sum(1 for s in new if s.get("kind", "auto") == "auto") > limit:
+        for i, s in enumerate(new):
+            if s.get("kind", "auto") == "auto":
+                evicted.append(new.pop(i))
+                break
+    return new, evicted
+
+
+# ---------------------------------------------------------------------------
+# Sandbox connection + backend deletion
 # ---------------------------------------------------------------------------
 def get_sandbox_client(sandbox_id: str):
     """Connect to a CubeSandbox; import on demand."""
@@ -128,30 +207,37 @@ def get_sandbox_client(sandbox_id: str):
     return Sandbox.connect(sandbox_id=sandbox_id)
 
 
-# ---------------------------------------------------------------------------
-# Config hash (detect stale #765 env)
-# ---------------------------------------------------------------------------
-def get_config_hash() -> str:
-    """SHA-256 of #765's .env file content."""
-    if _ENV_PATH_765.exists():
-        content = _ENV_PATH_765.read_bytes()
-    else:
-        content = b""
-    return hashlib.sha256(content).hexdigest()
+def delete_snapshot_backend(snapshot_id: str) -> None:
+    """Best-effort backend deletion; swallow all exceptions (caller keeps
+    local state consistent)."""
+    if not snapshot_id:
+        return
+    try:
+        from cubesandbox import Sandbox
+        Sandbox.delete_snapshot(snapshot_id)
+    except Exception:
+        pass
 
 
-def check_config_stale(session_id: str) -> bool:
-    """Return True if our stored config hash differs from #765's current env."""
-    stored = read_my_state(session_id).get("config_hash", "")
-    current = get_config_hash()
-    return stored and stored != current
+# ---------------------------------------------------------------------------
+# Rollback tunables
+# ---------------------------------------------------------------------------
+def get_max_auto_snapshots() -> int:
+    """CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS, default 30, clamped to >= 1."""
+    raw = os.environ.get("CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS", "")
+    try:
+        n = int(raw.strip())
+    except (ValueError, AttributeError):
+        n = 30
+    return max(1, n)
 
 
 # ---------------------------------------------------------------------------
 # Orphan detection
 # ---------------------------------------------------------------------------
 def orphan_check(session_id: str) -> bool:
-    """Delete our state if #765's state is gone. Return True if orphaned."""
+    """Delete our state if cubesandbox-hook's state is gone. Return True if
+    orphaned."""
     if not _sandbox_state_path(session_id).exists():
         our = _my_state_path(session_id)
         if our.exists():
@@ -159,4 +245,3 @@ def orphan_check(session_id: str) -> bool:
                 our.unlink()
         return True
     return False
-

--- a/examples/claude-code-integration/rollback/cubesandbox_poststart.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_poststart.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""PostToolUse/Bash hook: take baseline snapshot after the first command."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+
+from cubesandbox_lib import (
+    get_config_hash,
+    get_sandbox_client,
+    read_my_state,
+    read_sandbox_state,
+    write_my_state,
+)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        print("{}")
+        return 0
+
+    if payload.get("hook_event_name") != "PostToolUse":
+        print("{}")
+        return 0
+    if payload.get("tool_name") != "Bash":
+        print("{}")
+        return 0
+
+    session_id = payload.get("session_id", "default")
+    my = read_my_state(session_id)
+
+    # Already have snapshots → not the first command
+    if my.get("snapshots"):
+        print("{}")
+        return 0
+
+    # First command: we need a sandbox (#765 should have created one)
+    sstate = read_sandbox_state(session_id)
+    if not sstate or not sstate.get("sandbox_id"):
+        print("[cubesandbox-poststart] no sandbox yet", file=sys.stderr)
+        print("{}")
+        return 0
+
+    stored = my.get("config_hash", "")
+    current = get_config_hash()
+    if stored and stored != current:
+        print("[cubesandbox-poststart] config stale", file=sys.stderr)
+        print("{}")
+        return 0
+
+    try:
+        client = get_sandbox_client(sstate["sandbox_id"])
+        snapshot = client.create_snapshot()
+    except Exception as exc:
+        print(f"[cubesandbox-poststart] snapshot error: {exc}", file=sys.stderr)
+        print("{}")
+        return 0
+
+    my.setdefault("snapshots", []).append({
+        "snapshot_id": snapshot.snapshot_id,
+        "name": getattr(snapshot, "name", ""),
+        "command": "<initial>",
+        "timestamp": int(time.time()),
+    })
+    my["config_hash"] = get_config_hash()
+    try:
+        write_my_state(session_id, my)
+    except Exception as exc:
+        print(f"[cubesandbox-poststart] state write error: {exc}", file=sys.stderr)
+        print("{}")
+        return 0
+
+    print("[cubesandbox-poststart] baseline snapshot taken", file=sys.stderr)
+    print("{}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/rollback/cubesandbox_poststart.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_poststart.py
@@ -12,8 +12,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPT_DIR)
 
 from cubesandbox_lib import (
-    get_config_hash,
     get_sandbox_client,
+    load_hook_env,
     read_my_state,
     read_sandbox_state,
     write_my_state,
@@ -21,6 +21,8 @@ from cubesandbox_lib import (
 
 
 def main() -> int:
+    load_hook_env()
+
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, UnicodeDecodeError):
@@ -37,22 +39,15 @@ def main() -> int:
     session_id = payload.get("session_id", "default")
     my = read_my_state(session_id)
 
-    # Already have snapshots → not the first command
+    # Already have snapshots → not the first command (baseline already exists)
     if my.get("snapshots"):
         print("{}")
         return 0
 
-    # First command: we need a sandbox (#765 should have created one)
+    # First command: we need a sandbox (cubesandbox-hook should have created one)
     sstate = read_sandbox_state(session_id)
     if not sstate or not sstate.get("sandbox_id"):
         print("[cubesandbox-poststart] no sandbox yet", file=sys.stderr)
-        print("{}")
-        return 0
-
-    stored = my.get("config_hash", "")
-    current = get_config_hash()
-    if stored and stored != current:
-        print("[cubesandbox-poststart] config stale", file=sys.stderr)
         print("{}")
         return 0
 
@@ -66,11 +61,11 @@ def main() -> int:
 
     my.setdefault("snapshots", []).append({
         "snapshot_id": snapshot.snapshot_id,
-        "name": getattr(snapshot, "name", ""),
+        "kind": "baseline",
+        "name": "<initial>",
         "command": "<initial>",
         "timestamp": int(time.time()),
     })
-    my["config_hash"] = get_config_hash()
     try:
         write_my_state(session_id, my)
     except Exception as exc:

--- a/examples/claude-code-integration/rollback/cubesandbox_poststart.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_poststart.py
@@ -39,8 +39,10 @@ def main() -> int:
     session_id = payload.get("session_id", "default")
     my = read_my_state(session_id)
 
-    # Already have snapshots → not the first command (baseline already exists)
-    if my.get("snapshots"):
+    # Baseline already exists → nothing to do (auto snapshots don't count:
+    # an `auto` snapshot from a risky first command must not suppress the
+    # baseline, or `rollback last` would skip it forever)
+    if any(s.get("kind") == "baseline" for s in my.get("snapshots", [])):
         print("{}")
         return 0
 

--- a/examples/claude-code-integration/rollback/cubesandbox_risky.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_risky.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Risky command classifier.  从严 (strict): over-classify, parse compound commands."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import Set, List, Tuple, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+SENTINEL_PREFIX = "cubesandbox-rollback"
+
+# Prefixes to skip before extracting the real first word
+_SKIPPABLE_PREFIXES: tuple = ("sudo", "env", "nohup", "nice")
+
+# Commands whose *presence* makes a compound segment risky
+_RISKY_FIRST_WORDS: Set[str] = {
+    "rm", "rmdir", "chmod", "chown", "mv", "dd", "shred", "mkfs", "fdisk",
+    "apt", "apt-get", "dnf", "yum", "pacman", "brew", "snap",
+}
+
+# Commands that are risky only with specific subcommands
+_RISKY_WITH_SUB: dict = {
+    "git":  {"reset", "clean"},
+    "npm":  {"install", "uninstall", "update"},
+    "pip":  {"install", "uninstall"},
+    "pip3": {"install", "uninstall"},
+    "yarn": {"add", "remove"},
+    "pnpm": {"add", "remove"},
+    "cargo": {"install", "uninstall"},
+    "go":   {"install", "get"},
+    "make":  {"install"},
+}
+
+# Commands dangerous when used with -o / -O / --output
+_RISKY_OUTPUT_CMDS: Set[str] = {"curl", "wget"}
+
+# regex for -o / -O / --output flag (short or long, outside quotes)
+_OUTPUT_FLAG_RE = re.compile(r"(?:\s|^)(?:-[oO]\b|--output\b)")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _strip_quoted(text: str) -> str:
+    """Remove single- and double-quoted substrings."""
+    return re.sub(r"""('[^']*'|"[^"]*")""", "", text)
+
+
+def _first_word(segment: str) -> str:
+    """Return the first non-empty whitespace-delimited token, lowercased,
+    after skipping `sudo`, `env`, `nohup`, `nice` prefixes.  basename
+    normalises absolute paths (e.g. `/usr/bin/rm` → `rm`)."""
+    seg = segment.strip()
+    if not seg:
+        return ""
+    parts = seg.split(None)
+    idx = 0
+    # Walk past skippable prefixes
+    while idx < len(parts) and parts[idx].lower() in _SKIPPABLE_PREFIXES:
+        idx += 1
+    if idx >= len(parts):
+        return ""
+    return os.path.basename(parts[idx].lower())
+
+
+_REDIR_RE = re.compile(
+    r'(?:^|\s)([0-9]{1,2}>>?|&>>?|>&>?|>>?)\s*(\S+)'
+)
+
+
+def _has_destructive_redirect(segment: str) -> bool:
+    """True if the segment has a redirect that writes to a real file.
+
+    Safe targets (/dev/null, fd refs like &1/&2, any /dev/* path) are NOT
+    destructive — so the ubiquitous `2>/dev/null` / `2>&1` / `>/dev/null`
+    never triggers a snapshot.  The operator forms `&>` and the csh-style
+    `>&` are parsed as a single operator (not `>` + a `&` target), and
+    fd-duplication targets like `2>&1` / `>&1` are treated as safe.
+    Only writes to an actual file or directory count.
+    """
+    for op, target in _REDIR_RE.findall(_strip_quoted(segment)):
+        if _is_safe_redirect_target(op, target):
+            continue
+        return True
+    return False
+
+
+def _is_safe_redirect_target(op: str, target: str) -> bool:
+    """True if a redirect targets /dev/null or a file descriptor.
+
+    ``2>&1`` / ``1>&2`` parse as fd-prefixed operator + ``&N`` target;
+    the csh-style ``>&1`` parses as ``>&`` operator + ``N`` target.  Both
+    duplicate to an existing descriptor and never touch the filesystem.
+    """
+    if target == '/dev/null' or target.startswith('/dev/'):
+        return True
+    if re.fullmatch(r'&[0-9]+', target):
+        return True  # 2>&1 / 1>&2 / 2>&3 style fd duplication
+    if op.startswith('>&') and re.fullmatch(r'[0-9]+', target):
+        return True  # csh-style >&1 (dup stdout to fd 1)
+    return False
+
+
+def _has_output_flag(segment: str) -> bool:
+    """True if the segment has -o / -O / --output flag (for curl/wget)."""
+    cleaned = _strip_quoted(segment)
+    return bool(_OUTPUT_FLAG_RE.search(cleaned))
+
+
+# ---------------------------------------------------------------------------
+# Quote-aware compound split
+# ---------------------------------------------------------------------------
+def _is_inside_quotes(command: str, pos: int) -> bool:
+    """Return True if position `pos` in `command` is inside single or double quotes."""
+    in_single = in_double = False
+    for i, ch in enumerate(command[:pos]):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+    # At the boundary, we consider the separator to be outside quotes
+    # only if both states are "closed" at the character just before pos.
+    return in_single or in_double
+
+
+def split_compound(command: str) -> List[str]:
+    """Split by &&, ||, ;, | that are NOT inside quotes. Return list of segments."""
+    sep_re = re.compile(r"(&&|\|\||;|\|)")
+    segments: List[str] = []
+    last = 0
+    for m in sep_re.finditer(command):
+        if _is_inside_quotes(command, m.start()):
+            continue
+        segments.append(command[last:m.start()].strip())
+        last = m.end()
+    if last < len(command):
+        segments.append(command[last:].strip())
+    return [s for s in segments if s]
+
+
+# ---------------------------------------------------------------------------
+# Per-segment risk evaluation  (whitelist checked here — 从严: per-segment)
+# ---------------------------------------------------------------------------
+def _segment_risky(segment: str, safe: Set[str]) -> Optional[str]:
+    """Return the matched risky word/subcommand, or None if safe."""
+    fw = _first_word(segment)
+    if not fw:
+        return None
+
+    # Redirect check (从严: any redirect to a real file makes it risky — even
+    # for whitelisted commands, since a redirect writes/changes files;
+    # /dev/null and fd refs like &1/&2 are harmless and excluded)
+    if _has_destructive_redirect(segment):
+        return f">{fw} (redirect)"
+
+    # Whitelist applies only to non-redirecting commands
+    if fw in safe:
+        return None
+
+    # Unconditional risky first-words
+    if fw in _RISKY_FIRST_WORDS:
+        return fw
+
+    # Risky first-word + subcommand check
+    if fw in _RISKY_WITH_SUB:
+        # Skip sudo/env prefixes before checking subcommand
+        parts = segment.strip().split(None)
+        sub_idx = 1
+        while sub_idx < len(parts) and parts[sub_idx].lower() in _SKIPPABLE_PREFIXES:
+            sub_idx += 1
+        if sub_idx < len(parts):
+            sub = os.path.basename(parts[sub_idx].lower())
+            if sub in _RISKY_WITH_SUB[fw]:
+                return f"{fw} {sub}"
+
+    # curl/wget with -o / -O / --output flag
+    if fw in _RISKY_OUTPUT_CMDS and _has_output_flag(segment):
+        return f"{fw} (output flag)"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+def load_safe_whitelist() -> Set[str]:
+    """Parse CUBE_ROLLBACK_SAFE env var (comma-separated) into a set."""
+    raw = os.environ.get("CUBE_ROLLBACK_SAFE", "")
+    if not raw.strip():
+        return set()
+    return {w.strip().lower() for w in raw.split(",") if w.strip()}
+
+
+def is_sentinel(command: str) -> bool:
+    """True if the command starts with `cubesandbox-rollback`."""
+    return command.strip().startswith(SENTINEL_PREFIX)
+
+
+def parse_sentinel(command: str) -> Tuple[str, Optional[str]]:
+    """Return (subcommand, argument) from a sentinel command."""
+    parts = command.strip().split(None, 2)
+    if len(parts) < 2:
+        return ("last", None)
+    return (parts[1].lower(), parts[2] if len(parts) > 2 else None)
+
+
+def is_risky(command: str, safe: Set[str]) -> bool:
+    """从严: compound commands checked per-segment. Any risky segment → risky.
+    Whitelist is checked *per segment*, not whole-command."""
+    cmd = command.strip()
+    if not cmd:
+        return False
+    if is_sentinel(cmd):
+        return False  # sentinel itself is never risky
+
+    segments = split_compound(cmd)
+    # Always check per-segment — even for single-segment commands
+    for seg in segments:
+        if not seg:
+            continue
+        if _segment_risky(seg, safe):
+            return True
+    # If no compound (i.e. split_compound returned empty because there are no
+    # separators), check the whole command as a single segment.
+    if not segments:
+        return _segment_risky(cmd, safe) is not None
+    return False

--- a/examples/claude-code-integration/rollback/cubesandbox_risky.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_risky.py
@@ -76,7 +76,7 @@ _EXEC_CMDS: Set[str] = {
 _WRITE_REDIR_TYPES: frozenset = frozenset({">", ">>", ">&", "&>", "&>>", ">|", "<>"})
 
 _ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
-_NUM_RE = re.compile(r"^[0-9]+$")
+_NUM_RE = re.compile(r"^[0-9]+(?:[smhd])?$")  # GNU timeout accepts 10s/5m/1h
 _FD_REF_RE = re.compile(r"^&[0-9]+$")
 _OUTPUT_FLAG_RE = re.compile(r"^(?:-[oO]\b|--output(?:-document)?\b)")
 
@@ -350,8 +350,14 @@ def load_safe_whitelist() -> Set[str]:
 
 
 def is_sentinel(command: str) -> bool:
-    """True if the command starts with `cubesandbox-rollback`."""
-    return command.strip().startswith(SENTINEL_PREFIX)
+    """True if the command is the rollback sentinel (or a call to it).
+
+    Requires a word boundary after the prefix so similarly-named tools
+    (``cubesandbox-rollback-helper``) are not mistaken for the sentinel —
+    a mistaken match would run a real rollback and deny the command.
+    """
+    cmd = command.strip()
+    return cmd == SENTINEL_PREFIX or cmd.startswith(SENTINEL_PREFIX + " ")
 
 
 def parse_sentinel(command: str) -> Tuple[str, Optional[str]]:
@@ -385,8 +391,10 @@ def is_risky(command: str, safe: Set[str]) -> bool:
         return False
     if is_sentinel(cmd):
         return False  # sentinel itself is never risky
-    if cmd.startswith("#"):
-        return False  # pure comment
+    if all(not ln.strip() or ln.strip().startswith("#")
+           for ln in cmd.splitlines()):
+        return False  # comment-only input; a leading comment + real command
+        # still reaches bashlex below
 
     if bashlex is None:
         # Deployment error: classifier unavailable → over-approximate.

--- a/examples/claude-code-integration/rollback/cubesandbox_risky.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_risky.py
@@ -1,28 +1,55 @@
 #!/usr/bin/env python3
-"""Risky command classifier.  从严 (strict): over-classify, parse compound commands."""
+"""Risky command classifier.
+
+Parses the whole command with bashlex — a Python port of bash's own parser —
+and evaluates risk from the AST structure (assignments, redirects, wrapper
+prefixes, subshells, pipelines).  Anything the parser cannot handle is
+treated as risky (fail-safe).
+"""
 
 from __future__ import annotations
 
 import os
 import re
 import sys
-from typing import Set, List, Tuple, Optional
+from typing import List, Optional, Set, Tuple
+
+try:
+    import bashlex
+except ImportError:  # pragma: no cover - deployment error path
+    bashlex = None  # type: ignore[assignment]
+
+SENTINEL_PREFIX = "cubesandbox-rollback"
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-SENTINEL_PREFIX = "cubesandbox-rollback"
 
-# Prefixes to skip before extracting the real first word
-_SKIPPABLE_PREFIXES: tuple = ("sudo", "env", "nohup", "nice")
+# Wrapper commands: skipped to find the real command word
+_WRAPPER_CMDS: frozenset = frozenset({
+    "sudo", "env", "nohup", "nice", "timeout", "command", "exec",
+    "setsid", "doas", "su",
+})
 
-# Commands whose *presence* makes a compound segment risky
+# Wrapper options that consume a following value (else the value would be
+# mistaken for the command word).  Unknown options are skipped bare — a
+# heuristic; see README "Known limitations".
+_WRAPPER_OPT_WITH_VALUE: dict = {
+    "sudo":   {"-u", "-g", "-p", "-C", "-h", "--user", "--group", "--prompt"},
+    "env":    {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"},
+    "nice":   {"-n", "--adjustment"},
+    "timeout": {"-s", "-k", "-f", "--signal", "--kill-after"},
+}
+
+# Commands whose *presence* makes a command risky
 _RISKY_FIRST_WORDS: Set[str] = {
     "rm", "rmdir", "chmod", "chown", "mv", "dd", "shred", "mkfs", "fdisk",
     "apt", "apt-get", "dnf", "yum", "pacman", "brew", "snap",
 }
 
-# Commands that are risky only with specific subcommands
+# Commands that are risky only with specific subcommands.
+# against every trailing token (a `git log reset` style false positive is a
+# harmless extra snapshot; a missed `git -C repo reset --hard` is not).
 _RISKY_WITH_SUB: dict = {
     "git":  {"reset", "clean"},
     "npm":  {"install", "uninstall", "update"},
@@ -32,155 +59,283 @@ _RISKY_WITH_SUB: dict = {
     "pnpm": {"add", "remove"},
     "cargo": {"install", "uninstall"},
     "go":   {"install", "get"},
-    "make":  {"install"},
+    "make": {"install"},
 }
 
 # Commands dangerous when used with -o / -O / --output
 _RISKY_OUTPUT_CMDS: Set[str] = {"curl", "wget"}
 
-# regex for -o / -O / --output flag (short or long, outside quotes)
-_OUTPUT_FLAG_RE = re.compile(r"(?:\s|^)(?:-[oO]\b|--output\b)")
+# curl|bash style: download on the left, interpreter on the right
+_DOWNLOAD_CMDS: Set[str] = {"curl", "wget"}
+_EXEC_CMDS: Set[str] = {
+    "bash", "sh", "zsh", "dash", "ksh", "fish",
+    "python", "python3", "python2", "perl", "php", "ruby", "node", "lua",
+}
+
+# Redirect operators that write to a file (vs `<`, `<<` which only read)
+_WRITE_REDIR_TYPES: frozenset = frozenset({">", ">>", ">&", "&>", "&>>", ">|", "<>"})
+
+_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_NUM_RE = re.compile(r"^[0-9]+$")
+_FD_REF_RE = re.compile(r"^&[0-9]+$")
+_OUTPUT_FLAG_RE = re.compile(r"^(?:-[oO]\b|--output(?:-document)?\b)")
 
 # ---------------------------------------------------------------------------
-# Helpers
+# AST helpers
 # ---------------------------------------------------------------------------
-def _strip_quoted(text: str) -> str:
-    """Remove single- and double-quoted substrings."""
-    return re.sub(r"""('[^']*'|"[^"]*")""", "", text)
+def _norm_command_word(w: str) -> str:
+    """Basename + strip backslash escapes + lowercase."""
+    return os.path.basename(w.lstrip("\\")).lower()
 
 
-def _first_word(segment: str) -> str:
-    """Return the first non-empty whitespace-delimited token, lowercased,
-    after skipping `sudo`, `env`, `nohup`, `nice` prefixes.  basename
-    normalises absolute paths (e.g. `/usr/bin/rm` → `rm`)."""
-    seg = segment.strip()
-    if not seg:
-        return ""
-    parts = seg.split(None)
-    idx = 0
-    # Walk past skippable prefixes
-    while idx < len(parts) and parts[idx].lower() in _SKIPPABLE_PREFIXES:
-        idx += 1
-    if idx >= len(parts):
-        return ""
-    return os.path.basename(parts[idx].lower())
+def _unwrap_index(words: List[str]) -> int:
+    """Index of the real command word.
 
-
-_REDIR_RE = re.compile(
-    r'(?:^|\s)([0-9]{1,2}>>?|&>>?|>&>?|>>?)\s*(\S+)'
-)
-
-
-def _has_destructive_redirect(segment: str) -> bool:
-    """True if the segment has a redirect that writes to a real file.
-
-    Safe targets (/dev/null, fd refs like &1/&2, any /dev/* path) are NOT
-    destructive — so the ubiquitous `2>/dev/null` / `2>&1` / `>/dev/null`
-    never triggers a snapshot.  The operator forms `&>` and the csh-style
-    `>&` are parsed as a single operator (not `>` + a `&` target), and
-    fd-duplication targets like `2>&1` / `>&1` are treated as safe.
-    Only writes to an actual file or directory count.
+    Skips wrapper prefixes (``sudo`` / ``env`` / ``nohup`` / ``nice`` /
+    ``timeout`` …) along with their options and option values, then skips
+    leading ``VAR=value`` tokens (``env FOO=bar npm install``).
     """
-    for op, target in _REDIR_RE.findall(_strip_quoted(segment)):
-        if _is_safe_redirect_target(op, target):
-            continue
-        return True
-    return False
+    i = 0
+    n = len(words)
+    while i < n and words[i] in _WRAPPER_CMDS:
+        wrapper = words[i]
+        i += 1
+        while i < n:
+            w = words[i]
+            if w.startswith("-"):
+                i += 1
+                if i < n and w in _WRAPPER_OPT_WITH_VALUE.get(wrapper, ()):
+                    i += 1  # option value
+                continue
+            if wrapper in ("timeout", "nice") and _NUM_RE.match(w):
+                i += 1  # bare duration / priority
+                continue
+            break
+    while i < n and _ASSIGN_RE.match(words[i]):
+        i += 1  # env FOO=bar cmd
+    return i
 
 
-def _is_safe_redirect_target(op: str, target: str) -> bool:
-    """True if a redirect targets /dev/null or a file descriptor.
+def _command_parts(cmd_node) -> Tuple[List[str], List]:
+    """Return (words, redirects) from a bashlex command node."""
+    words: List[str] = []
+    redirects: List = []
+    for part in cmd_node.parts:
+        if part.kind == "word":
+            words.append(part.word)
+        elif part.kind == "redirect":
+            redirects.append(part)
+    return words, redirects
 
-    ``2>&1`` / ``1>&2`` parse as fd-prefixed operator + ``&N`` target;
-    the csh-style ``>&1`` parses as ``>&`` operator + ``N`` target.  Both
-    duplicate to an existing descriptor and never touch the filesystem.
+
+def _redirect_destructive(rd) -> bool:
+    """True if a redirect writes to a real file.
+
+    Safe targets: /dev/* paths and fd references (``2>&1`` / ``>&1`` /
+    ``>&2``).  Anything else — including quoted targets and unparseable
+    opaque words — counts as destructive (fail-safe).
     """
-    if target == '/dev/null' or target.startswith('/dev/'):
-        return True
-    if re.fullmatch(r'&[0-9]+', target):
-        return True  # 2>&1 / 1>&2 / 2>&3 style fd duplication
-    if op.startswith('>&') and re.fullmatch(r'[0-9]+', target):
-        return True  # csh-style >&1 (dup stdout to fd 1)
-    return False
+    if rd.type not in _WRITE_REDIR_TYPES:
+        return False  # <, << heredoc, etc. only read
+    out = rd.output
+    if isinstance(out, int):
+        return False  # 2>&1 → fd 1
+    if isinstance(out, str):
+        if out.isdigit():
+            return False  # >&2 parsed as string fd
+        target = out
+    else:
+        target = getattr(out, "word", None)
+    if target is None:
+        return True  # opaque target → destructive (fail-safe)
+    if target.startswith("/dev/"):
+        return False
+    if _FD_REF_RE.match(target):
+        return False
+    return True
 
 
-def _has_output_flag(segment: str) -> bool:
-    """True if the segment has -o / -O / --output flag (for curl/wget)."""
-    cleaned = _strip_quoted(segment)
-    return bool(_OUTPUT_FLAG_RE.search(cleaned))
+def _find_risky_subcommand(fw: str, words: List[str], start: int) -> Optional[str]:
+    """Return the risky subcommand token if any trailing token matches."""
+    risky_subs = _RISKY_WITH_SUB.get(fw, frozenset())
+    for w in words[start:]:
+        n = _norm_command_word(w)
+        if n in risky_subs:
+            return n
+    return None
 
 
-# ---------------------------------------------------------------------------
-# Quote-aware compound split
-# ---------------------------------------------------------------------------
-def _is_inside_quotes(command: str, pos: int) -> bool:
-    """Return True if position `pos` in `command` is inside single or double quotes."""
-    in_single = in_double = False
-    for i, ch in enumerate(command[:pos]):
-        if ch == "'" and not in_double:
-            in_single = not in_single
-        elif ch == '"' and not in_single:
-            in_double = not in_double
-    # At the boundary, we consider the separator to be outside quotes
-    # only if both states are "closed" at the character just before pos.
-    return in_single or in_double
+def _has_output_flag(words: List[str]) -> bool:
+    return any(_OUTPUT_FLAG_RE.match(w) for w in words)
 
 
-def split_compound(command: str) -> List[str]:
-    """Split by &&, ||, ;, | that are NOT inside quotes. Return list of segments."""
-    sep_re = re.compile(r"(&&|\|\||;|\|)")
-    segments: List[str] = []
-    last = 0
-    for m in sep_re.finditer(command):
-        if _is_inside_quotes(command, m.start()):
+_SINGLE_CHILD_ATTRS = ("command", "list", "body")
+
+
+def _children(node):
+    """Yield child AST nodes of any bashlex node.
+
+    bashlex uses a ``parts`` list for compound nodes (list/pipeline/command),
+    singular ``command`` / ``body`` attributes for substitutions and function
+    bodies, and a *list-valued* ``list`` attribute on ``compound`` nodes
+    (subshells/braces).  Normalise all shapes so callers can walk the tree
+    uniformly.  Children are deduplicated by identity (a function body may be
+    reachable both via ``parts`` and via ``body``).
+    """
+    seen: set = set()
+    for child in getattr(node, "parts", None) or []:
+        if id(child) not in seen:
+            seen.add(id(child))
+            yield child
+    for attr in _SINGLE_CHILD_ATTRS:
+        v = getattr(node, attr, None)
+        if v is None:
             continue
-        segments.append(command[last:m.start()].strip())
-        last = m.end()
-    if last < len(command):
-        segments.append(command[last:].strip())
-    return [s for s in segments if s]
+        if isinstance(v, list):
+            for child in v:
+                if hasattr(child, "kind") and id(child) not in seen:
+                    seen.add(id(child))
+                    yield child
+        elif hasattr(v, "kind") and id(v) not in seen:
+            seen.add(id(v))
+            yield v
+
+
+def _has_self_pipe(node) -> bool:
+    """True if the subtree contains a pipeline whose ends run the same
+    command — the fork-bomb signature `:(){ :|:& };:` pipes `:` into `:`.
+    A normal `ls | grep` pipe has different names and is not flagged."""
+    if node.kind == "pipeline":
+        cmds = [p for p in node.parts if getattr(p, "kind", None) == "command"]
+        if len(cmds) >= 2:
+            names = []
+            for c in cmds:
+                words, _ = _command_parts(c)
+                i = _unwrap_index(words)
+                names.append(_norm_command_word(words[i]) if i < len(words) else "")
+            if names and names[0] and names[0] == names[-1]:
+                return True
+    return any(_has_self_pipe(c) for c in _children(node))
+
+
+def _command_in_subst(node) -> Optional[str]:
+    """First command name inside a process/command substitution."""
+    for n in _children(node):
+        if n.kind == "command":
+            words, _ = _command_parts(n)
+            i = _unwrap_index(words)
+            if i < len(words):
+                return _norm_command_word(words[i])
+        elif n.kind in ("list", "pipeline", "commandsubstitution",
+                        "processsubstitution"):
+            r = _command_in_subst(n)
+            if r:
+                return r
+    return None
 
 
 # ---------------------------------------------------------------------------
-# Per-segment risk evaluation  (whitelist checked here — 从严: per-segment)
+# Per-node evaluation
 # ---------------------------------------------------------------------------
-def _segment_risky(segment: str, safe: Set[str]) -> Optional[str]:
-    """Return the matched risky word/subcommand, or None if safe."""
-    fw = _first_word(segment)
+def _check_command_node(cmd_node, safe: Set[str], out: List[str]) -> None:
+    words, redirects = _command_parts(cmd_node)
+
+    # Recurse into nested substitutions / subshells FIRST, and always —
+    # even when the outer command word is missing or whitelisted
+    # (`VAR=$(rm -rf /tmp)` has no command word at all; the risky command
+    # lives inside the assignment).
+    for part in cmd_node.parts:
+        if part.kind in ("word", "assignment"):
+            _check_tree(list(_children(part)), safe, out)
+        elif part.kind in ("commandsubstitution", "processsubstitution",
+                           "subshell", "function", "heredoc"):
+            _check_tree([part], safe, out)
+
+    # Destructive redirect (checked before the whitelist — a redirect
+    # writes/changes files even for whitelisted commands)
+    for rd in redirects:
+        if _redirect_destructive(rd):
+            target = getattr(rd.output, "word", rd.output)
+            out.append(f"redirect > {target!r}")
+            return
+
+    start = _unwrap_index(words)
+    if start >= len(words):
+        return
+    fw = _norm_command_word(words[start])
     if not fw:
-        return None
-
-    # Redirect check (从严: any redirect to a real file makes it risky — even
-    # for whitelisted commands, since a redirect writes/changes files;
-    # /dev/null and fd refs like &1/&2 are harmless and excluded)
-    if _has_destructive_redirect(segment):
-        return f">{fw} (redirect)"
+        return
 
     # Whitelist applies only to non-redirecting commands
     if fw in safe:
+        return
+
+    if fw in _RISKY_FIRST_WORDS:
+        out.append(fw)
+        return
+    if fw in _RISKY_WITH_SUB:
+        sub = _find_risky_subcommand(fw, words, start + 1)
+        if sub:
+            out.append(f"{fw} {sub}")
+            return
+    if fw in _RISKY_OUTPUT_CMDS and _has_output_flag(words[start + 1:]):
+        out.append(f"{fw} (output flag)")
+        return
+
+    # exec <(download): `bash <(curl …)` style — interpreter consumes a
+    # download process substitution
+    if fw in _EXEC_CMDS:
+        for part in cmd_node.parts:
+            if part.kind == "word":
+                for sub in _children(part):
+                    if sub.kind == "processsubstitution":
+                        inner = _command_in_subst(sub)
+                        if inner in _DOWNLOAD_CMDS:
+                            out.append(f"exec <(download): {fw} <({inner} …)")
+                            return
+
+
+def _pipeline_risky(pipe_node) -> Optional[str]:
+    """curl|bash style: download command piped into an interpreter."""
+    cmds = [p for p in pipe_node.parts if getattr(p, "kind", None) == "command"]
+    if len(cmds) < 2:
         return None
 
-    # Unconditional risky first-words
-    if fw in _RISKY_FIRST_WORDS:
-        return fw
+    def _name_of(c) -> Optional[str]:
+        words, _ = _command_parts(c)
+        i = _unwrap_index(words)
+        return _norm_command_word(words[i]) if i < len(words) else None
 
-    # Risky first-word + subcommand check
-    if fw in _RISKY_WITH_SUB:
-        # Skip sudo/env prefixes before checking subcommand
-        parts = segment.strip().split(None)
-        sub_idx = 1
-        while sub_idx < len(parts) and parts[sub_idx].lower() in _SKIPPABLE_PREFIXES:
-            sub_idx += 1
-        if sub_idx < len(parts):
-            sub = os.path.basename(parts[sub_idx].lower())
-            if sub in _RISKY_WITH_SUB[fw]:
-                return f"{fw} {sub}"
-
-    # curl/wget with -o / -O / --output flag
-    if fw in _RISKY_OUTPUT_CMDS and _has_output_flag(segment):
-        return f"{fw} (output flag)"
-
+    first = _name_of(cmds[0])
+    last = _name_of(cmds[-1])
+    if first in _DOWNLOAD_CMDS and last in _EXEC_CMDS:
+        return f"pipe: {first} | {last}"
     return None
+
+
+def _check_tree(nodes, safe: Set[str], out: List[str]) -> None:
+    for node in nodes:
+        k = node.kind
+        if k == "command":
+            _check_command_node(node, safe, out)
+        elif k == "pipeline":
+            r = _pipeline_risky(node)
+            if r:
+                out.append(r)
+            for p in node.parts:
+                if getattr(p, "kind", None) == "command":
+                    _check_tree([p], safe, out)
+        elif k == "list":
+            _check_tree(list(_children(node)), safe, out)
+        elif k in ("subshell", "compound", "commandsubstitution",
+                   "processsubstitution", "function", "heredoc",
+                   "word", "assignment"):
+            if k == "function" and _has_self_pipe(node):
+                # Fork-bomb signature: `:(){ :|:& };:` — a function whose
+                # body pipes its own name.
+                out.append("fork bomb (function body pipeline)")
+            _check_tree(list(_children(node)), safe, out)
+        # operator / pipe / parameter / comment / redirect: nothing to check
 
 
 # ---------------------------------------------------------------------------
@@ -200,31 +355,51 @@ def is_sentinel(command: str) -> bool:
 
 
 def parse_sentinel(command: str) -> Tuple[str, Optional[str]]:
-    """Return (subcommand, argument) from a sentinel command."""
+    """Return (subcommand, argument) from a sentinel command.
+
+    Quoted arguments survive parsing (``checkpoint "my milestone"`` keeps
+    the spaces); unparseable input (e.g. unterminated quote) falls back to
+    a plain whitespace split rather than crashing.
+    """
     parts = command.strip().split(None, 2)
     if len(parts) < 2:
         return ("last", None)
-    return (parts[1].lower(), parts[2] if len(parts) > 2 else None)
+    try:
+        import shlex
+        shlexed = shlex.split(command)
+    except ValueError:
+        shlexed = parts
+    if len(shlexed) < 2:
+        return ("last", None)
+    return (shlexed[1].lower(),
+            shlexed[2] if len(shlexed) > 2 else None)
 
 
 def is_risky(command: str, safe: Set[str]) -> bool:
-    """从严: compound commands checked per-segment. Any risky segment → risky.
-    Whitelist is checked *per segment*, not whole-command."""
+    """
+    Fail-safe: commands bashlex cannot parse (arithmetic expansion, `[[ ]]`,
+    fork bombs, …) are treated as risky rather than silently safe.
+    """
     cmd = command.strip()
     if not cmd:
         return False
     if is_sentinel(cmd):
         return False  # sentinel itself is never risky
+    if cmd.startswith("#"):
+        return False  # pure comment
 
-    segments = split_compound(cmd)
-    # Always check per-segment — even for single-segment commands
-    for seg in segments:
-        if not seg:
-            continue
-        if _segment_risky(seg, safe):
-            return True
-    # If no compound (i.e. split_compound returned empty because there are no
-    # separators), check the whole command as a single segment.
-    if not segments:
-        return _segment_risky(cmd, safe) is not None
-    return False
+    if bashlex is None:
+        # Deployment error: classifier unavailable → over-approximate.
+        print("cubesandbox-risky: bashlex not installed; treating command as "
+              "risky (fail-safe). Install requirements: "
+              "`pip install -r requirements.txt`", file=sys.stderr)
+        return True
+
+    try:
+        ast = bashlex.parse(cmd)
+    except Exception:
+        return True  # unparseable → risky (fail-safe)
+
+    reasons: List[str] = []
+    _check_tree(ast, safe, reasons)
+    return bool(reasons)

--- a/examples/claude-code-integration/rollback/cubesandbox_rollback.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_rollback.py
@@ -99,8 +99,8 @@ def _cmd_checkpoint(session_id: str, command: str, arg: str | None) -> int:
         return _deny(f"Checkpoint failed: {exc}")
 
     # A checkpoint is new activity — invalidate any pending undo point
-    if my.get("undo"):
-        delete_snapshot_backend(my["undo"].get("snapshot_id"))
+    old_undo = my.get("undo")
+    if old_undo:
         my["undo"] = None
 
     my.setdefault("snapshots", []).append({
@@ -114,6 +114,10 @@ def _cmd_checkpoint(session_id: str, command: str, arg: str | None) -> int:
         write_my_state(session_id, my)
     except Exception as exc:
         return _deny(f"Checkpoint state write error: {exc}")
+    # State persisted first — backend delete is best-effort, so a state-write
+    # failure never leaves a local entry pointing at a deleted snapshot.
+    if old_undo:
+        delete_snapshot_backend(old_undo.get("snapshot_id"))
     return _deny(f"Checkpoint `{name}` saved: {snapshot.snapshot_id}")
 
 
@@ -158,11 +162,13 @@ def _cmd_drop(session_id: str, arg: str | None) -> int:
         return _deny(f"Snapshot `{arg}` not found.")
     target = snaps[idx]
     my["snapshots"] = snaps[:idx] + snaps[idx + 1:]
-    delete_snapshot_backend(target.get("snapshot_id"))
     try:
         write_my_state(session_id, my)
     except Exception as exc:
         return _deny(f"Snapshot drop state write error: {exc}")
+    # State persisted first — backend delete is best-effort, so a state-write
+    # failure never leaves a local entry pointing at a deleted snapshot.
+    delete_snapshot_backend(target.get("snapshot_id"))
     return _deny(f"Snapshot `{target.get('snapshot_id')}` dropped.")
 
 
@@ -207,13 +213,10 @@ def _cmd_rollback(session_id: str, target: str) -> int:
         return _deny(f"Rollback failed: {exc}")
 
     # Rollback succeeded — old undo point (if any) is now stale
-    if my.get("undo"):
-        delete_snapshot_backend(my["undo"].get("snapshot_id"))
+    old_undo = my.get("undo")
 
-    # Prune snapshots taken after the rollback target (backend + local)
+    # Prune snapshots taken after the rollback target
     kept, dropped = prune_after(snaps, idx)
-    for s in dropped:
-        delete_snapshot_backend(s.get("snapshot_id"))
 
     my["snapshots"] = kept
     my["undo"] = new_undo
@@ -221,6 +224,15 @@ def _cmd_rollback(session_id: str, target: str) -> int:
         write_my_state(session_id, my)
     except Exception as exc:
         return _deny(f"Rollback state write error: {exc}")
+
+    # State persisted first — backend deletes are best-effort, so a
+    # state-write failure never leaves local entries pointing at deleted
+    # snapshots.  The fresh undo snapshot (`new_undo`) stays in the backend
+    # and is referenced by the persisted state, so it is NOT deleted here.
+    if old_undo:
+        delete_snapshot_backend(old_undo.get("snapshot_id"))
+    for s in dropped:
+        delete_snapshot_backend(s.get("snapshot_id"))
 
     msg = (f"Rollback complete. State restored to snapshot "
            f"`{target_snap['snapshot_id']}` from command "

--- a/examples/claude-code-integration/rollback/cubesandbox_rollback.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_rollback.py
@@ -269,11 +269,8 @@ def main() -> int:
         return _cmd_drop(session_id, arg)
 
     # Rollback path: "last" | <N> | <snapshot-id> (bare sentinel → "last").
-    # Anything else is an unknown subcommand — deny with usage instead of
-    # silently rolling back.
-    if sub != "last" and not sub.isdigit() and not sub.startswith("snap-"):
-        return _deny(USAGE)
-
+    # Any other token is treated as a snapshot-id candidate; unmatched ids
+    # produce "No such snapshot." from _cmd_rollback.
     return _cmd_rollback(session_id, sub)
 
 

--- a/examples/claude-code-integration/rollback/cubesandbox_rollback.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_rollback.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""PreToolUse/Bash hook: detect rollback sentinel → deny + rollback.  Fail-closed."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+
+from cubesandbox_lib import (
+    get_config_hash,
+    get_sandbox_client,
+    orphan_check,
+    read_my_state,
+    read_sandbox_state,
+    write_my_state,
+)
+from cubesandbox_risky import is_sentinel, parse_sentinel
+
+
+def _deny(reason_text: str) -> int:
+    """Print deny decision and exit 0 (CC reads JSON, not exit code).
+
+    Live Claude Code testing proved that only `permissionDecisionReason` is
+    reliably rendered to the agent when a PreToolUse hook denies.  The full
+    user-facing message therefore goes into the reason; `stdout` carries the
+    same text as a harmless secondary copy (ignored by current CC, useful if a
+    future version renders it).
+    """
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason_text,
+            "stdout": reason_text,
+        }
+    }))
+    return 0
+
+
+def _pass() -> int:
+    """Print empty decision — not our command."""
+    print("{}")
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return _pass()
+
+    if payload.get("hook_event_name") != "PreToolUse":
+        return _pass()
+    if payload.get("tool_name") != "Bash":
+        return _pass()
+
+    command = payload.get("tool_input", {}).get("command", "")
+    session_id = payload.get("session_id", "default")
+
+    if not is_sentinel(command):
+        return _pass()
+
+    sub, arg = parse_sentinel(command)
+
+    # Orphan check
+    orphan_check(session_id)
+
+    # Config hash check (从严: stale → deny; empty = first run, allow)
+    stored = read_my_state(session_id).get("config_hash", "")
+    current = get_config_hash()
+    if stored and stored != current:
+        return _deny("Config mismatch with #765. Reinstall rollback hooks.")
+
+    # --- subcommands ---
+    if sub in ("list", "ls"):
+        my = read_my_state(session_id)
+        snaps = my.get("snapshots", [])
+        if not snaps:
+            return _deny("No snapshots available.")
+        lines = ["Available snapshots:", ""]
+        for i, s in enumerate(snaps):
+            ts = time.strftime("%H:%M:%S", time.localtime(s.get("timestamp", 0)))
+            lines.append(f"  [{i}] {s.get('snapshot_id','?')}  {ts}  {s.get('command','?')[:60]}")
+        return _deny("\n".join(lines))
+
+    if sub == "drop":
+        if not arg:
+            return _deny("Usage: cubesandbox-rollback drop <snapshot-id>")
+        my = read_my_state(session_id)
+        snaps = my.get("snapshots", [])
+        new_snaps = [s for s in snaps if s.get("snapshot_id") != arg]
+        if len(new_snaps) == len(snaps):
+            return _deny(f"Snapshot `{arg}` not found.")
+        my["snapshots"] = new_snaps
+        write_my_state(session_id, my)
+        return _deny(f"Snapshot `{arg}` dropped.")
+
+    # Anything other than `last` (or the implicit default) is an unknown
+    # subcommand — deny with usage instead of silently rolling back.
+    if sub not in (None, "", "last"):
+        return _deny("Usage: cubesandbox-rollback [last|list|drop <snapshot-id>]")
+
+    # "last" (default when no subcommand is given)
+    my = read_my_state(session_id)
+    snaps = my.get("snapshots", [])
+    if not snaps:
+        return _deny("No snapshots available to roll back.")
+
+    latest = snaps[-1]
+
+    sstate = read_sandbox_state(session_id)
+    if not sstate or not sstate.get("sandbox_id"):
+        return _deny("No sandbox found. Is #765 configured?")
+
+    try:
+        client = get_sandbox_client(sstate["sandbox_id"])
+        client.rollback(latest["snapshot_id"])
+    except Exception as exc:
+        return _deny(f"Rollback failed: {exc}")
+
+    # 从严: only keep snapshots up to and including the target
+    idx = snaps.index(latest)
+    my["snapshots"] = snaps[:idx + 1]
+    write_my_state(session_id, my)
+
+    return _deny(
+        f"Rollback complete. State restored to snapshot `{latest['snapshot_id']}` "
+        f"from command `{latest.get('command', '?')}`. "
+        "You may re-run your intended command now."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/rollback/cubesandbox_rollback.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_rollback.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""PreToolUse/Bash hook: detect rollback sentinel → deny + rollback.  Fail-closed."""
+"""PreToolUse/Bash hook: detect rollback sentinel → deny + rollback.
+Fail-closed."""
 
 from __future__ import annotations
 
@@ -12,14 +13,20 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPT_DIR)
 
 from cubesandbox_lib import (
-    get_config_hash,
+    delete_snapshot_backend,
+    find_snapshot_index,
     get_sandbox_client,
+    load_hook_env,
     orphan_check,
+    prune_after,
     read_my_state,
     read_sandbox_state,
     write_my_state,
 )
 from cubesandbox_risky import is_sentinel, parse_sentinel
+
+USAGE = ("Usage: cubesandbox-rollback [last|<N>|<snapshot-id>|list|"
+         "checkpoint <name>|undo|drop <last|N|snapshot-id>]")
 
 
 def _deny(reason_text: str) -> int:
@@ -48,7 +55,185 @@ def _pass() -> int:
     return 0
 
 
+def _kind_label(s: dict) -> str:
+    """Human label for a snapshot's kind (backward-compat: missing → auto)."""
+    kind = s.get("kind", "auto")
+    if kind == "checkpoint":
+        name = s.get("name", "")
+        return f"checkpoint:{name}" if name else "checkpoint"
+    return kind
+
+
+def _cmd_list(session_id: str) -> int:
+    my = read_my_state(session_id)
+    snaps = my.get("snapshots", [])
+    if not snaps:
+        return _deny("No snapshots available.")
+    lines = ["Available snapshots:", ""]
+    for i, s in enumerate(snaps):
+        ts = time.strftime("%H:%M:%S", time.localtime(s.get("timestamp", 0)))
+        lines.append(
+            f"  [{i}] {s.get('snapshot_id', '?')}  {ts}  "
+            f"[{_kind_label(s)}]  {s.get('command', '?')[:60]}"
+        )
+    if my.get("undo"):
+        lines.append("")
+        lines.append("Undo available: run `cubesandbox-rollback undo`")
+    return _deny("\n".join(lines))
+
+
+def _cmd_checkpoint(session_id: str, command: str, arg: str | None) -> int:
+    if not arg or not arg.strip():
+        return _deny("Usage: cubesandbox-rollback checkpoint <name>")
+    name = arg.strip()
+
+    my = read_my_state(session_id)
+    sstate = read_sandbox_state(session_id)
+    if not sstate or not sstate.get("sandbox_id"):
+        return _deny("No sandbox found. Is the cubesandbox-hook plugin configured?")
+
+    try:
+        client = get_sandbox_client(sstate["sandbox_id"])
+        snapshot = client.create_snapshot()
+    except Exception as exc:
+        return _deny(f"Checkpoint failed: {exc}")
+
+    # A checkpoint is new activity — invalidate any pending undo point
+    if my.get("undo"):
+        delete_snapshot_backend(my["undo"].get("snapshot_id"))
+        my["undo"] = None
+
+    my.setdefault("snapshots", []).append({
+        "snapshot_id": snapshot.snapshot_id,
+        "kind": "checkpoint",
+        "name": name,
+        "command": command[:256],
+        "timestamp": int(time.time()),
+    })
+    try:
+        write_my_state(session_id, my)
+    except Exception as exc:
+        return _deny(f"Checkpoint state write error: {exc}")
+    return _deny(f"Checkpoint `{name}` saved: {snapshot.snapshot_id}")
+
+
+def _cmd_undo(session_id: str) -> int:
+    my = read_my_state(session_id)
+    undo = my.get("undo")
+    if not undo:
+        return _deny("Nothing to undo.")
+
+    sstate = read_sandbox_state(session_id)
+    if not sstate or not sstate.get("sandbox_id"):
+        return _deny("No sandbox found. Is the cubesandbox-hook plugin configured?")
+
+    try:
+        client = get_sandbox_client(sstate["sandbox_id"])
+        client.rollback(undo["snapshot_id"])
+    except Exception as exc:
+        return _deny(f"Undo failed: {exc}")
+
+    # The undo snapshot's job is done — drop it from the backend and clear
+    # the undo point.  The snapshots list is NOT pruned on undo.
+    delete_snapshot_backend(undo["snapshot_id"])
+    my["undo"] = None
+    try:
+        write_my_state(session_id, my)
+    except Exception as exc:
+        return _deny(f"Undo state write error: {exc}")
+
+    return _deny(
+        f"Undo complete. State restored to pre-rollback snapshot "
+        f"`{undo['snapshot_id']}`."
+    )
+
+
+def _cmd_drop(session_id: str, arg: str | None) -> int:
+    if not arg:
+        return _deny("Usage: cubesandbox-rollback drop <last|N|snapshot-id>")
+    my = read_my_state(session_id)
+    snaps = my.get("snapshots", [])
+    idx = find_snapshot_index(snaps, arg)
+    if idx is None:
+        return _deny(f"Snapshot `{arg}` not found.")
+    target = snaps[idx]
+    my["snapshots"] = snaps[:idx] + snaps[idx + 1:]
+    delete_snapshot_backend(target.get("snapshot_id"))
+    try:
+        write_my_state(session_id, my)
+    except Exception as exc:
+        return _deny(f"Snapshot drop state write error: {exc}")
+    return _deny(f"Snapshot `{target.get('snapshot_id')}` dropped.")
+
+
+def _cmd_rollback(session_id: str, target: str) -> int:
+    my = read_my_state(session_id)
+    snaps = my.get("snapshots", [])
+    if not snaps:
+        return _deny("No snapshots available to roll back.")
+
+    idx = find_snapshot_index(snaps, target)
+    if idx is None:
+        return _deny("No such snapshot.")
+
+    target_snap = snaps[idx]
+
+    sstate = read_sandbox_state(session_id)
+    if not sstate or not sstate.get("sandbox_id"):
+        return _deny("No sandbox found. Is the cubesandbox-hook plugin configured?")
+
+    # Capture the pre-rollback state as the new undo point BEFORE rolling
+    # back.  On failure the old undo point must stay fully intact — so the
+    # old undo's backend snapshot is only deleted AFTER rollback succeeds
+    # (and the freshly captured undo snapshot is cleaned up on failure).
+    try:
+        client = get_sandbox_client(sstate["sandbox_id"])
+        undo_snapshot = client.create_snapshot()
+    except Exception as exc:
+        return _deny(f"Could not capture pre-rollback snapshot: {exc}")
+
+    new_undo = {
+        "snapshot_id": undo_snapshot.snapshot_id,
+        "command": "pre-rollback",
+        "timestamp": int(time.time()),
+    }
+
+    try:
+        client.rollback(target_snap["snapshot_id"])
+    except Exception as exc:
+        # Rollback failed — clean up the fresh undo snapshot and keep the
+        # old undo point (backend + state) untouched.
+        delete_snapshot_backend(new_undo["snapshot_id"])
+        return _deny(f"Rollback failed: {exc}")
+
+    # Rollback succeeded — old undo point (if any) is now stale
+    if my.get("undo"):
+        delete_snapshot_backend(my["undo"].get("snapshot_id"))
+
+    # Prune snapshots taken after the rollback target (backend + local)
+    kept, dropped = prune_after(snaps, idx)
+    for s in dropped:
+        delete_snapshot_backend(s.get("snapshot_id"))
+
+    my["snapshots"] = kept
+    my["undo"] = new_undo
+    try:
+        write_my_state(session_id, my)
+    except Exception as exc:
+        return _deny(f"Rollback state write error: {exc}")
+
+    msg = (f"Rollback complete. State restored to snapshot "
+           f"`{target_snap['snapshot_id']}` from command "
+           f"`{target_snap.get('command', '?')}`.")
+    if dropped:
+        ids = ", ".join(s.get("snapshot_id", "?") for s in dropped)
+        msg += f"\nDropped {len(dropped)} snapshot(s) after this point: {ids}"
+    return _deny(msg)
+
+
 def main() -> int:
+    load_hook_env()
+
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, UnicodeDecodeError):
@@ -70,69 +255,26 @@ def main() -> int:
     # Orphan check
     orphan_check(session_id)
 
-    # Config hash check (从严: stale → deny; empty = first run, allow)
-    stored = read_my_state(session_id).get("config_hash", "")
-    current = get_config_hash()
-    if stored and stored != current:
-        return _deny("Config mismatch with #765. Reinstall rollback hooks.")
-
     # --- subcommands ---
     if sub in ("list", "ls"):
-        my = read_my_state(session_id)
-        snaps = my.get("snapshots", [])
-        if not snaps:
-            return _deny("No snapshots available.")
-        lines = ["Available snapshots:", ""]
-        for i, s in enumerate(snaps):
-            ts = time.strftime("%H:%M:%S", time.localtime(s.get("timestamp", 0)))
-            lines.append(f"  [{i}] {s.get('snapshot_id','?')}  {ts}  {s.get('command','?')[:60]}")
-        return _deny("\n".join(lines))
+        return _cmd_list(session_id)
+
+    if sub == "checkpoint":
+        return _cmd_checkpoint(session_id, command, arg)
+
+    if sub == "undo":
+        return _cmd_undo(session_id)
 
     if sub == "drop":
-        if not arg:
-            return _deny("Usage: cubesandbox-rollback drop <snapshot-id>")
-        my = read_my_state(session_id)
-        snaps = my.get("snapshots", [])
-        new_snaps = [s for s in snaps if s.get("snapshot_id") != arg]
-        if len(new_snaps) == len(snaps):
-            return _deny(f"Snapshot `{arg}` not found.")
-        my["snapshots"] = new_snaps
-        write_my_state(session_id, my)
-        return _deny(f"Snapshot `{arg}` dropped.")
+        return _cmd_drop(session_id, arg)
 
-    # Anything other than `last` (or the implicit default) is an unknown
-    # subcommand — deny with usage instead of silently rolling back.
-    if sub not in (None, "", "last"):
-        return _deny("Usage: cubesandbox-rollback [last|list|drop <snapshot-id>]")
+    # Rollback path: "last" | <N> | <snapshot-id> (bare sentinel → "last").
+    # Anything else is an unknown subcommand — deny with usage instead of
+    # silently rolling back.
+    if sub != "last" and not sub.isdigit() and not sub.startswith("snap-"):
+        return _deny(USAGE)
 
-    # "last" (default when no subcommand is given)
-    my = read_my_state(session_id)
-    snaps = my.get("snapshots", [])
-    if not snaps:
-        return _deny("No snapshots available to roll back.")
-
-    latest = snaps[-1]
-
-    sstate = read_sandbox_state(session_id)
-    if not sstate or not sstate.get("sandbox_id"):
-        return _deny("No sandbox found. Is #765 configured?")
-
-    try:
-        client = get_sandbox_client(sstate["sandbox_id"])
-        client.rollback(latest["snapshot_id"])
-    except Exception as exc:
-        return _deny(f"Rollback failed: {exc}")
-
-    # 从严: only keep snapshots up to and including the target
-    idx = snaps.index(latest)
-    my["snapshots"] = snaps[:idx + 1]
-    write_my_state(session_id, my)
-
-    return _deny(
-        f"Rollback complete. State restored to snapshot `{latest['snapshot_id']}` "
-        f"from command `{latest.get('command', '?')}`. "
-        "You may re-run your intended command now."
-    )
+    return _cmd_rollback(session_id, sub)
 
 
 if __name__ == "__main__":

--- a/examples/claude-code-integration/rollback/cubesandbox_session.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_session.py
@@ -7,12 +7,16 @@ import json
 import sys
 
 MESSAGE = (
-    "CubeSandbox Rollback is active. Snapshots are taken automatically "
-    "before risky commands (rm, npm install, git reset, etc.). If a "
-    "command breaks the environment, run `cubesandbox-rollback last` to "
-    "restore the previous state. Use `cubesandbox-rollback list` to see "
-    "available snapshots. Use `cubesandbox-rollback drop <id>` to delete "
-    "a snapshot."
+    "CubeSandbox Rollback is active. A snapshot is taken automatically "
+    "before every risky command (rm, npm install, git reset, etc.), and a "
+    "baseline snapshot marks the session start. Run `cubesandbox-rollback "
+    "list` to see all snapshots; roll back to any of them with "
+    "`cubesandbox-rollback last`, `cubesandbox-rollback <N>`, or "
+    "`cubesandbox-rollback <snapshot-id>`. Use `cubesandbox-rollback "
+    "checkpoint <name>` to save a named milestone before a refactor. "
+    "After a rollback, `cubesandbox-rollback undo` restores the previous "
+    "state until a new snapshot is taken, and `cubesandbox-rollback drop "
+    "<last|N|snapshot-id>` deletes a snapshot."
 )
 
 

--- a/examples/claude-code-integration/rollback/cubesandbox_session.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_session.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject rollback awareness into agent context."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+MESSAGE = (
+    "CubeSandbox Rollback is active. Snapshots are taken automatically "
+    "before risky commands (rm, npm install, git reset, etc.). If a "
+    "command breaks the environment, run `cubesandbox-rollback last` to "
+    "restore the previous state. Use `cubesandbox-rollback list` to see "
+    "available snapshots. Use `cubesandbox-rollback drop <id>` to delete "
+    "a snapshot."
+)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        print("{}")
+        return 0
+
+    if payload.get("hook_event_name") != "SessionStart":
+        print("{}")
+        return 0
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": MESSAGE,
+        }
+    }
+    print(json.dumps(output))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/rollback/cubesandbox_snapshot.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_snapshot.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""PreToolUse/Bash hook: snapshot before risky commands.  Fail-open."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+
+from cubesandbox_lib import (
+    get_config_hash,
+    get_sandbox_client,
+    read_my_state,
+    read_sandbox_state,
+    session_digest,
+    write_my_state,
+)
+from cubesandbox_risky import is_risky, is_sentinel, load_safe_whitelist
+
+
+def _fail_open(reason: str) -> int:
+    """Log error and return empty decision (command proceeds)."""
+    print(f"[cubesandbox-snapshot] {reason}", file=sys.stderr)
+    print("{}")
+    return 0
+
+
+def main() -> int:
+    # 1. Parse hook input
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return _fail_open(f"invalid hook JSON: {exc}")
+
+    if payload.get("hook_event_name") != "PreToolUse":
+        print("{}")
+        return 0
+    if payload.get("tool_name") != "Bash":
+        print("{}")
+        return 0
+
+    tool_input = payload.get("tool_input", {})
+    command = tool_input.get("command", "")
+    session_id = payload.get("session_id", "default")
+
+    # 2. Skip sentinel
+    if is_sentinel(command):
+        print("{}")
+        return 0
+
+    # 3. Load whitelist and check risk
+    safe = load_safe_whitelist()
+    if not is_risky(command, safe):
+        print("{}")
+        return 0
+
+    # 4. Risky — need a sandbox
+    sstate = read_sandbox_state(session_id)
+    if not sstate or not sstate.get("sandbox_id"):
+        return _fail_open("no sandbox yet (first command?)")
+
+    # 5. Config hash check (从严: stale → skip; empty = first run, allow)
+    stored = read_my_state(session_id).get("config_hash", "")
+    current = get_config_hash()
+    if stored and stored != current:
+        return _fail_open("config stale — reinstall rollback hooks")
+
+    # 6. Connect + snapshot
+    try:
+        client = get_sandbox_client(sstate["sandbox_id"])
+        snapshot = client.create_snapshot()
+    except Exception as exc:
+        return _fail_open(f"sandbox error: {exc}")
+
+    # 7. Persist
+    my = read_my_state(session_id)
+    my.setdefault("snapshots", []).append({
+        "snapshot_id": snapshot.snapshot_id,
+        "name": getattr(snapshot, "name", ""),
+        "command": command[:256],
+        "timestamp": int(time.time()),
+    })
+    my["config_hash"] = get_config_hash()
+    try:
+        write_my_state(session_id, my)
+    except Exception as exc:
+        return _fail_open(f"state write error: {exc}")
+
+    print(f"[cubesandbox-snapshot] snapshot taken: {snapshot.snapshot_id}",
+          file=sys.stderr)
+    print("{}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/rollback/cubesandbox_snapshot.py
+++ b/examples/claude-code-integration/rollback/cubesandbox_snapshot.py
@@ -12,11 +12,13 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPT_DIR)
 
 from cubesandbox_lib import (
-    get_config_hash,
+    delete_snapshot_backend,
+    evict_auto,
+    get_max_auto_snapshots,
     get_sandbox_client,
+    load_hook_env,
     read_my_state,
     read_sandbox_state,
-    session_digest,
     write_my_state,
 )
 from cubesandbox_risky import is_risky, is_sentinel, load_safe_whitelist
@@ -30,6 +32,8 @@ def _fail_open(reason: str) -> int:
 
 
 def main() -> int:
+    load_hook_env()
+
     # 1. Parse hook input
     try:
         payload = json.load(sys.stdin)
@@ -63,28 +67,39 @@ def main() -> int:
     if not sstate or not sstate.get("sandbox_id"):
         return _fail_open("no sandbox yet (first command?)")
 
-    # 5. Config hash check (从严: stale → skip; empty = first run, allow)
-    stored = read_my_state(session_id).get("config_hash", "")
-    current = get_config_hash()
-    if stored and stored != current:
-        return _fail_open("config stale — reinstall rollback hooks")
-
-    # 6. Connect + snapshot
+    # 5. Connect + snapshot
     try:
         client = get_sandbox_client(sstate["sandbox_id"])
         snapshot = client.create_snapshot()
     except Exception as exc:
         return _fail_open(f"sandbox error: {exc}")
 
-    # 7. Persist
+    # 6. New activity invalidates any pending undo point
     my = read_my_state(session_id)
+    if my.get("undo"):
+        undo = my["undo"]
+        print(f"[cubesandbox-snapshot] new activity invalidates undo point "
+              f"{undo.get('snapshot_id')}", file=sys.stderr)
+        delete_snapshot_backend(undo.get("snapshot_id"))
+        my["undo"] = None
+
+    # 7. Append + ring-evict auto snapshots
     my.setdefault("snapshots", []).append({
         "snapshot_id": snapshot.snapshot_id,
+        "kind": "auto",
         "name": getattr(snapshot, "name", ""),
         "command": command[:256],
         "timestamp": int(time.time()),
     })
-    my["config_hash"] = get_config_hash()
+    my["snapshots"], evicted = evict_auto(
+        my["snapshots"], get_max_auto_snapshots()
+    )
+    for s in evicted:
+        print(f"[cubesandbox-snapshot] evicting old auto snapshot "
+              f"{s.get('snapshot_id')}", file=sys.stderr)
+        delete_snapshot_backend(s.get("snapshot_id"))
+
+    # 8. Persist
     try:
         write_my_state(session_id, my)
     except Exception as exc:

--- a/examples/claude-code-integration/rollback/install_rollback.sh
+++ b/examples/claude-code-integration/rollback/install_rollback.sh
@@ -12,23 +12,19 @@ HOOKS_DIR="${HOME}/.claude/hooks/rollback"
 _find_project_root() {
     local dir
     dir="${1:-$PWD}"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -d "${dir}/.git" ]]; then
-            echo "$dir"
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
+    if git -C "$dir" rev-parse --show-toplevel 2>/dev/null; then
+        return 0
+    fi
     echo "$PWD"
     return 1
 }
 
-PROJECT_ROOT="$(_find_project_root)"
+PROJECT_ROOT="$(_find_project_root || true)"
 PROJECT_SETTINGS="${PROJECT_ROOT}/.claude/settings.json"
 SKILL_DIR="${PROJECT_ROOT}/.claude/skills/cubesandbox-rollback"
 
 # ---------------------------------------------------------------------------
-# Helper: read/write JSON settings without jq (fallback to python)
+# Helper: read/write JSON settings
 # ---------------------------------------------------------------------------
 _HAS_JQ=false
 if command -v jq &>/dev/null; then _HAS_JQ=true; fi
@@ -180,7 +176,7 @@ The installer:
   - Copies hook scripts to ~/.claude/hooks/rollback/
   - Registers hooks in <project>/.claude/settings.json
   - Creates a skill at <project>/.claude/skills/cubesandbox-rollback/
-  - NEVER touches ~/.claude/settings.json (#765's domain)
+  - NEVER touches ~/.claude/settings.json (cubesandbox-hook's domain)
 EOF
 }
 
@@ -216,21 +212,23 @@ do_install() {
     cp "${SCRIPT_DIR}/SKILL.md" "${SKILL_DIR}/"
     echo "  done"
 
-    # 4. Check #765
+    # 4. Check cubesandbox-hook
     if [[ -f "${HOME}/.claude/settings.json" ]]; then
-        echo "  #765 user-level settings.json: found"
+        echo "  cubesandbox-hook user-level settings.json: found"
     else
-        echo "  ⚠  #765 user-level settings.json NOT found — install #765 first"
+        echo "  ⚠  cubesandbox-hook user-level settings.json NOT found — install cubesandbox-hook first"
     fi
 
     # 5. Deps
     if command -v pip &>/dev/null; then
-        if python3 -c "import cubesandbox" 2>/dev/null; then
-            echo "  cubesandbox-sdk: installed"
-        else
-            echo "  Installing cubesandbox-sdk via pip ..."
-            pip install cubesandbox-sdk
-        fi
+        for dep in cubesandbox bashlex; do
+            if python3 -c "import ${dep}" 2>/dev/null; then
+                echo "  ${dep}: installed"
+            else
+                echo "  Installing ${dep} via pip ..."
+                pip install "${dep}"
+            fi
+        done
     fi
 
     echo "=== Install complete ==="

--- a/examples/claude-code-integration/rollback/install_rollback.sh
+++ b/examples/claude-code-integration/rollback/install_rollback.sh
@@ -123,24 +123,30 @@ except (FileNotFoundError, json.JSONDecodeError):
 
 hooks = cfg.get("hooks", {})
 
+
+def _hook_cmd(h, default=""):
+    """CC hooks may be dicts ({type, command}) or plain strings."""
+    return h.get("command", default) if isinstance(h, dict) else h
+
+
 # Remove our commands from PreToolUse/Bash
 for b in hooks.get("PreToolUse", []):
     if isinstance(b, dict) and b.get("matcher") == "Bash":
         b["hooks"] = [h for h in b.get("hooks", [])
-                       if h.get("command", "").find("cubesandbox_rollback") == -1
-                       and h.get("command", "").find("cubesandbox_snapshot") == -1]
+                       if _hook_cmd(h).find("cubesandbox_rollback") == -1
+                       and _hook_cmd(h).find("cubesandbox_snapshot") == -1]
 
 # Remove SessionStart hooks
 for b in hooks.get("SessionStart", []):
     if isinstance(b, dict):
         b["hooks"] = [h for h in b.get("hooks", [])
-                       if h.get("command", "").find("cubesandbox_session") == -1]
+                       if _hook_cmd(h).find("cubesandbox_session") == -1]
 
 # Remove PostToolUse/Bash hooks
 for b in hooks.get("PostToolUse", []):
     if isinstance(b, dict) and b.get("matcher") == "Bash":
         b["hooks"] = [h for h in b.get("hooks", [])
-                       if h.get("command", "").find("cubesandbox_poststart") == -1]
+                       if _hook_cmd(h).find("cubesandbox_poststart") == -1]
 
 # Remove empty blocks
 for key in ("PreToolUse", "SessionStart", "PostToolUse"):

--- a/examples/claude-code-integration/rollback/install_rollback.sh
+++ b/examples/claude-code-integration/rollback/install_rollback.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# CubeSandbox Rollback — idempotent Claude Code hook installer
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOKS_DIR="${HOME}/.claude/hooks/rollback"
+
+# Project root detection
+_find_project_root() {
+    local dir
+    dir="${1:-$PWD}"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "${dir}/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "$PWD"
+    return 1
+}
+
+PROJECT_ROOT="$(_find_project_root)"
+PROJECT_SETTINGS="${PROJECT_ROOT}/.claude/settings.json"
+SKILL_DIR="${PROJECT_ROOT}/.claude/skills/cubesandbox-rollback"
+
+# ---------------------------------------------------------------------------
+# Helper: read/write JSON settings without jq (fallback to python)
+# ---------------------------------------------------------------------------
+_HAS_JQ=false
+if command -v jq &>/dev/null; then _HAS_JQ=true; fi
+
+_json_merge_hooks() {
+    # Merge rollback hooks into existing settings.json, preserving other hooks.
+    local file="$1"
+    python3 - "$file" "$HOOKS_DIR" "${_HAS_JQ}" <<'PYEOF'
+import json, sys, os
+
+path = sys.argv[1]
+hooks_dir = sys.argv[2]
+
+# Read existing
+try:
+    with open(path, "r") as fh:
+        cfg = json.load(fh)
+except (FileNotFoundError, json.JSONDecodeError):
+    cfg = {}
+
+hooks = cfg.setdefault("hooks", {})
+
+# --- PreToolUse / Bash ---
+ptu = hooks.setdefault("PreToolUse", [])
+bash_block = None
+for b in ptu:
+    if isinstance(b, dict) and b.get("matcher") == "Bash":
+        bash_block = b
+        break
+if bash_block is None:
+    bash_block = {"matcher": "Bash", "hooks": []}
+    ptu.append(bash_block)
+
+bash_hooks = bash_block.setdefault("hooks", [])
+snapshot_cmd = {"type": "command", "command": f"python3 {hooks_dir}/cubesandbox_snapshot.py"}
+rollback_cmd = {"type": "command", "command": f"python3 {hooks_dir}/cubesandbox_rollback.py"}
+# Idempotent: only add if not present
+existing_cmds = {json.dumps(h, sort_keys=True) for h in bash_hooks}
+if json.dumps(snapshot_cmd, sort_keys=True) not in existing_cmds:
+    bash_hooks.append(snapshot_cmd)
+if json.dumps(rollback_cmd, sort_keys=True) not in existing_cmds:
+    bash_hooks.append(rollback_cmd)
+
+# --- SessionStart ---
+ss = hooks.setdefault("SessionStart", [])
+session_block = None
+for b in ss:
+    if isinstance(b, dict):
+        session_block = b
+        break
+if session_block is None:
+    session_block = {"hooks": []}
+    ss.append(session_block)
+ss_hooks = session_block.setdefault("hooks", [])
+session_cmd = {"type": "command", "command": f"python3 {hooks_dir}/cubesandbox_session.py"}
+existing_ss = {json.dumps(h, sort_keys=True) for h in ss_hooks}
+if json.dumps(session_cmd, sort_keys=True) not in existing_ss:
+    ss_hooks.append(session_cmd)
+
+# --- PostToolUse / Bash ---
+post = hooks.setdefault("PostToolUse", [])
+post_block = None
+for b in post:
+    if isinstance(b, dict) and b.get("matcher") == "Bash":
+        post_block = b
+        break
+if post_block is None:
+    post_block = {"matcher": "Bash", "hooks": []}
+    post.append(post_block)
+post_hooks = post_block.setdefault("hooks", [])
+post_cmd = {"type": "command", "command": f"python3 {hooks_dir}/cubesandbox_poststart.py"}
+existing_post = {json.dumps(h, sort_keys=True) for h in post_hooks}
+if json.dumps(post_cmd, sort_keys=True) not in existing_post:
+    post_hooks.append(post_cmd)
+
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, "w") as fh:
+    json.dump(cfg, fh, indent=2)
+    fh.write("\n")
+PYEOF
+}
+
+_json_remove_rollback() {
+    local file="$1"
+    python3 - "$file" "$HOOKS_DIR" <<'PYEOF'
+import json, sys, os
+
+path = sys.argv[1]
+hooks_dir = sys.argv[2]
+
+try:
+    with open(path, "r") as fh:
+        cfg = json.load(fh)
+except (FileNotFoundError, json.JSONDecodeError):
+    cfg = {}
+
+hooks = cfg.get("hooks", {})
+
+# Remove our commands from PreToolUse/Bash
+for b in hooks.get("PreToolUse", []):
+    if isinstance(b, dict) and b.get("matcher") == "Bash":
+        b["hooks"] = [h for h in b.get("hooks", [])
+                       if h.get("command", "").find("cubesandbox_rollback") == -1
+                       and h.get("command", "").find("cubesandbox_snapshot") == -1]
+
+# Remove SessionStart hooks
+for b in hooks.get("SessionStart", []):
+    if isinstance(b, dict):
+        b["hooks"] = [h for h in b.get("hooks", [])
+                       if h.get("command", "").find("cubesandbox_session") == -1]
+
+# Remove PostToolUse/Bash hooks
+for b in hooks.get("PostToolUse", []):
+    if isinstance(b, dict) and b.get("matcher") == "Bash":
+        b["hooks"] = [h for h in b.get("hooks", [])
+                       if h.get("command", "").find("cubesandbox_poststart") == -1]
+
+# Remove empty blocks
+for key in ("PreToolUse", "SessionStart", "PostToolUse"):
+    if key in hooks:
+        hooks[key] = [b for b in hooks[key]
+                       if isinstance(b, dict) and b.get("hooks")]
+        if not hooks[key]:
+            del hooks[key]
+
+if not hooks:
+    cfg.pop("hooks", None)
+
+with open(path, "w") as fh:
+    json.dump(cfg, fh, indent=2)
+    fh.write("\n")
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<EOF
+Usage: $0 [--uninstall] [--help]
+
+Install or uninstall the CubeSandbox rollback hooks for Claude Code.
+
+Options:
+  --uninstall   Remove rollback hooks from project settings
+  --help        Show this help message
+
+The installer:
+  - Copies hook scripts to ~/.claude/hooks/rollback/
+  - Registers hooks in <project>/.claude/settings.json
+  - Creates a skill at <project>/.claude/skills/cubesandbox-rollback/
+  - NEVER touches ~/.claude/settings.json (#765's domain)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------------
+do_install() {
+    echo "=== CubeSandbox Rollback Installer ==="
+    echo "Project root: ${PROJECT_ROOT}"
+
+    # 1. Copy hooks
+    echo "Installing hooks to ${HOOKS_DIR} ..."
+    mkdir -p "${HOOKS_DIR}"
+    for f in cubesandbox_lib.py cubesandbox_risky.py \
+             cubesandbox_snapshot.py cubesandbox_rollback.py \
+             cubesandbox_session.py cubesandbox_poststart.py \
+             .env.example; do
+        if [[ -f "${SCRIPT_DIR}/${f}" ]]; then
+            cp "${SCRIPT_DIR}/${f}" "${HOOKS_DIR}/"
+            chmod +x "${HOOKS_DIR}/${f}" 2>/dev/null || true
+            echo "  ${f}"
+        fi
+    done
+
+    # 2. Register hooks in project settings
+    echo "Registering hooks in ${PROJECT_SETTINGS} ..."
+    _json_merge_hooks "${PROJECT_SETTINGS}"
+    echo "  done"
+
+    # 3. Create skill
+    echo "Creating skill at ${SKILL_DIR} ..."
+    mkdir -p "${SKILL_DIR}"
+    cp "${SCRIPT_DIR}/SKILL.md" "${SKILL_DIR}/"
+    echo "  done"
+
+    # 4. Check #765
+    if [[ -f "${HOME}/.claude/settings.json" ]]; then
+        echo "  #765 user-level settings.json: found"
+    else
+        echo "  ⚠  #765 user-level settings.json NOT found — install #765 first"
+    fi
+
+    # 5. Deps
+    if command -v pip &>/dev/null; then
+        if python3 -c "import cubesandbox" 2>/dev/null; then
+            echo "  cubesandbox-sdk: installed"
+        else
+            echo "  Installing cubesandbox-sdk via pip ..."
+            pip install cubesandbox-sdk
+        fi
+    fi
+
+    echo "=== Install complete ==="
+}
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+do_uninstall() {
+    echo "=== CubeSandbox Rollback Uninstaller ==="
+    echo "Project root: ${PROJECT_ROOT}"
+
+    echo "Removing hooks from ${PROJECT_SETTINGS} ..."
+    _json_remove_rollback "${PROJECT_SETTINGS}"
+    echo "  done"
+
+    echo "Removing ${HOOKS_DIR} ..."
+    rm -rf "${HOOKS_DIR}"
+    echo "  done"
+
+    echo "Removing ${SKILL_DIR} ..."
+    rm -rf "${SKILL_DIR}"
+    echo "  done"
+
+    echo "User-level ~/.claude/settings.json: left untouched"
+    echo "=== Uninstall complete ==="
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+case "${1:-}" in
+    --help|-h) usage; exit 0 ;;
+    --uninstall) do_uninstall ;;
+    "") do_install ;;
+    *) usage; exit 1 ;;
+esac

--- a/examples/claude-code-integration/rollback/install_rollback.sh
+++ b/examples/claude-code-integration/rollback/install_rollback.sh
@@ -227,7 +227,7 @@ do_install() {
 
     # 5. Deps
     if command -v pip &>/dev/null; then
-        for dep in cubesandbox bashlex; do
+        for dep in cubesandbox bashlex dotenv; do
             if python3 -c "import ${dep}" 2>/dev/null; then
                 echo "  ${dep}: installed"
             else

--- a/examples/claude-code-integration/rollback/requirements.txt
+++ b/examples/claude-code-integration/rollback/requirements.txt
@@ -1,3 +1,3 @@
-cubesandbox-sdk>=0.6.0
+cubesandbox>=0.6.0
 bashlex>=0.18
 python-dotenv>=1.0

--- a/examples/claude-code-integration/rollback/requirements.txt
+++ b/examples/claude-code-integration/rollback/requirements.txt
@@ -1,1 +1,3 @@
 cubesandbox-sdk>=0.6.0
+bashlex>=0.18
+python-dotenv>=1.0

--- a/examples/claude-code-integration/rollback/requirements.txt
+++ b/examples/claude-code-integration/rollback/requirements.txt
@@ -1,0 +1,1 @@
+cubesandbox-sdk>=0.6.0

--- a/examples/claude-code-integration/rollback/test_lib.py
+++ b/examples/claude-code-integration/rollback/test_lib.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Regression tests for the rollback state helpers (no network/backend).
+
+Covers:
+  - find_snapshot_index: 'last', decimal index, snapshot-id lookup
+  - prune_after: keeps up to idx, drops the rest
+  - evict_auto: ring eviction of 'auto' snapshots only (baseline and
+    checkpoint are NEVER evicted), backward-compat missing 'kind' → auto
+  - get_max_auto_snapshots: env parsing + clamp to >= 1
+  - load_hook_env: KEY=VALUE parsing, no clobber of existing env vars
+  - delete_snapshot_backend: backend errors are swallowed (no network:
+    the classmethod is patched)
+
+Run:  python3 test_lib.py
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import cubesandbox_lib  # noqa: E402
+from cubesandbox_lib import (  # noqa: E402
+    delete_snapshot_backend,
+    evict_auto,
+    find_snapshot_index,
+    get_max_auto_snapshots,
+    load_hook_env,
+    prune_after,
+)
+
+PASS = 0
+FAIL = 0
+FAILURES = []
+
+
+def check(desc: str, cond: bool, note: str = ""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+    else:
+        FAIL += 1
+        FAILURES.append(f"  FAIL {desc} {note}")
+
+
+def snap(sid: str, kind=None):
+    """Build a minimal snapshot dict; omit 'kind' to emulate old state."""
+    s = {"snapshot_id": sid}
+    if kind is not None:
+        s["kind"] = kind
+    return s
+
+
+# ---------------------------------------------------------------------------
+# find_snapshot_index
+# ---------------------------------------------------------------------------
+print("== find_snapshot_index ==")
+SNAPS = [
+    snap("snap-b", "baseline"),
+    snap("snap-a1"),
+    snap("snap-a2", "checkpoint"),
+    snap("snap-a3"),
+]
+check("find 'last' → len-1", find_snapshot_index(SNAPS, "last") == 3)
+check("find '0' → index 0", find_snapshot_index(SNAPS, "0") == 0)
+check("find '2' → index 2", find_snapshot_index(SNAPS, "2") == 2)
+check("find snapshot-id present",
+      find_snapshot_index(SNAPS, "snap-a2") == 2)
+check("find snapshot-id absent",
+      find_snapshot_index(SNAPS, "snap-zzz") is None)
+check("find 'abc' → None", find_snapshot_index(SNAPS, "abc") is None)
+check("find '' → None", find_snapshot_index(SNAPS, "") is None)
+check("find out-of-range digit → None",
+      find_snapshot_index(SNAPS, "9") is None)
+check("find negative → None", find_snapshot_index(SNAPS, "-1") is None)
+check("find 'last' empty list → None",
+      find_snapshot_index([], "last") is None)
+check("find '0' empty list → None", find_snapshot_index([], "0") is None)
+
+# ---------------------------------------------------------------------------
+# prune_after
+# ---------------------------------------------------------------------------
+print("== prune_after ==")
+kept, dropped = prune_after(SNAPS, 1)
+check("prune idx1 kept = first 2", kept == SNAPS[:2])
+check("prune idx1 dropped = rest", dropped == SNAPS[2:])
+kept, dropped = prune_after(SNAPS, 0)
+check("prune idx0 kept = first 1", kept == SNAPS[:1])
+check("prune idx0 dropped = rest", dropped == SNAPS[1:])
+kept, dropped = prune_after(SNAPS, len(SNAPS) - 1)
+check("prune last kept = all", kept == SNAPS)
+check("prune last dropped = none", dropped == [])
+check("prune preserves order", kept + dropped == SNAPS)
+
+# ---------------------------------------------------------------------------
+# evict_auto
+# ---------------------------------------------------------------------------
+print("== evict_auto ==")
+
+# baseline + checkpoint NEVER evicted even when max_auto=1
+S = [snap("snap-b", "baseline"), snap("snap-a1"),
+     snap("snap-c", "checkpoint"), snap("snap-a2")]
+new, ev = evict_auto(S, 1)
+check("max=1 baseline+checkpoint kept",
+      [s["snapshot_id"] for s in new] == ["snap-b", "snap-c", "snap-a2"])
+check("max=1 evicted oldest auto only",
+      [s["snapshot_id"] for s in ev] == ["snap-a1"])
+
+# oldest auto evicted even when it sits after a baseline at index 0
+# (3 autos, max=1 → evict the two oldest autos down to 1)
+S = [snap("snap-b", "baseline"), snap("snap-a1"), snap("snap-a2"),
+     snap("snap-a3")]
+new, ev = evict_auto(S, 1)
+check("oldest autos after baseline evicted",
+      [s["snapshot_id"] for s in new] == ["snap-b", "snap-a3"])
+check("evicted = two oldest autos",
+      [s["snapshot_id"] for s in ev] == ["snap-a1", "snap-a2"])
+
+# multiple evictions when max exceeded by > 1
+S = [snap("snap-a1"), snap("snap-a2"), snap("snap-a3"), snap("snap-a4")]
+new, ev = evict_auto(S, 2)
+check("evict multiple down to max",
+      [s["snapshot_id"] for s in new] == ["snap-a3", "snap-a4"])
+check("evicted two oldest",
+      [s["snapshot_id"] for s in ev] == ["snap-a1", "snap-a2"])
+
+# empty list
+new, ev = evict_auto([], 5)
+check("evict empty list → empty", new == [] and ev == [])
+
+# at/below limit → nothing evicted
+new, ev = evict_auto(SNAPS, 10)
+check("at limit nothing evicted",
+      ev == [] and len(new) == len(SNAPS) and new == SNAPS)
+
+# max clamp: max_auto=0 behaves as 1 (baseline never evicted)
+S = [snap("snap-b", "baseline"), snap("snap-a1")]
+new, ev = evict_auto(S, 0)
+check("evict clamp 0 → 1, nothing evicted",
+      new == S and ev == [])
+
+# backward compat: snapshots missing 'kind' are treated as 'auto'
+S = [snap("snap-old1"), snap("snap-old2")]
+new, ev = evict_auto(S, 1)
+check("missing-kind treated as auto (evicted)",
+      [s["snapshot_id"] for s in ev] == ["snap-old1"])
+check("missing-kind treated as auto (kept)",
+      [s["snapshot_id"] for s in new] == ["snap-old2"])
+
+# mixed: missing-kind autos around baseline/checkpoint
+S = [snap("snap-b", "baseline"), snap("snap-old1"),
+     snap("snap-c", "checkpoint"), snap("snap-old2")]
+new, ev = evict_auto(S, 1)
+check("missing-kind autos evicted around baseline/checkpoint",
+      [s["snapshot_id"] for s in new] == ["snap-b", "snap-c", "snap-old2"])
+check("missing-kind autos evicted = oldest",
+      [s["snapshot_id"] for s in ev] == ["snap-old1"])
+
+# ---------------------------------------------------------------------------
+# get_max_auto_snapshots (env parsing + clamp)
+# ---------------------------------------------------------------------------
+print("== get_max_auto_snapshots ==")
+os.environ["CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS"] = "0"
+check("clamp 0 → 1", get_max_auto_snapshots() == 1)
+os.environ["CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS"] = "-5"
+check("clamp -5 → 1", get_max_auto_snapshots() == 1)
+os.environ["CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS"] = "abc"
+check("garbage → default 30", get_max_auto_snapshots() == 30)
+os.environ["CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS"] = "7"
+check("parse 7 → 7", get_max_auto_snapshots() == 7)
+os.environ["CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS"] = " 42 "
+check("parse whitespace-padded 42 → 42", get_max_auto_snapshots() == 42)
+del os.environ["CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS"]
+check("unset → default 30", get_max_auto_snapshots() == 30)
+
+# ---------------------------------------------------------------------------
+# load_hook_env (filesystem-only; patches _HOOK_ENV_PATH to a temp file)
+# ---------------------------------------------------------------------------
+print("== load_hook_env ==")
+with tempfile.TemporaryDirectory() as tmp:
+    envf = Path(tmp) / "cubesandbox.env"
+    envf.write_text(
+        "# comment line\n\n"
+        "CUBE_TEST_VAR=hello\n"
+        "CUBE_ROLLBACK_SAFE=echo,cat\n"
+        "   CUBE_PADDED = spaced\n"
+        "NOT_A_KEY_VALUE_LINE\n"
+        "CUBE_QUOTED_SINGLE='http://127.0.0.1:3000'\n"
+        'CUBE_QUOTED_DOUBLE="tpl-abc"\n'
+    )
+    orig_path = cubesandbox_lib._HOOK_ENV_PATH
+    cubesandbox_lib._HOOK_ENV_PATH = envf
+    try:
+        os.environ.pop("CUBE_TEST_VAR", None)
+        os.environ["CUBE_ROLLBACK_SAFE"] = "already-set"
+        os.environ.pop("CUBE_QUOTED_SINGLE", None)
+        os.environ.pop("CUBE_QUOTED_DOUBLE", None)
+        load_hook_env()
+        check("sets missing var", os.environ.get("CUBE_TEST_VAR") == "hello")
+        check("does not clobber existing var",
+              os.environ.get("CUBE_ROLLBACK_SAFE") == "already-set")
+        check("parses padded key/value",
+              os.environ.get("CUBE_PADDED") == "spaced")
+        check("skips comment/blank/no-'=' lines",
+              os.environ.get("NOT_A_KEY_VALUE_LINE") is None)
+        check("strips single quotes (dotenv compat)",
+              os.environ.get("CUBE_QUOTED_SINGLE") == "http://127.0.0.1:3000")
+        check("strips double quotes (dotenv compat)",
+              os.environ.get("CUBE_QUOTED_DOUBLE") == "tpl-abc")
+    finally:
+        cubesandbox_lib._HOOK_ENV_PATH = orig_path
+        os.environ.pop("CUBE_TEST_VAR", None)
+        os.environ.pop("CUBE_ROLLBACK_SAFE", None)
+        os.environ.pop("CUBE_PADDED", None)
+        os.environ.pop("CUBE_QUOTED_SINGLE", None)
+        os.environ.pop("CUBE_QUOTED_DOUBLE", None)
+
+# missing env file → no-op, no crash
+orig_path = cubesandbox_lib._HOOK_ENV_PATH
+cubesandbox_lib._HOOK_ENV_PATH = Path("/nonexistent/definitely/missing.env")
+try:
+    load_hook_env()
+    check("missing env file → no-op", True)
+finally:
+    cubesandbox_lib._HOOK_ENV_PATH = orig_path
+
+# ---------------------------------------------------------------------------
+# delete_snapshot_backend (backend errors swallowed; classmethod patched —
+# no network)
+# ---------------------------------------------------------------------------
+print("== delete_snapshot_backend ==")
+try:
+    import cubesandbox
+except ImportError:  # pragma: no cover - only if package absent
+    cubesandbox = None
+
+if cubesandbox is not None:
+    _orig = cubesandbox.Sandbox.delete_snapshot
+
+    def _boom(snapshot_id, **kwargs):
+        raise RuntimeError("backend down")
+
+    cubesandbox.Sandbox.delete_snapshot = _boom
+    try:
+        delete_snapshot_backend("snap-x")  # must not raise
+        check("backend error swallowed", True)
+        delete_snapshot_backend("")  # empty → early return, no call
+        check("empty id → early return", True)
+    finally:
+        cubesandbox.Sandbox.delete_snapshot = _orig
+else:
+    print("  (cubesandbox not installed — skipping backend-swallow test)")
+
+# ---------------------------------------------------------------------------
+print(f"\n{'-' * 60}")
+print(f"PASS: {PASS}  FAIL: {FAIL}")
+if FAILURES:
+    print("Failures:")
+    print("\n".join(FAILURES))
+    sys.exit(1)
+print("All tests passed.")

--- a/examples/claude-code-integration/rollback/test_risky.py
+++ b/examples/claude-code-integration/rollback/test_risky.py
@@ -57,6 +57,9 @@ check("sudo yarn add foo", "sudo yarn add foo", True)
 check("sudo -u root rm -rf /tmp/x", "sudo -u root rm -rf /tmp/x", True)
 check("nice -n 5 npm install", "nice -n 5 npm install", True)
 check("timeout 10 git reset --hard", "timeout 10 git reset --hard", True)
+check("timeout suffixed duration", "timeout 10s git reset --hard", True)
+check("timeout min duration", "timeout 5m npm install", True)
+check("timeout hour duration", "timeout 1h rm -rf /tmp/x", True)
 check("env FOO=bar npm install", "env FOO=bar npm install", True)
 check("DEBUG=1 npm install", "DEBUG=1 npm install", True)
 check("FOO=bar rm -rf /tmp/x", "FOO=bar rm -rf /tmp/x", True)
@@ -123,6 +126,15 @@ check("assignment plain safe", "DEBUG=1 echo hi", False)
 check("env assignment safe", "env FOO=1 echo hi", False)
 
 # ---------------------------------------------------------------------------
+# Comment handling: comment-only input is safe; a leading comment/shebang
+# followed by a real command must still be classified
+# ---------------------------------------------------------------------------
+print("== comment handling ==")
+check("comment-only", "# just a comment", False)
+check("comment then risky cmd", "# install dependencies\nnpm install", True)
+check("shebang then risky cmd", "#!/bin/bash\nrm -rf /tmp/important", True)
+
+# ---------------------------------------------------------------------------
 # Whitelist behavior
 # ---------------------------------------------------------------------------
 print("== whitelist behavior ==")
@@ -140,8 +152,16 @@ check("whitelist git reset", "git reset --hard", False, safe={"git"},
 print("== sentinel / whitelist parsing ==")
 check("sentinel never risky", "cubesandbox-rollback last", False)
 check("sentinel in compound", "cubesandbox-rollback drop snap-1 && ls", False)
+check("bare sentinel safe", "cubesandbox-rollback", False)
+check("prefix-named tool not sentinel", "cubesandbox-rollback-helper", False,
+      note="word boundary required — else a real rollback would run")
+check("prefix tool + risky compound", "cubesandbox-rollback-tool.py && rm -rf x", True,
+      note="prefix tool is not the sentinel, so rm -rf must be flagged")
 assert is_sentinel("cubesandbox-rollback last")
+assert is_sentinel("cubesandbox-rollback")
 assert not is_sentinel("ls -la")
+assert not is_sentinel("cubesandbox-rollback-helper")
+assert not is_sentinel("cubesandbox-rollback-tool.py")
 assert parse_sentinel("cubesandbox-rollback drop snap-1") == ("drop", "snap-1")
 assert parse_sentinel("cubesandbox-rollback") == ("last", None)
 assert parse_sentinel('cubesandbox-rollback checkpoint "my milestone"') == ("checkpoint", "my milestone")

--- a/examples/claude-code-integration/rollback/test_risky.py
+++ b/examples/claude-code-integration/rollback/test_risky.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Regression tests for the bashlex-based risk classifier.
+
+Covers:
+  - every review-bot bypass sample (prefix commands, env assignments,
+    quoted / unspaced redirects) — must be RISKY
+  - fail-safe semantics: unparseable constructs (arithmetic expansion,
+    `[[ ]]`, fork bombs) are RISKY by design (never silently safe)
+  - legacy behavior guards: /dev/null + fd redirects are SAFE, whitelist
+    applies per command, destructive redirect beats whitelist
+  - new structural rules: pipe-into-shell, process-substitution exec,
+    command substitution recursion
+
+Run:  python3 test_risky.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cubesandbox_risky import (  # noqa: E402
+    is_risky,
+    is_sentinel,
+    load_safe_whitelist,
+    parse_sentinel,
+)
+
+EMPTY = set()
+PASS = 0
+FAIL = 0
+FAILURES = []
+
+
+def check(desc: str, command: str, expected_risky: bool, safe: set = EMPTY,
+          note: str = ""):
+    global PASS, FAIL
+    got = is_risky(command, safe)
+    ok = got == expected_risky
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+        FAILURES.append(f"  FAIL {desc}: {command!r} → risky={got}, "
+                        f"expected={expected_risky} {note}")
+
+
+# ---------------------------------------------------------------------------
+# Review-bot bypass samples — all must now be RISKY
+# ---------------------------------------------------------------------------
+print("== review-bot bypass samples (must be RISKY) ==")
+check("sudo git reset --hard", "sudo git reset --hard", True)
+check("sudo npm install", "sudo npm install", True)
+check("env npm install", "env npm install", True)
+check("sudo pip install", "sudo pip install", True)
+check("sudo yarn add foo", "sudo yarn add foo", True)
+check("sudo -u root rm -rf /tmp/x", "sudo -u root rm -rf /tmp/x", True)
+check("nice -n 5 npm install", "nice -n 5 npm install", True)
+check("timeout 10 git reset --hard", "timeout 10 git reset --hard", True)
+check("env FOO=bar npm install", "env FOO=bar npm install", True)
+check("DEBUG=1 npm install", "DEBUG=1 npm install", True)
+check("FOO=bar rm -rf /tmp/x", "FOO=bar rm -rf /tmp/x", True)
+check("quoted redirect target", 'echo hi > "out file.txt"', True)
+check("quoted redirect, no space", 'echo hi>"out file.txt"', True)
+check("redirect to variable", 'echo hi > "$f"', True)
+check("unspaced redirect", "echo hi>file", True)
+check("unspaced append", "cmd>>log", True)
+check("csh-style &>", "echo hi &>all.log", True)
+check("csh-style >&", "echo hi >&all.log", True)
+check("fd-prefixed append", "echo hi 2>>log", True)
+
+# ---------------------------------------------------------------------------
+# Fail-safe semantics: unparseable → RISKY (never silently safe)
+# ---------------------------------------------------------------------------
+print("== fail-safe: unparseable → RISKY ==")
+check("arithmetic expansion", "echo $((1 > 0))", True,
+      note="bashlex cannot parse; fail-safe → risky (by design)")
+check("[[ ]] comparison", "[[ 5 > 3 ]]", True,
+      note="bashlex cannot parse; fail-safe → risky (by design)")
+check("fork bomb", ":(){ :|:& };:", True,
+      note="unparseable; fail-safe → risky (by design)")
+
+# ---------------------------------------------------------------------------
+# Legacy behavior guards (must stay correct)
+# ---------------------------------------------------------------------------
+print("== legacy behavior guards ==")
+check("plain ls", "ls -la", False)
+check("dev null redirect", "echo hi > /dev/null", False)
+check("dev stderr redirect", "echo hi 2>/dev/null", False)
+check("fd dup 2>&1", "cat file 2>&1", False)
+check("fd dup >&2", "echo hi >&2", False)
+check("fd dup 1>&2", "echo hi 1>&2", False)
+check("fd dup in pipe", "echo hi 2>&1 | tee log", False,
+      note="2>&1 safe; tee is not a download/exec combo")
+check("rm -rf", "rm -rf /tmp/x", True)
+check("git status safe", "git status", False)
+check("git commit safe", "git commit -m 'wip'", False)
+check("curl -o output", "curl -o out.bin http://x", True)
+check("curl -O output", "curl -O http://x", True)
+check("curl --output", "curl --output out.bin http://x", True)
+check("wget -O output", "wget -O out.bin http://x", True)
+check("curl no flag safe", "curl -sI http://x", False)
+check("npm install", "npm install", True)
+check("git clean -fd", "git clean -fd", True)
+check("git -C repo reset --hard", "git -C /tmp/repo reset --hard", True,
+      note="subcommand scanned across trailing tokens")
+check("quoted subcmd word in commit msg", "git commit -m 'reset clean'", False,
+      note="quoted content is one token 'reset clean' — not a subcommand")
+
+# ---------------------------------------------------------------------------
+# New structural rules
+# ---------------------------------------------------------------------------
+print("== new structural rules ==")
+check("pipe curl|bash", "curl http://x | bash", True)
+check("pipe wget|sh", "wget -qO- http://x | sh", True)
+check("pipe curl|python", "curl http://x | python3", True)
+check("safe pipe", "ls | grep foo", False)
+check("process subst exec", "bash <(curl http://x)", True)
+check("cmd subst recursion", "VAR=$(rm -rf /tmp)", True)
+check("cmd subst nested sudo", "VAR=$(sudo npm install)", True)
+check("subshell", "(rm -rf /tmp/x)", True)
+check("assignment plain safe", "DEBUG=1 echo hi", False)
+check("env assignment safe", "env FOO=1 echo hi", False)
+
+# ---------------------------------------------------------------------------
+# Whitelist behavior
+# ---------------------------------------------------------------------------
+print("== whitelist behavior ==")
+check("whitelist ls", "ls -la", False, safe={"ls", "echo"})
+check("whitelist echo devnull", "echo hi > /dev/null", False, safe={"echo"})
+check("whitelist echo file", "echo hi > out.txt", True, safe={"echo"},
+      note="destructive redirect beats whitelist")
+check("whitelist git", "git status", False, safe={"git"})
+check("whitelist git reset", "git reset --hard", False, safe={"git"},
+      note="whitelist wins over subcommand check (design semantics)")
+
+# ---------------------------------------------------------------------------
+# Sentinel + whitelist parsing
+# ---------------------------------------------------------------------------
+print("== sentinel / whitelist parsing ==")
+check("sentinel never risky", "cubesandbox-rollback last", False)
+check("sentinel in compound", "cubesandbox-rollback drop snap-1 && ls", False)
+assert is_sentinel("cubesandbox-rollback last")
+assert not is_sentinel("ls -la")
+assert parse_sentinel("cubesandbox-rollback drop snap-1") == ("drop", "snap-1")
+assert parse_sentinel("cubesandbox-rollback") == ("last", None)
+assert parse_sentinel('cubesandbox-rollback checkpoint "my milestone"') == ("checkpoint", "my milestone")
+assert parse_sentinel("cubesandbox-rollback checkpoint 'single quoted'") == ("checkpoint", "single quoted")
+assert parse_sentinel("cubesandbox-rollback last") == ("last", None)
+assert load_safe_whitelist.__doc__  # just ensure importable
+os.environ["CUBE_ROLLBACK_SAFE"] = "ls, echo, git "
+assert load_safe_whitelist() == {"ls", "echo", "git"}
+del os.environ["CUBE_ROLLBACK_SAFE"]
+PASS += 6
+
+# ---------------------------------------------------------------------------
+print(f"\n{'-' * 60}")
+print(f"PASS: {PASS}  FAIL: {FAIL}")
+if FAILURES:
+    print("Failures:")
+    print("\n".join(FAILURES))
+    sys.exit(1)
+print("All tests passed.")


### PR DESCRIPTION
## What

Snapshot and rollback protection for Claude Code sessions running inside
CubeSandbox MicroVMs, built on top of the **#765** Claude Code integration
(which redirects every Bash tool call into an isolated sandbox).

**Problem**: Claude Code's `/rewind` restores the transcript and file edits,
but does **not** undo what Bash commands did inside a sandbox — a destructive
`rm`, `git reset`, or `npm install` cannot be unwound.

**Solution**: snapshot the sandbox automatically before risky commands; the
agent drives a full snapshot history with a single `cubesandbox-rollback`
command supporting `checkpoint`, `rollback`, `undo`, `drop`, and `list`.

```mermaid
sequenceDiagram
    autonumber
    participant CC as Claude Code
    participant HR as hook runtime
    participant H765 as cubesandbox-hook<br/>(rewrite, #765)
    participant RB as rollback plugin<br/>(risky / snapshot / rollback)
    participant SB as CubeSandbox MicroVM

    Note over CC,SB: Session start
    CC->>HR: SessionStart
    RB-->>CC: inject skill + session context (additionalContext)

    Note over CC,SB: Normal command
    CC->>HR: PreToolUse: bash <cmd>
    HR->>H765: rewrite command into sandbox exec
    HR->>RB: parallel risk check (deny-only)
    RB-->>HR: {} if safe
    RB-->>HR: deny + auto pre-snapshot if risky (fail-open)
    H765->>SB: run cmd inside sandbox

    Note over CC,SB: Recovery
    CC->>HR: PreToolUse: cubesandbox-rollback <arg>
    HR->>RB: dispatch (list / rollback / undo / drop)
    RB->>SB: snapshot API (create / restore / delete)
    RB-->>CC: result via permissionDecisionReason
```

Refs https://github.com/TencentCloud/CubeSandbox/issues/644

## How it works

- Based on #765: reads #765's session state file
  (`~/.cache/cubesandbox-hook/<sha256(session_id)>.json`) to locate the
  session's sandbox, and never writes to #765's state.
- **Parallel-hook safe**: CC runs PreToolUse hooks in parallel — our hooks
  return only `{}` or `deny`, never `updatedInput`, so they coexist with
  #765's rewrite hook.
- **Deny channel**: verified live that CC renders
  `permissionDecisionReason` to the agent but not `stdout`; all user-facing
  output is carried in the reason (which is why command output appears with
  an `Error:` prefix in the transcript — it is the deny reason, not a
  failure).
- **Fail-open snapshot / fail-closed rollback**.
- **Discoverability**: SessionStart `additionalContext` + installed skill so
  the agent knows the commands.

### Command set (v2)

```
cubesandbox-rollback [last|<N>|<snapshot-id>]   restore any prior snapshot
cubesandbox-rollback list                       show snapshot history
cubesandbox-rollback checkpoint <name>          explicit milestone, exempt from eviction
cubesandbox-rollback undo                       revert the last rollback
cubesandbox-rollback drop <last|N|snapshot-id>  delete snapshots (real backend deletion)
```

- `rollback <N>` restores snapshot N steps back; snapshots after it are
  discarded (the discarded list is printed) but an undo point is kept, so a
  mistaken rollback can be undone.
- **Circular eviction**: automatic snapshots are capped at 30
  (`CUBE_ROLLBACK_MAX_AUTO_SNAPSHOTS`, default 30); the oldest is evicted
  with real backend deletion when the cap is exceeded. The baseline snapshot
  is permanent, and named checkpoints are never evicted.

## Files

`examples/claude-code-integration/rollback/`: 6 hook scripts
(lib / risky / snapshot / rollback / session / poststart) + idempotent
`install_rollback.sh` + `SKILL.md` + README + `.env.example` +
`requirements.txt`, plus unit tests (`test_lib.py`, `test_risky.py`).

```
examples/claude-code-integration/rollback/
├── cubesandbox_lib.py         shared logic: session state, env loading, snapshot list/prune/evict
├── cubesandbox_risky.py       PreToolUse gate: auto-snapshot before risky commands
├── cubesandbox_snapshot.py    explicit snapshot command entry
├── cubesandbox_rollback.py    rollback/checkpoint/undo/drop/list command entry
├── cubesandbox_session.py     SessionStart hook: announce plugin to the agent
├── cubesandbox_poststart.py   PostToolUse hook: sandbox bookkeeping
├── install_rollback.sh        idempotent install/uninstall (project-level only)
├── SKILL.md                   agent-facing skill with command reference
├── README.md                  user documentation
├── .env.example               config template (CUBE_* variables)
├── requirements.txt           python-dotenv dependency
├── test_lib.py                unit tests for shared lib logic
└── test_risky.py              unit tests for the risky-command gate
```

Project-level install only — never touches user-level
`~/.claude/settings.json`

## Verification

Tested end-to-end on a bare-metal CubeSandbox v0.6.0 deployment
(11 services, KVM) with Claude Code 2.1.226. One continuous session
(snapshots cross-checked against CubeAPI):

1. `echo v1 > /tmp/demo.txt` → sandbox has v1 (host-mount warning 130400
  shown, command still runs — see Known limitations #1)
2. `cubesandbox-rollback checkpoint milestone1` → named checkpoint created
3. `echo v2 > /tmp/demo.txt` → sandbox has v2; auto pre-snapshot taken
4. `cubesandbox-rollback list` → 4 snapshots: baseline + 2 checkpoints + auto
5. `cubesandbox-rollback 2` → restores the checkpoint state (v1), prints the
  discarded auto snapshot
6. `cat /tmp/demo.txt` → v1, rollback confirmed
7. `cubesandbox-rollback undo` → restores the pre-rollback state (v2)
8. `cat /tmp/demo.txt` → v2, undo confirmed
9. `cubesandbox-rollback list` → 3 snapshots (undo point consumed)
10. `cubesandbox-rollback drop 1` → deletes a snapshot by index, confirmed
  via CubeAPI
11. `cubesandbox-rollback list` → 2 snapshots remain (baseline + checkpoint)

[SCREENSHOT_1: session start — v1 + checkpoint create]
<img width="2560" height="1276" alt="屏幕截图_20260810_072736" src="https://github.com/user-attachments/assets/63bd7dbf-000b-4690-9b47-9c8d199d3aaf" />

[SCREENSHOT_2: list + rollback 2 + discarded snapshot]
<img width="2555" height="1253" alt="屏幕截图_20260810_072810" src="https://github.com/user-attachments/assets/36ead0fd-bc8e-46e2-9228-90851063f83a" />

[SCREENSHOT_3: undo + list + drop]
<img width="2552" height="1271" alt="屏幕截图_20260810_072833" src="https://github.com/user-attachments/assets/77003bb5-3b03-4274-95ab-aa34bde369d1" />

[SCREENSHOT_4: final list — baseline + checkpoint]
<img width="2527" height="325" alt="屏幕截图_20260810_073053" src="https://github.com/user-attachments/assets/4e117fbd-5132-40cc-abdf-bfa70d54eb08" />

Notes from this verification round:

- Env values wrapped in quotes (`CUBE_API_URL='http://...'`) no longer
  break config loading (python-dotenv).
- The intermittent sandbox-domain resolution failures seen mid-verification
  were traced to the bare-metal deploy's CoreDNS config
  (`deploy/one-click/coredns/Corefile.template` lacks an AAAA template,
  causing NXDOMAIN negative caching) — unrelated to this plugin; the
  session continued over direct proxy connection
  (`CUBE_PROXY_NODE_IP`/`CUBE_PROXY_PORT_HTTP`).

## Known limitations (verified during testing)

1. **Host-mount and snapshot are mutually exclusive** (platform constraint,
  Cubelet `validateCommitSandboxTarget`): adding the project dir to
  `allowed_host_mount_prefixes` breaks snapshot/rollback with error 130400.
  Keep the default prefix list — no host mount, snapshots work.
2. **Rollback on long-active sandboxes can hit a TAP `EBUSY` race** (VM
  restart rebuilds virtio-net devices; related fix in v0.3.1 changelog
  #442). Retry after a few seconds or start a fresh session.

Depends on the #765 Claude Code hooks.

Assisted-by: OPENCODE:deepseek-v4-flash

Signed-off-by: Mizup79 <1321709320a@gmail.com>