### PR TITLE
fix(cubeproxy): invalidate deleted sandbox route cache

### DIFF
--- a/CubeProxy/Makefile
+++ b/CubeProxy/Makefile
@@ -50,11 +50,13 @@ test:
 	@if command -v lua >/dev/null 2>&1; then \
 		lua tests/redis_iresty_sentinel_test.lua; \
 		lua tests/backend_cache_test.lua; \
+		lua tests/sandbox_route_lookup_test.lua; \
 	elif command -v luajit >/dev/null 2>&1; then \
 		luajit tests/redis_iresty_sentinel_test.lua; \
 		luajit tests/backend_cache_test.lua; \
+		luajit tests/sandbox_route_lookup_test.lua; \
 	else \
-		echo "skip lua unit tests (no lua/luajit): redis_iresty_sentinel_test.lua backend_cache_test.lua"; \
+		echo "skip lua unit tests (no lua/luajit): redis_iresty_sentinel_test.lua backend_cache_test.lua sandbox_route_lookup_test.lua"; \
 	fi
 
 # Push the architecture-specific image to all registries.

--- a/CubeProxy/lua/admin_phase.lua
+++ b/CubeProxy/lua/admin_phase.lua
@@ -106,20 +106,19 @@ local function handle_meta_delete()
     local sid, e2 = require_string(obj, "sandbox_id")
     if not sid then return reply_error(ngx.HTTP_BAD_REQUEST, e2) end
 
+    -- Invalidate fixed route metadata so the next data-plane request reloads
+    -- the sandbox route from Redis.
+    local deleted = backend_cache.invalidate_sandbox(sid)
     META:delete(sid)
     STATE:delete(sid)
     LAST:delete(sid)
-    -- Drop stale SandboxIP / host-port routing cache too; otherwise a later
-    -- recreate/resume with the same sandbox_id can keep serving the old
-    -- backend until TTL expires (and hits renew TTL).
-    local deleted = backend_cache.delete_sandbox(sid)
     return reply(ngx.HTTP_OK, { ok = true, backend_cache_deleted = deleted })
 end
 
 -- POST /admin/backend_cache/delete
 --   body: {"sandbox_id": "..."}
---   semantics: drop ngx.shared.local_cache routing entries for this sandbox
---              ({sid}:meta_cached, {sid}:{port}:backend_*, Redis field mirrors).
+--   semantics: invalidate fixed ngx.shared.local_cache route metadata for this
+--              sandbox without scanning dynamic per-port entries.
 --              Used by CubeMaster after Resume rewrites Redis SandboxIP/ports.
 local function handle_backend_cache_delete()
     local obj, err = read_json_body()
@@ -127,7 +126,7 @@ local function handle_backend_cache_delete()
     local sid, e2 = require_string(obj, "sandbox_id")
     if not sid then return reply_error(ngx.HTTP_BAD_REQUEST, e2) end
 
-    local deleted = backend_cache.delete_sandbox(sid)
+    local deleted = backend_cache.invalidate_sandbox(sid)
     return reply(ngx.HTTP_OK, { ok = true, deleted = deleted })
 end
 

--- a/CubeProxy/lua/backend_cache.lua
+++ b/CubeProxy/lua/backend_cache.lua
@@ -5,13 +5,25 @@
 
 local _M = {}
 
+local ROUTE_CACHE_SUFFIXES = {
+    "meta_cached",
+    "HostIP",
+    "SandboxIP",
+    "CreatedAt",
+    "AllowPublicTraffic",
+    "TrafficAccessToken",
+    "MaskRequestHost",
+}
+
 local function cache_dict()
     return ngx.shared.local_cache
 end
 
--- delete_sandbox removes every local_cache entry belonging to sandbox_id.
--- Returns the number of keys deleted. Safe when the dict is missing.
-function _M.delete_sandbox(sandbox_id)
+-- Invalidate the cache-hit sentinel first, then remove the fixed route metadata
+-- mirrored from Redis. Dynamic per-port entries are intentionally left to their
+-- existing TTL so invalidation stays bounded and never scans the shared dict.
+-- Returns the number of fixed keys that existed. Safe when the dict is missing.
+function _M.invalidate_sandbox(sandbox_id)
     if type(sandbox_id) ~= "string" or sandbox_id == "" then
         return 0
     end
