### PR TITLE
cubeapi: accept e2b flattened autoPause/autoResume on sandbox create

### DIFF
--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -138,6 +138,25 @@ pub struct SandboxLifecycleConfig {
     pub auto_resume: bool,
 }
 
+/// Wire shape of the top-level `autoResume` field the e2b SDK sends. Current
+/// SDK releases send `{"enabled": true}`; older ones and hand-rolled clients
+/// send a bare `true`. Both mean the same thing, so accept either rather than
+/// rejecting on shape.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum SandboxAutoResume {
+    Enabled(bool),
+    Config { enabled: bool },
+}
+
+impl SandboxAutoResume {
+    pub fn enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) | Self::Config { enabled } => *enabled,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum SandboxOnTimeout {
@@ -190,6 +209,17 @@ pub struct NewSandbox {
     /// (None) means today's behaviour: idle sandboxes are killed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lifecycle: Option<SandboxLifecycleConfig>,
+
+    /// e2b SDK compatibility: the SDK flattens its user-facing `lifecycle`
+    /// object into top-level `autoPause` / `autoResume` before it hits the
+    /// wire, so `lifecycle` never arrives from an SDK caller. Ignored when
+    /// `lifecycle` is present.
+    #[serde(rename = "autoPause", alias = "auto_pause", default)]
+    pub auto_pause: Option<bool>,
+
+    /// See `auto_pause`. Only meaningful alongside `autoPause = true`.
+    #[serde(rename = "autoResume", alias = "auto_resume", default)]
+    pub auto_resume: Option<SandboxAutoResume>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secure: Option<bool>,

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -1675,22 +1675,17 @@ mod tests {
     /// The inbound API mirrors the e2b `lifecycle` object (camelCase nested
     /// struct). CubeAPI then translates it to the two CubeMaster-side bools
     /// when constructing the create-sandbox RPC. Verify the translation
-    /// covers each meaningful combination.
+    /// covers each meaningful combination via the real resolver.
     #[test]
     fn lifecycle_object_translates_to_cubemaster_bools() {
-        use crate::models::{NewSandbox, SandboxOnTimeout};
+        use crate::models::NewSandbox;
 
-        // Helper that mimics services::create_sandbox's lifecycle decoding.
-        fn translate(body: &NewSandbox) -> (bool, bool) {
-            body.lifecycle
-                .as_ref()
-                .map(|lc| {
-                    (
-                        matches!(lc.on_timeout, SandboxOnTimeout::Pause),
-                        lc.auto_resume,
-                    )
-                })
-                .unwrap_or((false, false))
+        fn flags(body: &NewSandbox) -> (bool, bool) {
+            resolve_lifecycle_flags(
+                body.lifecycle.as_ref(),
+                body.auto_pause,
+                body.auto_resume.as_ref(),
+            )
         }
 
         // Absent lifecycle => preserve historical behaviour.
@@ -1698,7 +1693,7 @@ mod tests {
             "templateID": "tpl",
         }))
         .unwrap();
-        assert_eq!(translate(&absent), (false, false));
+        assert_eq!(flags(&absent), (false, false));
 
         // Explicit kill (with auto_resume=true) is still kill — auto_resume
         // doesn't auto-imply pause. Server-side enforcement of the e2b
@@ -1709,7 +1704,7 @@ mod tests {
             "lifecycle": {"onTimeout": "kill", "autoResume": true},
         }))
         .unwrap();
-        assert_eq!(translate(&kill), (false, true));
+        assert_eq!(flags(&kill), (false, true));
 
         // Pause + auto_resume — the canonical e2b auto-resume case.
         let pause_with_resume: NewSandbox = serde_json::from_value(serde_json::json!({
@@ -1717,7 +1712,7 @@ mod tests {
             "lifecycle": {"onTimeout": "pause", "autoResume": true},
         }))
         .unwrap();
-        assert_eq!(translate(&pause_with_resume), (true, true));
+        assert_eq!(flags(&pause_with_resume), (true, true));
 
         // Some Python SDK versions and direct callers may send the Pythonic
         // snake_case shape. Keep accepting it so lifecycle does not silently
@@ -1727,7 +1722,7 @@ mod tests {
             "lifecycle": {"on_timeout": "pause", "auto_resume": true},
         }))
         .unwrap();
