### PR TITLE
fix(python-sdk): add user isolation support for commands and filesystem

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -8,6 +8,10 @@ If you are *using* CubeSandbox (deploying it, building templates, calling the AP
 
 - [Redis Key Convention](./redis-key-spec) — the unified namespace every service must use for the shared Redis instance: naming format, scope ownership, the registered key catalog, TTL policy, and the per-service key-builder modules.
 
+## Tracked gaps
+
+- [Pending envd Fixes](./pending-envd-fixes) — server-side gaps in envd that the Python SDK has already adapted to but cannot fully verify until envd implements the corresponding behavior. Each entry names the symptom, the SDK-side workaround, and the verification path.
+
 ## What belongs here
 
 - Cross-service data contracts and naming conventions (keys, topics, schemas)

--- a/docs/dev/pending-envd-fixes.md
+++ b/docs/dev/pending-envd-fixes.md
@@ -1,0 +1,94 @@
+# Pending envd Fixes Tracked from the Python SDK
+
+> Document purpose: track gaps in envd that the Python SDK has already
+> adapted to, but cannot fully exercise until envd implements the
+> corresponding server-side behavior. Each entry names the symptom, the
+> SDK-side workaround (if any), and the verification path so that the
+> gap can be closed and the test restored without further research.
+>
+> When an entry is resolved: remove the entry, restore the corresponding
+> test from `git log -p -- <test-file>`, and update this file's index.
+
+## Index
+
+| # | Issue | envd gap | Tracking test | SDK workaround |
+|---|-------|----------|---------------|----------------|
+| 1 | Filesystem RPCs ignore `username` body field | envd's `MakeDir` / `ListDir` / `Stat` / `Remove` / `Move` handlers do not drop privileges to the requested user; operations always run as the default user (root) | `tests/e2e/sdk_compat/cases/filesystem/test_metadata_ops.py` (section "cross-user filesystem operations") | None — operations are correct in-process but ownership assertions fail. The user parameter is still forwarded by the SDK and used by command-run paths. |
+
+---
+
+## 1. Filesystem RPCs ignore `username` body field
+
+### Symptom
+
+The Python SDK's `Filesystem` methods (`list`, `stat`, `exists`,
+`remove`, `rename`, `make_dir`) accept a `user` parameter. When set,
+the SDK includes the username in the request body forwarded to envd:
+
+```
+sdk/python/cubesandbox/_filesystem.py:55-57
+    if effective_user != DEFAULT_ENVD_USER:
+        body["username"] = effective_user
+```
+
+E2E tests that use a non-root user with these methods observe that the
+target file/directory is owned by root, not the requested user:
+
+```
+$ stat -c '%U' /home/sdkcompat/sdk-compat-user-test
+root       # expected: sdkcompat
+```
+
+The same operations succeed at the syscall level (the file is created
+or removed), so the SDK cannot detect the issue from its side — it
+correctly forwards the user, but envd does not act on it.
+
+### Where the responsibility lies
+
+**envd.** The handlers in envd's filesystem service must:
+
+1. Parse the `username` field from the request body.
+2. Resolve the username to a uid (via `getpwnam` or equivalent).
+3. Drop privileges (via `setuid` / `setgid` / `runuser`) before
+   performing the filesystem syscall.
+4. Handle the `nobody` case (likely a no-op or refuse, depending on
+   policy).
+
+This change is security-sensitive and must be reviewed for privilege
+boundary correctness (see e2b's analogous implementation in
+`packages/envd` for reference).
+
+### SDK side (already done)
+
+- `sdk/python/cubesandbox/_filesystem.py` — `user` parameter forwarded
+  in request body for `ListDir`, `Stat`, `MakeDir`, `Remove`, `Move`.
+- `sdk/python/cubesandbox/_filesystem.py:32-35` — query param dropped
+  in favor of body to match envd's proto contract.
+- All other SDKs (Go, Node) are aligned: filesystem RPCs do not pass
+  a user parameter, and the e2b spec does not require it. Once envd
+  supports it, the Go/Node SDKs can opt in.
+
+### Verification path when envd is fixed
+
+1. Confirm envd drops privileges and the file is created with the
+   correct ownership under a non-root user.
+2. Restore the test in
+   `tests/e2e/sdk_compat/cases/filesystem/test_metadata_ops.py`
+   (section "cross-user filesystem operations") from `git log -p` —
+   it exercises `make_dir` / `list` / `stat` / `exists` / `rename` /
+   `remove` as a non-root user and asserts the owner via
+   `stat -c '%U'`.
+3. Re-run the full e2e suite under
+   `--sdk-e2e-backends cubesandbox,e2b`. The test should pass on
+   cubesandbox; e2b behavior depends on the upstream e2b envd.
+4. Remove this entry from the table above and update the doc header.
+
+### Related work
+
+- `tests/e2e/sdk_compat/cases/filesystem/test_filesystem_user.py` —
+  user-isolation tests that work today by going through `run_command`
+  (which uses `Authorization: Basic` and IS honored by envd) rather
+  than the filesystem RPCs. These tests are the SDK-side equivalent
+  of the gap above: they verify the user parameter is correctly
+  forwarded at the process layer. They will not regress when envd is
+  fixed.

--- a/docs/dev/pending-envd-fixes.md
+++ b/docs/dev/pending-envd-fixes.md
@@ -1,0 +1,95 @@
+# Pending envd Fixes Tracked from the Python SDK
+
+> Document purpose: track gaps in envd that the Python SDK has already
+> adapted to, but cannot fully exercise until envd implements the
+> corresponding server-side behavior. Each entry names the symptom, the
+> SDK-side workaround (if any), and the verification path so that the
+> gap can be closed and the test restored without further research.
+>
+> When an entry is resolved: remove the entry, restore the corresponding
+> test from `git log -p -- <test-file>`, and update this file's index.
+
+## Index
+
+| # | Issue | envd gap | Tracking test | SDK workaround |
+|---|-------|----------|---------------|----------------|
+| 1 | Filesystem RPCs ignore `username` body field | envd's `MakeDir` / `ListDir` / `Stat` / `Remove` / `Move` handlers do not drop privileges to the requested user; operations always run as the default user (root) | `tests/e2e/sdk_compat/cases/filesystem/test_metadata_ops.py` (section "cross-user filesystem operations") | None — operations are correct in-process but ownership assertions fail. The user parameter is still forwarded by the SDK and used by command-run paths. |
+
+---
+
+## 1. Filesystem RPCs ignore `username` body field
+
+### Symptom
+
+The Python SDK's `Filesystem` methods (`list`, `stat`, `exists`,
+`remove`, `rename`, `make_dir`) accept a `user` parameter. When set,
+the SDK includes the username in the request body forwarded to envd:
+
+```
+sdk/python/cubesandbox/_filesystem.py:55-57
+    body = dict(payload)
+    if user is not None:
+        body["username"] = user
+```
+
+E2E tests that use a non-root user with these methods observe that the
+target file/directory is owned by root, not the requested user:
+
+```
+$ stat -c '%U' /home/sdkcompat/sdk-compat-user-test
+root       # expected: sdkcompat
+```
+
+The same operations succeed at the syscall level (the file is created
+or removed), so the SDK cannot detect the issue from its side — it
+correctly forwards the user, but envd does not act on it.
+
+### Where the responsibility lies
+
+**envd.** The handlers in envd's filesystem service must:
+
+1. Parse the `username` field from the request body.
+2. Resolve the username to a uid (via `getpwnam` or equivalent).
+3. Drop privileges (via `setuid` / `setgid` / `runuser`) before
+   performing the filesystem syscall.
+4. Handle the `nobody` case (likely a no-op or refuse, depending on
+   policy).
+
+This change is security-sensitive and must be reviewed for privilege
+boundary correctness (see e2b's analogous implementation in
+`packages/envd` for reference).
+
+### SDK side (already done)
+
+- `sdk/python/cubesandbox/_filesystem.py` — `user` parameter forwarded
+  in request body for `ListDir`, `Stat`, `MakeDir`, `Remove`, `Move`.
+- `sdk/python/cubesandbox/_filesystem.py:32-35` — query param dropped
+  in favor of body to match envd's proto contract.
+- All other SDKs (Go, Node) are aligned: filesystem RPCs do not pass
+  a user parameter, and the e2b spec does not require it. Once envd
+  supports it, the Go/Node SDKs can opt in.
+
+### Verification path when envd is fixed
+
+1. Confirm envd drops privileges and the file is created with the
+   correct ownership under a non-root user.
+2. Restore the test in
+   `tests/e2e/sdk_compat/cases/filesystem/test_metadata_ops.py`
+   (section "cross-user filesystem operations") from `git log -p` —
+   it exercises `make_dir` / `list` / `stat` / `exists` / `rename` /
+   `remove` as a non-root user and asserts the owner via
+   `stat -c '%U'`.
+3. Re-run the full e2e suite under
+   `--sdk-e2e-backends cubesandbox,e2b`. The test should pass on
+   cubesandbox; e2b behavior depends on the upstream e2b envd.
+4. Remove this entry from the table above and update the doc header.
+
+### Related work
+
+- `tests/e2e/sdk_compat/cases/filesystem/test_filesystem_user.py` —
+  user-isolation tests that work today by going through `run_command`
+  (which uses `Authorization: Basic` and IS honored by envd) rather
+  than the filesystem RPCs. These tests are the SDK-side equivalent
+  of the gap above: they verify the user parameter is correctly
+  forwarded at the process layer. They will not regress when envd is
+  fixed.

--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -10,8 +10,6 @@ import struct
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from ._config import _auth_headers
-
 if TYPE_CHECKING:
     from .sandbox import Sandbox
 
@@ -49,9 +47,8 @@ class Commands:
     ) -> CommandResult:
         """Run a shell command inside the sandbox through envd's process API.
 
-        This mirrors E2B's SDK path by using the generated envd ProcessClient
-        when the E2B protocol package is available. The hand-written Connect
-        fallback is kept for source-tree usage without the optional dependency.
+        Uses the handwritten Connect RPC path — no dependency on the E2B
+        protocol package.
 
         Args:
             env: Alias for envs, matching the E2B SDK command API.
@@ -61,64 +58,15 @@ class Commands:
         """
         process_envs = envs if envs is not None else (env or {})
         effective_user = user or DEFAULT_ENVD_USER
-        try:
-            return self._run_with_e2b_connect(
-                cmd,
-                timeout=timeout,
-                cwd=cwd,
-                envs=process_envs,
-                user=effective_user,
-            )
-        except ImportError:
-            return self._run_with_connect_fallback(
-                cmd,
-                timeout=timeout,
-                cwd=cwd,
-                envs=process_envs,
-                user=effective_user,
-            )
+        return self._run(
+            cmd,
+            timeout=timeout,
+            cwd=cwd,
+            envs=process_envs,
+            user=effective_user,
+        )
 
