### PR TITLE
fix(kubernetes): make cubecli discoverable on compute nodes

### DIFF
--- a/.github/workflows/kubernetes-chart-check.yml
+++ b/.github/workflows/kubernetes-chart-check.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches: [master]
     paths:
+      - 'Cubelet/Dockerfile'
       - 'deploy/kubernetes/chart/**'
       - 'deploy/kubernetes/images/scripts/**'
       - 'scripts/bump-image.sh'
       - '.github/workflows/kubernetes-chart-check.yml'
   pull_request:
     paths:
+      - 'Cubelet/Dockerfile'
       - 'deploy/kubernetes/chart/**'
       - 'deploy/kubernetes/images/scripts/**'
       - 'scripts/bump-image.sh'

--- a/Cubelet/Dockerfile
+++ b/Cubelet/Dockerfile
@@ -83,7 +83,7 @@ ARG CUBE_VERSION=unknown
 ENV IMAGE_ROOT=/opt/cube-image
 ENV TOOLBOX_ROOT=/usr/local/services/cubetoolbox
 ENV CUBE_COMPONENT=cubelet
-ENV PATH="/usr/local/services/cubetoolbox/cube-shim/bin:${PATH}"
+ENV PATH="/usr/local/services/cubetoolbox/Cubelet/bin:/usr/local/services/cubetoolbox/cube-shim/bin:${PATH}"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -157,6 +157,14 @@ can set it to `false`.
 - `cubeNode.network.autoDetectEthName=true` auto-detects the primary host NIC and patches Cubelet `eth_name`;
 - `cubeNode.network.cidr` patches Cubelet cubevs/sandbox CIDR (default `172.16.0.0/18`, chosen to avoid common cluster Service CIDR `192.168.0.0/16` while keeping a /18 pool). A Helm `pre-install`/`pre-upgrade` Hook fails fast when this range overlaps the cluster Service CIDR or existing ClusterIPs; set `cubeNode.network.cidrSkipConflictCheck=true` only if you accept that risk.
 
+The `cube-node` Pod defaults `kubectl exec` to its `cubelet` container, where `cubecli` uses the node-local Cubelet and containerd sockets. In a multi-node cluster, select the Pod scheduled on the compute node you want to inspect:
+
+```bash
+kubectl get pods -n cube-system \
+  -l app.kubernetes.io/component=cube-node -o wide
+kubectl exec -n cube-system <cube-node-pod> -- cubecli ls
+```
+
 ### Guest kernel (bm vs PVM)
 
 What actually decides the guest kernel on a node:

--- a/deploy/kubernetes/chart/scripts/test-cubecli-discovery.sh
+++ b/deploy/kubernetes/chart/scripts/test-cubecli-discovery.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+CHART_DIR="${CHART_DIR:-$(dirname "$SCRIPT_DIR")}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+render() {
+  output="$1"
+  shift
+  helm template cubecli-discovery "$CHART_DIR" \
+    --set-string mysql.password=test \
+    --set-string mysql.rootPassword=test \
+    --set-string redis.password=test \
+    "$@" > "$output"
+}
+
+extract_daemonset() {
+  component="$1"
+  input="$2"
+  output="$3"
+  python3 - "$component" "$input" "$output" <<'PY'
+import pathlib
+import re
+import sys
+
+component = sys.argv[1]
+documents = pathlib.Path(sys.argv[2]).read_text().split("\n---\n")
+matches = [
+    doc for doc in documents
+    if "\nkind: DaemonSet\n" in f"\n{doc}\n"
+    and f"\n    app.kubernetes.io/component: {component}\n" in f"\n{doc}\n"
+    and re.search(r"(?m)^apiVersion:\s*apps/v1\s*$", doc)
+]
+if len(matches) != 1:
+    raise SystemExit(f"expected one {component} DaemonSet, found {len(matches)}")
+pathlib.Path(sys.argv[3]).write_text(matches[0].strip() + "\n")
+PY
+}
+
+render "$TMP_DIR/default.yaml"
+extract_daemonset cube-node "$TMP_DIR/default.yaml" "$TMP_DIR/default-node.yaml"
+grep -q '^        kubectl.kubernetes.io/default-container: cubelet$' \
+  "$TMP_DIR/default-node.yaml" || {
+    echo "cube-node must default kubectl exec to the cubelet container" >&2
+    exit 1
+  }
+
+printf '%s\n' \
+  'cubeNode:' \
+  '  podAnnotations:' \
+  '    kubectl.kubernetes.io/default-container: network-agent' \
+  > "$TMP_DIR/override.yaml"
+render "$TMP_DIR/override-rendered.yaml" -f "$TMP_DIR/override.yaml"
+extract_daemonset cube-node "$TMP_DIR/override-rendered.yaml" "$TMP_DIR/override-node.yaml"
+grep -q '^        kubectl.kubernetes.io/default-container: network-agent$' \
+  "$TMP_DIR/override-node.yaml" || {
+    echo "cubeNode.podAnnotations must be able to override the default container" >&2
+    exit 1
+  }
+
+printf '%s\n' \
+  'cubeNode:' \
+  '  podAnnotations:' \
+  '    example.com/operator-note: retained' \
+  > "$TMP_DIR/unrelated-override.yaml"
+render "$TMP_DIR/unrelated-rendered.yaml" -f "$TMP_DIR/unrelated-override.yaml"
+extract_daemonset cube-node "$TMP_DIR/unrelated-rendered.yaml" "$TMP_DIR/unrelated-node.yaml"
+grep -q '^        kubectl.kubernetes.io/default-container: cubelet$' \
+  "$TMP_DIR/unrelated-node.yaml" || {
+    echo "unrelated cubeNode.podAnnotations must preserve the cubelet default" >&2
+    exit 1
+  }
+grep -q '^        example.com/operator-note: retained$' \
+  "$TMP_DIR/unrelated-node.yaml" || {
+    echo "custom cubeNode.podAnnotations must be preserved" >&2
+    exit 1
+  }
+
+echo "CubeCLI Helm discovery guard passed"

