### PR TITLE
docs(troubleshooting): add WSL2 DNS troubleshooting for install preflight and sandbox data plane

### DIFF
--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -230,7 +230,7 @@ check_dns_preflight() {
       local nm_load_state
       nm_load_state="$(systemctl show -p LoadState --value NetworkManager 2>/dev/null || true)"
       [[ "${nm_load_state}" == "loaded" ]] || \
-        die "DNS setup requires resolvectl or NetworkManager (or set CUBE_PROXY_DNSMASQ_MODE=standalone)"
+        die "DNS setup requires resolvectl or NetworkManager: install the systemd-resolved package that provides resolvectl (apt install systemd-resolved, dnf install systemd-resolved), or set CUBE_PROXY_DNSMASQ_MODE=standalone"
       ;;
     standalone)
       # standalone mode manages dnsmasq itself and only uses NetworkManager

--- a/deploy/one-click/online-install.sh
+++ b/deploy/one-click/online-install.sh
@@ -292,11 +292,11 @@ EOF
         local nm_load_state
         nm_load_state="$(systemctl show -p LoadState --value NetworkManager 2>/dev/null || true)"
         if [[ "${nm_load_state}" != "loaded" ]]; then
-          echo "[online-install] ERROR: DNS setup requires resolvectl or NetworkManager." >&2
+          echo "[online-install] ERROR: DNS setup requires resolvectl or NetworkManager. resolvectl is provided by the systemd-resolved package: apt install systemd-resolved (or dnf install systemd-resolved)." >&2
           exit 3
         fi
       else
-        echo "[online-install] ERROR: DNS setup requires resolvectl or systemd/NetworkManager." >&2
+        echo "[online-install] ERROR: DNS setup requires resolvectl or systemd/NetworkManager. resolvectl is provided by the systemd-resolved package: apt install systemd-resolved (or dnf install systemd-resolved)." >&2
         exit 3
       fi
 

--- a/docs/guide/troubleshooting/index.md
+++ b/docs/guide/troubleshooting/index.md
@@ -58,4 +58,5 @@ lang: en-US
 | [Template Creation Times Out When the Sandbox CIDR Overlaps the LAN](./local-network-cidr-conflict.md) | luzhixing12345 | 2026-05-20 | deployment, networking, one-click |
 | [Host Mounts Fail with Permission Denied](./host-mount-permissions.md) | barry166 | 2026-06-14 | runtime, host-mount, permissions |
 | [How to Find CubeSandbox Component Logs (cubecli logs and the Guest Kernel Log)](./component-log-locations.md) | ls-ggg | 2026-07-15 | logging, cubelet, cubeshim, operations |
+| [WSL2: Two DNS Problems That Block One-Click Install and the Sandbox Data Plane](./wsl-dns.md) | Tantanovo | 2026-08-03 | deployment, networking, dns, wsl |
 | _Add your article here_ | - | - | - |

--- a/docs/guide/troubleshooting/wsl-dns.md
+++ b/docs/guide/troubleshooting/wsl-dns.md
@@ -53,7 +53,7 @@ triggered by restarting WSL rather than by anything you changed.
 - Cube Sandbox version: v0.6.0 (`cubemastercli` `8721dd15`, built 2026-07-24)
 - Deployment mode: one-click, single node (control + compute on the same host)
 - Host OS / kernel: Ubuntu 24.04.4 LTS on WSL2, `6.18.33.2-microsoft-standard-WSL2`, glibc 2.39
-- Related components: `online-install.sh` preflight, CoreDNS (`cube-sandbox-coredns`), CubeProxy, `scripts/systemd/dns-host-route-up.sh`
+- Related components: `online-install.sh` preflight, CoreDNS (`cube-sandbox-coredns`), CubeProxy, `deploy/one-click/scripts/systemd/dns-host-route-up.sh`
 
 Other WSL preconditions were already satisfied and are not the subject of this
 page: `/dev/kvm` exists (recent WSL enables nested virtualization by default),
@@ -97,13 +97,20 @@ stuck on WSL anyway:
 The E2B-compatible SDK reaches a sandbox through a per-sandbox hostname of the
 form `<port>-<sandboxId>.cube.app`. Because the sandbox ID changes every time,
 the client needs wildcard resolution for `*.cube.app`; the bundled CoreDNS
-provides it, and `scripts/systemd/dns-host-route-up.sh` points
-`/etc/resolv.conf` at it (`169.254.254.53` on the `systemd-resolved` path,
-`127.0.0.54` on the `dnsmasq` fallback path). See
+provides it, and `deploy/one-click/scripts/systemd/dns-host-route-up.sh` routes
+`cube.app` queries to it. On both DNS backends the client-facing nameserver is
+`169.254.254.53` (the dummy-link address): on the `systemd-resolved` path the
+script attaches that address to the `cube-dns0` link via `resolvectl`, and on
+the `dnsmasq` fallback path it writes the same address into `/etc/resolv.conf`.
+`127.0.0.54` is only CoreDNS's internal loopback bind, which `dnsmasq` forwards
+`cube.app` queries to; it never appears in `/etc/resolv.conf`. See
 [HTTPS and domain](../https-and-domain.md) for the full addressing scheme.
 
-WSL, by default, regenerates `/etc/resolv.conf` on every start. That silently
-discards the nameserver the installer wrote, so:
+WSL, by default, regenerates `/etc/resolv.conf` on every start. On the
+`dnsmasq` fallback path that silently discards the nameserver the installer
+wrote; on the `systemd-resolved` path the routing lives on the `cube-dns0`
+dummy link and is dropped too, because WSL tears the link down. Either way the
+client loses the wildcard resolution, so:
 
 - The control plane keeps working, because it is reached over `127.0.0.1:3000`
   and needs no name resolution.
@@ -156,10 +163,14 @@ Two details matter here:
 - Keep an upstream resolver as the second entry. With only the CoreDNS address,
   `*.cube.app` resolves but general internet resolution breaks.
 
-Use the address that matches your DNS backend. After the fix for Problem 1 you
-are on the `systemd-resolved` path, so `169.254.254.53` is the one to use; on
-the `dnsmasq` fallback path it is `127.0.0.54`. You can confirm which one
-CoreDNS is bound to from the running Corefile.
+The nameserver to write is `169.254.254.53` regardless of which DNS backend
+you are on: it is the dummy-link address that both the `systemd-resolved` and
+the `dnsmasq` paths expose to clients. (`127.0.0.54` is only CoreDNS's internal
+loopback bind, which `dnsmasq` forwards `cube.app` queries to; it is not a
+client-facing resolver and must not be written to `/etc/resolv.conf` — a
+loopback address there would be unreachable from inside Docker containers,
+which is exactly the problem the dummy-link address was introduced to solve.)
+You can confirm the live address from the running Corefile.
 
 Verify both directions before moving on:
 
