### PR TITLE
fix(templatecenter): restore snapshot-create request_id idempotency

### DIFF
--- a/CubeMaster/pkg/templatecenter/fingerprint.go
+++ b/CubeMaster/pkg/templatecenter/fingerprint.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 
 	"github.com/google/uuid"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 )
 
@@ -92,6 +93,25 @@ func marshalTemplateCommitJobRequest(req *types.CreateCubeSandboxReq) (string, e
 	return string(payload), nil
 }
 
+func marshalSnapshotFingerprintRequest(req *types.CreateCubeSandboxReq) (string, error) {
+	if req == nil {
+		return "", errors.New("request is nil")
+	}
+	cloned, err := cloneCreateRequest(req)
+	if err != nil {
+		return "", err
+	}
+	cloned.Request = nil
+	// Exclude the server-generated snapshot ID from the fingerprint input so
+	// identical snapshot-create retries produce the same fingerprint (#1105)
+	delete(cloned.Annotations, constants.CubeAnnotationAppSnapshotTemplateID)
+	payload, err := json.Marshal(cloned)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
 func buildCommitTemplateSpecFingerprintFromSnapshot(requestSnapshot string) string {
 	sum := sha256.Sum256([]byte(requestSnapshot))
 	return hex.EncodeToString(sum[:])
@@ -104,6 +124,6 @@ func buildCommitTemplateSpecFingerprintFromSnapshot(requestSnapshot string) stri
 // avoids touching every snapshot call site while still routing fingerprint
 // generation through a single canonical encoder.
 func buildCommitTemplateSpecFingerprint(req *types.CreateCubeSandboxReq) string {
-	payload, _ := marshalTemplateCommitJobRequest(req)
+	payload, _ := marshalSnapshotFingerprintRequest(req)
 	return buildCommitTemplateSpecFingerprintFromSnapshot(payload)
 }

--- a/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
@@ -694,3 +694,43 @@ func TestExecuteSnapshotDeleteJobReturnsReadyWithoutJobLookup(t *testing.T) {
 		t.Fatalf("GetTemplateImageJobInfo called %d time(s), want 0", getJobInfoCallCount)
 	}
 }
+
+func TestSnapshotCreateRequestIDIdempotency(t *testing.T) {
+	build := func() *sandboxtypes.CreateCubeSandboxReq {
+		_, storedReq, err := buildSnapshotRequests(&sandboxtypes.CreateCubeSandboxReq{
+			Request:      &sandboxtypes.Request{RequestID: "req-1"},
+			InstanceType: "cubebox",
+		}, "")
+		if err != nil {
+			t.Fatalf("buildSnapshotRequests: %v", err)
+		}
+		return storedReq
+	}
+
+	t.Run("rebuild is deterministic", func(t *testing.T) {
+		if buildCommitTemplateSpecFingerprint(build()) != buildCommitTemplateSpecFingerprint(build()) {
+			t.Fatal("two identical rebuilds produced different fingerprints")
+		}
+	})
+
+	t.Run("identical retry matches stored job", func(t *testing.T) {
+		// Store side, exactly as SubmitSandboxSnapshot does it: stamp the
+		// generated snapshot id, then fingerprint.
+		submitted := build()
+		submitted.Annotations[constants.CubeAnnotationAppSnapshotTemplateID] = "snap-generated"
+		raw, err := marshalSnapshotCreateRequest(snapshotCreateJobRequest{
+			RequestID:       "req-1",
+			SandboxID:       "sb-1",
+			SnapshotID:      "snap-generated",
+			NodeID:          "node-1",
+			NodeIP:          "10.0.0.1",
+			SpecFingerprint: buildCommitTemplateSpecFingerprint(submitted),
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !snapshotCreateRequestMatches(raw, "req-1", "sb-1", "node-1", "10.0.0.1", "", build()) {
+			t.Fatal("byte-identical retry did not match the stored job")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #1105

`SubmitSandboxSnapshot` previously included the server-generated snapshot ID in the request fingerprint. When a client retried the same payload with the same `request_id`, rebuilding the request could produce a different generated ID, causing the fingerprint comparison to fail and preventing the retry from reusing the existing job.

This PR:

- Adds `marshalSnapshotFingerprintRequest` to exclude `CubeAnnotationAppSnapshotTemplateID` from the snapshot fingerprint input.
- Uses the new marshaller only for snapshot-create fingerprint generation.
- Keeps `marshalTemplateCommitJobRequest` unchanged so the template COMMIT serialization and deduplication behavior are unaffected.
- Adds two regression cases covering deterministic fingerprint rebuilding and matching an identical retry to the stored job.

## Impact

Identical snapshot-create retries using the same `request_id` can now reattach to the existing job or recover its stored result instead of being rejected as a payload mismatch.

The generated snapshot ID remains part of the stored request data; it is excluded only from the fingerprint input.

## Test plan

The following tests passed in the repository-provided builder environment:

- `TestBuildSnapshotRequestsUsesSnapshotID`
- `TestSubmitSandboxSnapshotReusesExistingRequest`
- `TestSubmitSandboxSnapshotResumesPendingExistingRequest`
- `TestSubmitSandboxSnapshotReturnsStoredFailureForExistingRequest`
- `TestSnapshotCreateRequestIDIdempotency`
- `TestBuildCommitTemplateSpecFingerprintIgnoresRequestID`

Each test was run with:

```bash
make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go test -count=1 -v -run <test-name> ./pkg/templatecenter/'
```

## Notes

`make cubemaster-test` is not fully green locally because of pre-existing ARM64/gomonkey test failures that are reproducible on the unmodified `master` branch. The targeted snapshot-create and COMMIT regression tests listed above pass.

Assisted-by: Codex:GPT-5
