### PR TITLE
fix(Node SDK): Add SetTimeout() to Node SDK

### DIFF
--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -386,6 +386,7 @@ var**. Inline fields accepted by `create`: `apiUrl`, `proxyNodeIp`,
 | `sb.getInfo()` | `GET /sandboxes/:id` — get sandbox state and metadata |
 | `sb.pause(options?)` | `POST /sandboxes/:id/pause` — pause sandbox |
 | `sb.resume(timeout?)` | `POST /sandboxes/:id/resume` — resume (deprecated, use `connect`) |
+| `sb.setTimeout(timeout)` | `POST /sandboxes/:id/timeout` — set sandbox idle timeout |
 | `sb.kill()` | `DELETE /sandboxes/:id` — destroy sandbox |
 | `sb.createSnapshot(name?)` | `POST /sandboxes/:id/snapshots` — create a snapshot |
 | `sb.rollback(snapshotId)` | `POST /sandboxes/:id/rollback` — roll back to a snapshot |

--- a/sdk/node/src/config.ts
+++ b/sdk/node/src/config.ts
@@ -68,6 +68,9 @@ function normalizeProxyScheme(scheme: string | undefined, port: number): string 
 /** Default sandbox TTL in seconds retained on {@link Config}. */
 export const DEFAULT_SANDBOX_TIMEOUT_S = 300;
 
+/** Sentinel value that disables sandbox idle timeout. */
+export const NEVER_TIMEOUT = -1;
+
 export class Config {
   apiUrl: string;
   apiKey: string | null;

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -14,7 +14,7 @@ export {
   type LifecycleOptions,
 } from "./sandbox.js";
 
-export { Config, resolveConfig, type ConfigOptions } from "./config.js";
+export { Config, resolveConfig, NEVER_TIMEOUT, type ConfigOptions } from "./config.js";
 
 export {
   Execution,

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -4,7 +4,7 @@
 import { fetch, type Dispatcher } from "undici";
 
 import { Commands } from "./commands.js";
-import { Config, resolveConfig, type ConfigOptions } from "./config.js";
+import { Config, NEVER_TIMEOUT, resolveConfig, type ConfigOptions } from "./config.js";
 import {
   ApiError,
   AuthenticationError,
@@ -580,6 +580,28 @@ export class Sandbox {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
+    await checkControlResponse(resp);
+  }
+
+  /** POST /sandboxes/:id/timeout — set sandbox idle timeout. */
+  async setTimeout(timeout: number): Promise<void> {
+    if (!Number.isFinite(timeout)) {
+      throw new Error(`timeout must be a finite number of seconds, got ${timeout}`);
+    }
+    if (timeout < 0 && timeout !== NEVER_TIMEOUT) {
+      throw new Error(`timeout must be >= 0 or NEVER_TIMEOUT (-1), got ${timeout}`);
+    }
+
+    const seconds = Math.ceil(timeout);
+    const resp = await controlFetch(
+      this.config,
+      `${this.config.apiUrl}/sandboxes/${this.sandboxId}/timeout`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ timeout: seconds }),
+      },
+    );
     await checkControlResponse(resp);
   }
 

--- a/sdk/node/test/sandbox.test.ts
+++ b/sdk/node/test/sandbox.test.ts
@@ -13,7 +13,7 @@ import {
   SandboxNotFoundError,
   TemplateNotFoundError,
 } from "../src/exceptions.js";
-import { Sandbox } from "../src/index.js";
+import { NEVER_TIMEOUT, Sandbox } from "../src/index.js";
 import { stubCubeEnv } from "./_env.js";
 
 stubCubeEnv();