@@ -195,14 +206,18 @@ See [HTTPS and domain](../https-and-domain.md) for both.
 
 ## Notes for WSL Restarts
 
-Two pieces of state do not survive `wsl --shutdown`, and both produce confusing
-errors on the next run:
+Several pieces of state do not survive `wsl --shutdown`, and all produce
+confusing errors on the next run:
 
 - The loopback XFS mount at `/data/cubelet` is not remounted automatically. Add
   it back before starting the services (see
   [#311](https://github.com/TencentCloud/CubeSandbox/issues/311)).
 - `/etc/resolv.conf` is regenerated unless `generateResolvConf = false` is set
   as described above.
+- On the `systemd-resolved` path, the `cube-dns0` dummy link and its
+  `~cube.app` routing are also gone until the service unit restarts; on the
+  `dnsmasq` fallback path the same applies to the link and the
+  `server=/cube.app/...` forwarder rule.
 
 ## References
 

--- a/docs/guide/troubleshooting/wsl-dns.md
+++ b/docs/guide/troubleshooting/wsl-dns.md
@@ -1,0 +1,218 @@
+---
+title: WSL2 - Two DNS Problems That Block One-Click Install and the Sandbox Data Plane
+author: Tantanovo
+date: 2026-08-03
+tags:
+  - deployment
+  - networking
+  - dns
+  - wsl
+lang: en-US
+---
+
+# WSL2: Two DNS Problems That Block One-Click Install and the Sandbox Data Plane
+
+WSL2 is a convenient way to try Cube Sandbox on a Windows machine, and
+[quickstart](../quickstart.md) lists it as a supported platform. Two DNS
+problems are specific to WSL and are not covered elsewhere in the docs. They
+occur at different stages and look nothing alike, so they are documented
+separately below.
+
+Both were reproduced and fixed on a real single-node deployment; the versions
+are in [Environment](#environment).
+
+## Symptom
+
+### Problem 1: preflight exits 3 before anything is downloaded
+
+`online-install.sh` stops immediately with:
+
+```text
+[online-install] ERROR: DNS setup requires resolvectl or NetworkManager.
+```
+
+The exit code is `3`. Nothing has been downloaded or changed on the system yet.
+
+### Problem 2: the sandbox is created, but `run_code` fails to resolve
+
+Installation succeeds and the control plane is healthy — the sandbox is created
+in about a second — but the first data-plane call fails:
+
+```text
+[1] sandbox created in 0.99s
+    sandbox_id: 9e0b35c6183f4e969e1a6a8f6bdc5629     <- control plane OK
+httpx.ConnectError: [Errno -2] Name or service not known   <- data plane fails
+```
+
+The error mentions neither DNS nor `cube.app`, which makes this one hard to
+attribute. It can also appear *after* a previously working setup, because it is
+triggered by restarting WSL rather than by anything you changed.
+
+## Environment
+
+- Cube Sandbox version: v0.6.0 (`cubemastercli` `8721dd15`, built 2026-07-24)
+- Deployment mode: one-click, single node (control + compute on the same host)
+- Host OS / kernel: Ubuntu 24.04.4 LTS on WSL2, `6.18.33.2-microsoft-standard-WSL2`, glibc 2.39
+- Related components: `online-install.sh` preflight, CoreDNS (`cube-sandbox-coredns`), CubeProxy, `scripts/systemd/dns-host-route-up.sh`
+
+Other WSL preconditions were already satisfied and are not the subject of this
+page: `/dev/kvm` exists (recent WSL enables nested virtualization by default),
+`/data/cubelet` is a loopback XFS volume with `reflink=1` (see
+[#311](https://github.com/TencentCloud/CubeSandbox/issues/311)), `/sys/fs/bpf`
+is mounted, and the cgroup v2 `cpu` controller is exposed.
+
+## Root Cause
+
+### Problem 1: WSL ships neither `resolvectl` nor NetworkManager
+
+The preflight requires at least one supported resolver manager
+(`deploy/one-click/online-install.sh`):
+
+```bash
+# DNS check (requires resolvectl or NetworkManager loaded status)
+if ! command -v resolvectl >/dev/null 2>&1; then
+  if command -v systemctl >/dev/null 2>&1; then
+    nm_load_state="$(systemctl show -p LoadState --value NetworkManager 2>/dev/null || true)"
+    if [[ "${nm_load_state}" != "loaded" ]]; then
+      echo "[online-install] ERROR: DNS setup requires resolvectl or NetworkManager." >&2
+      exit 3
+    fi
+  ...
+```
+
+The check itself is correct, and the requirement is documented in
+[self-build-deploy](../self-build-deploy.md) ("DNS routing: `systemd-resolved`
+(preferred) or `NetworkManager + dnsmasq`"). Two things make it easy to get
+stuck on WSL anyway:
+
+- A default Ubuntu-on-WSL install has **neither**. `systemd-resolved` is not
+  installed, and NetworkManager is not present, so the first branch fails.
+- The message names the *command* `resolvectl`, but the command is shipped by
+  the **`systemd-resolved` package**. The package name does not appear in the
+  error, and `apt install resolvectl` does not exist, so the next step is not
+  obvious.
+
+### Problem 2: WSL rewrites `/etc/resolv.conf` on every start
+
+The E2B-compatible SDK reaches a sandbox through a per-sandbox hostname of the
+form `<port>-<sandboxId>.cube.app`. Because the sandbox ID changes every time,
+the client needs wildcard resolution for `*.cube.app`; the bundled CoreDNS
+provides it, and `scripts/systemd/dns-host-route-up.sh` points
+`/etc/resolv.conf` at it (`169.254.254.53` on the `systemd-resolved` path,
+`127.0.0.54` on the `dnsmasq` fallback path). See
+[HTTPS and domain](../https-and-domain.md) for the full addressing scheme.
+
+WSL, by default, regenerates `/etc/resolv.conf` on every start. That silently
+discards the nameserver the installer wrote, so:
+
+- The control plane keeps working, because it is reached over `127.0.0.1:3000`
+  and needs no name resolution.
+- The data plane breaks, because `*.cube.app` no longer resolves.
+
+This is why the failure can appear on a deployment that worked yesterday: the
+trigger is a WSL restart, not a configuration change.
+
+## Resolution
+
+### Problem 1: install `systemd-resolved` to provide `resolvectl`
+
+```bash
+sudo apt-get update
+sudo apt-get install -y systemd-resolved
+sudo systemctl enable --now systemd-resolved
+
+command -v resolvectl   # should print a path
+```
+
+Re-run `online-install.sh` afterwards. If `systemd-resolved` is unavailable on
+your distribution, the documented alternative is `NetworkManager + dnsmasq`;
+the preflight accepts that path as long as `NetworkManager` reports
+`LoadState=loaded`.
+
+### Problem 2: stop WSL from rewriting `resolv.conf`, then write it
+
+Both steps are required — doing only one of them does not survive a restart.
+
+```bash
+# 1. tell WSL to leave resolv.conf alone
+sudo tee -a /etc/wsl.conf >/dev/null <<'EOF'
+
+[network]
+generateResolvConf = false
+EOF
+
+# 2. resolv.conf is usually a symlink into /run, so remove it before writing
+sudo rm -f /etc/resolv.conf
+sudo tee /etc/resolv.conf >/dev/null <<'EOF'
+nameserver 169.254.254.53
+nameserver 223.5.5.5
+EOF
+```
+
+Two details matter here:
+
+- `/etc/resolv.conf` is typically a **symlink** into `/run/...`. Writing
+  through the symlink does not persist, so it has to be removed first.
+- Keep an upstream resolver as the second entry. With only the CoreDNS address,
+  `*.cube.app` resolves but general internet resolution breaks.
+
+Use the address that matches your DNS backend. After the fix for Problem 1 you
+are on the `systemd-resolved` path, so `169.254.254.53` is the one to use; on
+the `dnsmasq` fallback path it is `127.0.0.54`. You can confirm which one
+CoreDNS is bound to from the running Corefile.
+
+Verify both directions before moving on:
+
+```bash
+# wildcard sandbox domain must resolve
+dig +short +tcp +timeout=3 foo.cube.app @169.254.254.53
+
+# ordinary resolution must still work
+getent hosts github.com
+```
+
+After a `wsl --shutdown`, re-check that the file survived:
+
+```bash
+cat /etc/resolv.conf
+```
+
+### If you would rather not touch host DNS
+
+The project already offers ways to avoid wildcard DNS entirely, which are
+useful on WSL:
+
+- **Path-based access** — reach a sandbox through
+  `http://<cube-proxy-host>:<http-port>/sandbox/<sandbox-id>/<container-port>/`
+  with no DNS or certificate setup. Good for HTTP APIs; single-page apps are
+  better served by the host-based route because CubeProxy does not rewrite HTML
+  bodies.
+- **`examples/e2b-dev-sidecar`** — a local proxy that intercepts SDK data-plane
+  requests and rewrites the `Host` header before forwarding to CubeProxy. It
+  needs neither wildcard DNS nor a trusted self-signed certificate.
+
+See [HTTPS and domain](../https-and-domain.md) for both.
+
+## Notes for WSL Restarts
+
+Two pieces of state do not survive `wsl --shutdown`, and both produce confusing
+errors on the next run:
+
+- The loopback XFS mount at `/data/cubelet` is not remounted automatically. Add
+  it back before starting the services (see
+  [#311](https://github.com/TencentCloud/CubeSandbox/issues/311)).
+- `/etc/resolv.conf` is regenerated unless `generateResolvConf = false` is set
+  as described above.
+
+## References
+
+- Related docs: [Quickstart](../quickstart.md),
+  [Self-build deployment](../self-build-deploy.md),
+  [HTTPS and domain](../https-and-domain.md)
+- Related issue: [#311](https://github.com/TencentCloud/CubeSandbox/issues/311)
+  (XFS loopback workaround for WSL),
+  [#411](https://github.com/TencentCloud/CubeSandbox/issues/411)
+  (running Cube Sandbox on WSL2)
+- Verified while working on [#644](https://github.com/TencentCloud/CubeSandbox/issues/644);
+  deployment evidence is attached to
+  [#1238](https://github.com/TencentCloud/CubeSandbox/pull/1238)

--- a/docs/guide/troubleshooting/wsl-dns.md
+++ b/docs/guide/troubleshooting/wsl-dns.md
@@ -28,7 +28,7 @@ are in [Environment](#environment).
 `online-install.sh` stops immediately with:
 
 ```text
-[online-install] ERROR: DNS setup requires resolvectl or NetworkManager.
+[online-install] ERROR: DNS setup requires resolvectl or NetworkManager. resolvectl is provided by the systemd-resolved package: apt install systemd-resolved (or dnf install systemd-resolved).
 ```
 
 The exit code is `3`. Nothing has been downloaded or changed on the system yet.
@@ -74,7 +74,7 @@ if ! command -v resolvectl >/dev/null 2>&1; then
   if command -v systemctl >/dev/null 2>&1; then
     nm_load_state="$(systemctl show -p LoadState --value NetworkManager 2>/dev/null || true)"
     if [[ "${nm_load_state}" != "loaded" ]]; then
-      echo "[online-install] ERROR: DNS setup requires resolvectl or NetworkManager." >&2
+      echo "[online-install] ERROR: DNS setup requires resolvectl or NetworkManager. resolvectl is provided by the systemd-resolved package: apt install systemd-resolved (or dnf install systemd-resolved)." >&2
       exit 3
     fi
   ...
@@ -87,10 +87,10 @@ stuck on WSL anyway:
 
 - A default Ubuntu-on-WSL install has **neither**. `systemd-resolved` is not
   installed, and NetworkManager is not present, so the first branch fails.
-- The message names the *command* `resolvectl`, but the command is shipped by
-  the **`systemd-resolved` package**. The package name does not appear in the
-  error, and `apt install resolvectl` does not exist, so the next step is not
-  obvious.
+- The message names the *command* `resolvectl`, which is shipped by the
+  **`systemd-resolved` package** — `apt install resolvectl` does not exist. The
+  error now names the package, so this is only a problem on releases that
+  predate that change.
 
 ### Problem 2: WSL rewrites `/etc/resolv.conf` on every start
 

--- a/docs/guide/troubleshooting/wsl-dns.md
+++ b/docs/guide/troubleshooting/wsl-dns.md
@@ -142,6 +142,8 @@ Both steps are required — doing only one of them does not survive a restart.
 
 ```bash
 # 1. tell WSL to leave resolv.conf alone
+#    if /etc/wsl.conf already has a [network] section, add the key to that
+#    section instead of appending a second one
 sudo tee -a /etc/wsl.conf >/dev/null <<'EOF'
 
 [network]
@@ -149,6 +151,8 @@ generateResolvConf = false
 EOF
 
 # 2. resolv.conf is usually a symlink into /run, so remove it before writing
+#    223.5.5.5 is only an example upstream; use any resolver reachable on
+#    your network
 sudo rm -f /etc/resolv.conf
 sudo tee /etc/resolv.conf >/dev/null <<'EOF'
 nameserver 169.254.254.53
@@ -156,12 +160,18 @@ nameserver 223.5.5.5
 EOF
 ```
 
-Two details matter here:
+Three details matter here:
 
 - `/etc/resolv.conf` is typically a **symlink** into `/run/...`. Writing
   through the symlink does not persist, so it has to be removed first.
+- If `/etc/wsl.conf` already contains a `[network]` section, put
+  `generateResolvConf = false` inside it rather than appending a second
+  section.
 - Keep an upstream resolver as the second entry. With only the CoreDNS address,
-  `*.cube.app` resolves but general internet resolution breaks.
+  `*.cube.app` resolves but general internet resolution breaks. The installer's
+  own `write_host_resolv_conf` preserves the host's existing upstream
+  automatically; here the file is written by hand, so choose an upstream that
+  works on your network.
 
 The nameserver to write is `169.254.254.53` regardless of which DNS backend
 you are on: it is the dummy-link address that both the `systemd-resolved` and
@@ -172,10 +182,14 @@ loopback address there would be unreachable from inside Docker containers,
 which is exactly the problem the dummy-link address was introduced to solve.)
 You can confirm the live address from the running Corefile.
 
-Verify both directions before moving on:
+Verify both directions before moving on (`dig` comes from `dnsutils` /
+`bind9-dnsutils`, which Ubuntu does not install by default — the `getent`
+checks work without it):
 
 ```bash
 # wildcard sandbox domain must resolve
+getent hosts foo.cube.app
+# or, to query CoreDNS directly: sudo apt-get install -y dnsutils
 dig +short +tcp +timeout=3 foo.cube.app @169.254.254.53
 
 # ordinary resolution must still work

--- a/docs/guide/troubleshooting/wsl-dns.md
+++ b/docs/guide/troubleshooting/wsl-dns.md
@@ -180,7 +180,11 @@ loopback bind, which `dnsmasq` forwards `cube.app` queries to; it is not a
 client-facing resolver and must not be written to `/etc/resolv.conf` — a
 loopback address there would be unreachable from inside Docker containers,
 which is exactly the problem the dummy-link address was introduced to solve.)
-You can confirm the live address from the running Corefile.
+To confirm the live address on your deployment:
+
+```bash
+grep -n 'bind' /usr/local/services/cubetoolbox/coredns/Corefile
+```
 
 Verify both directions before moving on (`dig` comes from `dnsutils` /
 `bind9-dnsutils`, which Ubuntu does not install by default — the `getent`
@@ -232,6 +236,30 @@ confusing errors on the next run:
   `~cube.app` routing are also gone until the service unit restarts; on the
   `dnsmasq` fallback path the same applies to the link and the
   `server=/cube.app/...` forwarder rule.
+
+`cube-sandbox-dns.service` is a `Type=oneshot` unit that owns the dummy link
+and the host routing, so restarting it is what rebuilds them. A working
+recovery sequence after `wsl --shutdown` is:
+
+```bash
+# 1. remount the XFS volume first (cubelet needs it)
+sudo mount -o loop /path/to/cubelet.img /data/cubelet
+
+# 2. bring the services back
+sudo systemctl start cube-sandbox-control.target
+
+# 3. if *.cube.app still does not resolve, rebuild the DNS routing
+sudo systemctl restart cube-sandbox-coredns.service
+sudo systemctl restart cube-sandbox-dns.service
+
+# 4. confirm
+ip addr show cube-dns0
+getent hosts foo.cube.app
+```
+
+Restart `cube-sandbox-coredns.service` before `cube-sandbox-dns.service`: the
+latter declares `Requires=` / `BindsTo=` on the former and waits for CoreDNS to
+be listening before it switches host resolution over.
 
 ## References
 

--- a/docs/zh/guide/troubleshooting/index.md
+++ b/docs/zh/guide/troubleshooting/index.md
@@ -58,4 +58,5 @@ lang: zh-CN
 | [沙箱网段和局域网冲突导致创建模板超时](./local-network-cidr-conflict.md) | luzhixing12345 | 2026-05-20 | deployment, networking, one-click |
 | [Host Mount 写入时报 Permission Denied](./host-mount-permissions.md) | barry166 | 2026-06-14 | runtime, host-mount, permissions |
 | [如何查看 CubeSandbox 各组件日志（含 cubecli logs 与 guest kernel log）](./component-log-locations.md) | ls-ggg | 2026-07-15 | logging, cubelet, cubeshim, operations |
+| [WSL2 上两个卡住一键安装与沙箱数据面的 DNS 问题](./wsl-dns.md) | Tantanovo | 2026-08-03 | deployment, networking, dns, wsl |
 | _在这里补充你的文章_ | - | - | - |

--- a/docs/zh/guide/troubleshooting/wsl-dns.md
+++ b/docs/zh/guide/troubleshooting/wsl-dns.md
@@ -161,7 +161,11 @@ EOF
 （`127.0.0.54` 只是 CoreDNS 的内部 loopback 绑定，`dnsmasq` 会把 `cube.app`
 查询转发给它；它不是面向客户端的解析器，**不要写进 `/etc/resolv.conf`** ——
 loopback 地址在 Docker 容器内不可达，而这正是引入 dummy link 地址要解决的问题。）
-当前生效的地址可以从运行中的 Corefile 确认。
+当前部署上生效的地址可以这样确认：
+
+```bash
+grep -n 'bind' /usr/local/services/cubetoolbox/coredns/Corefile
+```
 
 继续之前先把两个方向都验证一遍（`dig` 来自 `dnsutils` / `bind9-dnsutils` 包，
 Ubuntu 默认不装 —— 下面的 `getent` 检查不依赖它）：
@@ -205,6 +209,29 @@ cat /etc/resolv.conf
 - `systemd-resolved` 路径下的 `cube-dns0` dummy link 及其 `~cube.app` 路由
   也会随 WSL 重启消失，直到服务单元重启；`dnsmasq` 回退路径下，
   link 和 `server=/cube.app/...` 转发规则同理。
+
+`cube-sandbox-dns.service` 是 `Type=oneshot` 单元，dummy link 与宿主路由由它创建，
+所以重启这个单元才能把它们重建出来。`wsl --shutdown` 之后一套可用的恢复流程是：
+
+```bash
+# 1. 先挂回 XFS（cubelet 需要）
+sudo mount -o loop /path/to/cubelet.img /data/cubelet
+
+# 2. 把服务拉起来
+sudo systemctl start cube-sandbox-control.target
+
+# 3. 如果 *.cube.app 仍然解析不了，重建 DNS 路由
+sudo systemctl restart cube-sandbox-coredns.service
+sudo systemctl restart cube-sandbox-dns.service
+
+# 4. 确认
+ip addr show cube-dns0
+getent hosts foo.cube.app
+```
+
+注意先重启 `cube-sandbox-coredns.service` 再重启 `cube-sandbox-dns.service`：
+后者对前者声明了 `Requires=` / `BindsTo=`，会等 CoreDNS 真正开始监听之后
+才切换宿主机的解析。
 
 ## 参考资料
 

--- a/docs/zh/guide/troubleshooting/wsl-dns.md
+++ b/docs/zh/guide/troubleshooting/wsl-dns.md
@@ -128,6 +128,8 @@ command -v resolvectl   # 应当输出一个路径
 
 ```bash
 # 1. 让 WSL 不再自动生成 resolv.conf
+#    如果 /etc/wsl.conf 里已经有 [network] 段，请把这个键加进那一段，
+#    不要再追加第二个 [network]
 sudo tee -a /etc/wsl.conf >/dev/null <<'EOF'
 
 [network]
@@ -135,6 +137,7 @@ generateResolvConf = false
 EOF
 
 # 2. resolv.conf 通常是指向 /run 的符号链接，写入前需要先删掉
+#    223.5.5.5 只是示例上游，请换成你的网络里能通的解析器
 sudo rm -f /etc/resolv.conf
 sudo tee /etc/resolv.conf >/dev/null <<'EOF'
 nameserver 169.254.254.53
@@ -142,12 +145,16 @@ nameserver 223.5.5.5
 EOF
 ```
 
-这里有两个细节值得注意：
+这里有三个细节值得注意：
 
 - `/etc/resolv.conf` 一般是指向 `/run/...` 的**符号链接**，
   透过符号链接写入不会保留，因此必须先删除。
+- 如果 `/etc/wsl.conf` 里已经存在 `[network]` 段，请把
+  `generateResolvConf = false` 写进该段，而不是再追加一个 `[network]`。
 - 第二行要保留一个上游解析器。如果只写 CoreDNS 地址，
-  `*.cube.app` 能解析，但普通上网会断。
+  `*.cube.app` 能解析，但普通上网会断。安装器自己的
+  `write_host_resolv_conf` 会自动沿用宿主机原有的上游；这里是手写文件，
+  所以要自己挑一个在当前网络里可用的上游。
 
 要写入的 nameserver 是 `169.254.254.53`，与走哪条 DNS 后端无关：它是
 `systemd-resolved` 与 `dnsmasq` 两条路径都暴露给客户端的 dummy link 地址。
@@ -156,10 +163,13 @@ EOF
 loopback 地址在 Docker 容器内不可达，而这正是引入 dummy link 地址要解决的问题。）
 当前生效的地址可以从运行中的 Corefile 确认。
 
-继续之前先把两个方向都验证一遍：
+继续之前先把两个方向都验证一遍（`dig` 来自 `dnsutils` / `bind9-dnsutils` 包，
+Ubuntu 默认不装 —— 下面的 `getent` 检查不依赖它）：
 
 ```bash
 # 通配沙箱域名必须能解析
+getent hosts foo.cube.app
+# 若想直接问 CoreDNS：sudo apt-get install -y dnsutils
 dig +short +tcp +timeout=3 foo.cube.app @169.254.254.53
 
 # 普通解析也必须正常

--- a/docs/zh/guide/troubleshooting/wsl-dns.md
+++ b/docs/zh/guide/troubleshooting/wsl-dns.md
@@ -25,7 +25,7 @@ lang: zh-CN
 `online-install.sh` 会立刻退出：
 
 ```text
-[online-install] ERROR: DNS setup requires resolvectl or NetworkManager.
+[online-install] ERROR: DNS setup requires resolvectl or NetworkManager. resolvectl is provided by the systemd-resolved package: apt install systemd-resolved (or dnf install systemd-resolved).
 ```
 
 退出码是 `3`。此时还没有下载任何东西，也没有修改系统。
@@ -68,7 +68,7 @@ if ! command -v resolvectl >/dev/null 2>&1; then
   if command -v systemctl >/dev/null 2>&1; then
     nm_load_state="$(systemctl show -p LoadState --value NetworkManager 2>/dev/null || true)"
     if [[ "${nm_load_state}" != "loaded" ]]; then
-      echo "[online-install] ERROR: DNS setup requires resolvectl or NetworkManager." >&2
+      echo "[online-install] ERROR: DNS setup requires resolvectl or NetworkManager. resolvectl is provided by the systemd-resolved package: apt install systemd-resolved (or dnf install systemd-resolved)." >&2
       exit 3
     fi
   ...
@@ -81,8 +81,8 @@ if ! command -v resolvectl >/dev/null 2>&1; then
 - WSL 上的 Ubuntu 默认安装**两者都没有**。`systemd-resolved` 没装，
   NetworkManager 也不存在，因此第一个分支就失败了。
 - 报错提示的是**命令名** `resolvectl`，而这个命令是由 **`systemd-resolved` 包**
-  提供的。包名没有出现在报错里，而 `apt install resolvectl` 并不存在，
-  所以下一步该做什么并不明显。
+  提供的—— `apt install resolvectl` 并不存在。现在报错里已经写明了包名，
+  所以这一点只会影响该改动之前的版本。
 
 ### 问题 2：WSL 每次启动都会重写 `/etc/resolv.conf`
 

--- a/docs/zh/guide/troubleshooting/wsl-dns.md
+++ b/docs/zh/guide/troubleshooting/wsl-dns.md
@@ -1,0 +1,198 @@
+---
+title: WSL2 上两个卡住一键安装与沙箱数据面的 DNS 问题
+author: Tantanovo
+date: 2026-08-03
+tags:
+  - deployment
+  - networking
+  - dns
+  - wsl
+lang: zh-CN
+---
+
+# WSL2 上两个卡住一键安装与沙箱数据面的 DNS 问题
+
+在 Windows 上试用 Cube Sandbox，WSL2 是比较方便的选择，
+[快速开始](../quickstart.md) 也把它列为支持的平台。有两个 DNS 问题是 WSL 特有的，
+现有文档没有覆盖。它们出现在不同阶段、现象也完全不同，因此下面分开记录。
+
+两个问题都是在真实的单机部署上复现并解决的，版本信息见[环境信息](#环境信息)。
+
+## 问题现象
+
+### 问题 1：安装前 preflight 直接 exit 3
+
+`online-install.sh` 会立刻退出：
+
+```text
+[online-install] ERROR: DNS setup requires resolvectl or NetworkManager.
+```
+
+退出码是 `3`。此时还没有下载任何东西，也没有修改系统。
+
+### 问题 2：沙箱能创建，但 `run_code` 解析失败
+
+安装成功、控制面完全正常（沙箱一秒左右就创建好了），但第一次数据面调用就失败：
+
+```text
+[1] sandbox created in 0.99s
+    sandbox_id: 9e0b35c6183f4e969e1a6a8f6bdc5629     <- 控制面正常
+httpx.ConnectError: [Errno -2] Name or service not known   <- 数据面失败
+```
+
+报错里既没有 DNS 也没有 `cube.app`，很难往这个方向联想。它也可能出现在
+**昨天还正常**的环境上，因为触发条件是重启 WSL，而不是你改了什么配置。
+
+## 环境信息
+
+- Cube Sandbox 版本：v0.6.0（`cubemastercli` `8721dd15`，构建于 2026-07-24）
+- 部署模式：one-click 单机（control 与 compute 同机）
+- 宿主机 OS / 内核：WSL2 上的 Ubuntu 24.04.4 LTS，`6.18.33.2-microsoft-standard-WSL2`，glibc 2.39
+- 相关组件：`online-install.sh` preflight、CoreDNS（`cube-sandbox-coredns`）、CubeProxy、`scripts/systemd/dns-host-route-up.sh`
+
+WSL 上其他前置条件当时都已满足，不属于本文范围：`/dev/kvm` 存在（较新版本的 WSL
+默认开启嵌套虚拟化）、`/data/cubelet` 是带 `reflink=1` 的 loopback XFS
+（见 [#311](https://github.com/TencentCloud/CubeSandbox/issues/311)）、
+`/sys/fs/bpf` 已挂载、cgroup v2 的 `cpu` 控制器已暴露。
+
+## 根因分析
+
+### 问题 1：WSL 上既没有 `resolvectl` 也没有 NetworkManager
+
+preflight 要求至少存在一个受支持的解析器管理组件
+（`deploy/one-click/online-install.sh`）：
+
+```bash
+# DNS check (requires resolvectl or NetworkManager loaded status)
+if ! command -v resolvectl >/dev/null 2>&1; then
+  if command -v systemctl >/dev/null 2>&1; then
+    nm_load_state="$(systemctl show -p LoadState --value NetworkManager 2>/dev/null || true)"
+    if [[ "${nm_load_state}" != "loaded" ]]; then
+      echo "[online-install] ERROR: DNS setup requires resolvectl or NetworkManager." >&2
+      exit 3
+    fi
+  ...
+```
+
+这个检查本身是对的，前置条件也写在了
+[自建部署](../self-build-deploy.md)（「DNS 路由：`systemd-resolved`（推荐）或
+`NetworkManager + dnsmasq`」）。但在 WSL 上仍然容易卡住，有两个原因：
+
+- WSL 上的 Ubuntu 默认安装**两者都没有**。`systemd-resolved` 没装，
+  NetworkManager 也不存在，因此第一个分支就失败了。
+- 报错提示的是**命令名** `resolvectl`，而这个命令是由 **`systemd-resolved` 包**
+  提供的。包名没有出现在报错里，而 `apt install resolvectl` 并不存在，
+  所以下一步该做什么并不明显。
+
+### 问题 2：WSL 每次启动都会重写 `/etc/resolv.conf`
+
+E2B 兼容 SDK 访问沙箱使用的是形如 `<port>-<sandboxId>.cube.app` 的独立域名。
+由于 sandboxId 每次都变，客户端必须支持 `*.cube.app` 的通配解析；
+一键安装自带的 CoreDNS 负责提供这个能力，`scripts/systemd/dns-host-route-up.sh`
+会把 `/etc/resolv.conf` 指向它（`systemd-resolved` 路径下是 `169.254.254.53`，
+`dnsmasq` 回退路径下是 `127.0.0.54`）。完整的寻址方案见
+[HTTPS 与域名](../https-and-domain.md)。
+
+而 WSL 默认在每次启动时重新生成 `/etc/resolv.conf`，这会静默地丢掉安装器写入的
+nameserver，于是：
+
+- 控制面照常工作，因为它走 `127.0.0.1:3000`，不需要域名解析。
+- 数据面失败，因为 `*.cube.app` 已经解析不出来了。
+
+这也解释了为什么昨天还正常的环境今天会挂：触发条件是重启 WSL，而不是配置变更。
+
+## 解决方法
+
+### 问题 1：安装 `systemd-resolved` 以提供 `resolvectl`
+
+```bash
+sudo apt-get update
+sudo apt-get install -y systemd-resolved
+sudo systemctl enable --now systemd-resolved
+
+command -v resolvectl   # 应当输出一个路径
+```
+
+之后重新执行 `online-install.sh`。如果你的发行版上没有 `systemd-resolved`，
+文档给出的替代方案是 `NetworkManager + dnsmasq`；只要 `NetworkManager` 的
+`LoadState=loaded`，preflight 同样会通过。
+
+### 问题 2：先让 WSL 不再重写 resolv.conf，再写入
+
+两步都要做，只做其中一步无法在重启后保留。
+
+```bash
+# 1. 让 WSL 不再自动生成 resolv.conf
+sudo tee -a /etc/wsl.conf >/dev/null <<'EOF'
+
+[network]
+generateResolvConf = false
+EOF
+
+# 2. resolv.conf 通常是指向 /run 的符号链接，写入前需要先删掉
+sudo rm -f /etc/resolv.conf
+sudo tee /etc/resolv.conf >/dev/null <<'EOF'
+nameserver 169.254.254.53
+nameserver 223.5.5.5
+EOF
+```
+
+这里有两个细节值得注意：
+
+- `/etc/resolv.conf` 一般是指向 `/run/...` 的**符号链接**，
+  透过符号链接写入不会保留，因此必须先删除。
+- 第二行要保留一个上游解析器。如果只写 CoreDNS 地址，
+  `*.cube.app` 能解析，但普通上网会断。
+
+请使用与你的 DNS 后端匹配的地址。修完问题 1 之后你会走 `systemd-resolved` 路径，
+因此用 `169.254.254.53`；如果走的是 `dnsmasq` 回退路径，则是 `127.0.0.54`。
+具体绑定到哪个地址，可以从运行中的 Corefile 确认。
+
+继续之前先把两个方向都验证一遍：
+
+```bash
+# 通配沙箱域名必须能解析
+dig +short +tcp +timeout=3 foo.cube.app @169.254.254.53
+
+# 普通解析也必须正常
+getent hosts github.com
+```
+
+执行过 `wsl --shutdown` 之后，再确认文件是否还在：
+
+```bash
+cat /etc/resolv.conf
+```
+
+### 如果不想改宿主机 DNS
+
+项目本身提供了绕开通配 DNS 的方式，在 WSL 上也很实用：
+
+- **基于路径的访问** —— 通过
+  `http://<cube-proxy-host>:<http-port>/sandbox/<sandbox-id>/<container-port>/`
+  访问沙箱，不需要配置 DNS 与证书。适合 HTTP API；单页应用更适合用基于域名的方式，
+  因为 CubeProxy 不会改写 HTML body。
+- **`examples/e2b-dev-sidecar`** —— 一个本地代理，拦截 SDK 的数据面请求，
+  改写 `Host` 头后转发给 CubeProxy。既不需要通配 DNS，也不需要信任自签证书。
+
+两种方式都见 [HTTPS 与域名](../https-and-domain.md)。
+
+## 关于 WSL 重启的提醒
+
+有两项状态不会在 `wsl --shutdown` 后保留，且都会在下次运行时产生容易误判的报错：
+
+- `/data/cubelet` 上的 loopback XFS 不会自动挂回，启动服务前需要先挂上
+  （见 [#311](https://github.com/TencentCloud/CubeSandbox/issues/311)）。
+- 除非按上文设置了 `generateResolvConf = false`，`/etc/resolv.conf` 会被重新生成。
+
+## 参考资料
+
+- 相关文档：[快速开始](../quickstart.md)、
+  [自建部署](../self-build-deploy.md)、
+  [HTTPS 与域名](../https-and-domain.md)
+- 相关 issue：[#311](https://github.com/TencentCloud/CubeSandbox/issues/311)
+  （WSL 的 XFS loopback 方案）、
+  [#411](https://github.com/TencentCloud/CubeSandbox/issues/411)
+  （在 WSL2 上运行 Cube Sandbox）
+- 在处理 [#644](https://github.com/TencentCloud/CubeSandbox/issues/644) 期间验证；
+  部署证据见 [#1238](https://github.com/TencentCloud/CubeSandbox/pull/1238)

--- a/docs/zh/guide/troubleshooting/wsl-dns.md
+++ b/docs/zh/guide/troubleshooting/wsl-dns.md
@@ -48,7 +48,7 @@ httpx.ConnectError: [Errno -2] Name or service not known   <- 数据面失败
 - Cube Sandbox 版本：v0.6.0（`cubemastercli` `8721dd15`，构建于 2026-07-24）
 - 部署模式：one-click 单机（control 与 compute 同机）
 - 宿主机 OS / 内核：WSL2 上的 Ubuntu 24.04.4 LTS，`6.18.33.2-microsoft-standard-WSL2`，glibc 2.39
-- 相关组件：`online-install.sh` preflight、CoreDNS（`cube-sandbox-coredns`）、CubeProxy、`scripts/systemd/dns-host-route-up.sh`
+- 相关组件：`online-install.sh` preflight、CoreDNS（`cube-sandbox-coredns`）、CubeProxy、`deploy/one-click/scripts/systemd/dns-host-route-up.sh`
 
 WSL 上其他前置条件当时都已满足，不属于本文范围：`/dev/kvm` 存在（较新版本的 WSL
 默认开启嵌套虚拟化）、`/data/cubelet` 是带 `reflink=1` 的 loopback XFS
@@ -88,13 +88,18 @@ if ! command -v resolvectl >/dev/null 2>&1; then
 
 E2B 兼容 SDK 访问沙箱使用的是形如 `<port>-<sandboxId>.cube.app` 的独立域名。
 由于 sandboxId 每次都变，客户端必须支持 `*.cube.app` 的通配解析；
-一键安装自带的 CoreDNS 负责提供这个能力，`scripts/systemd/dns-host-route-up.sh`
-会把 `/etc/resolv.conf` 指向它（`systemd-resolved` 路径下是 `169.254.254.53`，
-`dnsmasq` 回退路径下是 `127.0.0.54`）。完整的寻址方案见
-[HTTPS 与域名](../https-and-domain.md)。
+一键安装自带的 CoreDNS 负责提供这个能力，`deploy/one-click/scripts/systemd/dns-host-route-up.sh`
+会把 `cube.app` 查询路由到它。两条 DNS 后端路径下，面向客户端的 nameserver 都是
+`169.254.254.53`（dummy link 地址）：`systemd-resolved` 路径下脚本通过 `resolvectl`
+把这个地址挂到 `cube-dns0` 链路上；`dnsmasq` 回退路径下脚本把同一个地址写进
+`/etc/resolv.conf`。`127.0.0.54` 只是 CoreDNS 的内部 loopback 绑定，
+`dnsmasq` 会把 `cube.app` 查询转发给它，但它**不会出现在 `/etc/resolv.conf` 里**。
+完整的寻址方案见 [HTTPS 与域名](../https-and-domain.md)。
 
-而 WSL 默认在每次启动时重新生成 `/etc/resolv.conf`，这会静默地丢掉安装器写入的
-nameserver，于是：
+而 WSL 默认在每次启动时重新生成 `/etc/resolv.conf`。在 `dnsmasq` 回退路径下，
+这会静默地丢掉安装器写入的 nameserver；在 `systemd-resolved` 路径下，
+路由挂在 `cube-dns0` dummy link 上，WSL 重启时链路被拆除，同样会丢。
+无论哪种情况，客户端都会失去通配解析，于是：
 
 - 控制面照常工作，因为它走 `127.0.0.1:3000`，不需要域名解析。
 - 数据面失败，因为 `*.cube.app` 已经解析不出来了。
@@ -144,9 +149,12 @@ EOF
 - 第二行要保留一个上游解析器。如果只写 CoreDNS 地址，
   `*.cube.app` 能解析，但普通上网会断。
 
-请使用与你的 DNS 后端匹配的地址。修完问题 1 之后你会走 `systemd-resolved` 路径，
-因此用 `169.254.254.53`；如果走的是 `dnsmasq` 回退路径，则是 `127.0.0.54`。
-具体绑定到哪个地址，可以从运行中的 Corefile 确认。
+要写入的 nameserver 是 `169.254.254.53`，与走哪条 DNS 后端无关：它是
+`systemd-resolved` 与 `dnsmasq` 两条路径都暴露给客户端的 dummy link 地址。
+（`127.0.0.54` 只是 CoreDNS 的内部 loopback 绑定，`dnsmasq` 会把 `cube.app`
+查询转发给它；它不是面向客户端的解析器，**不要写进 `/etc/resolv.conf`** ——
+loopback 地址在 Docker 容器内不可达，而这正是引入 dummy link 地址要解决的问题。）
+当前生效的地址可以从运行中的 Corefile 确认。
 
 继续之前先把两个方向都验证一遍：
 
@@ -179,11 +187,14 @@ cat /etc/resolv.conf
 
 ## 关于 WSL 重启的提醒
 
-有两项状态不会在 `wsl --shutdown` 后保留，且都会在下次运行时产生容易误判的报错：
+有几项状态不会在 `wsl --shutdown` 后保留，且都会在下次运行时产生容易误判的报错：
 
 - `/data/cubelet` 上的 loopback XFS 不会自动挂回，启动服务前需要先挂上
   （见 [#311](https://github.com/TencentCloud/CubeSandbox/issues/311)）。
 - 除非按上文设置了 `generateResolvConf = false`，`/etc/resolv.conf` 会被重新生成。
+- `systemd-resolved` 路径下的 `cube-dns0` dummy link 及其 `~cube.app` 路由
+  也会随 WSL 重启消失，直到服务单元重启；`dnsmasq` 回退路径下，
+  link 和 `server=/cube.app/...` 转发规则同理。
 
 ## 参考资料
 


### PR DESCRIPTION
## What

Adds a bilingual troubleshooting page for two DNS problems that are specific to WSL2, requested by @fslongjin.

- `docs/guide/troubleshooting/wsl-dns.md`
- `docs/zh/guide/troubleshooting/wsl-dns.md`
- One index row in each language

`quickstart.md` lists WSL as a supported platform, and [#311](https://github.com/TencentCloud/CubeSandbox/issues/311) covers the XFS loopback workaround, but neither of the two DNS failures below is documented anywhere. Both were hit while bringing up v0.6.0 on WSL2 for [#644](https://github.com/TencentCloud/CubeSandbox/issues/644).

## The two problems

**1. Preflight exits 3 before anything is downloaded**

`online-install.sh` requires `resolvectl` or a loaded `NetworkManager`. A default Ubuntu-on-WSL install has neither.

The generic prerequisite *is* documented in `self-build-deploy.md` ("DNS routing: `systemd-resolved` (preferred) or `NetworkManager + dnsmasq`"), so this is not a missing requirement — it is a discoverability gap:

- `quickstart.md` lists WSL as supported but its requirements table only mentions glibc and XFS.
- The error names the *command* `resolvectl`, while the command is shipped by the **`systemd-resolved` package**. `apt install resolvectl` does not exist, so the next step is not obvious.

Fix: `apt-get install -y systemd-resolved && systemctl enable --now systemd-resolved`.

**2. Install succeeds, sandbox is created, but `run_code` cannot resolve**

```
[1] sandbox created in 0.99s
    sandbox_id: 9e0b35c6183f4e969e1a6a8f6bdc5629     <- control plane OK
httpx.ConnectError: [Errno -2] Name or service not known   <- data plane fails
```

The control plane is fine because it goes through `127.0.0.1:3000`. The data plane needs wildcard resolution for `*.cube.app`, and WSL regenerates `/etc/resolv.conf` on every start, discarding the CoreDNS nameserver written by `dns-host-route-up.sh`.

This one is the more valuable of the two for a troubleshooting page: the error mentions neither DNS nor `cube.app`, and it can appear on a deployment that worked yesterday, because the trigger is a WSL restart rather than a config change.

Fix requires both steps — either alone does not survive a restart:

1. `/etc/wsl.conf` → `[network]` / `generateResolvConf = false`
2. `/etc/resolv.conf` is usually a symlink into `/run/...`, so `rm` it before writing; point the first nameserver at CoreDNS and keep an upstream resolver as a fallback (with only the CoreDNS address, `*.cube.app` resolves but general internet resolution breaks).

The page also notes which CoreDNS address applies to which backend (`169.254.254.53` on the `systemd-resolved` path, `127.0.0.54` on the `dnsmasq` fallback), points to the two DNS-free alternatives already in the repo (path-based access and `examples/e2b-dev-sidecar`), and lists the two pieces of state that do not survive `wsl --shutdown` (the loopback XFS mount and `resolv.conf`).

## Environment used for verification

| Item | Value |
|---|---|
| Cube Sandbox | v0.6.0 (`cubemastercli` `8721dd15`, built 2026-07-24) |
| Deployment | one-click, single node |
| Distro | Ubuntu 24.04.4 LTS on WSL2 |
| Host kernel | `6.18.33.2-microsoft-standard-WSL2` |
| glibc | 2.39 |
| `/data/cubelet` | loopback XFS, `reflink=1` |

Deployment screenshots and logs from that run are attached to [#1238](https://github.com/TencentCloud/CubeSandbox/pull/1238) (14 systemd units active, template `READY`, guest kernel `6.6.1199` vs host `6.18.33.2`).

## Checklist

- [x] Both language files added with the same slug
- [x] Index row added in both `docs/guide/troubleshooting/index.md` and `docs/zh/guide/troubleshooting/index.md`
- [x] Follows `_template.md` section structure (Symptom / Environment / Root Cause / Resolution / References)
- [x] Frontmatter keys aligned across both files (`title`, `author`, `date`, `tags`, `lang`)
- [x] All six relative links verified to exist
- [x] The quoted `online-install.sh` snippet matches upstream (marked as an excerpt)
- [x] Files are LF-only; index diffs are one added line each
- [x] DCO signed off

Happy to adjust the wording, section split, or file placement if you would prefer this merged into `deployment.md` instead of a standalone page.
