### PR TITLE
cubelet: drop stale sched_core key from containerd config

### DIFF
--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -189,7 +189,6 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
     # Declare both platforms so the same config runs on amd64 and arm64 hosts;
     # containerd matches image manifests against the host's native platform.
     platforms = ["linux/amd64", "linux/arm64"]
-    sched_core = false
   [plugins."io.cubelet.chi.v1.vsocket-manager"]
     proxyPort = 1032
   [plugins."io.containerd.cri.v1.images"]


### PR DESCRIPTION
Closes #1153

## What

Removes the stale `sched_core = false` key from `[plugins."io.containerd.runtime.v2.task"]` in `Cubelet/config/config.toml`.

## Why

`sched_core` was a field of the runtime v2 task plugin config in containerd **v1.x**. In **v2.2.2** — the version Cubelet pins (`Cubelet/go.mod:175`) — that struct (`core/runtime/v2/task_manager.go`) carries only `platforms`:

```go
type Config struct {
	Platforms []string `toml:"platforms"`
}
```

containerd does ship a migration that rewrites `sched_core` into the shim plugin's `env` as `SCHED_CORE=1`, but it is guarded (`core/runtime/v2/shim_manager.go`):

```go
ConfigMigration: func(ctx context.Context, configVersion int, pluginConfigs map[string]interface{}) error {
	if configVersion >= version.ConfigVersion {
		return nil
	}
	...
	delete(src, "sched_core")
}
```

`Cubelet/config/config.toml:6` declares `version = 3`, and containerd v2.2.2 defines `ConfigVersion = 3`. Since `3 >= 3`, the migration returns early and never strips the key, so the strict-mode decode at plugin init reports it on every Cubelet start.

## Verification

Driven through the production path against real containerd v2.2.2 — `srvconfig.LoadConfig` followed by `Config.Decode("io.containerd.runtime.v2.task", ...)` — with a logrus hook counting warnings.

**Before** (current `master`):

```
LoadConfig OK (version=3, warnings so far=0)
cfg.Decode("io.containerd.runtime.v2.task", *TaskConfig)
  level=warning msg="Ignoring unknown key in TOML for plugin"
    error="strict mode: fields in the document are missing in the target struct"
    key=sched_core plugin=io.containerd.runtime.v2.task
decoded platforms = [linux/amd64 linux/arm64]
TOTAL WARNINGS = 1
```

**After** (this change):

```
LoadConfig OK (version=3, warnings so far=0)
cfg.Decode("io.containerd.runtime.v2.task", *TaskConfig)
decoded platforms = [linux/amd64 linux/arm64]
TOTAL WARNINGS = 0
```

`platforms` still decodes to `[linux/amd64 linux/arm64]`, so nothing else in the section regressed.

## Two corrections to the issue report

Both are minor but worth recording for anyone reading #1153 later:

1. The issue attributes the warning to `loadConfigFile` in `Cubelet/services/server/config/config.go`. I tested that directly — `LoadConfig` emits **zero** warnings even with `sched_core` present, because the top-level `plugins` field decodes as `map[string]interface{}` and tolerates unknown nested keys. The warning actually originates in `Config.Decode` at plugin-init time.
2. Consequently the real log line is `"Ignoring unknown key in TOML for plugin"` (containerd's), not `"Ignoring unknown key in TOML"` (Cubelet's) as quoted in the issue.

## Behavior impact

None. The value was `false`, and the migration only injects `SCHED_CORE=1` when it is `true`, so Linux core scheduling remains disabled either way.

For operators who *do* want core scheduling on a `version = 3` config, the supported form under containerd v2.x is:

```toml
[plugins."io.containerd.shim.v1.manager"]
  env = ["SCHED_CORE=1"]
```

## Testing notes

`Cubelet/cmd/cubelet` is Linux-only (cgroups, erofs, cgo `nsenter.c`) and could not be built or tested on the macOS host used here; the verification above was run against the `services/server/config` package, which builds natively. The one existing test that reads this file (`cmd/cubelet/main_test.go:32`) asserts only on the network plugin section and is unaffected by this change.