--- a/deploy/kubernetes/chart/templates/NOTES.txt
+++ b/deploy/kubernetes/chart/templates/NOTES.txt
@@ -104,6 +104,8 @@ Useful commands:
   kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node-bootstrap -c cube-node-init --tail=100
   kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node -c wait-node-prep --tail=100
   kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node -c cubelet --tail=100
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node -o wide
+  kubectl exec -n {{ .Release.Namespace }} <cube-node-pod> -- cubecli ls
 {{- if eq (include "cube.cubemastercliEnabled" .) "true" }}
   kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "cube.cubemastercliName" . }} -- cubemastercli --help
   kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "cube.cubemastercliName" . }} -- sh -lc 'cubemastercli --address "$CUBEMASTERCLI_ADDRESS" --port "$CUBEMASTERCLI_PORT" node list'

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -495,7 +495,9 @@ redis:
 
 cubeNode:
   enabled: true
-  podAnnotations: {}
+  podAnnotations:
+    # kubectl exec/logs without -c should enter the node-local Cubelet runtime.
+    kubectl.kubernetes.io/default-container: cubelet
   # Native apps/v1 DaemonSet. Image/tag/resource changes recreate the Pod
   # (PodIP / netns change; existing sandboxes on that node are interrupted).
   updateStrategy:

--- a/deploy/kubernetes/images/scripts/component-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/component-entrypoint.sh
@@ -170,6 +170,7 @@ stage_component() {
     cubelet)
       chmod +x "${dst}/bin/cubelet" "${dst}/bin/cubecli" 2>/dev/null || true
       [[ -x "${dst}/bin/cubelet" ]] || fail "missing cubelet after stage"
+      [[ -x "${dst}/bin/cubecli" ]] || fail "missing cubecli after stage"
       ;;
     network-agent)
       chmod +x "${dst}/bin/network-agent" "${dst}/bin/cubevsmapdump" 2>/dev/null || true

--- a/deploy/kubernetes/images/scripts/test-cubelet-cubecli-path.sh
+++ b/deploy/kubernetes/images/scripts/test-cubelet-cubecli-path.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../../../.." && pwd)"
+DOCKERFILE="$REPO_ROOT/Cubelet/Dockerfile"
+ENTRYPOINT="$REPO_ROOT/deploy/kubernetes/images/scripts/component-entrypoint.sh"
+
+grep -Fq 'ENV PATH="/usr/local/services/cubetoolbox/Cubelet/bin:/usr/local/services/cubetoolbox/cube-shim/bin:${PATH}"' \
+  "$DOCKERFILE" || {
+    echo "cubelet image must expose the staged Cubelet bin directory through PATH" >&2
+    exit 1
+  }
+
+grep -Fq '[[ -x "${dst}/bin/cubecli" ]] || fail "missing cubecli after stage"' \
+  "$ENTRYPOINT" || {
+    echo "cubelet staging must fail when cubecli is missing" >&2
+    exit 1
+  }
+
+if grep -Fq 'ln -sfn "${dst}/bin/cubecli" /usr/local/bin/cubecli' "$ENTRYPOINT"; then
+  echo "cubelet staging should not need a container-side cubecli symlink" >&2
+  exit 1
+fi
+
+echo "Cubelet cubecli PATH guard passed"