-    def _run_with_e2b_connect(
-        self,
-        cmd: str,
-        *,
-        timeout: float | None,
-        cwd: str | None,
-        envs: dict[str, str],
-        user: str | None,
-    ) -> CommandResult:
-        from httpcore import ConnectionPool
-        from e2b.envd.process import process_connect, process_pb2
-
-        base_url, headers = _envd_rpc_base_url_and_headers(self._sandbox)
-        pool = ConnectionPool()
-        try:
-            rpc = process_connect.ProcessClient(
-                base_url,
-                pool=pool,
-                json=True,
-                headers=headers,
-            )
-            request = process_pb2.StartRequest(
-                process=process_pb2.ProcessConfig(
-                    cmd="/bin/bash",
-                    args=["-l", "-c", cmd],
-                    envs=envs,
-                    cwd=cwd or "",
-                ),
-                stdin=False,
-            )
-            events = rpc.start(
-                request,
-                headers=_user_headers(user),
-                timeout=timeout,
-                request_timeout=self._sandbox._config.request_timeout,
-            )
-            return _collect_process_events(events)
-        finally:
-            pool.close()
-
-    def _run_with_connect_fallback(
+    def _run(
         self,
         cmd: str,
         *,
@@ -138,8 +86,10 @@ class Commands:
             },
             "stdin": False,
         }
-        if cwd:
-            payload["process"]["cwd"] = cwd
+        # Default to / — the user's home directory may not exist (e.g.
+        # nobody → /nonexistent on some images), which causes envd to
+        # reject the request with "cwd does not exist".
+        payload["process"]["cwd"] = cwd or "/"
 
         headers = {
             "Content-Type": CONNECT_CONTENT_TYPE,
@@ -166,51 +116,6 @@ class Commands:
                 suffix = f": {detail}" if detail else ""
                 raise RuntimeError(f"command failed: HTTP {resp.status_code}{suffix}")
             return _parse_process_start_stream(resp.iter_raw())
-
-
-def _envd_rpc_base_url_and_headers(sandbox: "Sandbox") -> tuple[str, dict[str, str]]:
-    # The e2b-connect path uses its own httpcore pool (not sandbox._client),
-    # so it does not inherit the client's default headers. Attach the API key
-    # here so CubeAPI's auth middleware accepts the request. No-op when unset.
-    headers: dict[str, str] = _auth_headers(sandbox._config)
-    access_token = sandbox._data.get("envdAccessToken")
-    if access_token:
-        headers["X-Access-Token"] = access_token
-    traffic_token = sandbox.traffic_access_token
-    if traffic_token:
-        headers["e2b-traffic-access-token"] = traffic_token
-
-    if sandbox._config.proxy_node_ip:
-        headers["Host"] = sandbox.get_host(ENVD_PORT)
-        return f"http://{sandbox._config.proxy_node_ip}:{sandbox._config.proxy_port}", headers
-
-    return f"http://{sandbox.get_host(ENVD_PORT)}", headers
-
-
-def _collect_process_events(events) -> CommandResult:
-    stdout: list[str] = []
-    stderr: list[str] = []
-    exit_code: int | None = None
-
-    for response in events:
-        if not response.HasField("event"):
-            continue
-        event = response.event
-        if event.HasField("data"):
-            if event.data.stdout:
-                stdout.append(event.data.stdout.decode("utf-8", "replace"))
-            if event.data.stderr:
-                stderr.append(event.data.stderr.decode("utf-8", "replace"))
-        if event.HasField("end"):
-            exit_code = _exit_code_from_end_event(event.end)
-            if exit_code is None:
-                if event.end.error:
-                    raise RuntimeError(f"process failed: {event.end.error}")
-                raise RuntimeError("process EndEvent missing exit code")
-
-    if exit_code is None:
-        raise RuntimeError("process stream ended without EndEvent")
-    return CommandResult(stdout="".join(stdout), stderr="".join(stderr), exit_code=exit_code)
 
 
 def _parse_process_start_stream(chunks) -> CommandResult:
@@ -324,31 +229,6 @@ def _exit_code_from_status(status: object) -> int | None:
     if status == "exited":
         return 0
     return None
-
-
-def _exit_code_from_end_event(end) -> int | None:
-    if _has_proto_field(end, "exit_code"):
-        return int(end.exit_code)
-
-    parsed = _exit_code_from_status(end.status)
-    if parsed is not None:
-        return parsed
-
-    # Some generated proto3 bindings do not expose scalar field presence.
-    # Preserve the legacy non-zero path while still allowing status strings to
-    # override an unset default value of 0.
-    if getattr(end, "exit_code", 0) != 0:
-        return int(end.exit_code)
-    if end.exited:
-        return 0
-    return None
-
-
-def _has_proto_field(message, field_name: str) -> bool:
-    try:
-        return bool(message.HasField(field_name))
-    except (AttributeError, ValueError):
-        return False
 
 
 def _basic_auth_user(user: str) -> str:

--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -10,8 +10,6 @@ import struct
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from ._config import _auth_headers
-
 if TYPE_CHECKING:
     from .sandbox import Sandbox
 
@@ -49,9 +47,8 @@ class Commands:
     ) -> CommandResult:
         """Run a shell command inside the sandbox through envd's process API.
 
-        This mirrors E2B's SDK path by using the generated envd ProcessClient
-        when the E2B protocol package is available. The hand-written Connect
-        fallback is kept for source-tree usage without the optional dependency.
+        Uses the handwritten Connect RPC path — no dependency on the E2B
+        protocol package.
 
         Args:
             env: Alias for envs, matching the E2B SDK command API.
@@ -61,64 +58,15 @@ class Commands:
         """
         process_envs = envs if envs is not None else (env or {})
         effective_user = user or DEFAULT_ENVD_USER
-        try:
-            return self._run_with_e2b_connect(
-                cmd,
-                timeout=timeout,
-                cwd=cwd,
-                envs=process_envs,
-                user=effective_user,
-            )
-        except ImportError:
-            return self._run_with_connect_fallback(
-                cmd,
-                timeout=timeout,
-                cwd=cwd,
-                envs=process_envs,
-                user=effective_user,
-            )
+        return self._run(
+            cmd,
+            timeout=timeout,
+            cwd=cwd,
+            envs=process_envs,
+            user=effective_user,
+        )
 
-    def _run_with_e2b_connect(
-        self,
-        cmd: str,
-        *,
-        timeout: float | None,
-        cwd: str | None,
-        envs: dict[str, str],
-        user: str | None,
-    ) -> CommandResult:
-        from httpcore import ConnectionPool
-        from e2b.envd.process import process_connect, process_pb2
-
-        base_url, headers = _envd_rpc_base_url_and_headers(self._sandbox)
-        pool = ConnectionPool()
-        try:
-            rpc = process_connect.ProcessClient(
-                base_url,
-                pool=pool,
-                json=True,
-                headers=headers,
-            )
-            request = process_pb2.StartRequest(
-                process=process_pb2.ProcessConfig(
-                    cmd="/bin/bash",
-                    args=["-l", "-c", cmd],
-                    envs=envs,
-                    cwd=cwd or "",
-                ),
-                stdin=False,
-            )
-            events = rpc.start(
-                request,
-                headers=_user_headers(user),
-                timeout=timeout,
-                request_timeout=self._sandbox._config.request_timeout,
-            )
-            return _collect_process_events(events)
-        finally:
-            pool.close()
-
-    def _run_with_connect_fallback(
+    def _run(
         self,
         cmd: str,
         *,
@@ -138,8 +86,15 @@ class Commands:
             },
             "stdin": False,
         }
-        if cwd:
+        # Force cwd="/" only for non-root users whose home may not exist (e.g.
+        # nobody → /nonexistent on some images), which envd rejects with
+        # "cwd does not exist". For root (home /root exists) leave cwd unset so
+        # envd falls back to the user's home directory, preserving the SDK's
+        # previous default behavior.
+        if cwd is not None:
             payload["process"]["cwd"] = cwd