-        assert_eq!(translate(&snake_case_pause_with_resume), (true, true));
+        assert_eq!(flags(&snake_case_pause_with_resume), (true, true));
 
         // Pause without auto_resume — caller must call connect() manually.
         let pause_only: NewSandbox = serde_json::from_value(serde_json::json!({
@@ -1735,7 +1730,7 @@ mod tests {
             "lifecycle": {"onTimeout": "pause"},
         }))
         .unwrap();
-        assert_eq!(translate(&pause_only), (true, false));
+        assert_eq!(flags(&pause_only), (true, false));
 
         // Empty lifecycle object — defaults: kill on timeout, no auto-resume.
         let empty: NewSandbox = serde_json::from_value(serde_json::json!({
@@ -1743,7 +1738,104 @@ mod tests {
             "lifecycle": {},
         }))
         .unwrap();
-        assert_eq!(translate(&empty), (false, false));
+        assert_eq!(flags(&empty), (false, false));
+
+        // e2b SDK wire shape: flattened top-level fields, no nested lifecycle.
+        let flat: NewSandbox = serde_json::from_value(serde_json::json!({
+            "templateID": "tpl",
+            "autoPause": true,
+            "autoResume": { "enabled": true },
+        }))
+        .unwrap();
+        assert_eq!(flags(&flat), (true, true));
+    }
+
+    /// The failure mode this PR fixes is silent drop between inbound flat
+    /// fields and the CubeMaster create body. Deserialization and
+    /// `resolve_lifecycle_flags` alone cannot catch a regression that unbinds
+    /// `auto_pause`/`auto_resume` from the `NewSandbox` destructuring (`..`
+    /// still compiles). Drive the full service path and assert the outbound
+    /// flags.
+    #[tokio::test]
+    async fn create_sandbox_forwards_e2b_flat_lifecycle_flags_to_cubemaster() {
+        #[derive(Clone, Default)]
+        struct Capture {
+            create_body: Arc<Mutex<Option<Value>>>,
+        }
+
+        async fn create_handler(
+            State(capture): State<Capture>,
+            Json(body): Json<Value>,
+        ) -> Json<Value> {
+            *capture.create_body.lock().await = Some(body);
+            Json(serde_json::json!({
+                "requestID": "req-1",
+                "sandbox_id": "sb-flat-lifecycle",
+                "ret": { "ret_code": 0, "ret_msg": "ok" }
+            }))
+        }
+
+        async fn spawn_server(app: Router) -> String {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("listener should bind");
+            let addr = listener.local_addr().expect("listener addr");
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.expect("server should run");
+            });
+            format!("http://{}", addr)
+        }
+
+        let capture = Capture::default();
+        let cubemaster_url = spawn_server(
+            Router::new()
+                .route("/cube/sandbox", post(create_handler))
+                .with_state(capture.clone()),
+        )
+        .await;
+
+        let service = SandboxService::new(
+            CubeMasterClient::new(cubemaster_url, reqwest::Client::new()),
+            "cubebox".to_string(),
+            "cube.app".to_string(),
+        );
+
+        let sandbox = service
+            .create_sandbox(NewSandbox {
+                template_id: "tpl-1".to_string(),
+                timeout: Some(30),
+                lifecycle: None,
+                auto_pause: Some(true),
+                auto_resume: Some(SandboxAutoResume::Config { enabled: true }),
+                secure: None,
+                allow_internet_access: None,
+                network: None,
+                metadata: None,
+                distribution_scope: None,
+                env_vars: None,
+                mcp: None,
+                volume_mounts: None,
+            })
+            .await
+            .expect("sandbox create should succeed");
+
+        assert_eq!(sandbox.sandbox_id, "sb-flat-lifecycle");
+        let create_body = capture
+            .create_body
+            .lock()
+            .await
+            .clone()
+            .expect("create body");
+        assert_eq!(
+            create_body.get("auto_pause"),
+            Some(&serde_json::Value::Bool(true)),
+            "flat autoPause must reach CubeMaster, got: {create_body}"
+        );
+        assert_eq!(
+            create_body.get("auto_resume"),
+            Some(&serde_json::Value::Bool(true)),
+            "flat autoResume must reach CubeMaster, got: {create_body}"
+        );
     }
 
     #[tokio::test]

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -17,8 +17,9 @@ use crate::{
     },
     error::{AppError, AppResult},
     models::{
-        EgressRule, LogLevel as ModelLogLevel, NewSandbox, Sandbox, SandboxDetail, SandboxLog,
-        SandboxLogEntry, SandboxLogs, SandboxLogsV2Response, SandboxNetworkConfig, SandboxState,
+        EgressRule, LogLevel as ModelLogLevel, NewSandbox, Sandbox, SandboxAutoResume,
+        SandboxDetail, SandboxLifecycleConfig, SandboxLog, SandboxLogEntry, SandboxLogs,
+        SandboxLogsV2Response, SandboxNetworkConfig, SandboxOnTimeout, SandboxState,
         SandboxVolumeMount,
     },
 };