--- a/docs/guide/kubernetes/faq.md
+++ b/docs/guide/kubernetes/faq.md
@@ -251,6 +251,23 @@ kubectl -n cube-system logs -l app.kubernetes.io/component=cube-node -c cubelet 
 
 A common cause is inability to reach CubeMaster (network / DNS).
 
+### How do I run `cubecli` in a Kubernetes deployment?
+
+`cubecli` accesses the local Cubelet and containerd sockets of a single compute node. First find the `cube-node` Pod corresponding to the target node, then use `kubectl exec` to run commands inside that Pod:
+
+```bash
+# List the node assigned to each cube-node Pod and find the Pod for the target node
+kubectl get pods -n cube-system \
+  -l app.kubernetes.io/component=cube-node -o wide
+
+# Run cubecli in the cube-node Pod for the target node
+kubectl exec -n cube-system <cube-node-pod> -- cubecli ls
+```
+
+By default, `kubectl exec` enters the `cubelet` container in that `cube-node` Pod, which is the supported place to run `cubecli` in a Kubernetes deployment.
+
+For network-device diagnostics such as `cubecli container taps`, run the command inside the target `cube-node` Pod. The chart defaults to `hostNetwork: false`, so TAP devices are created in the `cube-node` Pod's network namespace. A host login shell normally uses a different network namespace and cannot provide the same diagnostic view. Only when a user customizes `cube-node` with `hostNetwork: true` does the Pod share the host network namespace, allowing the same TAP devices to be inspected from either side.
+
 ### Sandbox start is slow (>10s) while the node is mostly idle
 
 - Check whether the node's CPU load is high.
@@ -382,6 +399,8 @@ kubectl -n cube-system logs <cube-node-pod> -c cube-egress-net --tail=100
 **Bumping Big Pod runtime images / changing the Pod template: yes.** `cube-node` is a native DaemonSet; changes recreate the Pod (UID / IP / netns change) and interrupt existing sandboxes on that node. Bumping only Installer / Bootstrap / PVM while leaving the Big Pod template untouched can leave the Big Pod unchanged. Steps and red lines: [Upgrade](./upgrade.md).
 
 Typical Big Pod recreate triggers: bump `images.cubelet` and other runtime images, add/remove containers, change volumeMount / securityContext / container name / env.
+
+This release changes the default no-`-c` `kubectl exec` and `kubectl logs` target for `cube-node` Pods from `network-agent` to `cubelet`; use `cubeNode.podAnnotations` to set an explicit default if your operational workflow needs another container.
 
 ### Does `helm rollback` roll back the host kernel?
 

--- a/docs/zh/guide/kubernetes/faq.md
+++ b/docs/zh/guide/kubernetes/faq.md
@@ -251,6 +251,23 @@ kubectl -n cube-system logs -l app.kubernetes.io/component=cube-node -c cubelet 
 
 常见原因是连不上 CubeMaster（网络 / DNS）。
 
+### 如何在 Kubernetes 部署中运行 `cubecli`？
+
+`cubecli` 访问的是单个计算节点本地的 Cubelet 和 containerd socket。因此，需要先找到目标计算节点对应的 `cube-node` Pod，再通过 `kubectl exec` 在该 `cube-node` Pod 中运行 `cubecli` 命令：
+
+```bash
+# 查看各个 cube-node Pod 所在的节点，并根据 NODE 列找到目标节点对应的 Pod
+kubectl get pods -n cube-system \
+  -l app.kubernetes.io/component=cube-node -o wide
+
+# 在目标节点对应的 cube-node Pod 中运行 cubecli
+kubectl exec -n cube-system <cube-node-pod> -- cubecli ls
+```
+
+默认情况下，`kubectl exec` 会进入该 `cube-node` Pod 的 `cubelet` container，这是 Kubernetes 部署中运行 `cubecli` 的支持入口。
+
+对于 `cubecli container taps` 这类网络设备诊断命令，建议在目标 `cube-node` Pod 内执行。Chart 默认使用 `hostNetwork: false`，TAP 设备创建在 `cube-node` Pod 的 network namespace 中；宿主机 login shell 通常使用不同的 network namespace，无法提供同一视角。只有在用户自定义 `cube-node` 使用 `hostNetwork: true` 时，`cube-node` Pod 才会与宿主机共享 network namespace，此时才可以从两侧排查同一批 TAP 设备。
+
 ### 沙箱启动很慢（>10s），节点却很空
 
 - 排查节点CPU 负载是否较高。