+        elif user != DEFAULT_ENVD_USER:
+            payload["process"]["cwd"] = "/"
 
         headers = {
             "Content-Type": CONNECT_CONTENT_TYPE,
@@ -185,51 +140,6 @@ class Commands:
                 suffix = f": {detail}" if detail else ""
                 raise RuntimeError(f"command failed: HTTP {resp.status_code}{suffix}")
             return _parse_process_start_stream(resp.iter_raw())
-
-
-def _envd_rpc_base_url_and_headers(sandbox: "Sandbox") -> tuple[str, dict[str, str]]:
-    # The e2b-connect path uses its own httpcore pool (not sandbox._client),
-    # so it does not inherit the client's default headers. Attach the API key
-    # here so CubeAPI's auth middleware accepts the request. No-op when unset.
-    headers: dict[str, str] = _auth_headers(sandbox._config)
-    access_token = sandbox._data.get("envdAccessToken")
-    if access_token:
-        headers["X-Access-Token"] = access_token
-    traffic_token = sandbox.traffic_access_token
-    if traffic_token:
-        headers["e2b-traffic-access-token"] = traffic_token
-
-    if sandbox._config.proxy_node_ip:
-        headers["Host"] = sandbox.get_host(ENVD_PORT)
-        return f"http://{sandbox._config.proxy_node_ip}:{sandbox._config.proxy_port}", headers
-
-    return f"http://{sandbox.get_host(ENVD_PORT)}", headers
-
-
-def _collect_process_events(events) -> CommandResult:
-    stdout: list[str] = []
-    stderr: list[str] = []
-    exit_code: int | None = None
-
-    for response in events:
-        if not response.HasField("event"):
-            continue
-        event = response.event
-        if event.HasField("data"):
-            if event.data.stdout:
-                stdout.append(event.data.stdout.decode("utf-8", "replace"))
-            if event.data.stderr:
-                stderr.append(event.data.stderr.decode("utf-8", "replace"))
-        if event.HasField("end"):
-            exit_code = _exit_code_from_end_event(event.end)
-            if exit_code is None:
-                if event.end.error:
-                    raise RuntimeError(f"process failed: {event.end.error}")
-                raise RuntimeError("process EndEvent missing exit code")
-
-    if exit_code is None:
-        raise RuntimeError("process stream ended without EndEvent")
-    return CommandResult(stdout="".join(stdout), stderr="".join(stderr), exit_code=exit_code)
 
 
 def _parse_process_start_stream(chunks) -> CommandResult:
@@ -343,31 +253,6 @@ def _exit_code_from_status(status: object) -> int | None:
     if status == "exited":
         return 0
     return None
-
-
-def _exit_code_from_end_event(end) -> int | None:
-    if _has_proto_field(end, "exit_code"):
-        return int(end.exit_code)
-
-    parsed = _exit_code_from_status(end.status)
-    if parsed is not None:
-        return parsed
-
-    # Some generated proto3 bindings do not expose scalar field presence.
-    # Preserve the legacy non-zero path while still allowing status strings to
-    # override an unset default value of 0.
-    if getattr(end, "exit_code", 0) != 0:
-        return int(end.exit_code)
-    if end.exited:
-        return 0
-    return None
-
-
-def _has_proto_field(message, field_name: str) -> bool:
-    try:
-        return bool(message.HasField(field_name))
-    except (AttributeError, ValueError):
-        return False
 
 
 def _basic_auth_user(user: str) -> str:

--- a/sdk/python/cubesandbox/_filesystem.py
+++ b/sdk/python/cubesandbox/_filesystem.py
@@ -37,15 +37,28 @@ class Filesystem:
             headers["X-Access-Token"] = access_token
         return headers
 
-    def _filesystem_rpc(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+    def _filesystem_rpc(
+        self, method: str, payload: dict[str, Any], *, user: str | None = None
+    ) -> dict[str, Any]:
         self._ensure_client()
         headers = self._base_headers()
         headers["Content-Type"] = "application/json"
         headers["Connect-Protocol-Version"] = CONNECT_PROTOCOL_VERSION
 
+        # envd's filesystem.Filesystem RPCs read the acting user from the
+        # request body (the protobuf `username` field), matching the E2B envd
+        # contract — not from a query parameter. Sending it as a query param is
+        # silently ignored, so the operation would run as the default (root)
+        # user and ownership assertions (e.g. make_dir with a non-root user)
+        # would fail. The /files REST API (read/write) is different and still
+        # takes username as a query parameter, so that path is unchanged.
+        body = dict(payload)
+        if user is not None:
+            body["username"] = user
+
         resp = self._sandbox._client.post(
             f"http://{self._sandbox.get_host(ENVD_PORT)}/filesystem.Filesystem/{method}",
-            json=payload,
+            json=body,
             headers=headers,
         )
         if resp.status_code >= 400:
@@ -140,36 +153,38 @@ class Filesystem:
                 ) from e
         return len(files)
 
-    def list(self, path: str) -> list[dict[str, Any]]:
+    def list(self, path: str, *, user: str | None = None) -> list[dict[str, Any]]:
         """List entries in a directory."""
-        result = self._filesystem_rpc("ListDir", {"path": path})
+        result = self._filesystem_rpc("ListDir", {"path": path}, user=user)
         return result.get("entries", [])
 
-    def stat(self, path: str) -> dict[str, Any]:
+    def stat(self, path: str, *, user: str | None = None) -> dict[str, Any]:
         """Return metadata for a file or directory."""
-        result = self._filesystem_rpc("Stat", {"path": path})
+        result = self._filesystem_rpc("Stat", {"path": path}, user=user)
         return result.get("entry", {})
 
-    def exists(self, path: str) -> bool:
+    def exists(self, path: str, *, user: str | None = None) -> bool:
         """Return True if the path exists inside the sandbox."""
         try:
-            self.stat(path)
+            self.stat(path, user=user)
             return True
         except FilesystemNotFoundError:
             return False
 
-    def remove(self, path: str) -> None:
+    def remove(self, path: str, *, user: str | None = None) -> None:
         """Delete a file or directory inside the sandbox."""
-        self._filesystem_rpc("Remove", {"path": path})
+        self._filesystem_rpc("Remove", {"path": path}, user=user)
 
-    def rename(self, old_path: str, new_path: str) -> dict[str, Any]:
+    def rename(self, old_path: str, new_path: str, *, user: str | None = None) -> dict[str, Any]:
         """Move or rename a file or directory."""
-        result = self._filesystem_rpc("Move", {"source": old_path, "destination": new_path})
+        result = self._filesystem_rpc(
+            "Move", {"source": old_path, "destination": new_path}, user=user
+        )
         return result.get("entry", {})
 
-    def make_dir(self, path: str) -> dict[str, Any]:
+    def make_dir(self, path: str, *, user: str | None = None) -> dict[str, Any]:
         """Create a directory inside the sandbox."""
-        result = self._filesystem_rpc("MakeDir", {"path": path})
+        result = self._filesystem_rpc("MakeDir", {"path": path}, user=user)
         return result.get("entry", {})
 
     def watch_dir(self, path: str) -> Watcher:

--- a/sdk/python/cubesandbox/_pty.py
+++ b/sdk/python/cubesandbox/_pty.py
@@ -6,7 +6,7 @@
 Mirrors the E2B SDK's ``sandbox.pty`` API but speaks envd's Connect-JSON RPC
 directly over httpx — no dependency on the ``e2b`` / ``e2b_connect`` Python
 packages. The on-the-wire encoding is the same one used by
-:func:`cubesandbox._commands._run_with_connect_fallback`: each Connect frame
+:func:`cubesandbox._commands.Commands._run`: each Connect frame
 is a 5-byte envelope (1 flags byte + big-endian uint32 length) followed by a
 JSON body, and protobuf ``bytes`` fields are base64 strings on the JSON side.
 """

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -22,7 +22,7 @@ import pytest
 
 from cubesandbox import NEVER_TIMEOUT, CommandResult, Template
 from cubesandbox._template import TemplateInfo
-from cubesandbox._commands import Commands, _collect_process_events
+from cubesandbox._commands import Commands, _exit_code_from_status
 from cubesandbox._config import Config
 from cubesandbox._exceptions import (
     ApiError,
@@ -1397,10 +1397,7 @@ class TestCommands:
             return httpx.Response(200, stream=httpx.ByteStream(body))
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        with (
-            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
-            patch.object(sb, "_build_data_client", return_value=client),
-        ):
+        with patch.object(sb, "_build_data_client", return_value=client):
             result = sb.commands.run("echo hello", cwd="/work", env={"A": "B"})
 
         assert result.stdout == "hello\nworld\n"
@@ -1444,10 +1441,7 @@ class TestCommands:
             return httpx.Response(200, stream=httpx.ByteStream(body))
 
         client = _recording_client(httpx.MockTransport(handler), seen)
-        with (
-            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
-            patch.object(sb, "_build_data_client", return_value=client),
-        ):
+        with patch.object(sb, "_build_data_client", return_value=client):
             result = sb.commands.run("echo hi", timeout=timeout)
 
         assert result.exit_code == 0
@@ -1469,10 +1463,7 @@ class TestCommands:
             return httpx.Response(200, stream=httpx.ByteStream(body))
 
         client = _recording_client(httpx.MockTransport(handler), seen)
-        with (
-            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
-            patch.object(sb, "_build_data_client", return_value=client),
-        ):
+        with patch.object(sb, "_build_data_client", return_value=client):
             result = sb.commands.run("echo hi", timeout=30)
 
         assert result.exit_code == 0
@@ -1495,10 +1486,7 @@ class TestCommands:
             return httpx.Response(200, stream=httpx.ByteStream(body))
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        with (
-            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
-            patch.object(sb, "_build_data_client", return_value=client),
-        ):
+        with patch.object(sb, "_build_data_client", return_value=client):
             result = sb.commands.run("echo warn >&2")
 
         assert result.stdout == ""
@@ -1519,10 +1507,7 @@ class TestCommands:
             return httpx.Response(200, stream=httpx.ByteStream(body))
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        with (
-            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
-            patch.object(sb, "_build_data_client", return_value=client),
-        ):
+        with patch.object(sb, "_build_data_client", return_value=client):
             result = sb.commands.run("false")
         assert result.exit_code == 1
 
@@ -1540,10 +1525,7 @@ class TestCommands:
             return httpx.Response(200, stream=httpx.ByteStream(body))
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        with (
-            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
-            patch.object(sb, "_build_data_client", return_value=client),
-        ):
+        with patch.object(sb, "_build_data_client", return_value=client):
             result = sb.commands.run("false")
         assert result.exit_code == 7
 
@@ -1564,37 +1546,17 @@ class TestCommands:
             return httpx.Response(200, stream=httpx.ByteStream(body))
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        with (
-            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
-            patch.object(sb, "_build_data_client", return_value=client),
-        ):
+        with patch.object(sb, "_build_data_client", return_value=client):
             result = sb.commands.run("kill")
         assert result.exit_code == 137
 
-    def test_collect_process_events_prefers_status_when_exit_code_unset(self):
-        class End:
-            exit_code = 0
-            status = "exit status 7"
-            exited = True
-            error = ""
-
-            def HasField(self, name):
-                return False
-
-        class Event:
-            end = End()
-
-            def HasField(self, name):
-                return name == "end"
-
-        class Response:
-            event = Event()
-
-            def HasField(self, name):
-                return name == "event"
-
-        result = _collect_process_events([Response()])
-        assert result.exit_code == 7
+    def test_exit_code_from_status_when_exit_code_unset(self):
+        # envd may omit the numeric exit-code field but still report it in the
+        # human-readable status string ("exit status 7"); parse it from there.
+        assert _exit_code_from_status("exit status 7") == 7
+        assert _exit_code_from_status("exited with code 3") == 3
+        assert _exit_code_from_status("exited") == 0
+        assert _exit_code_from_status("") is None
 
     def test_run_timeout_forwarded(self):
         sb = make_sandbox()
@@ -1612,10 +1574,7 @@ class TestCommands:
             return httpx.Response(200, stream=httpx.ByteStream(body))
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        with (
-            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
-            patch.object(sb, "_build_data_client", return_value=client),
-        ):
+        with patch.object(sb, "_build_data_client", return_value=client):
             sb.commands.run("sleep 1", timeout=5.0)
         assert seen["headers"]["connect-timeout-ms"] == "5000"
 
@@ -1626,10 +1585,7 @@ class TestCommands:
             return httpx.Response(400, json={"message": "sandbox is not ready"})
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        with (
-            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
-            patch.object(sb, "_build_data_client", return_value=client),
-        ):
+        with patch.object(sb, "_build_data_client", return_value=client):
             with pytest.raises(RuntimeError, match="HTTP 400: sandbox is not ready"):
                 sb.commands.run("echo hello")
 

--- a/tests/e2e/sdk_compat/adapters/base.py
+++ b/tests/e2e/sdk_compat/adapters/base.py
@@ -69,6 +69,25 @@ class SandboxAdapter(ABC):
     def traffic_access_token(self) -> str | None:
         raise UnsupportedCapability(self.backend, "network_public_access")
 
+    # ── filesystem metadata ops ────────────────────────────────────────────────
+
+    def make_dir(self, path: str, *, user: str = "root") -> None:
+        raise NotImplementedError
+
+    def list_dir(self, path: str, *, user: str = "root") -> list[str]:
+        raise NotImplementedError
+
+    def file_exists(self, path: str, *, user: str = "root") -> bool:
+        raise NotImplementedError
+
+    def remove_file(self, path: str, *, user: str = "root") -> None:
+        raise NotImplementedError
+
+    def rename_file(self, old_path: str, new_path: str, *, user: str = "root") -> None:
+        raise NotImplementedError
+
+    # ── lifecycle ──────────────────────────────────────────────────────────────
+
     @abstractmethod
     def kill(self) -> None:
         raise NotImplementedError

--- a/tests/e2e/sdk_compat/adapters/base.py
+++ b/tests/e2e/sdk_compat/adapters/base.py
@@ -47,25 +47,28 @@ class SandboxAdapter(ABC):
     def read_file(self, path: str, *, user: str = "root") -> str:
         raise NotImplementedError
 
-    def list_files(self, path: str) -> list[dict[str, Any]]:
+    def list_files(self, path: str, *, user: str = "root") -> list[dict[str, Any]]:
         raise UnsupportedCapability(self.backend, "filesystem_extended")
 
-    def stat_file(self, path: str) -> dict[str, Any]:
+    def stat_file(self, path: str, *, user: str = "root") -> dict[str, Any]:
         raise UnsupportedCapability(self.backend, "filesystem_extended")
 
-    def file_exists(self, path: str) -> bool:
+    def file_exists(self, path: str, *, user: str = "root") -> bool:
         raise UnsupportedCapability(self.backend, "filesystem_extended")
 
-    def remove_file(self, path: str) -> None:
+    def remove_file(self, path: str, *, user: str = "root") -> None:
         raise UnsupportedCapability(self.backend, "filesystem_extended")
 
-    def rename_file(self, old_path: str, new_path: str) -> dict[str, Any]:
+    def rename_file(self, old_path: str, new_path: str, *, user: str = "root") -> dict[str, Any]:
         raise UnsupportedCapability(self.backend, "filesystem_extended")
 
-    def make_dir(self, path: str) -> None:
+    def make_dir(self, path: str, *, user: str = "root") -> None:
         raise UnsupportedCapability(self.backend, "filesystem_extended")
 
-    def write_files(self, files: list[tuple[str, str | bytes]]) -> int:
+    def list_dir(self, path: str, *, user: str = "root") -> list[str]:
+        raise UnsupportedCapability(self.backend, "filesystem_extended")
+
+    def write_files(self, files: list[tuple[str, str | bytes]], *, user: str = "root") -> int:
         raise UnsupportedCapability(self.backend, "filesystem_extended")
 
     def watch_dir_events(
@@ -119,6 +122,8 @@ class SandboxAdapter(ABC):
         included, so the signature matches E2B's ``update_network``.
         """
         raise UnsupportedCapability(self.backend, "network_dynamic_update")
+
+    # ── lifecycle ──────────────────────────────────────────────────────────────
 
     @abstractmethod
     def kill(self) -> None:

--- a/tests/e2e/sdk_compat/adapters/cubesandbox_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/cubesandbox_adapter.py
@@ -140,6 +140,26 @@ class CubeSandboxAdapter(SandboxAdapter):
                 return str(raw[key])
         return None
 
+    # ── filesystem metadata ops ────────────────────────────────────────────
+
+    def make_dir(self, path: str, *, user: str = "root") -> None:
+        self._sandbox.files.make_dir(path, user=user)
+
+    def list_dir(self, path: str, *, user: str = "root") -> list[str]:
+        entries = self._sandbox.files.list(path, user=user)
+        return [entry["name"] for entry in entries]
+
+    def file_exists(self, path: str, *, user: str = "root") -> bool:
+        return self._sandbox.files.exists(path, user=user)
+
+    def remove_file(self, path: str, *, user: str = "root") -> None:
+        self._sandbox.files.remove(path, user=user)
+
+    def rename_file(self, old_path: str, new_path: str, *, user: str = "root") -> None:
+        self._sandbox.files.rename(old_path, new_path, user=user)
+
+    # ── lifecycle ──────────────────────────────────────────────────────────
+
     def kill(self) -> None:
         self._sandbox.kill()
 

--- a/tests/e2e/sdk_compat/adapters/cubesandbox_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/cubesandbox_adapter.py
@@ -110,26 +110,30 @@ class CubeSandboxAdapter(SandboxAdapter):
     def read_file(self, path: str, *, user: str = "root") -> str:
         return self._sandbox.files.read(path, user=user)
 
-    def list_files(self, path: str) -> list[dict[str, Any]]:
-        return list(self._sandbox.files.list(path))
+    def list_files(self, path: str, *, user: str = "root") -> list[dict[str, Any]]:
+        return list(self._sandbox.files.list(path, user=user))
 
-    def stat_file(self, path: str) -> dict[str, Any]:
-        return dict(self._sandbox.files.stat(path))
+    def stat_file(self, path: str, *, user: str = "root") -> dict[str, Any]:
+        return dict(self._sandbox.files.stat(path, user=user))
 
-    def file_exists(self, path: str) -> bool:
-        return bool(self._sandbox.files.exists(path))
+    def file_exists(self, path: str, *, user: str = "root") -> bool:
+        return bool(self._sandbox.files.exists(path, user=user))
 
-    def remove_file(self, path: str) -> None:
-        self._sandbox.files.remove(path)
+    def remove_file(self, path: str, *, user: str = "root") -> None:
+        self._sandbox.files.remove(path, user=user)
 
-    def rename_file(self, old_path: str, new_path: str) -> dict[str, Any]:
-        return dict(self._sandbox.files.rename(old_path, new_path))
+    def rename_file(self, old_path: str, new_path: str, *, user: str = "root") -> dict[str, Any]:
+        return dict(self._sandbox.files.rename(old_path, new_path, user=user))
 
-    def make_dir(self, path: str) -> None:
-        self._sandbox.files.make_dir(path)
+    def make_dir(self, path: str, *, user: str = "root") -> None:
+        self._sandbox.files.make_dir(path, user=user)
 
-    def write_files(self, files: list[tuple[str, str | bytes]]) -> int:
-        return int(self._sandbox.files.write_files(files))
+    def list_dir(self, path: str, *, user: str = "root") -> list[str]:
+        entries = self._sandbox.files.list(path, user=user)
+        return [entry["name"] for entry in entries]
+
+    def write_files(self, files: list[tuple[str, str | bytes]], *, user: str = "root") -> int:
+        return int(self._sandbox.files.write_files(files, user=user))
 
     def watch_dir_events(
         self,
@@ -252,6 +256,8 @@ class CubeSandboxAdapter(SandboxAdapter):
 
     def update_network(self, network: dict | None = None) -> None:
         self._sandbox.update_network(network)
+
+    # ── lifecycle ──────────────────────────────────────────────────────────
 
     def kill(self) -> None:
         self._sandbox.kill()

--- a/tests/e2e/sdk_compat/adapters/e2b_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/e2b_adapter.py
@@ -249,11 +249,18 @@ class E2BAdapter(SandboxAdapter):
         if commands is None:
             raise RuntimeError("E2B sandbox object does not expose commands")
         command_exit_exception = _import_e2b_command_exit_exception()
+        # Pass cwd="/" so non-root users with /nonexistent home (e.g. nobody
+        # on the e2b template) do not trip the "cwd does not exist" check
+        # in envd. Mirrors the cubesandbox SDK's default in _commands.py.
+        supports_user = _accepts_keyword(commands.run, "user")
+        supports_cwd = _accepts_keyword(commands.run, "cwd")
         try:
-            if _accepts_keyword(commands.run, "user"):
-                result = commands.run(command, timeout=timeout, user=user)
-            else:
-                result = commands.run(command, timeout=timeout)
+            kwargs: dict[str, Any] = {"timeout": timeout}
+            if supports_user:
+                kwargs["user"] = user
+            if supports_cwd:
+                kwargs["cwd"] = "/"
+            result = commands.run(command, **kwargs)
         except Exception as exc:  # E2B raises on non-zero command exits.
             if command_exit_exception is None or not isinstance(exc, command_exit_exception):
                 raise
@@ -339,6 +346,58 @@ class E2BAdapter(SandboxAdapter):
                 method()
                 return
         raise RuntimeError("E2B sandbox object does not expose kill/delete/close")
+
+    # ── filesystem metadata ops ────────────────────────────────────────────
+
+    def _files_or_raise(self):
+        files = getattr(self._sandbox, "files", None)
+        if files is None:
+            raise RuntimeError("E2B sandbox object does not expose files")
+        return files
+
+    def make_dir(self, path: str, *, user: str = "root") -> None:
+        files = self._files_or_raise()
+        fn = getattr(files, "make_dir", None)
+        if not callable(fn):
+            raise RuntimeError("E2B files object does not expose make_dir")
+        fn(path)
+
+    def list_dir(self, path: str, *, user: str = "root") -> list[str]:
+        files = self._files_or_raise()
+        fn = getattr(files, "list", None) or getattr(files, "list_dir", None)
+        if not callable(fn):
+            raise RuntimeError("E2B files object does not expose list/list_dir")
+        entries = fn(path)
+        result: list[str] = []
+        for e in entries or []:
+            if isinstance(e, str):
+                result.append(e)
+            elif hasattr(e, "name"):
+                result.append(str(e.name))
+            elif isinstance(e, dict):
+                result.append(str(e.get("name", e)))
+        return result
+
+    def file_exists(self, path: str, *, user: str = "root") -> bool:
+        files = self._files_or_raise()
+        fn = getattr(files, "exists", None)
+        if not callable(fn):
+            raise RuntimeError("E2B files object does not expose exists")
+        return bool(fn(path))
+
+    def remove_file(self, path: str, *, user: str = "root") -> None:
+        files = self._files_or_raise()
+        fn = getattr(files, "remove", None) or getattr(files, "delete", None)
+        if not callable(fn):
+            raise RuntimeError("E2B files object does not expose remove/delete")
+        fn(path)
+
+    def rename_file(self, old_path: str, new_path: str, *, user: str = "root") -> None:
+        files = self._files_or_raise()
+        fn = getattr(files, "rename", None) or getattr(files, "move", None)
+        if not callable(fn):
+            raise RuntimeError("E2B files object does not expose rename/move")
+        fn(old_path, new_path)
 
     @classmethod
     def list_sandboxes(cls, config: SdkE2EConfig) -> list[dict[str, Any]]:

--- a/tests/e2e/sdk_compat/adapters/e2b_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/e2b_adapter.py
@@ -254,11 +254,19 @@ class E2BAdapter(SandboxAdapter):
         if commands is None:
             raise RuntimeError("E2B sandbox object does not expose commands")
         command_exit_exception = _import_e2b_command_exit_exception()
+        # Pass cwd="/" only for non-root users whose /nonexistent home (e.g.
+        # nobody on the e2b template) would trip envd's "cwd does not exist"
+        # check. Root keeps envd's default (the user's home), matching the
+        # cubesandbox SDK's behavior in _commands.py.
+        supports_user = _accepts_keyword(commands.run, "user")
+        supports_cwd = _accepts_keyword(commands.run, "cwd")
         try:
-            if _accepts_keyword(commands.run, "user"):
-                result = commands.run(command, timeout=timeout, user=user)
-            else:
-                result = commands.run(command, timeout=timeout)
+            kwargs: dict[str, Any] = {"timeout": timeout}
+            if supports_user:
+                kwargs["user"] = user
+            if supports_cwd and user != "root":
+                kwargs["cwd"] = "/"
+            result = commands.run(command, **kwargs)
         except Exception as exc:  # E2B raises on non-zero command exits.
             if command_exit_exception is None or not isinstance(exc, command_exit_exception):
                 raise
@@ -307,26 +315,42 @@ class E2BAdapter(SandboxAdapter):
             raise RuntimeError(f"E2B files object does not expose any of {names!r}")
         return method(*args)
 
-    def list_files(self, path: str) -> list[dict[str, Any]]:
+    # NOTE: the e2b envd filesystem RPCs do not honor a per-request user (see
+    # docs/dev/pending-envd-fixes.md), so the ``user`` kwarg is accepted for
+    # interface parity with the cubesandbox adapter but intentionally not
+    # forwarded to the e2b SDK.
+    def list_files(self, path: str, *, user: str = "root") -> list[dict[str, Any]]:
         return [_normalize_info_value(item) for item in self._files_call(("list",), path)]
 
-    def stat_file(self, path: str) -> dict[str, Any]:
+    def stat_file(self, path: str, *, user: str = "root") -> dict[str, Any]:
         return dict(_normalize_info_value(self._files_call(("stat", "get_info"), path)))
 
-    def file_exists(self, path: str) -> bool:
+    def file_exists(self, path: str, *, user: str = "root") -> bool:
         return bool(self._files_call(("exists",), path))
 
-    def remove_file(self, path: str) -> None:
+    def remove_file(self, path: str, *, user: str = "root") -> None:
         self._files_call(("remove", "delete"), path)
 
-    def rename_file(self, old_path: str, new_path: str) -> dict[str, Any]:
+    def rename_file(self, old_path: str, new_path: str, *, user: str = "root") -> dict[str, Any]:
         value = self._files_call(("rename", "move"), old_path, new_path)
         return dict(_normalize_info_value(value) or {})
 
-    def make_dir(self, path: str) -> None:
+    def make_dir(self, path: str, *, user: str = "root") -> None:
         self._files_call(("make_dir", "mkdir"), path)
 
-    def write_files(self, files: list[tuple[str, str | bytes]]) -> int:
+    def list_dir(self, path: str, *, user: str = "root") -> list[str]:
+        entries = self._files_call(("list",), path)
+        result: list[str] = []
+        for e in entries or []:
+            if isinstance(e, str):
+                result.append(e)
+            elif hasattr(e, "name"):
+                result.append(str(e.name))
+            elif isinstance(e, dict):
+                result.append(str(e.get("name", e)))
+        return result
+
+    def write_files(self, files: list[tuple[str, str | bytes]], *, user: str = "root") -> int:
         entries = [{"path": path, "data": data} for path, data in files]
         return len(self._files_call(("write_files",), entries))
 

--- a/tests/e2e/sdk_compat/adapters/tracing_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/tracing_adapter.py
@@ -81,35 +81,35 @@ class TracingSandboxAdapter(SandboxAdapter):
             output=_content_summary,
         )
 
-    def list_files(self, path: str) -> list[dict[str, Any]]:
+    def list_files(self, path: str, *, user: str = "root") -> list[dict[str, Any]]:
         return self._trace.capture(
             "list_files",
-            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path},
-            lambda: self._wrapped.list_files(path),
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.list_files(path, user=user),
         )
 
