### PR TITLE
agent: create /dev symlinks even when /dev is bind mounted from the guest

### DIFF
--- a/agent/rustjail/src/mount.rs
+++ b/agent/rustjail/src/mount.rs
@@ -297,11 +297,14 @@ pub fn init_rootfs(
     let olddir = unistd::getcwd()?;
     unistd::chdir(rootfs).map_err(|e| anyhow!("chdir {:} failed:{:}", rootfs, e))?;
 
+    // /dev/fd and /dev/{stdin,stdout,stderr} point into /proc/self/fd. devtmpfs
+    // never provides them, so they are needed even when /dev is bind mounted
+    // from the guest; only the device nodes can be skipped in that case.
+    default_symlinks().map_err(|e| anyhow!("default_symlinks failed:{:}", e))?;
+
     // in case the /dev directory was binded mount from guest,
-    // then there's no need to create devices nodes and symlinks
-    // in /dev.
+    // then there's no need to create devices nodes in /dev.
     if !bind_mount_dev {
-        default_symlinks().map_err(|e| anyhow!("default_symlinks failed:{:}", e))?;
         create_devices(&linux.devices, bind_device)
             .map_err(|e| anyhow!("create_devices failed:{:}", e))?;
         ensure_ptmx()?;
@@ -893,12 +896,21 @@ static SYMLINKS: &[(&str, &str)] = &[
 
 fn default_symlinks() -> Result<()> {
     if Path::new("/proc/kcore").exists() {
-        unix::fs::symlink("/proc/kcore", "dev/kcore")?;
+        ensure_symlink("/proc/kcore", "dev/kcore")?;
     }
     for &(src, dst) in SYMLINKS {
-        unix::fs::symlink(src, dst)?;
+        ensure_symlink(src, dst)?;
     }
     Ok(())
+}
+
+// A bind mounted guest /dev is shared, so the links may already have been
+// created by an earlier container in the same sandbox.
+fn ensure_symlink(src: &str, dst: &str) -> Result<()> {
+    match unix::fs::symlink(src, dst) {
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        other => other.map_err(|e| e.into()),
+    }
 }
 
 fn dev_rel_path(path: &str) -> Option<&Path> {
@@ -1348,6 +1360,28 @@ mod tests {
 
         let ret = stat::stat(path);
         assert!(ret.is_ok(), "Should pass. Got: {:?}", ret);
+    }
+
+    #[test]
+    #[serial(chdir)]
+    fn test_default_symlinks() {
+        let tempdir = tempdir().unwrap();
+
+        let olddir = unistd::getcwd().unwrap();
+        defer!(let _ = unistd::chdir(&olddir););
+        let _ = unistd::chdir(tempdir.path());
+        create_dir("dev").unwrap();
+
+        let ret = default_symlinks();
+        assert!(ret.is_ok(), "Should pass. Got: {:?}", ret);
+        for &(src, dst) in SYMLINKS {
+            assert_eq!(std::fs::read_link(dst).unwrap(), Path::new(src));
+        }
+
+        // A bind mounted guest /dev is shared between containers, so the links
+        // can already be there.
+        let ret = default_symlinks();
+        assert!(ret.is_ok(), "Should be idempotent. Got: {:?}", ret);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The four `/dev` symlinks that the OCI runtime spec requires — `/dev/fd`,
`/dev/stdin`, `/dev/stdout`, `/dev/stderr`, all pointing into `/proc/self/fd` —
are missing inside every sandbox.

`Cubelet` replaces the container's `/dev` with the guest devtmpfs
(`oci.WithoutMounts("/dev")` in `replaceDevMounts()`), so `init_rootfs()` in
`agent/rustjail/src/mount.rs` sees `bind_mount_dev = true` and skips
`default_symlinks()` together with `create_devices()`:

```rust
// in case the /dev directory was binded mount from guest,
// then there's no need to create devices nodes and symlinks
// in /dev.
if !bind_mount_dev {
    default_symlinks()...;
    create_devices(...)?;
    ensure_ptmx()?;
}
```

Skipping `create_devices()` is right — devtmpfs supplies the device nodes. But
devtmpfs never supplies those four symlinks, and `runc` creates them
unconditionally.

## Impact

Measured 14 cases in a sandbox. They fall into three groups:

**1. Hard failure (ENOENT)** — all bash process substitution, plus explicit paths:

```
cat <(echo A)                                  # No such file or directory
diff <(echo a) <(echo a)
readarray -t x < <(printf 'a\nb\n')
source <(echo export FOO=1)
echo x | tee >(cat >/tmp/t)
exec 3</etc/hostname; cat /dev/fd/3
echo hi | cat /dev/stdin
```

**2. Silent data loss, exit code 0** — this is the dangerous group. devtmpfs is
writable, so a redirect to the missing `/dev/stdout` *creates a regular file*
there and swallows the output:

```
$ echo hello >/dev/stdout ; echo "rc=$?"
rc=0                       # nothing printed, nothing on stderr
$ ls -l /dev/stdout
-rw-r--r-- 1 root root 6 /dev/stdout      # a regular file, in RAM
```

Same for `tar -cf /dev/stdout ... | wc -c` → 0 bytes. A service configured to
log to `/dev/stdout` writes into devtmpfs until it fills.

**3. Unaffected** — plain pipes, `sys.stdin`, and `awk '{print}' /dev/stdin`
(awk special-cases the name rather than opening the path).

Creating the four links at runtime makes all 14 cases pass, which is what
pinned the cause down.

## Fix

Hoist `default_symlinks()` out of the `!bind_mount_dev` branch, and make link
creation idempotent: a bind mounted guest `/dev` is shared, so a second
container in the same sandbox would otherwise hit `EEXIST` and fail to start.

## Tests

```
cargo test  -p rustjail --lib mount::        # 14 passed, incl. the new test_default_symlinks
cargo fmt   -p rustjail -- --check           # clean
cargo clippy -p rustjail --all-targets       # no new warnings in the changed code
```

Also verified end to end on a running sandbox: once the four links exist, all 14
cases above pass and the four paths are symlinks into `/proc/self/fd`.