@@ -455,6 +455,74 @@ describe("Sandbox instance operations", () => {
     await sb.resume(0);
     expect(JSON.parse(requests[0].body.toString())).toEqual({ timeout: 0 });
     sb.close();
+  });
+
+  describe("Sandbox.setTimeout", () => {
+    it("sends the requested idle timeout", async () => {
+      const sb = await createSandbox();
+      setHandler((req) => {
+        expect(req.method).toBe("POST");
+        expect(req.pathname).toBe(`/sandboxes/${SANDBOX_ID}/timeout`);
+        expect(JSON.parse(req.body.toString())).toEqual({ timeout: 3600 });
+        return { status: 204 };
+      });
+
+      await sb.setTimeout(3600);
+      expect(requests).toHaveLength(1);
+      sb.close();
+    });
+
+    it("preserves an immediate timeout", async () => {
+      const sb = await createSandbox();
+      setHandler((req) => {
+        expect(JSON.parse(req.body.toString())).toEqual({ timeout: 0 });
+        return { status: 204 };
+      });
+
+      await sb.setTimeout(0);
+      sb.close();
+    });
+
+    it("rounds a fractional timeout up to whole seconds", async () => {
+      const sb = await createSandbox();
+      setHandler((req) => {
+        expect(JSON.parse(req.body.toString())).toEqual({ timeout: 1 });
+        return { status: 204 };
+      });
+
+      await sb.setTimeout(0.5);
+      sb.close();
+    });
+
+    it("sends NEVER_TIMEOUT unchanged", async () => {
+      const sb = await createSandbox();
+      setHandler((req) => {
+        expect(JSON.parse(req.body.toString())).toEqual({ timeout: -1 });
+        return { status: 204 };
+      });
+
+      await sb.setTimeout(NEVER_TIMEOUT);
+      sb.close();
+    });
+
+    it.each([-2, NaN, Infinity])(
+      "rejects invalid timeout %p before sending a request",
+      async (timeout) => {
+        const sb = await createSandbox();
+
+        await expect(sb.setTimeout(timeout)).rejects.toThrow();
+        expect(requests).toHaveLength(0);
+        sb.close();
+      },
+    );
+
+    it("maps a missing sandbox to SandboxNotFoundError", async () => {
+      const sb = await createSandbox();
+      setHandler(() => ({ status: 404, json: { message: "sandbox not found" } }));
+
+      await expect(sb.setTimeout(3600)).rejects.toBeInstanceOf(SandboxNotFoundError);
+      sb.close();
+    });
   });
 
   it("pauses and polls getInfo until the sandbox is paused", async () => {


### PR DESCRIPTION
## Summary

Fix the missing `Sandbox.setTimeout()` API in the Node SDK, allowing users to update a sandbox's idle TTL while it is running.

Closes #1250

## Changes

### Modified Files

- `sdk/node/src/config.ts` — Add the `NEVER_TIMEOUT = -1` constant.
- `sdk/node/src/index.ts` — Export `NEVER_TIMEOUT` from the Node SDK package entry point.
- `sdk/node/src/sandbox.ts` — Add `Sandbox.setTimeout(timeout)`, which calls `POST /sandboxes/:id/timeout`.
- `sdk/node/test/sandbox.test.ts` — Add regression coverage for timeout updates, boundary values, input validation, and error mapping.
- `sdk/node/README.md` — Document `sb.setTimeout(timeout)` in the API method table.

## API

```ts
async setTimeout(timeout: number): Promise<void>
```

## Behavior

- Positive integers update the sandbox idle TTL in seconds.
- `0` requests immediate expiry.
- `NEVER_TIMEOUT` (`-1`) disables the idle timeout.
- Positive fractional seconds are rounded up to whole seconds, matching the Go SDK's `time.Duration` semantics: `0.5` seconds is sent as `1` second.
- Other negative values, `NaN`, and `Infinity` are rejected before a request is sent.
- Reuses the Node SDK's existing control-plane error mapping; a 404 response results in `SandboxNotFoundError`.

## Testing

```
cd sdk/node
npm test -- sandbox.test.ts
npm run typecheck
npm test
```

Test results:

- `npm test -- sandbox.test.ts`: passed, 45 tests.
- `npm run typecheck`: passed.
- `npm test`: passed, 186 tests passed and 1 integration test skipped.
- `git diff --check`: passed.

## Not in Scope

- No changes to CubeAPI, CubeMaster, Cubelet, or lifecycle services.
- No changes to existing sandbox URL path escaping behavior.
- Does not expose `POST /sandboxes/:id/refreshes`.