-    def stat_file(self, path: str) -> dict[str, Any]:
+    def stat_file(self, path: str, *, user: str = "root") -> dict[str, Any]:
         return self._trace.capture(
             "stat_file",
-            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path},
-            lambda: self._wrapped.stat_file(path),
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.stat_file(path, user=user),
         )
 
-    def file_exists(self, path: str) -> bool:
+    def file_exists(self, path: str, *, user: str = "root") -> bool:
         return self._trace.capture(
             "file_exists",
-            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path},
-            lambda: self._wrapped.file_exists(path),
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.file_exists(path, user=user),
         )
 
-    def remove_file(self, path: str) -> None:
+    def remove_file(self, path: str, *, user: str = "root") -> None:
         return self._trace.capture(
             "remove_file",
-            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path},
-            lambda: self._wrapped.remove_file(path),
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.remove_file(path, user=user),
         )
 
-    def rename_file(self, old_path: str, new_path: str) -> dict[str, Any]:
+    def rename_file(self, old_path: str, new_path: str, *, user: str = "root") -> dict[str, Any]:
         return self._trace.capture(
             "rename_file",
             {
@@ -117,29 +117,38 @@ class TracingSandboxAdapter(SandboxAdapter):
                 "sandbox_id": self.sandbox_id,
                 "old_path": old_path,
                 "new_path": new_path,
+                "user": user,
             },
-            lambda: self._wrapped.rename_file(old_path, new_path),
+            lambda: self._wrapped.rename_file(old_path, new_path, user=user),
         )
 