@@ -20,23 +32,14 @@ function _M.delete_sandbox(sandbox_id)
         return 0
     end
 
-    local prefix = sandbox_id .. ":"
     local deleted = 0
-    -- get_keys(0) returns at most 1024 keys; loop until a pass finds none
-    -- matching this sandbox so large dicts still converge.
-    for _ = 1, 32 do
-        local keys = cache:get_keys(0)
-        local n = 0
-        for _, k in ipairs(keys) do
-            if type(k) == "string" and k:sub(1, #prefix) == prefix then
-                cache:delete(k)
-                deleted = deleted + 1
-                n = n + 1
-            end
+    local prefix = sandbox_id .. ":"
+    for _, suffix in ipairs(ROUTE_CACHE_SUFFIXES) do
+        local key = prefix .. suffix
+        if cache:get(key) ~= nil then
+            deleted = deleted + 1
         end
-        if n == 0 then
-            break
-        end
+        cache:delete(key)
     end
     return deleted
 end

--- a/CubeProxy/lua/sandbox_backend.lua
+++ b/CubeProxy/lua/sandbox_backend.lua
@@ -111,11 +111,6 @@ local function load_sandbox_proxy_metadata(ins_id)
             last_err = err
         elseif value and #value > 0 then
             return value, nil
-        else
-            -- This Redis command succeeded but the key is empty/missing. Clear
-            -- any previous key's transport error so the final result is a
-            -- truthful "not found" instead of a stale connectivity error.
-            last_err = nil
         end
     end
 
@@ -123,8 +118,7 @@ local function load_sandbox_proxy_metadata(ins_id)
         return nil, string.format("request %s using keys for %s get redis err: %s",
             ngx.var.http_x_cube_request_id, ins_id, last_err)
     end
-    return nil, string.format("request %s using keys for %s get redis nil",
-        ngx.var.http_x_cube_request_id, ins_id)
+    return nil, nil
 end
 
 --[[
@@ -177,6 +171,12 @@ function _M.resolve_backend(ins_id, container_port)
     if err then
         ngx.log(ngx.ERR, "LEVEL_ERROR||", err)
         utils:respond_unavailable()
+    end
+    if not metadata then
+        ngx.log(ngx.WARN, "LEVEL_WARN||",
+            string.format("request %s using instance %s has no Redis route",
+                ngx.var.http_x_cube_request_id, ins_id))
+        utils:respond_not_found()
     end
 
     cache:set(ins_id .. ":meta_cached", "1", timeout)

--- a/CubeProxy/nginx.conf
+++ b/CubeProxy/nginx.conf
@@ -478,7 +478,7 @@ http {
     # Routes:
     #   POST /admin/meta/upsert           body=JSON {sandbox_id, ...}    → cube_sandbox_meta
     #   POST /admin/meta/delete           body=JSON {sandbox_id}         → drops meta+state+last_active+backend cache
-    #   POST /admin/backend_cache/delete  body=JSON {sandbox_id}         → drops local_cache routing entries
+    #   POST /admin/backend_cache/delete  body=JSON {sandbox_id}         → invalidates fixed route-cache entries
     #   POST /admin/state                 body=JSON {sandbox_id, state}  → cube_sandbox_state
     #   GET  /admin/last_active                                           → JSON snapshot of dict
     #   GET  /admin/last_active?since=<ms>                                → only entries newer than `since`

--- a/CubeProxy/tests/backend_cache_test.lua
+++ b/CubeProxy/tests/backend_cache_test.lua
@@ -2,6 +2,7 @@ package.path = "./lua/?.lua;" .. package.path
 
 local store = {}
 local cache = {}
+local deleted_keys = {}
 
 function cache:get(key)
     return store[key]
@@ -13,16 +14,13 @@ function cache:set(key, value, _ttl)
 end
 
 function cache:delete(key)
+    deleted_keys[#deleted_keys + 1] = key
     store[key] = nil
     return true
 end
 
 function cache:get_keys(_max)
-    local keys = {}
-    for k, _ in pairs(store) do
-        keys[#keys + 1] = k
-    end
-    return keys
+    error("invalidate_sandbox must not scan the shared cache")
 end
 
 ngx = {
@@ -34,21 +32,42 @@ ngx = {
 local backend_cache = require "backend_cache"
 
 store["sb-1:meta_cached"] = "1"
+store["sb-1:HostIP"] = "10.0.0.1"
 store["sb-1:SandboxIP"] = "192.168.0.10"
+store["sb-1:CreatedAt"] = "1786900000000000000"
+store["sb-1:AllowPublicTraffic"] = "false"
+store["sb-1:TrafficAccessToken"] = false
+store["sb-1:MaskRequestHost"] = false
 store["sb-1:49999:backend_ip"] = "192.168.0.10"
 store["sb-1:49999:backend_port"] = "49999"
 store["sb-2:meta_cached"] = "1"
 store["cube_proxy_heartbeat_last_pushed_ms"] = "1"
 
-local deleted = backend_cache.delete_sandbox("sb-1")
-assert(deleted == 4, "deleted=" .. tostring(deleted))
-assert(store["sb-1:meta_cached"] == nil)
-assert(store["sb-1:SandboxIP"] == nil)
-assert(store["sb-1:49999:backend_ip"] == nil)
+local deleted = backend_cache.invalidate_sandbox("sb-1")
+assert(deleted == 7, "deleted=" .. tostring(deleted))
+assert(deleted_keys[1] == "sb-1:meta_cached",
+    "meta_cached must be invalidated first")
+
+local fixed_suffixes = {
+    "meta_cached",
+    "HostIP",
+    "SandboxIP",
+    "CreatedAt",
+    "AllowPublicTraffic",
+    "TrafficAccessToken",
+    "MaskRequestHost",
+}
+for _, suffix in ipairs(fixed_suffixes) do
+    assert(store["sb-1:" .. suffix] == nil,
+        "fixed route key must be deleted: " .. suffix)
+end
+
+assert(store["sb-1:49999:backend_ip"] == "192.168.0.10")
+assert(store["sb-1:49999:backend_port"] == "49999")
 assert(store["sb-2:meta_cached"] == "1")
 assert(store["cube_proxy_heartbeat_last_pushed_ms"] == "1")
 
-assert(backend_cache.delete_sandbox("") == 0)
-assert(backend_cache.delete_sandbox("missing") == 0)
+assert(backend_cache.invalidate_sandbox("") == 0)
+assert(backend_cache.invalidate_sandbox("missing") == 0)
 
 print("backend_cache_test OK")

--- a/CubeProxy/tests/sandbox_route_lookup_test.lua
+++ b/CubeProxy/tests/sandbox_route_lookup_test.lua
@@ -1,0 +1,119 @@
+package.path = "./lua/?.lua;" .. package.path
+
+local cache = {}
+
+function cache:get(key)
+    return nil
+end
+
+function cache:set(key, value, _ttl)
+    return true, nil, false
+end
+
+local response_body
+local logs = {}
+
+ngx = {
+    ERR = "ERR",
+    WARN = "WARN",
+    var = {
+        timeout_min = "500",
+        timeout_max = "700",
+        cube_proxy_host_ip = "10.0.0.1",
+        server_addr = "10.0.0.1",
+        http_x_cube_request_id = "test-request",
+    },
+    shared = {
+        local_cache = cache,
+    },
+    header = {},
+    log = function(level, ...)
+        logs[#logs + 1] = { level = level, message = table.concat({ ... }) }
+    end,
+    say = function(body)
+        response_body = body
+    end,
+    exit = function(status)
+        error({ status = status }, 0)
+    end,
+}
+
+local redis_calls = {}
+package.loaded["redis_iresty"] = {
+    new = function()
+        return {
+            hgetall = function(_, key)
+                local sandbox_id = key:match("([^:]+)$")
+                redis_calls[sandbox_id] = (redis_calls[sandbox_id] or 0) + 1
+                if sandbox_id == "missing" then
+                    return {}, nil
+                end
+                if sandbox_id == "redis-error" then
+                    return nil, "connection refused"
+                end
+                local is_legacy = key:match("^bypass_host_proxy:") ~= nil
+                if sandbox_id == "current-error" then
+                    if not is_legacy then
+                        return nil, "connection refused"
+                    end
+                    return {}, nil
+                end
+                if sandbox_id == "legacy-error" then
+                    if is_legacy then
+                        return nil, "connection refused"
+                    end
+                    return {}, nil
+                end
+                local sandbox_ip = sandbox_id == "recreated"
+                    and "192.168.0.20" or "192.168.0.10"
+                return {
+                    "HostIP", "10.0.0.1",
+                    "SandboxIP", sandbox_ip,
+                    "AllowPublicTraffic", "true",
+                }, nil
+            end,
+        }
+    end,
+}
+
+local backend = require "sandbox_backend"
+
+local function expect_exit(status, body, fn)
+    response_body = nil
+    local ok, exit = pcall(fn)
+    assert(not ok, "request must terminate through ngx.exit")
+    assert(type(exit) == "table" and exit.status == status,
+        "unexpected response status")
+    assert(response_body == body, "unexpected response body")
+end
+
+-- Only successful misses from every supported Redis route key are authoritative.
+expect_exit(404, '{"error":"not found"}', function()
+    backend.resolve_backend("missing", "3000")
+end)
+assert(redis_calls["missing"] == 2,
+    "missing route must check every supported Redis key")
+assert(logs[#logs].level == ngx.WARN,
+    "an expected confirmed miss must not be logged as an error")
+assert(logs[#logs].message:find("has no Redis route", 1, true),
+    "confirmed-miss warning must identify the missing Redis route")
+
+-- Redis transport failures remain 503.
+expect_exit(503, '{"error":"service unavailable"}', function()
+    backend.resolve_backend("redis-error", "3000")
+end)
+assert(redis_calls["redis-error"] == 6,
+    "Redis failures must retry each supported key three times")
+
+-- A successful miss from one key must not hide a transport failure from another.
+expect_exit(503, '{"error":"service unavailable"}', function()
+    backend.resolve_backend("current-error", "3000")
+end)
+assert(redis_calls["current-error"] == 4)
+
+expect_exit(503, '{"error":"service unavailable"}', function()
+    backend.resolve_backend("legacy-error", "3000")
+end)
+assert(redis_calls["legacy-error"] == 4)
+
+print("sandbox route lookup tests passed")


### PR DESCRIPTION
## Motivation

CubeProxy should stop using stale local routes after a sandbox is deleted and expose a clear response when Redis confirms that no route metadata exists.

Scanning the entire shared cache during invalidation makes lifecycle operations proportional to the global cache size and blocks the Nginx worker performing the scan. After invalidation, a confirmed route miss and a Redis lookup failure also both return HTTP 503, so clients cannot distinguish missing metadata from a temporary metadata-store failure.

## What Changed

* Replace shared-cache scans with bounded invalidation of `meta_cached` and the fixed route metadata mirrored from Redis.
* Invalidate `meta_cached` first so new data-plane requests reload route metadata instead of immediately using stale per-port entries.
* Reuse the bounded helper for lifecycle deletion and explicit backend-cache invalidation without enumerating dynamic per-port keys.
* Return HTTP 404 when both supported Redis route lookups complete successfully and neither contains route metadata.
* Preserve HTTP 503 when any Redis route lookup fails and no valid route is found.
* Log confirmed route misses at warning level and add focused regression coverage.

## Validation

* `make -C CubeProxy test` passed with the target OpenResty LuaJIT runtime.
* Regression coverage confirms that invalidation never calls `get_keys()`, removes the cache-hit sentinel before the fixed route keys, leaves dynamic per-port entries to TTL cleanup, and does not affect other sandboxes.
* Route lookup coverage confirms HTTP 404 for authoritative misses and HTTP 503 for Redis failures and mixed miss/error outcomes.

## Scope

This PR keeps cache invalidation bounded to known per-sandbox keys. It intentionally does not scan or eagerly delete dynamic per-port entries; those entries cannot form an immediate cache hit after `meta_cached` is removed and remain subject to their existing TTL.

This PR does not add negative caching, change the lifecycle event protocol, or modify Redis route publication ordering. Requests for nonexistent sandbox IDs continue to perform the same Redis lookups as before.

## Note: E2B Compatibility

Official E2B's data-plane proxy returns HTTP 502 when the requested sandbox cannot be found, while this PR currently returns HTTP 404 for a confirmed missing sandbox route.

Maintainer confirmation is needed on whether CubeProxy should keep HTTP 404 or use HTTP 502 for closer E2B data-plane compatibility. Redis lookup failures remain HTTP 503 in either case.
