### PR TITLE
build: route make fmt through builder container outside CI

### DIFF
--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -135,7 +135,7 @@ jobs:
           set -euo pipefail
           make builder-run \
             BUILDER_IMAGE="${{ steps.builder_image.outputs.image }}" \
-            BUILDER_CMD='make fmt'
+            BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make fmt'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/Makefile
+++ b/Makefile
@@ -425,8 +425,11 @@ web-sync-dev-env:
 
 # Run make fmt in each component directory that has a fmt target.
 # Components without formattable code (e.g. CubeProxy) are skipped.
+# Outside the builder, route through builder-run so agent/Makefile's
+# MUSL+SECCOMP parse-time libseccomp.a check does not fail on the host.
 .PHONY: fmt
 fmt:
+ifeq ($(IN_CUBE_SANDBOX_BUILDER),1)
 	@printf '  %-8s %s\n' "FMT" "agent"
 	@$(MAKE) -C agent fmt
 	@printf '  %-8s %s\n' "FMT" "cubecow"
@@ -461,3 +464,7 @@ fmt:
 	else \
 		printf '  %-8s %s\n' "SKIP" "web (npm not available)"; \
 	fi
+else
+	@$(MAKE) builder-image
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make fmt'
+endif


### PR DESCRIPTION
## Summary

When running `make fmt` on a developer machine, the `agent/Makefile` performs a MUSL+SECCOMP parse-time check against `libseccomp.a` which fails on the host. This change routes the `fmt` target through the builder container so the same environment used in CI is also used locally.

### Changes

- **Makefile**: Gate the existing `fmt` logic behind a new `IN_CUBE_SANDBOX_BUILDER` flag. When unset (developer machine), the target builds the builder image and runs `fmt` inside it.
- **fmt-check.yml**: Pass `IN_CUBE_SANDBOX_BUILDER=1` when invoking `make fmt` inside the builder, so CI runs the formatters directly (no nested builder).

### Rationale

Agent FMT checks should be performed in the builder environment. This avoids parse-time `libseccomp.a` resolution failures on developer hosts while keeping CI behavior unchanged.