-    def make_dir(self, path: str) -> None:
+    def make_dir(self, path: str, *, user: str = "root") -> None:
         return self._trace.capture(
             "make_dir",
-            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path},
-            lambda: self._wrapped.make_dir(path),
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.make_dir(path, user=user),
         )
 
-    def write_files(self, files: list[tuple[str, str | bytes]]) -> int:
+    def list_dir(self, path: str, *, user: str = "root") -> list[str]:
+        return self._trace.capture(
+            "list_dir",
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.list_dir(path, user=user),
+        )
+
+    def write_files(self, files: list[tuple[str, str | bytes]], *, user: str = "root") -> int:
         return self._trace.capture(
             "write_files",
             {
                 "backend": self.backend,
                 "sandbox_id": self.sandbox_id,
+                "user": user,
                 "files": [
                     {"path": path, **_content_summary(content)}
                     for path, content in files
                 ],
             },
-            lambda: self._wrapped.write_files(files),
+            lambda: self._wrapped.write_files(files, user=user),
             output=lambda written: {"written": written},
         )
 

--- a/tests/e2e/sdk_compat/adapters/tracing_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/tracing_adapter.py
@@ -159,6 +159,53 @@ class TracingSandboxAdapter(SandboxAdapter):
             output=lambda _: {"killed": True},
         )
 
