### PR TITLE
cubemaster: remove ossdb_config, keep a single instance database

### DIFF
--- a/CubeMaster/cmd/cubemaster/app/main.go
+++ b/CubeMaster/cmd/cubemaster/app/main.go
@@ -134,16 +134,15 @@ func coreInit(ctx context.Context, cfg *config.Config) error {
 
 	grpcconn.Init(ctx)
 
-	if cfg.OssDBConfig == nil || cfg.InstanceDBConfig == nil {
-		CubeLog.WithContext(ctx).Warnf("run in degraded mode: oss/instance db config missing, skip localcache/instancecache/scheduler/sandbox init")
+	if cfg.InstanceDBConfig == nil {
+		CubeLog.WithContext(ctx).Warnf("run in degraded mode: instance db config missing, skip localcache/instancecache/scheduler/sandbox init")
 		return nil
 	}
 
 	// Run schema migrations BEFORE any business package Init so they all
-	// see the HEAD schema. Migration uses the same connection pool the
-	// dao facade hands back via dao.Default(); business packages that
-	// still use db.Init() get their own pool but talk to the same MySQL
-	// instance, so they observe the post-migration schema.
+	// see the HEAD schema. Migration uses the single dao.Default() handle
+	// that dao.Open establishes below, so every business package observes
+	// the post-migration schema.
 	if err := initDatabaseSchema(ctx, cfg); err != nil {
 		return fmt.Errorf("dao migrate: %w", err)
 	}
@@ -198,29 +197,13 @@ func coreInit(ctx context.Context, cfg *config.Config) error {
 // process; whoever loses the lock race blocks until the winner is done,
 // then sees the schema is already at HEAD and returns immediately.
 func initDatabaseSchema(ctx context.Context, cfg *config.Config) error {
-	// The schema produced by CubeDB/migrate/migrations is a single
-	// catalog covering both the OSS-side tables (t_cube_host_*, t_cube_node_*,
-	// ...) and the instance-side tables (t_cube_template_*, t_cube_instance_*,
-	// t_cube_sandbox_spec, ...). Running migrations against only one of the
-	// two configured databases would silently leave the other half empty, so
-	// any deployment that genuinely points the two configs at different
-	// physical databases is unsupported and must fail fast at startup.
-	if inst, oss := cfg.InstanceDBConfig, cfg.OssDBConfig; inst != nil && oss != nil {
-		if inst.Driver != oss.Driver || inst.Addr != oss.Addr || inst.DBName != oss.DBName {
-			return fmt.Errorf(
-				"dao: instance_db_config and ossdb_config must point to the same physical database "+
-					"(instance=%s/%s/%s, oss=%s/%s/%s); split-database deployments are not supported by the current schema",
-				inst.Driver, inst.Addr, inst.DBName,
-				oss.Driver, oss.Addr, oss.DBName,
-			)
-		}
-	}
+	// The schema produced by CubeDB/migrate/migrations is a single catalog
+	// covering the host/node inventory tables (t_cube_host_*, t_cube_node_*)
+	// and the instance tables (t_cube_template_*, t_cube_instance_*,
+	// t_cube_sandbox_spec, ...), all in the one configured database.
 	src := cfg.InstanceDBConfig
 	if src == nil {
-		src = cfg.OssDBConfig
-	}
-	if src == nil {
-		return fmt.Errorf("dao: neither instance_db_config nor ossdb_config is set")
+		return fmt.Errorf("dao: instance_db_config is not set")
 	}
 	daoCfg := dao.Config{
 		Driver:                      src.Driver,

--- a/CubeMaster/conf.yaml
+++ b/CubeMaster/conf.yaml
@@ -46,18 +46,6 @@ req_template_conf:
   cube_box_req_template: >-
     {"volumes":[{"name":"tmp","volume_source":{"empty_dir":{"medium":0}}}],"containers":[{"name":"cubebox-default","envs":[{"key":"TZ","value":"Asia/Shanghai"},{"key":"TERM","value":"xterm"}],"volume_mounts":[{"name":"tmp","container_path":"/"}],"security_context":{"privileged":true,"readonly_rootfs":false,"no_new_privs":false}}],"network_type":"tap","cube_network_config":{"allowInternetAccess":true,"denyOut":["10.0.0.0/8","100.64.0.0/10","172.16.0.0/12","192.168.0.0/18"]}}
 
-ossdb_config:
-  addr: "127.0.0.1:3306"
-  user: "cube"
-  pwd: "cube_pass"
-  db_name: "cube_mvp"
-  conn_timeout: 5
-  read_timeout: 5
-  write_timeout: 5
-  max_idle_conns: 5
-  max_open_conns: 20
-  max_conn_life_time_seconds: 300
-
 instance_db_config:
   addr: "127.0.0.1:3306"
   user: "cube"

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -34,7 +34,6 @@ type Config struct {
 	AuthConf         *AuthConf             `yaml:"auth"`
 	Log              *log.Conf             `yaml:"log"`
 	CubeletConf      *CubeletConf          `yaml:"cubelet_conf"`
-	OssDBConfig      *DBConfig             `yaml:"ossdb_config"`
 	InstanceDBConfig *DBConfig             `yaml:"instance_db_config"`
 	RedisConf        *RedisConf            `yaml:"redis"`
 	ExtraConf        *ExtraConf            `yaml:"extra_conf"`
@@ -649,10 +648,6 @@ type HookWhitelist struct {
 }
 
 func GetDbConfig() *DBConfig {
-	return cfg.OssDBConfig
-}
-
-func GetInstanceConfig() *DBConfig {
 	return cfg.InstanceDBConfig
 }
 

--- a/CubeMaster/pkg/instancecache/export.go
+++ b/CubeMaster/pkg/instancecache/export.go
@@ -55,8 +55,8 @@ func Init(ctx context.Context) error {
 	_ = ctx
 	// Schema is owned by pkg/base/dao/migrate and applied at startup
 	// before this package's Init runs.
-	l.db = db.Init(config.GetInstanceConfig())
-	l.dbAddr = config.GetInstanceConfig().Addr
+	l.db = db.Init(config.GetDbConfig())
+	l.dbAddr = config.GetDbConfig().Addr
 	return nil
 }
 

--- a/CubeMaster/pkg/localcache/export.go
+++ b/CubeMaster/pkg/localcache/export.go
@@ -56,7 +56,7 @@ func Init(ctx context.Context) error {
 	l.imageCache = cache.New(0, 0)
 	l.templateNodeCache = cache.New(0, 0)
 	l.db = db.Init(config.GetDbConfig())
-	l.dbAddr = config.GetConfig().OssDBConfig.Addr
+	l.dbAddr = config.GetDbConfig().Addr
 	l.totalSelfNodes = config.GetConfig().Common.DefaultHeadlessServiceNodesNum
 	l.sortedNodesByClusters = make(map[string]node.NodeList)
 	l.sortedNodesByClusters[constants.DefaultInstanceTypeName] = node.NodeList{}

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -251,7 +251,7 @@ func ListTemplates(ctx context.Context) ([]TemplateInfo, error) {
 
 func Init(ctx context.Context) error {
 	_ = ctx
-	if config.GetInstanceConfig() == nil {
+	if config.GetDbConfig() == nil {
 		return ErrTemplateStoreNotInitialized
 	}
 	var initErr error
@@ -259,8 +259,8 @@ func Init(ctx context.Context) error {
 		// Schema is owned by pkg/base/dao/migrate and applied in main.go
 		// before any business package Init runs; here we only attach to
 		// the existing *gorm.DB.
-		store.db = db.Init(config.GetInstanceConfig())
-		store.dbAddr = config.GetInstanceConfig().Addr
+		store.db = db.Init(config.GetDbConfig())
+		store.dbAddr = config.GetDbConfig().Addr
 		if initErr = sandboxspec.Init(store.db); initErr != nil {
 			return
 		}

--- a/configs/single-node/cubemaster.yaml
+++ b/configs/single-node/cubemaster.yaml
@@ -50,18 +50,6 @@ req_template_conf:
   cube_box_req_template: >-
     {"volumes":[{"name":"tmp","volume_source":{"empty_dir":{"medium":0}}}],"containers":[{"name":"cubebox-default","envs":[{"key":"TZ","value":"Asia/Shanghai"},{"key":"TERM","value":"xterm"}],"volume_mounts":[{"name":"tmp","container_path":"/"}],"security_context":{"privileged":true,"readonly_rootfs":false,"no_new_privs":false}}],"network_type":"tap","cube_network_config":{"allowInternetAccess":true,"denyOut":["10.0.0.0/8","100.64.0.0/10","172.16.0.0/12","192.168.0.0/16"]}}
 
-ossdb_config:
-  addr: "127.0.0.1:__CUBE_SANDBOX_MYSQL_PORT__"
-  user: "__CUBE_SANDBOX_MYSQL_USER__"
-  pwd: "__CUBE_SANDBOX_MYSQL_PASSWORD__"
-  db_name: "__CUBE_SANDBOX_MYSQL_DB__"
-  conn_timeout: 5
-  read_timeout: 5
-  write_timeout: 5
-  max_idle_conns: 5
-  max_open_conns: 20
-  max_conn_life_time_seconds: 300
-
 instance_db_config:
   addr: "127.0.0.1:__CUBE_SANDBOX_MYSQL_PORT__"
   user: "__CUBE_SANDBOX_MYSQL_USER__"

--- a/deploy/kubernetes/chart/files/cube-master/conf.yaml
+++ b/deploy/kubernetes/chart/files/cube-master/conf.yaml
@@ -42,19 +42,6 @@ req_template_conf:
   cube_box_req_template: >-
     {"volumes":[{"name":"tmp","volume_source":{"empty_dir":{"medium":0}}}],"containers":[{"name":"cubebox-default","envs":[{"key":"TZ","value":"Asia/Shanghai"},{"key":"TERM","value":"xterm"}],"volume_mounts":[{"name":"tmp","container_path":"/"}],"security_context":{"privileged":true,"readonly_rootfs":false,"no_new_privs":false}}],"network_type":"tap","cubevs_context":{"allowInternetAccess":true,"denyOut":["10.0.0.0/8","100.64.0.0/10","172.16.0.0/12","192.168.0.0/18"]}}
 
-ossdb_config:
-  driver: {{ include "cube.dbDriver" . | quote }}
-  addr: {{ printf "%s:%v" (include "cube.dbHost" .) (include "cube.dbPort" .) | quote }}
-  user: {{ include "cube.dbUser" . | quote }}
-  pwd: {{ include "cube.dbPassword" . | quote }}
-  db_name: {{ include "cube.dbName" . | quote }}
-  conn_timeout: 5
-  read_timeout: 5
-  write_timeout: 5
-  max_idle_conns: 5
-  max_open_conns: 20
-  max_conn_life_time_seconds: 300
-
 instance_db_config:
   driver: {{ include "cube.dbDriver" . | quote }}
   addr: {{ printf "%s:%v" (include "cube.dbHost" .) (include "cube.dbPort" .) | quote }}

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -354,7 +354,7 @@ patch_cubemaster_external_deps() {
     # Match only on the YAML key prefix ('addr:'/'user:'/'pwd:'/'db_name:') and
     # accept any current value, so these patterns keep working even if the
     # conf.yaml template is regenerated with different defaults. These keys only
-    # appear in the MySQL sections (ossdb_config/instance_db_config), so without
+    # appear in the MySQL section (instance_db_config), so without
     # a trailing 'g' flag each line is patched exactly once and Redis fields
     # (nodes:/password:) are never touched.
     sed -i \

--- a/deploy/one-click/terraform/tencentcloud/tke-addons.tf
+++ b/deploy/one-click/terraform/tencentcloud/tke-addons.tf
@@ -311,18 +311,6 @@ resource "kubernetes_secret" "cubemaster_conf" {
         # checks THIS template uses cube_network_config (and not cubevs_context).
         cube_box_req_template = "{\"volumes\":[{\"name\":\"tmp\",\"volume_source\":{\"empty_dir\":{\"medium\":0}}}],\"containers\":[{\"name\":\"cubebox-default\",\"envs\":[{\"key\":\"TZ\",\"value\":\"Asia/Shanghai\"},{\"key\":\"TERM\",\"value\":\"xterm\"}],\"volume_mounts\":[{\"name\":\"tmp\",\"container_path\":\"/\"}],\"security_context\":{\"privileged\":true,\"readonly_rootfs\":false,\"no_new_privs\":false}}],\"network_type\":\"tap\",\"cube_network_config\":{\"allowInternetAccess\":true,\"denyOut\":[\"10.0.0.0/8\",\"100.64.0.0/10\",\"172.16.0.0/12\",\"192.168.0.0/16\"]}}"
       }
-      ossdb_config = {
-        addr                       = "${tencentcloud_mysql_instance.mysql.intranet_ip}:3306"
-        user                       = local.cube_user
-        pwd                        = local.cube_password
-        db_name                    = local.cube_db
-        conn_timeout               = 5
-        read_timeout               = 5
-        write_timeout              = 5
-        max_idle_conns             = 5
-        max_open_conns             = 20
-        max_conn_life_time_seconds = 300
-      }
       instance_db_config = {
         addr                       = "${tencentcloud_mysql_instance.mysql.intranet_ip}:3306"
         user                       = local.cube_user


### PR DESCRIPTION
## Summary

Remove the now-unneeded OSSDB configuration and code paths from CubeMaster. The open-source CubeSandbox ships a single MySQL database (`instance_db_config`); `ossdb_config` is legacy.

## Motivation

The migration catalog is a single set of tables (inventory `t_cube_host_*`/`t_cube_node_*` plus instance `t_cube_template_*`/`t_cube_instance_*`/`t_cube_sandbox_spec`) living in one database, and startup already required both DB configs to point at the same physical database. Keeping two config entries adds misconfiguration surface (changing one silently diverges the other) with no functional value.

## Changes

- **config** — drop `Config.OssDBConfig`; `GetDbConfig()` now returns `InstanceDBConfig`, folding in the old `GetInstanceConfig()`.
- **main** — the degraded-mode check and `initDatabaseSchema()` consult only `instance_db_config`; the now-unreachable split-database consistency check is deleted.
- **instancecache / localcache / templatecenter** — read the single DB config via `GetDbConfig()`.
- **configs & deploy** — remove the `ossdb_config` section from `CubeMaster/conf.yaml`, `configs/single-node/cubemaster.yaml`, the K8s chart `cube-master/conf.yaml`, one-click `install.sh` (comment), and terraform `tke-addons.tf`.

Net -88 lines, no behavior change.

## Compatibility

- A lone `instance_db_config` has the exact same meaning as before (the two configs were already required to point at the same database).
- An old conf.yaml that still carries `ossdb_config` is fine: the lenient yaml parser ignores the unknown key, so no migration is required (verified on a test machine that still has the legacy section).
- Only leftover: the `mocktest_OssDb` variable name in `CubeMaster/integration/mock_init.go` (historical naming, functionally backed by `GetDbConfig()`); can be renamed in a follow-up, not blocking this PR.

## Testing

- `make cubemaster` builds clean.
- Deployed to a one-click test environment and restarted `cube-sandbox-cubemaster.service`: startup OK, `/notify/health` returns 200, no errors in the journal, `cubecli version` reports Server v0.6.0, all `cube-sandbox-*` systemd services have zero failures.
