### PR TITLE
Fix Kubernetes node probe portability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.yaml text eol=lf
+*.tpl text eol=lf

--- a/deploy/kubernetes/chart/templates/node-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-daemonset.yaml
@@ -261,7 +261,7 @@ spec:
               command:
                 - /bin/bash
                 - -ec
-                - {{ include "cube.egressNetProbeCommand" . | quote }}
+                - {{ include "cube.egressNetProbeCommand" . | replace "\r" "" | quote }}
             initialDelaySeconds: {{ .Values.cubeEgress.network.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.cubeEgress.network.probes.readiness.periodSeconds }}
             failureThreshold: {{ .Values.cubeEgress.network.probes.readiness.failureThreshold }}
@@ -272,7 +272,7 @@ spec:
               command:
                 - /bin/bash
                 - -ec
-                - {{ include "cube.egressNetProbeCommand" . | quote }}
+                - {{ include "cube.egressNetProbeCommand" . | replace "\r" "" | quote }}
             initialDelaySeconds: {{ .Values.cubeEgress.network.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.cubeEgress.network.probes.liveness.periodSeconds }}
             failureThreshold: {{ .Values.cubeEgress.network.probes.liveness.failureThreshold }}

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -262,9 +262,9 @@ spec:
         - -ec
         - |
           echo '[health-test] check CubeProxy via ClusterIP Service'
-          curl --connect-timeout 5 --max-time 15 -fsS -o /dev/null \
+          curl --connect-timeout 5 --max-time 15 -sS -o /dev/null \
             "http://{{ include "cube.proxyServiceFQDN" . }}:{{ .Values.cubeProxy.ports.http.containerPort }}/" \
-            || curl --connect-timeout 5 --max-time 15 -k -fsS -o /dev/null \
+            || curl --connect-timeout 5 --max-time 15 -k -sS -o /dev/null \
             "https://{{ include "cube.proxyServiceFQDN" . }}:{{ .Values.cubeProxy.ports.https.containerPort }}/" \
             || { echo "cube-proxy Service unreachable"; exit 1; }
 {{- end }}

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -96,9 +96,9 @@ spec:
           printf '%s\n' "${proxy_pods_json}" \
             | grep -oE '"ready"[[:space:]]*:[[:space:]]*true' | grep -q true
           echo '[health-test] check CubeProxy ClusterIP Service HTTP'
-          curl --connect-timeout 5 --max-time 15 -fsS -o /dev/null \
+          curl --connect-timeout 5 --max-time 15 -sS -o /dev/null \
             "http://{{ include "cube.proxyName" . }}.{{ .Release.Namespace }}.svc.{{ include "cube.clusterDomain" . }}:{{ .Values.cubeProxy.ports.http.containerPort }}/" \
-            || echo '[health-test] cube-proxy Service HTTP soft-failed (may require Host header / TLS path)'
+            || { echo '[health-test] cube-proxy Service unreachable'; exit 1; }
           {{- end }}
 
           {{- if .Values.cubeNode.enabled }}


### PR DESCRIPTION
## Summary

- strip carriage returns from rendered CubeEgress readiness and liveness probe commands
- treat any HTTP response from CubeProxy as transport reachability in the Helm health test

## Why

A Windows checkout can inject CRLF into the included Bash probe and make `set -e` fail with an invalid option. CubeProxy also validly returns HTTP 400 for `/` without a sandbox `Host` header, so `curl --fail` incorrectly reports a reachable proxy as unhealthy.

## Testing

- `helm lint deploy/kubernetes/chart` with non-default test credentials
- `helm template` renders without carriage returns
- all eight Helm tests passed on AKS Kubernetes v1.35.6

Assisted-by: GitHub Copilot:GPT-5.4