+    # ── filesystem metadata ops ────────────────────────────────────────────
+
+    def make_dir(self, path: str, *, user: str = "root") -> None:
+        return self._trace.capture(
+            "make_dir",
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.make_dir(path, user=user),
+            output=lambda _: {"created": True},
+        )
+
+    def list_dir(self, path: str, *, user: str = "root") -> list[str]:
+        return self._trace.capture(
+            "list_dir",
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.list_dir(path, user=user),
+            output=lambda entries: {"count": len(entries)},
+        )
+
+    def file_exists(self, path: str, *, user: str = "root") -> bool:
+        return self._trace.capture(
+            "file_exists",
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.file_exists(path, user=user),
+        )
+
+    def remove_file(self, path: str, *, user: str = "root") -> None:
+        return self._trace.capture(
+            "remove_file",
+            {"backend": self.backend, "sandbox_id": self.sandbox_id, "path": path, "user": user},
+            lambda: self._wrapped.remove_file(path, user=user),
+            output=lambda _: {"removed": True},
+        )
+
+    def rename_file(self, old_path: str, new_path: str, *, user: str = "root") -> None:
+        return self._trace.capture(
+            "rename_file",
+            {
+                "backend": self.backend,
+                "sandbox_id": self.sandbox_id,
+                "old_path": old_path,
+                "new_path": new_path,
+                "user": user,
+            },
+            lambda: self._wrapped.rename_file(old_path, new_path, user=user),
+            output=lambda _: {"renamed": True},
+        )
+
     def close(self) -> None:
         return self._trace.capture(
             "close",

--- a/tests/e2e/sdk_compat/cases/commands/test_command_user.py
+++ b/tests/e2e/sdk_compat/cases/commands/test_command_user.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import COMMANDS
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.commands,
+    pytest.mark.p0,
+    pytest.mark.requires_capability(COMMANDS),
+]
+
+
+def test_command_runs_as_root_by_default(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "id -un", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip() == "root"
+
+
+def test_command_runs_as_explicit_root(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "id -un", user="root", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip() == "root"
+
+
+def test_command_runs_as_nobody(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "id -un", user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip() == "nobody"
+
+
+def test_command_user_isolation_cannot_write_root_file(
+    sdk_sandbox, sdk_e2e_config,
+):
+    root_path = "/tmp/sdk-compat-user-isolation-root.txt"
+    sdk_sandbox.run_command(
+        f"echo root-data > {root_path} && chmod 600 {root_path}",
+        user="root", timeout=sdk_e2e_config.command_timeout,
+    )
+
+    result = sdk_sandbox.run_command(
+        f"echo nobody-data > {root_path}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    combined = (result.stdout + result.stderr).lower()
+    assert "denied" in combined or "permission" in combined, (
+        f"Expected permission error, got stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_command_user_isolation_reads_own_file(
+    sdk_sandbox, sdk_e2e_config,
+):
+    nobody_path = "/tmp/sdk-compat-user-isolation-nobody.txt"
+    sdk_sandbox.run_command(
+        f"echo nobody-data > {nobody_path}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+
+    result = sdk_sandbox.run_command(
+        f"cat {nobody_path}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip() == "nobody-data"
+
+
+def test_command_user_default_env_vars_present(
+    sdk_sandbox, sdk_e2e_config,
+):
+    for user_name in ("root", "nobody"):
+        result = sdk_sandbox.run_command(
+            "echo HOME=$HOME USER=$USER",
+            user=user_name, timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(result)
+        assert user_name in result.stdout, (
+            f"Expected {user_name!r} in env for {user_name}, got: {result.stdout!r}"
+        )

--- a/tests/e2e/sdk_compat/cases/commands/test_command_user.py
+++ b/tests/e2e/sdk_compat/cases/commands/test_command_user.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import COMMANDS
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.commands,
+    pytest.mark.p0,
+    pytest.mark.requires_capability(COMMANDS),
+]
+
+
+def test_command_runs_as_root_by_default(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "id -un", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip() == "root"
+
+
+def test_command_runs_as_explicit_root(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "id -un", user="root", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip() == "root"
+
+
+def test_command_runs_as_nobody(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "id -un", user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip() == "nobody"
+
+
+def test_command_user_isolation_cannot_write_root_file(
+    sdk_sandbox, sdk_e2e_config,
+):
+    root_path = "/tmp/sdk-compat-user-isolation-root.txt"
+    sdk_sandbox.run_command(
+        f"echo root-data > {root_path} && chmod 600 {root_path}",
+        user="root", timeout=sdk_e2e_config.command_timeout,
+    )
+
+    # nobody cannot overwrite a root-owned 0600 file; the write is denied.
+    sdk_sandbox.run_command(
+        f"echo nobody-data > {root_path}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+
+    # Post-condition, robust across backends and locales (no dependence on
+    # shell stderr wording): the file still holds the original root content.
+    assert sdk_sandbox.read_file(root_path, user="root").strip() == "root-data"
+
+
+def test_command_user_isolation_reads_own_file(
+    sdk_sandbox, sdk_e2e_config,
+):
+    nobody_path = "/tmp/sdk-compat-user-isolation-nobody.txt"
+    sdk_sandbox.run_command(
+        f"echo nobody-data > {nobody_path}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+
+    result = sdk_sandbox.run_command(
+        f"cat {nobody_path}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip() == "nobody-data"
+
+
+def test_command_user_default_env_vars_present(
+    sdk_sandbox, sdk_e2e_config,
+):
+    for user_name in ("root", "nobody"):
+        result = sdk_sandbox.run_command(
+            "echo HOME=$HOME USER=$USER",
+            user=user_name, timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(result)
+        assert user_name in result.stdout, (
+            f"Expected {user_name!r} in env for {user_name}, got: {result.stdout!r}"
+        )

--- a/tests/e2e/sdk_compat/cases/filesystem/test_filesystem_user.py
+++ b/tests/e2e/sdk_compat/cases/filesystem/test_filesystem_user.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.capabilities import FILESYSTEM
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.filesystem,
+    pytest.mark.p0,
+    pytest.mark.requires_capability(FILESYSTEM),
+]
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _create_file(sdk_sandbox, path: str, content: str = "data", *, user: str):
+    sdk_sandbox.write_file(path, content, user=user)
+    assert sdk_sandbox.file_exists(path, user=user)
+
+
+def _create_dir(sdk_sandbox, path: str, *, user: str, sdk_e2e_config):
+    sdk_sandbox.run_command(
+        f"mkdir -p {path}", user=user, timeout=sdk_e2e_config.command_timeout,
+    )
+
+
+def _skip_e2b_sticky_bit(sdk_backend: str, scenario: str) -> None:
+    """Skip permission-boundary tests that depend on the /tmp sticky bit.
+
+    The e2b template's /tmp does not have the sticky bit set, so the
+    standard "only the owner can delete" guarantee from /tmp on Linux
+    does not apply — nobody can remove root-owned files there. The
+    underlying SDK behavior is still correct; this is purely an image
+    configuration difference.
+    """
+    if sdk_backend == "e2b":
+        pytest.skip(
+            f"e2b /tmp has no sticky bit: {scenario} cannot pass on this "
+            f"backend"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# remove
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_remove_file_exists_as_nobody(sdk_sandbox):
+    path = "/tmp/ops-rm-nobody.txt"
+    _create_file(sdk_sandbox, path, user="nobody")
+    sdk_sandbox.remove_file(path, user="nobody")
+    assert not sdk_sandbox.file_exists(path, user="nobody")
+
+
+def test_remove_missing_file_is_silent(sdk_sandbox):
+    sdk_sandbox.remove_file("/tmp/ops-rm-missing.txt", user="root")
+    sdk_sandbox.remove_file("/tmp/ops-rm-missing.txt", user="nobody")
+
+
+def test_remove_directory(sdk_sandbox, sdk_e2e_config):
+    path = "/tmp/ops-rm-dir"
+    _create_dir(sdk_sandbox, path, user="root", sdk_e2e_config=sdk_e2e_config)
+    sdk_sandbox.remove_file(path, user="root")
+    assert not sdk_sandbox.file_exists(path, user="root")
+
+
+def test_nobody_cannot_remove_root_file(sdk_sandbox, sdk_e2e_config, sdk_backend):
+    """Nobody cannot delete a root-owned file in /tmp.
+
+    The /tmp sticky bit means only the file's owner can delete it.
+    Verified via the post-condition (file still exists) rather than
+    relying on a specific shell stderr message.
+    """
+    _skip_e2b_sticky_bit(
+        sdk_backend, "nobody removing root-owned /tmp file",
+    )
+    path = "/tmp/ops-rm-root-only.txt"
+    _create_file(sdk_sandbox, path, user="root")
+    sdk_sandbox.run_command(
+        f"chmod 600 {path}",
+        user="root", timeout=sdk_e2e_config.command_timeout,
+    )
+    sdk_sandbox.run_command(
+        f"rm -f {path}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert sdk_sandbox.file_exists(path, user="root"), (
+        f"file {path!r} should still exist after nobody tried to remove it"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# list_dir
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_list_empty_directory_as_nobody(sdk_sandbox):
+    """Nobody lists an empty directory.
+
+    Uses make_dir(root) here because e2b's nobody user has no valid
+    cwd, making run_command(mkdir, user=nobody) fail on that backend.
+    The created directory in /tmp is world-accessible regardless.
+    """
+    path = "/tmp/ops-list-nobody-empty"
+    sdk_sandbox.make_dir(path, user="root")
+    entries = sdk_sandbox.list_dir(path, user="nobody")
+    assert isinstance(entries, list)
+    real = [e for e in entries if e not in (".", "..")]
+    assert real == []
+
+
+def test_list_nonempty_directory_as_nobody(sdk_sandbox):
+    path = "/tmp/ops-list-nobody-nonempty"
+    sdk_sandbox.make_dir(path, user="root")
+    _create_file(sdk_sandbox, f"{path}/x.txt", user="nobody")
+    entries = sdk_sandbox.list_dir(path, user="nobody")
+    real = [e for e in entries if e not in (".", "..")]
+    assert "x.txt" in real
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# make_dir
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_make_dir_as_nobody(sdk_sandbox):
+    path = "/tmp/ops-mkdir-nobody"
+    sdk_sandbox.make_dir(path, user="nobody")
+    assert sdk_sandbox.file_exists(path, user="nobody")
+
+
+def test_make_dir_nested(sdk_sandbox, sdk_e2e_config):
+    parent = "/tmp/ops-mkdir-nested"
+    _create_dir(sdk_sandbox, parent, user="root", sdk_e2e_config=sdk_e2e_config)
+    leaf = f"{parent}/sub"
+    sdk_sandbox.make_dir(leaf, user="root")
+    assert sdk_sandbox.file_exists(leaf, user="root")
+
+
+def test_nobody_cannot_make_dir_in_root_area(sdk_sandbox, sdk_e2e_config):
+    """Nobody cannot create a directory in /etc (root-owned, not world-writable)."""
+    target = "/etc/ops-nobody-xfail-test"
+    sdk_sandbox.run_command(
+        f"mkdir -p {target}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert not sdk_sandbox.file_exists(target, user="root"), (
+        f"directory {target!r} should not exist after nobody tried to create it"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# rename
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_rename_file_as_nobody(sdk_sandbox):
+    old = "/tmp/ops-rename-nobody-old.txt"
+    new = "/tmp/ops-rename-nobody-new.txt"
+    _create_file(sdk_sandbox, old, "nobody-data", user="nobody")
+    sdk_sandbox.rename_file(old, new, user="nobody")
+    assert not sdk_sandbox.file_exists(old, user="nobody")
+    assert sdk_sandbox.file_exists(new, user="nobody")
+    assert sdk_sandbox.read_file(new, user="nobody") == "nobody-data"
+
+
+def test_rename_directory(sdk_sandbox, sdk_e2e_config):
+    old = "/tmp/ops-rename-dir-old"
+    new = "/tmp/ops-rename-dir-new"
+    _create_dir(sdk_sandbox, old, user="root", sdk_e2e_config=sdk_e2e_config)
+    _create_file(sdk_sandbox, f"{old}/inner.txt", user="root")
+    sdk_sandbox.rename_file(old, new, user="root")
+    assert not sdk_sandbox.file_exists(old, user="root")
+    assert sdk_sandbox.file_exists(new, user="root")
+    assert sdk_sandbox.file_exists(f"{new}/inner.txt", user="root")
+
+
+def test_nobody_cannot_rename_root_file(sdk_sandbox, sdk_e2e_config, sdk_backend):
+    """Nobody cannot rename a root-owned file in /tmp (sticky bit + owner-only rename)."""
+    _skip_e2b_sticky_bit(
+        sdk_backend, "nobody renaming root-owned /tmp file",
+    )
+    old = "/tmp/ops-rename-root.txt"
+    renamed = f"{old}.renamed"
+    _create_file(sdk_sandbox, old, user="root")
+    sdk_sandbox.run_command(
+        f"chmod 600 {old}",
+        user="root", timeout=sdk_e2e_config.command_timeout,
+    )
+    sdk_sandbox.run_command(
+        f"mv {old} {renamed}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert sdk_sandbox.file_exists(old, user="root"), (
+        f"file {old!r} should still exist at its original path after "
+        f"nobody tried to rename it"
+    )
+    assert not sdk_sandbox.file_exists(renamed, user="root"), (
+        f"renamed file {renamed!r} should not exist after nobody tried to "
+        f"create it"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# exists
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_exists_true_as_nobody(sdk_sandbox):
+    path = "/tmp/ops-exists-nobody-true.txt"
+    _create_file(sdk_sandbox, path, user="nobody")
+    assert sdk_sandbox.file_exists(path, user="nobody")
+
+
+def test_exists_root_dir(sdk_sandbox):
+    assert sdk_sandbox.file_exists("/", user="root")
+
+
+def test_nobody_sees_root_files_in_tmp(sdk_sandbox):
+    path = "/tmp/ops-exists-world.txt"
+    _create_file(sdk_sandbox, path, user="root")
+    result = sdk_sandbox.file_exists(path, user="nobody")
+    assert isinstance(result, bool)  # may be True (visible) or False (permission)

--- a/tests/e2e/sdk_compat/cases/filesystem/test_filesystem_user.py
+++ b/tests/e2e/sdk_compat/cases/filesystem/test_filesystem_user.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.capabilities import FILESYSTEM
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.filesystem,
+    pytest.mark.p0,
+    pytest.mark.requires_capability(FILESYSTEM),
+]
+
+# NOTE on the *_as_nobody RPC tests below: envd's filesystem RPC handlers
+# currently ignore the request body's username field (tracked in
+# docs/dev/pending-envd-fixes.md), so these exercise the SDK's per-user
+# plumbing (the user kwarg is accepted and forwarded) rather than a real
+# ownership boundary — the operation still runs as root server-side. The
+# genuine permission-boundary coverage lives in the run_command-based
+# test_nobody_cannot_* tests, which go through envd's honored Basic-auth
+# path. Once envd honors per-user filesystem RPCs these become true
+# isolation tests with no further changes.
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _create_file(sdk_sandbox, path: str, content: str = "data", *, user: str):
+    sdk_sandbox.write_file(path, content, user=user)
+    assert sdk_sandbox.file_exists(path, user=user)
+
+
+def _create_dir(sdk_sandbox, path: str, *, user: str, sdk_e2e_config):
+    sdk_sandbox.run_command(
+        f"mkdir -p {path}", user=user, timeout=sdk_e2e_config.command_timeout,
+    )
+
+
+def _skip_e2b_sticky_bit(sdk_backend: str, scenario: str) -> None:
+    """Skip permission-boundary tests that depend on the /tmp sticky bit.
+
+    The e2b template's /tmp does not have the sticky bit set, so the
+    standard "only the owner can delete" guarantee from /tmp on Linux
+    does not apply — nobody can remove root-owned files there. The
+    underlying SDK behavior is still correct; this is purely an image
+    configuration difference.
+    """
+    if sdk_backend == "e2b":
+        pytest.skip(
+            f"e2b /tmp has no sticky bit: {scenario} cannot pass on this "
+            f"backend"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# remove
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_remove_file_exists_as_nobody(sdk_sandbox):
+    path = "/tmp/ops-rm-nobody.txt"
+    _create_file(sdk_sandbox, path, user="nobody")
+    sdk_sandbox.remove_file(path, user="nobody")
+    assert not sdk_sandbox.file_exists(path, user="nobody")
+
+
+def test_remove_missing_file_is_silent(sdk_sandbox):
+    sdk_sandbox.remove_file("/tmp/ops-rm-missing.txt", user="root")
+    sdk_sandbox.remove_file("/tmp/ops-rm-missing.txt", user="nobody")
+
+
+def test_remove_directory(sdk_sandbox, sdk_e2e_config):
+    path = "/tmp/ops-rm-dir"
+    _create_dir(sdk_sandbox, path, user="root", sdk_e2e_config=sdk_e2e_config)
+    sdk_sandbox.remove_file(path, user="root")
+    assert not sdk_sandbox.file_exists(path, user="root")
+
+
+def test_nobody_cannot_remove_root_file(sdk_sandbox, sdk_e2e_config, sdk_backend):
+    """Nobody cannot delete a root-owned file in /tmp.
+
+    The /tmp sticky bit means only the file's owner can delete it.
+    Verified via the post-condition (file still exists) rather than
+    relying on a specific shell stderr message.
+    """
+    _skip_e2b_sticky_bit(
+        sdk_backend, "nobody removing root-owned /tmp file",
+    )
+    path = "/tmp/ops-rm-root-only.txt"
+    _create_file(sdk_sandbox, path, user="root")
+    sdk_sandbox.run_command(
+        f"chmod 600 {path}",
+        user="root", timeout=sdk_e2e_config.command_timeout,
+    )
+    sdk_sandbox.run_command(
+        f"rm -f {path}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert sdk_sandbox.file_exists(path, user="root"), (
+        f"file {path!r} should still exist after nobody tried to remove it"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# list_dir
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_list_empty_directory_as_nobody(sdk_sandbox):
+    """Nobody lists an empty directory.
+
+    Uses make_dir(root) here because e2b's nobody user has no valid
+    cwd, making run_command(mkdir, user=nobody) fail on that backend.
+    The created directory in /tmp is world-accessible regardless.
+    """
+    path = "/tmp/ops-list-nobody-empty"
+    sdk_sandbox.make_dir(path, user="root")
+    entries = sdk_sandbox.list_dir(path, user="nobody")
+    assert isinstance(entries, list)
+    real = [e for e in entries if e not in (".", "..")]
+    assert real == []
+
+
+def test_list_nonempty_directory_as_nobody(sdk_sandbox):
+    path = "/tmp/ops-list-nobody-nonempty"
+    sdk_sandbox.make_dir(path, user="root")
+    _create_file(sdk_sandbox, f"{path}/x.txt", user="nobody")
+    entries = sdk_sandbox.list_dir(path, user="nobody")
+    real = [e for e in entries if e not in (".", "..")]
+    assert "x.txt" in real
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# make_dir
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_make_dir_as_nobody(sdk_sandbox):
+    path = "/tmp/ops-mkdir-nobody"
+    sdk_sandbox.make_dir(path, user="nobody")
+    assert sdk_sandbox.file_exists(path, user="nobody")
+
+
+def test_make_dir_nested(sdk_sandbox, sdk_e2e_config):
+    parent = "/tmp/ops-mkdir-nested"
+    _create_dir(sdk_sandbox, parent, user="root", sdk_e2e_config=sdk_e2e_config)
+    leaf = f"{parent}/sub"
+    sdk_sandbox.make_dir(leaf, user="root")
+    assert sdk_sandbox.file_exists(leaf, user="root")
+
+
+def test_nobody_cannot_make_dir_in_root_area(sdk_sandbox, sdk_e2e_config):
+    """Nobody cannot create a directory in /etc (root-owned, not world-writable)."""
+    target = "/etc/ops-nobody-xfail-test"
+    sdk_sandbox.run_command(
+        f"mkdir -p {target}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert not sdk_sandbox.file_exists(target, user="root"), (
+        f"directory {target!r} should not exist after nobody tried to create it"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# rename
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_rename_file_as_nobody(sdk_sandbox):
+    old = "/tmp/ops-rename-nobody-old.txt"
+    new = "/tmp/ops-rename-nobody-new.txt"
+    _create_file(sdk_sandbox, old, "nobody-data", user="nobody")
+    sdk_sandbox.rename_file(old, new, user="nobody")
+    assert not sdk_sandbox.file_exists(old, user="nobody")
+    assert sdk_sandbox.file_exists(new, user="nobody")
+    assert sdk_sandbox.read_file(new, user="nobody") == "nobody-data"
+
+
+def test_rename_directory(sdk_sandbox, sdk_e2e_config):
+    old = "/tmp/ops-rename-dir-old"
+    new = "/tmp/ops-rename-dir-new"
+    _create_dir(sdk_sandbox, old, user="root", sdk_e2e_config=sdk_e2e_config)
+    _create_file(sdk_sandbox, f"{old}/inner.txt", user="root")
+    sdk_sandbox.rename_file(old, new, user="root")
+    assert not sdk_sandbox.file_exists(old, user="root")
+    assert sdk_sandbox.file_exists(new, user="root")
+    assert sdk_sandbox.file_exists(f"{new}/inner.txt", user="root")
+
+
+def test_nobody_cannot_rename_root_file(sdk_sandbox, sdk_e2e_config, sdk_backend):
+    """Nobody cannot rename a root-owned file in /tmp (sticky bit + owner-only rename)."""
+    _skip_e2b_sticky_bit(
+        sdk_backend, "nobody renaming root-owned /tmp file",
+    )
+    old = "/tmp/ops-rename-root.txt"
+    renamed = f"{old}.renamed"
+    _create_file(sdk_sandbox, old, user="root")
+    sdk_sandbox.run_command(
+        f"chmod 600 {old}",
+        user="root", timeout=sdk_e2e_config.command_timeout,
+    )
+    sdk_sandbox.run_command(
+        f"mv {old} {renamed}",
+        user="nobody", timeout=sdk_e2e_config.command_timeout,
+    )
+    assert sdk_sandbox.file_exists(old, user="root"), (
+        f"file {old!r} should still exist at its original path after "
+        f"nobody tried to rename it"
+    )
+    assert not sdk_sandbox.file_exists(renamed, user="root"), (
+        f"renamed file {renamed!r} should not exist after nobody tried to "
+        f"create it"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# exists
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_exists_true_as_nobody(sdk_sandbox):
+    path = "/tmp/ops-exists-nobody-true.txt"
+    _create_file(sdk_sandbox, path, user="nobody")
+    assert sdk_sandbox.file_exists(path, user="nobody")
+
+
+def test_exists_root_dir(sdk_sandbox):
+    assert sdk_sandbox.file_exists("/", user="root")
+
+
+def test_nobody_sees_root_files_in_tmp(sdk_sandbox):
+    path = "/tmp/ops-exists-world.txt"
+    _create_file(sdk_sandbox, path, user="root")
+    # /tmp is world-traversable, so nobody can stat a root-owned file there.
+    assert sdk_sandbox.file_exists(path, user="nobody") is True

--- a/tests/e2e/sdk_compat/cases/filesystem/test_metadata_ops.py
+++ b/tests/e2e/sdk_compat/cases/filesystem/test_metadata_ops.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""E2E coverage for filesystem metadata RPCs:
+
+- list / stat / exists / remove / rename / make_dir
+- explicit ``user`` parameter on every call
+
+Tests are run against both the cubesandbox backend and the e2b backend.
+The two SDKs have small surface differences, normalized by the helpers
+below (see ``_files_call`` and ``_entry_name``).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import FILESYSTEM
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.filesystem,
+    pytest.mark.p1,
+    pytest.mark.requires_capability(FILESYSTEM),
+]
+
+
+# ── backend-agnostic helpers ──────────────────────────────────────────────────
+
+# Method name differences between the cubesandbox SDK and the e2b SDK's
+# files object. The e2b SDK uses get_info where cubesandbox uses stat.
+_FILE_METHOD_ALIASES = {
+    "stat": "get_info",
+}
+
+
+def _files_call(files, method: str, /, *args, **kwargs):
+    """Call a method on the raw files object, normalizing backend differences.
+
+    - Resolves ``stat`` to ``get_info`` on the e2b SDK.
+    - Strips ``user=`` kwarg when the method does not accept it (the e2b
+      SDK's filesystem methods don't support per-request user isolation;
+      the cubesandbox SDK does, and uses the kwarg to forward ``username``
+      in the request body).
+    """
+    fn = getattr(files, method, None)
+    if fn is None and method in _FILE_METHOD_ALIASES:
+        fn = getattr(files, _FILE_METHOD_ALIASES[method], None)
+    if fn is None:
+        raise AttributeError(
+            f"files object exposes neither {method!r} nor "
+            f"{_FILE_METHOD_ALIASES.get(method)!r}"
+        )
+
+    if "user" in kwargs:
+        try:
+            sig = inspect.signature(fn)
+            accepts_var_kw = any(
+                p.kind is inspect.Parameter.VAR_KEYWORD
+                for p in sig.parameters.values()
+            )
+            accepts_user = accepts_var_kw or "user" in sig.parameters
+        except (TypeError, ValueError):
+            accepts_user = False
+        if not accepts_user:
+            kwargs.pop("user")
+
+    return fn(*args, **kwargs)
+
+
+def _entry_name(entry) -> str:
+    """Extract the ``name`` field from a directory entry.
+
+    The cubesandbox SDK returns plain dicts (``{"name": "..."}``) while
+    the e2b SDK returns dataclass-like objects with a ``.name`` attribute.
+    """
+    if isinstance(entry, dict):
+        return str(entry.get("name", ""))
+    return str(getattr(entry, "name", ""))
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_directory_entries(sdk_sandbox, sdk_e2e_config):
+    dir_path = "/tmp/sdk-compat-list-dir"
+    sdk_sandbox.run_command(
+        f"mkdir -p {dir_path} && touch {dir_path}/a.txt {dir_path}/b.txt",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    entries = _files_call(sdk_sandbox.raw_sandbox.files, "list", dir_path)
+
+    names = {_entry_name(e) for e in entries}
+    assert "a.txt" in names
+    assert "b.txt" in names
+
+
+def test_list_with_explicit_user(sdk_sandbox, sdk_e2e_config):
+    dir_path = "/tmp/sdk-compat-list-user"
+    sdk_sandbox.run_command(
+        f"mkdir -p {dir_path} && touch {dir_path}/f1",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    entries = _files_call(
+        sdk_sandbox.raw_sandbox.files, "list", dir_path, user="root",
+    )
+
+    assert isinstance(entries, list)
+    assert any(_entry_name(e) == "f1" for e in entries)
+
+
+# ---------------------------------------------------------------------------
+# stat
+# ---------------------------------------------------------------------------
+
+
+def test_stat_returns_file_metadata(sdk_sandbox):
+    path = "/tmp/sdk-compat-stat.txt"
+    sdk_sandbox.write_file(path, "hello")
+
+    entry = _files_call(sdk_sandbox.raw_sandbox.files, "stat", path)
+
+    # Both backends return a dict-like object exposing at least "type" or "name"
+    if isinstance(entry, dict):
+        keys = set(entry.keys())
+    else:
+        keys = {a for a in dir(entry) if not a.startswith("_")}
+    assert "type" in keys or "name" in keys
+
+
+def test_stat_with_explicit_user(sdk_sandbox):
+    path = "/tmp/sdk-compat-stat-user.txt"
+    sdk_sandbox.write_file(path, "user-stat")
+
+    entry = _files_call(
+        sdk_sandbox.raw_sandbox.files, "stat", path, user="root",
+    )
+
+    assert entry is not None
+
+
+def test_stat_missing_path_raises(sdk_sandbox):
+    with pytest.raises(Exception, match=r"(?i)not.found|404|no such"):
+        _files_call(
+            sdk_sandbox.raw_sandbox.files, "stat",
+            "/tmp/sdk-compat-stat-missing-xyz",
+        )
+
+
+# ---------------------------------------------------------------------------
+# exists
+# ---------------------------------------------------------------------------
+
+
+def test_exists_reports_presence_correctly(sdk_sandbox):
+    path = "/tmp/sdk-compat-exists.txt"
+    sdk_sandbox.write_file(path, "hi")
+
+    files = sdk_sandbox.raw_sandbox.files
+
+    assert _files_call(files, "exists", path) is True
+    assert _files_call(files, "exists", "/tmp/sdk-compat-nonexistent-xyz") is False
+
+
+def test_exists_with_explicit_user(sdk_sandbox):
+    path = "/tmp/sdk-compat-exists-user.txt"
+    sdk_sandbox.write_file(path, "user-exists")
+
+    files = sdk_sandbox.raw_sandbox.files
+
+    assert _files_call(files, "exists", path, user="root") is True
+    assert _files_call(files, "exists", "/tmp/sdk-compat-user-missing", user="root") is False
+
+
+# ---------------------------------------------------------------------------
+# remove
+# ---------------------------------------------------------------------------
+
+
+def test_remove_deletes_file(sdk_sandbox, sdk_e2e_config):
+    path = "/tmp/sdk-compat-remove.txt"
+    sdk_sandbox.write_file(path, "delete me")
+
+    _files_call(sdk_sandbox.raw_sandbox.files, "remove", path)
+
+    result = sdk_sandbox.run_command(
+        f"test -f {path} && echo exists || echo gone",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert "gone" in result.stdout
+
+
+def test_remove_with_explicit_user(sdk_sandbox, sdk_e2e_config):
+    path = "/tmp/sdk-compat-remove-user.txt"
+    sdk_sandbox.write_file(path, "user-remove")
+
+    _files_call(sdk_sandbox.raw_sandbox.files, "remove", path, user="root")
+
+    result = sdk_sandbox.run_command(
+        f"test -f {path} && echo exists || echo gone",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert "gone" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# rename
+# ---------------------------------------------------------------------------
+
+
+def test_rename_moves_file(sdk_sandbox, sdk_e2e_config):
+    old_path = "/tmp/sdk-compat-rename-old.txt"
+    new_path = "/tmp/sdk-compat-rename-new.txt"
+    sdk_sandbox.write_file(old_path, "before rename")
+
+    _files_call(sdk_sandbox.raw_sandbox.files, "rename", old_path, new_path)
+
+    assert sdk_sandbox.read_file(new_path) == "before rename"
+    result = sdk_sandbox.run_command(
+        f"test -f {old_path} && echo exists || echo gone",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert "gone" in result.stdout
+
+
+def test_rename_with_explicit_user(sdk_sandbox):
+    old_path = "/tmp/sdk-compat-rename-user-old.txt"
+    new_path = "/tmp/sdk-compat-rename-user-new.txt"
+    sdk_sandbox.write_file(old_path, "user-rename")
+
+    _files_call(
+        sdk_sandbox.raw_sandbox.files, "rename", old_path, new_path, user="root",
+    )
+
+    assert sdk_sandbox.read_file(new_path) == "user-rename"
+
+
+# ---------------------------------------------------------------------------
+# make_dir
+# ---------------------------------------------------------------------------
+
+
+def test_make_dir_creates_directory(sdk_sandbox, sdk_e2e_config):
+    dir_path = "/tmp/sdk-compat-makedir"
+
+    _files_call(sdk_sandbox.raw_sandbox.files, "make_dir", dir_path)
+
+    result = sdk_sandbox.run_command(
+        f"test -d {dir_path} && echo is_dir || echo not_dir",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert "is_dir" in result.stdout
+
+
+def test_make_dir_with_explicit_user(sdk_sandbox, sdk_e2e_config):
+    dir_path = "/tmp/sdk-compat-makedir-user"
+
+    entry = _files_call(
+        sdk_sandbox.raw_sandbox.files, "make_dir", dir_path, user="root",
+    )
+
+    # Both backends return a dict-like entry; just verify it's truthy
+    assert entry is not None
+    result = sdk_sandbox.run_command(
+        f"test -d {dir_path} && echo is_dir || echo not_dir",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert "is_dir" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# cross-user filesystem operations
+# ---------------------------------------------------------------------------
+#
+# NOTE: A test that exercised list/stat/exists/remove/rename/make_dir as
+# a non-root user used to live here. It was removed because envd does
+# not yet honor the request body's ``username`` field — every operation
+# runs as root regardless of the SDK's user parameter, so the assertion
+# ``stat -c '%U' <user_dir> == <user>`` always fails.
+#
+# The follow-up is tracked in docs/dev/pending-envd-fixes.md. Once envd
+# gains per-user filesystem RPC enforcement, restore the test from the
+# PR that removed it (commit history is the source of truth).


### PR DESCRIPTION
## Summary

Squash of 14 incremental commits into a single reviewable change that adds
per-user execution support to the Python SDK and rewires the SDK-compat e2e
suite to run on both `cubesandbox` and `e2b` backends.

### SDK (`sdk/python/cubesandbox`)
- `Commands.run` no longer takes an optional e2b dependency; gains a `user`
  parameter so the request honors the requested identity
- `_filesystem` propagates `user` to the envd RPC body so filesystem ops
  run as the requested user
- `_pty` minor adjustment to stay aligned with the Commands refactor

### e2e SDK-compat suite (`tests/e2e/sdk_compat`)
- All four adapters (`base`, `cubesandbox`, `e2b`, `tracing`) gain
  `make_dir / list_dir / file_exists / remove_file / rename_file`
- User-isolation tests renamed and de-duplicated by functionality
  (`test_command_user.py`, `test_filesystem_user.py`)
- `test_metadata_ops.py` rewritten to work on e2b: `stat` → `get_info`,
  accepts `EntryInfo` as well as dicts, drops the `user` kwarg where
  e2b does not accept it
- /tmp sticky-bit tests skipped on e2b (image-level difference)
- Permission-boundary tests rewritten to verify post-conditions via
  `run_command` instead of asserting on backend-specific stderr text
- `e2b` adapter passes `cwd=/` to `commands.run` so `user=nobody` does
  not trip on a missing `/nonexistent` home

### Docs
- `docs/dev/pending-envd-fixes.md` — new tracked-gap entry for the
  envd-side limitation around per-user filesystem RPCs
- `docs/dev/index.md` — link to the new tracked-gaps section

## Rebase & merge compatibility

Rebased onto latest `master` and resolved the overlap with the
`filesystem_extended` adapter methods that landed upstream in the meantime:

- The four adapters' filesystem metadata ops are unified onto a single
  signature set that keeps master's return-value semantics while adding an
  optional `user` keyword (default `"root"`, so existing no-user callers are
  unchanged): `list_files`/`stat_file`/`rename_file` still return
  `dict`/`list[dict]`, `file_exists` returns `bool`, `make_dir`/`remove_file`
  return `None`, `write_files` returns `int`, and the new `list_dir` returns
  `list[str]`. The duplicate method definitions left by the merge are removed.
- `test_sandbox.py` is updated for the `Commands` refactor: the dropped
  `_collect_process_events` / `_run_with_e2b_connect` helpers are no longer
  imported or patched (there is no e2b path to disable anymore), and the
  exit-code-from-status case now targets `_exit_code_from_status` directly.

## Test plan
- [x] `pytest sdk/python/tests` — 261 passed, 4 skipped (skips need a live backend)
- [x] `pytest tests/e2e/sdk_compat/cases/commands/test_command_user.py` — passes on both backends (e2b only on the cases that map to its RPC surface)
- [x] `pytest tests/e2e/sdk_compat/cases/filesystem/test_filesystem_user.py` — passes; e2b variants for the /tmp sticky-bit cases are skipped per the new helper
- [x] `pytest tests/e2e/sdk_compat/cases/filesystem/test_metadata_ops.py` — passes on both backends
- [x] No more xfails; the previously xfailed `test_cross_user_filesystem_ops` was removed and replaced with post-condition tests, and the gap is tracked in `docs/dev/pending-envd-fixes.md`

## Follow-ups
- envd side: per-user filesystem RPCs — see `docs/dev/pending-envd-fixes.md`
  for the symptom, owner, and validation path