@@ -382,6 +399,8 @@ kubectl -n cube-system logs <cube-node-pod> -c cube-egress-net --tail=100
 **升 Big Pod 运行时镜像 / 改 Pod template：会。** `cube-node` 是原生 DaemonSet，变更会 recreate Pod（UID / IP / netns 变化），该节点存量沙箱会中断。只升 Installer / Bootstrap / PVM 且不动 Big Pod template 时，Big Pod 可保持不变。步骤与红线见 [升级](./upgrade.md)。
 
 会 recreate Big Pod 的典型操作：bump `images.cubelet` 等运行时镜像、增删容器、改 volumeMount / securityContext / 容器名 / env。
+
+本次变更会把 `cube-node` Pod 中不带 `-c` 的 `kubectl exec` 和 `kubectl logs` 默认目标从 `network-agent` 改为 `cubelet`；如果运维流程需要其他 container，可通过 `cubeNode.podAnnotations` 显式设置默认值。
 
 ### `helm rollback` 会回滚 host kernel 吗？
 


### PR DESCRIPTION
## Motivation

Kubernetes deployments already stage `cubecli` in the Cubelet toolbox, but operators cannot use it through the normal Kubernetes entry point.

By default, `kubectl exec` into a `cube-node` Pod targets the `network-agent` container, while `cubecli` requires access to the local Cubelet and containerd sockets. Even when operators explicitly select the `cubelet` container, the staged `Cubelet/bin` directory is not on `PATH`.

This makes an already-installed node-local CLI hard to use. Operators need to know both the `cubelet` container name and the absolute toolbox path before they can run basic node-local checks.

Since `cubecli` uses the selected node's local Cubelet and containerd sockets, this PR makes the `cubelet` container the supported Kubernetes entry point.

## What Changed

* Set the default container annotation for `cube-node` Pods to `cubelet`, so `kubectl exec` and logs use the container that owns the local Cubelet tools.
* Preserve custom default-container annotations through `cubeNode.podAnnotations`.
* Add the staged Cubelet `bin` directory to the Cubelet image `PATH`, so `kubectl exec` into the `cubelet` container resolves `cubecli` after toolbox staging without a container-side symlink.
* Keep the existing staging validation so Cubelet startup fails clearly when `Cubelet/bin/cubecli` is missing.
* Document how to select a `cube-node` Pod and run `cubecli`, including the network-namespace requirement for `cubecli container taps`.
* Add regression checks for Helm rendering, default-container overrides, and Cubelet staging PATH exposure.
* Publish the Cubelet runtime image built from the updated Dockerfile together with the Chart, using the matching `images.cubelet.tag`.

## Validation

* Ran Helm lint.
* Ran the CubeCLI discovery, Cubelet PATH, and shell syntax guards.
* Ran the complete Kubernetes chart/image guard suite.
* Rendered the Chart and verified the `cubelet` default-container annotation and custom annotation override behavior.
* Installed the Chart on the K3s test cluster and verified:

  * `kubectl exec` without `-c` entered the `cubelet` container.
  * `command -v cubecli && cubecli ls` succeeded inside the selected `cube-node` Pod.
  * the Cubelet image PATH guard covers the staged `Cubelet/bin` directory, and a standalone staging run fails clearly if `Cubelet/bin/cubecli` is missing.

## Scope

This PR only makes the existing staged `cubecli` available inside the `cubelet` container of Kubernetes compute-node Pods.

It does not add host login-shell integration, a standalone `cubecli` workload, expose node-local sockets to another Pod, or change how `cubecli` connects to Cubelet and containerd.

Existing custom default-container annotations remain supported through `cubeNode.podAnnotations`.

Because the default-container annotation changes the `cube-node` Pod template, upgrading an existing release triggers a RollingUpdate of the `cube-node` DaemonSet. Recreated Pods receive new Pod IPs and network namespaces, so running sandboxes may be interrupted; schedule the upgrade during a maintenance window. To preserve the previous no-`-c` behavior, set `cubeNode.podAnnotations["kubectl.kubernetes.io/default-container"]` to `network-agent` before upgrading.