@@ -155,6 +156,8 @@ impl SandboxService {
             template_id,
             timeout,
             lifecycle,
+            auto_pause: flat_auto_pause,
+            auto_resume: flat_auto_resume,
             allow_internet_access,
             network,
             metadata,
@@ -190,19 +193,11 @@ impl SandboxService {
         let cube_network_config =
             build_cube_network_config(allow_internet_access, network.as_ref())?;
 
-        // Derive the two CubeMaster-side bools from the e2b-shaped lifecycle
-        // object. Absent lifecycle keeps today's behaviour: idle sandboxes
-        // are killed (auto_pause = false), and auto_resume defaults off.
-        let (auto_pause, auto_resume) = lifecycle
-            .as_ref()
-            .map(|lc| {
-                use crate::models::SandboxOnTimeout;
-                (
-                    matches!(lc.on_timeout, SandboxOnTimeout::Pause),
-                    lc.auto_resume,
-                )
-            })
-            .unwrap_or((false, false));
+        let (auto_pause, auto_resume) = resolve_lifecycle_flags(
+            lifecycle.as_ref(),
+            flat_auto_pause,
+            flat_auto_resume.as_ref(),
+        );
 
         // Convert e2b-style volumeMounts into the CubeMaster wire format.
         // Volumes (pod-level declarations) are passed in the volumes field;
@@ -1012,6 +1007,34 @@ fn validate_mask_request_host(value: &str) -> AppResult<()> {
     Ok(())
 }
 
+/// Derive CubeMaster's `(auto_pause, auto_resume)` bools from whichever
+/// lifecycle representation the caller sent.
+///
+/// Two shapes reach this endpoint. `lifecycle` is CubeSandbox's native nested
+/// object. The e2b SDK never sends it — `Sandbox.create(lifecycle=...)` is
+/// flattened client-side into top-level `autoPause` / `autoResume` before the
+/// request goes out. Both are accepted; the nested object wins when present,
+/// since an explicit `lifecycle` can only come from a direct API caller who
+/// meant it. Neither present keeps today's behaviour: idle sandboxes are
+/// killed.
+pub(crate) fn resolve_lifecycle_flags(
+    lifecycle: Option<&SandboxLifecycleConfig>,
+    auto_pause: Option<bool>,
+    auto_resume: Option<&SandboxAutoResume>,
+) -> (bool, bool) {
+    if let Some(lc) = lifecycle {
+        return (
+            matches!(lc.on_timeout, SandboxOnTimeout::Pause),
+            lc.auto_resume,
+        );
+    }
+
+    (
+        auto_pause.unwrap_or(false),
+        auto_resume.is_some_and(SandboxAutoResume::enabled),
+    )
+}
+
 pub(crate) fn build_cube_network_config(
     allow_internet_access: Option<bool>,
     network: Option<&SandboxNetworkConfig>,
@@ -1090,9 +1113,9 @@ mod tests {
 
     use super::{
         build_cube_network_config, filter_by_metadata, from_cubemaster_info,
-        map_delete_cubemaster_err, map_volume_mounts, validate_mask_request_host, SandboxService,
-        RET_CODE_CONFLICT, RET_CODE_NOT_FOUND, RET_CODE_TASK_RESUME_FAILED,
-        RET_CODE_TASK_STATE_INVALID,
+        map_delete_cubemaster_err, map_volume_mounts, resolve_lifecycle_flags,
+        validate_mask_request_host, SandboxService, RET_CODE_CONFLICT, RET_CODE_NOT_FOUND,
+        RET_CODE_TASK_RESUME_FAILED, RET_CODE_TASK_STATE_INVALID,
     };
     use crate::cubemaster::{
         CreateSandboxRequest, CubeMasterClient, CubeMasterError, CubeVolumeMount,
@@ -1101,7 +1124,8 @@ mod tests {
     use crate::error::AppError;
     use crate::models::{
         EgressRule, EgressRuleAction, EgressRuleInject, EgressRuleMatch, NewSandbox,
-        SandboxNetworkConfig, SandboxState, SandboxVolumeMount,
+        SandboxAutoResume, SandboxLifecycleConfig, SandboxNetworkConfig, SandboxOnTimeout,
+        SandboxState, SandboxVolumeMount,
     };
     use axum::{
         extract::State,
@@ -1486,6 +1510,86 @@ mod tests {
         );
     }
 
+    /// The e2b Python SDK does not put `lifecycle` on the wire. It flattens
+    /// the user-facing object into top-level `autoPause` / `autoResume` before
+    /// calling `POST /sandboxes`. Unknown fields are dropped silently by serde,
+    /// so a missing binding here means auto-pause is ignored and the sandbox is
+    /// killed at timeout instead of paused.
+    #[test]
+    fn new_sandbox_deserializes_e2b_flat_lifecycle_fields() {
+        let body = serde_json::json!({
+            "templateID": "tpl-1",
+            "timeout": 30,
+            "autoPause": true,
+            "autoResume": { "enabled": true }
+        });
+
+        let new_sandbox: NewSandbox =
+            serde_json::from_value(body).expect("e2b create body should deserialize");
+
+        assert_eq!(new_sandbox.auto_pause, Some(true));
+        assert_eq!(
+            new_sandbox
+                .auto_resume
+                .as_ref()
+                .map(SandboxAutoResume::enabled),
+            Some(true)
+        );
+    }
+
+    /// `autoResume` is an object in the current SDK, but older releases and
+    /// hand-rolled clients send a bare bool. Accept both rather than 400-ing on
+    /// a shape difference that carries the same meaning.
+    #[test]
+    fn new_sandbox_accepts_bare_bool_auto_resume() {
+        let body = serde_json::json!({
+            "templateID": "tpl-1",
+            "autoResume": true
+        });
+
+        let new_sandbox: NewSandbox =
+            serde_json::from_value(body).expect("bare-bool autoResume should deserialize");
+
+        assert_eq!(
+            new_sandbox
+                .auto_resume
+                .as_ref()
+                .map(SandboxAutoResume::enabled),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn flat_lifecycle_fields_enable_pause_and_resume() {
+        let auto_resume = SandboxAutoResume::Config { enabled: true };
+        let flags = resolve_lifecycle_flags(None, Some(true), Some(&auto_resume));
+
+        assert_eq!(flags, (true, true));
+    }
+
+    /// `lifecycle` is CubeSandbox's native, richer form. When a caller sends it
+    /// explicitly it wins over the flattened compatibility fields. The e2b SDK
+    /// never sends both, so this only disambiguates direct API callers.
+    #[test]
+    fn nested_lifecycle_wins_over_flat_lifecycle_fields() {
+        let lifecycle = SandboxLifecycleConfig {
+            on_timeout: SandboxOnTimeout::Kill,
+            auto_resume: false,
+        };
+        let auto_resume = SandboxAutoResume::Enabled(true);
+
+        let flags = resolve_lifecycle_flags(Some(&lifecycle), Some(true), Some(&auto_resume));
+
+        assert_eq!(flags, (false, false));
+    }
+
+    #[test]
+    fn absent_lifecycle_fields_keep_kill_behaviour() {
+        let flags = resolve_lifecycle_flags(None, None, None);
+
+        assert_eq!(flags, (false, false));
+    }
+
     fn empty_create_request() -> CreateSandboxRequest {
         CreateSandboxRequest {
             request_id: "req-1".to_string(),
@@ -1695,6 +1799,8 @@ mod tests {
                 template_id: "tpl-1".to_string(),
                 timeout: Some(15),
                 lifecycle: None,
+                auto_pause: None,
+                auto_resume: None,
                 secure: None,
                 allow_internet_access: None,
                 network: None,
@@ -1770,6 +1876,8 @@ mod tests {
                 template_id: "tpl-1".to_string(),
                 timeout: Some(15),
                 lifecycle: None,
+                auto_pause: None,
+                auto_resume: None,
                 secure: None,
                 allow_internet_access: None,
                 network: None,
@@ -1837,6 +1945,8 @@ mod tests {
                 template_id: "tpl-1".to_string(),
                 timeout: Some(15),
                 lifecycle: None,
+                auto_pause: None,
+                auto_resume: None,
                 secure: None,
                 allow_internet_access: None,
                 network: None,

--- a/openapi.yml
+++ b/openapi.yml
@@ -1493,6 +1493,20 @@ components:
           - boolean
           - 'null'
           description: SDK sends this as snake_case (known quirk).
+        autoPause:
+          type:
+          - boolean
+          - 'null'
+          description: |-
+            e2b SDK compatibility: the SDK flattens its user-facing `lifecycle`
+            object into top-level `autoPause` / `autoResume` before it hits the
+            wire, so `lifecycle` never arrives from an SDK caller. Ignored when
+            `lifecycle` is present.
+        autoResume:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/SandboxAutoResume'
+            description: See `auto_pause`. Only meaningful alongside `autoPause = true`.
         distributionScope:
           type:
           - array
@@ -1645,6 +1659,20 @@ components:
           type:
           - string
           - 'null'
+    SandboxAutoResume:
+      oneOf:
+      - type: boolean
+      - type: object
+        required:
+        - enabled
+        properties:
+          enabled:
+            type: boolean
+      description: |-
+        Wire shape of the top-level `autoResume` field the e2b SDK sends. Current
+        SDK releases send `{"enabled": true}`; older ones and hand-rolled clients
+        send a bare `true`. Both mean the same thing, so accept either rather than
+        rejecting on shape.
     SandboxDetail:
       type: object
       description: Detailed sandbox info returned by GET /sandboxes/{sandboxID}.


### PR DESCRIPTION
## Problem

The e2b Python SDK does not put `lifecycle` on the wire. `Sandbox.create(lifecycle={"on_timeout": "pause", "auto_resume": True})` is flattened client-side into top-level fields before `POST /sandboxes`:

```json
{ "templateID": "<id>", "timeout": 30, "autoPause": true, "autoResume": { "enabled": true } }
```

`NewSandbox` bound neither field, so serde dropped them silently. CubeAPI then resolved `lifecycle = None` and forwarded `auto_pause=false` to CubeMaster — the sandbox was **killed** at timeout instead of paused. The setting appeared to succeed at the SDK layer and did nothing.

## Fix

- `NewSandbox` binds `autoPause` and `autoResume`.
- New `SandboxAutoResume` untagged enum accepts both `{"enabled": true}` (current SDK) and bare `true` (older releases, hand-rolled clients) — same meaning, so no reason to 400 on shape.
- Lifecycle derivation extracted from the inline closure in `create_sandbox` into `resolve_lifecycle_flags()`, a pure function that unit tests can reach.

## Design decision worth reviewing

**When a request carries both `lifecycle` and the flattened fields, the nested `lifecycle` object wins.**

Reasoning: the e2b SDK never sends both, so this only disambiguates direct API callers — and an explicit `lifecycle` can only come from someone who meant it. Happy to invert this if maintainers prefer the flat fields taking precedence.

## Tests

7 lifecycle tests, 5 of them new, written test-first:

- `new_sandbox_deserializes_e2b_flat_lifecycle_fields` — the exact e2b wire body
- `new_sandbox_accepts_bare_bool_auto_resume`
- `flat_lifecycle_fields_enable_pause_and_resume`
- `nested_lifecycle_wins_over_flat_lifecycle_fields`
- `absent_lifecycle_fields_keep_kill_behaviour` — no behaviour change for callers that don't opt in

## Verification

Run in the project builder image (`rustc 1.89`, `aarch64-unknown-linux-musl`):

- `make cube-api-test` → 108 passed, 0 failed
- `make cubeapi` → clean release build
- `cargo fmt --check` → clean
- `cargo clippy --all-targets` → warning set identical to the pre-change baseline; none in new code
- `cargo build --locked` passes — no dependency changes, `Cargo.lock` untouched

## Also updated

- `openapi.yml` — regenerated via `cube-api --export-openapi`, applying only the additive schema hunks so the hand-maintained license header and `servers:` block survive.
- `docs/guide/lifecycle.md` and `docs/zh/guide/lifecycle.md` — new "Wire format" section covering both accepted shapes and the precedence rule, EN and ZH in sync.

Closes #965
