### PR TITLE
fix(templatecenter): fix snapshot-create request ID idempotency

### DIFF
--- a/CubeMaster/pkg/templatecenter/snapshot_ops.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops.go
@@ -128,10 +128,7 @@ func SubmitSandboxSnapshot(ctx context.Context, requestID, sandboxID, hostID, ho
 	} else {
 		originReq.Request.RequestID = requestID
 	}
-	createReq, storedReq, err := buildSnapshotRequests(originReq, "")
-	if err != nil {
-		return nil, err
-	}
+
 	var jobID string
 	reusedExistingJob := false
 	if err := withSnapshotWriteLocks([]string{
@@ -141,6 +138,10 @@ func SubmitSandboxSnapshot(ctx context.Context, requestID, sandboxID, hostID, ho
 		if existing, err := getTemplateImageJobByRequestID(ctx, requestID); err == nil {
 			if existing.Operation != JobOperationSnapshotCreate {
 				return fmt.Errorf("%w: request %s is already bound to %s", ErrTemplateAttemptInProgress, requestID, existing.Operation)
+			}
+			_, storedReq, err := buildSnapshotRequests(originReq, existing.TemplateID)
+			if err != nil {
+				return err
 			}
 			if !snapshotCreateRequestMatches(existing.RequestJSON, requestID, sandboxID, nodeID, nodeIP, displayName, storedReq) {
 				return fmt.Errorf("%w: request %s payload does not match existing snapshot create job", ErrTemplateAttemptInProgress, requestID)
@@ -163,8 +164,10 @@ func SubmitSandboxSnapshot(ctx context.Context, requestID, sandboxID, hostID, ho
 		}
 
 		snapshotID := generateSnapshotID()
-		createReq.Annotations[constants.CubeAnnotationAppSnapshotTemplateID] = snapshotID
-		storedReq.Annotations[constants.CubeAnnotationAppSnapshotTemplateID] = snapshotID
+		createReq, storedReq, err := buildSnapshotRequests(originReq, snapshotID)
+		if err != nil {
+			return err
+		}
 		fingerprint := buildCommitTemplateSpecFingerprint(storedReq)
 		requestJSON, err := marshalSnapshotCreateRequest(snapshotCreateJobRequest{
 			RequestID:       requestID,

--- a/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
@@ -86,6 +86,68 @@ func TestSubmitSandboxSnapshotReusesExistingRequest(t *testing.T) {
 	}
 }
 
+func TestSubmitSandboxSnapshotRetryMatchesExistingSnapshotID(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	_, storedReq, err := buildSnapshotRequests(&sandboxtypes.CreateCubeSandboxReq{
+		Request:      &sandboxtypes.Request{RequestID: "req-existing"},
+		InstanceType: "cubebox",
+		Annotations:  map[string]string{},
+	}, "snap-existing")
+	if err != nil {
+		t.Fatalf("buildSnapshotRequests returned error: %v", err)
+	}
+	requestJSON, err := marshalSnapshotCreateRequest(snapshotCreateJobRequest{
+		RequestID:       "req-existing",
+		SandboxID:       "sb-1",
+		SnapshotID:      "snap-existing",
+		NodeID:          "node-1",
+		NodeIP:          "10.0.0.1",
+		DisplayName:     "snap",
+		SpecFingerprint: buildCommitTemplateSpecFingerprint(storedReq),
+	})
+	if err != nil {
+		t.Fatalf("marshalSnapshotCreateRequest returned error: %v", err)
+	}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	origLoad := loadSandboxCreateRequestFn
+	defer func() { loadSandboxCreateRequestFn = origLoad }()
+	loadSandboxCreateRequestFn = func(ctx context.Context, sandboxID string) (*sandboxtypes.CreateCubeSandboxReq, error) {
+		return &sandboxtypes.CreateCubeSandboxReq{
+			InstanceType: "cubebox",
+			Annotations:  map[string]string{},
+		}, nil
+	}
+	patches.ApplyFunc(getTemplateImageJobByRequestID, func(ctx context.Context, requestID string) (*models.TemplateImageJob, error) {
+		return &models.TemplateImageJob{
+			TemplateID:  "snap-existing",
+			JobID:       "job-existing",
+			Operation:   JobOperationSnapshotCreate,
+			RequestJSON: requestJSON,
+		}, nil
+	})
+	patches.ApplyFunc(GetTemplateImageJobInfo, func(ctx context.Context, jobID string) (*sandboxtypes.TemplateImageJobInfo, error) {
+		return &sandboxtypes.TemplateImageJobInfo{
+			JobID:      jobID,
+			TemplateID: "snap-existing",
+			Status:     JobStatusReady,
+		}, nil
+	})
+
+	info, err := SubmitSandboxSnapshot(context.Background(), "req-existing", "sb-1", "node-1", "10.0.0.1", "snap")
+	if err != nil {
+		t.Fatalf("SubmitSandboxSnapshot returned error: %v", err)
+	}
+	if info == nil || info.JobID != "job-existing" {
+		t.Fatalf("unexpected job info: %#v", info)
+	}
+}
+
 func TestSubmitSandboxSnapshotResumesPendingExistingRequest(t *testing.T) {
 	oldDB := store.db
 	store.db = &gorm.DB{}


### PR DESCRIPTION
## Summary

Fixes #1105

`SubmitSandboxSnapshot` previously called `buildSnapshotRequests` before taking the snapshot write lock and passed an empty snapshot ID. `NormalizeRequest` filled that empty value with a random `tpl-*` ID. The first-time path later overwrote it with the generated snapshot ID, but the retry path compared a newly randomized request against the stored fingerprint, so an identical retry was rejected as payload drift.

This PR:

- Moves snapshot request construction inside the snapshot write lock.
- Rebuilds retry requests with the existing job's `TemplateID` before normalization.
- Generates the snapshot ID before request construction on the first-time path and uses that same ID throughout job and definition creation.
- Preserves the existing full-request fingerprint semantics, including the snapshot ID, and leaves the template COMMIT flow unchanged.
- Adds a regression test that exercises the real `SubmitSandboxSnapshot` retry matcher without patching it.

## Impact

An identical snapshot-create retry with the same `request_id` can reattach to the existing job or recover its stored result. Genuine request drift is still rejected, and no fingerprint fields are excluded.

## Test plan

The following tests passed in the repository-provided builder environment:

```bash
make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go test -count=1 -v -run TestSubmitSandboxSnapshot ./pkg/templatecenter/'
make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go test -count=1 -v -run TestBuildSnapshotRequestsUsesSnapshotID ./pkg/templatecenter/'
make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go test -count=1 -v -run TestBuildCommitTemplateSpecFingerprintIgnoresRequestID ./pkg/templatecenter/'
```

`make cubemaster-test` is not fully green locally because of pre-existing ARM64/gomonkey failures that are reproducible on the unmodified `master` branch.

Assisted-by: Codex:GPT-5
