### PR TITLE
feat(sdk/go): add Volume API (CRUD + volumeMounts)

### DIFF
--- a/docs/guide/volume-plugin.md
+++ b/docs/guide/volume-plugin.md
@@ -4,7 +4,7 @@ CubeSandbox is gradually adopting e2b Volume compatibility to provide persistent
 
 > **Version requirement**
 >
-> Volume features require **Cube platform ≥ 0.6.0** (CubeMaster, CubeAPI, and Cubelet must all be upgraded), plus **Python SDK `cubesandbox` ≥ 0.6.0** (`Volume` and `Sandbox.create(volume_mounts=...)`). Environments below these versions have no Volume API — do not call `/volumes` with an older SDK.
+> Volume features require **Cube platform ≥ 0.6.0** (CubeMaster, CubeAPI, and Cubelet must all be upgraded), plus **Python SDK `cubesandbox` ≥ 0.6.0** (`Volume` and `Sandbox.create(volume_mounts=...)`). The **Go SDK** (`sdk/go`) provides equivalent support as of repository master (`Client.CreateVolume` etc. and `CreateOptions.VolumeMounts`). Environments below these versions have no Volume API — do not call `/volumes` with an older SDK.
 
 > **Current status** (API / SDK)
 >
@@ -14,10 +14,12 @@ CubeSandbox is gradually adopting e2b Volume compatibility to provide persistent
 > | REST `POST /volumes` — create volume | ✅ Supported |
 > | REST `GET /volumes/{volumeID}` — get volume + token | ✅ Supported |
 > | REST `DELETE /volumes/{volumeID}` — delete volume | ✅ Supported (409 when still mounted) |
-> | SDK `Volume.create` / `connect` / `list` / `get_info` / `destroy` | ✅ Supported (SDK ≥ 0.6.0) |
-> | SDK `Sandbox.create(volume_mounts={path: volume})` | ✅ Supported (e2b dict mapping) |
+> | Python SDK `Volume.create` / `connect` / `list` / `get_info` / `destroy` | ✅ Supported (SDK ≥ 0.6.0) |
+> | Python SDK `Sandbox.create(volume_mounts={path: volume})` | ✅ Supported (e2b dict mapping) |
+> | Go SDK `Client.CreateVolume / ListVolumes / GetVolume / DeleteVolume` | ✅ Supported |
+> | Go SDK `CreateOptions.VolumeMounts` (incl. `ReadOnly`) | ✅ Supported |
 > | One volume mounted by multiple sandboxes | ✅ Supported |
-> | Per-sandbox read-only attachment | ✅ Cube SDK extension (`VolumeMount(..., read_only=True)`); the official e2b SDK itself has no read-only mount option |
+> | Per-sandbox read-only attachment | ✅ Cube SDK extension (Python `VolumeMount(..., read_only=True)`, Go `VolumeMount{ReadOnly: true}`); the official e2b SDK itself has no read-only mount option |
 > | Omit `driver` on create (e2b default) | ✅ Supported |
 
 > **e2b API vs SDK**
@@ -46,6 +48,12 @@ Register the same `driver` name on both sides (`volume_plugins`), point `binary_
 
 ```bash
 pip install 'cubesandbox>=0.6.0'
+```
+
+For Go, use the `sdk/go` module:
+
+```bash
+go get github.com/tencentcloud/CubeSandbox/sdk/go
 ```
 
 Use **`cubesandbox`**, not the official e2b Python SDK. Set `CUBE_API_URL`, `CUBE_TEMPLATE_ID`, and (for remote I/O) `CUBE_PROXY_NODE_IP`. See [Environment Setup](#environment-setup).
@@ -363,7 +371,7 @@ CubeAPI forwards `volume_mounts` for plugin volumes via the `plugin-volume-mount
 
 ## SDK Usage
 
-Examples below use **Python SDK `cubesandbox` ≥ 0.6.0**. CubeAPI exposes e2b-compatible `/volumes` REST endpoints; applications should prefer the SDK over raw HTTP.
+Examples below use **Python SDK `cubesandbox` ≥ 0.6.0**; for Go see [Go SDK Usage](#go-sdk-usage). CubeAPI exposes e2b-compatible `/volumes` REST endpoints; applications should prefer the SDK over raw HTTP.
 
 ### e2b compatibility note
 
@@ -372,6 +380,7 @@ Examples below use **Python SDK `cubesandbox` ≥ 0.6.0**. CubeAPI exposes e2b-c
 | CubeAPI `/volumes` REST | ✅ Yes | `POST/GET/DELETE /volumes`, `GET /volumes/{volumeID}` |
 | Official e2b Python SDK | ❌ No | Hardcoded to e2b.cloud; **do not use** with CubeSandbox |
 | `cubesandbox` Python SDK | ✅ Yes | `Volume`, `Sandbox.create(volume_mounts={path: volume})` (e2b dict) |
+| `cubesandbox` Go SDK (`sdk/go`) | ✅ Yes | `Client.CreateVolume / ListVolumes / GetVolume / DeleteVolume`; mounts use the explicit `CreateOptions.VolumeMounts` structs (not the e2b dict) |
 | Omit `driver` on create | ✅ Yes | CubeMaster uses the **first** `volume_plugins` entry |
 | Per-sandbox read-only attachment | ❌ No | The official e2b SDK itself has no read-only Volume mount option; Cube SDK adds `VolumeMount(volume, read_only=True)` |
 
@@ -444,6 +453,53 @@ Volume.destroy(vol.volume_id)  # returns True; False when already gone (idempote
 | `volume_mounts` | e2b dict `{mount_path: Volume \| volume_id \| name}` — key is path inside sandbox, value is a `Volume` instance or volume ID string; Cube SDK can additionally wrap the value with `VolumeMount(..., read_only=True)` for a read-only attachment |
 
 `driver` is stored in `t_cube_volume` and forwarded to Cubelet via annotations — `volume_plugins[].name` must match on both CubeMaster and Cubelet.
+
+### Go SDK Usage
+
+The Go SDK (`sdk/go`) covers the same full lifecycle and uses the same environment variables as Python:
+
+```go
+import (
+	"context"
+	"errors"
+
+	cubesandbox "github.com/tencentcloud/CubeSandbox/sdk/go"
+)
+
+client := cubesandbox.NewClient(cubesandbox.NewConfigFromEnv())
+ctx := context.Background()
+
+// ① Create a volume (control plane) — omitting Driver selects the first volume_plugins entry
+volume, err := client.CreateVolume(ctx, cubesandbox.CreateVolumeOptions{Name: "my-data"})
+
+// List / get one
+volumes, err := client.ListVolumes(ctx)              // no tokens
+volume, err = client.GetVolume(ctx, volume.VolumeID) // includes token
+
+// ② Create a sandbox with the volume mounted (data plane: Attach); ReadOnly is the Cube read-only extension
+sb, err := client.Create(ctx, cubesandbox.CreateOptions{
+	TemplateID: "base",
+	VolumeMounts: []cubesandbox.VolumeMount{
+		{Name: volume.VolumeID, Path: "/workspace"},
+		// {Name: volume.VolumeID, Path: "/dataset", ReadOnly: true}
+	},
+})
+
+// ③ Destroy the sandbox (data plane: Detach)
+err = sb.Kill(ctx)
+
+// ④ Delete the volume (control plane: Destroy)
+if err := client.DeleteVolume(ctx, volume.VolumeID); err != nil {
+	switch {
+	case errors.Is(err, cubesandbox.ErrVolumeInUse):
+		// still mounted (HTTP 409) — destroy the sandboxes using it first
+	case errors.Is(err, cubesandbox.ErrVolumeNotFound):
+		// already gone — idempotent cleanup can ignore this
+	}
+}
+```
+
+Differences from the Python SDK: mounts are the explicit `[]VolumeMount{Name, Path, ReadOnly}` structs (not the e2b dict mapping), and delete outcomes are distinguished with the `ErrVolumeInUse` / `ErrVolumeNotFound` sentinel errors via `errors.Is`. Name rules, the omitted-driver behavior, and token-less list results match Python. See [`sdk/go/README.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/sdk/go/README.md) for more examples.
 
 ### Per-sandbox access mode
 

--- a/docs/zh/guide/volume-plugin.md
+++ b/docs/zh/guide/volume-plugin.md
@@ -4,7 +4,7 @@ CubeSandbox 正在逐步兼容 e2b Volume，为沙箱提供跨生命周期的持
 
 > **版本要求**
 >
-> Volume 能力需要 **Cube 平台 ≥ 0.6.0**（CubeMaster、CubeAPI、Cubelet 均需升级），以及 **Python SDK `cubesandbox` ≥ 0.6.0**（提供 `Volume` 与 `Sandbox.create(volume_mounts=...)`）。低于上述版本的环境无 Volume API，请勿混用旧版 SDK 调用 `/volumes`。
+> Volume 能力需要 **Cube 平台 ≥ 0.6.0**（CubeMaster、CubeAPI、Cubelet 均需升级），以及 **Python SDK `cubesandbox` ≥ 0.6.0**（提供 `Volume` 与 `Sandbox.create(volume_mounts=...)`）。**Go SDK**（`sdk/go`）自仓库 master 起提供等价能力（`Client.CreateVolume` 等与 `CreateOptions.VolumeMounts`）。低于上述版本的环境无 Volume API，请勿混用旧版 SDK 调用 `/volumes`。
 
 > **当前进展**（API / SDK）
 >
@@ -14,10 +14,12 @@ CubeSandbox 正在逐步兼容 e2b Volume，为沙箱提供跨生命周期的持
 > | REST `POST /volumes` — 创建 Volume | ✅ 已支持 |
 > | REST `GET /volumes/{volumeID}` — 查询 Volume + token | ✅ 已支持 |
 > | REST `DELETE /volumes/{volumeID}` — 删除 Volume | ✅ 已支持（仍被挂载时返回 409） |
-> | SDK `Volume.create` / `connect` / `list` / `get_info` / `destroy` | ✅ 已支持（SDK ≥ 0.6.0） |
-> | SDK `Sandbox.create(volume_mounts={path: volume})` | ✅ 已支持（e2b dict 映射） |
+> | Python SDK `Volume.create` / `connect` / `list` / `get_info` / `destroy` | ✅ 已支持（SDK ≥ 0.6.0） |
+> | Python SDK `Sandbox.create(volume_mounts={path: volume})` | ✅ 已支持（e2b dict 映射） |
+> | Go SDK `Client.CreateVolume / ListVolumes / GetVolume / DeleteVolume` | ✅ 已支持 |
+> | Go SDK `CreateOptions.VolumeMounts`（含 `ReadOnly`） | ✅ 已支持 |
 > | 同一 Volume 被多个沙箱同时挂载 | ✅ 已支持 |
-> | 按沙箱只读挂载 | ✅ Cube SDK 扩展（`VolumeMount(..., read_only=True)`）；官方 e2b SDK 自身没有只读挂载选项 |
+> | 按沙箱只读挂载 | ✅ Cube SDK 扩展（Python `VolumeMount(..., read_only=True)`，Go `VolumeMount{ReadOnly: true}`）；官方 e2b SDK 自身没有只读挂载选项 |
 > | 创建时省略 `driver`（e2b 默认行为） | ✅ 已支持 |
 
 > **e2b API 与 SDK**
@@ -46,6 +48,12 @@ CubeSandbox 正在逐步兼容 e2b Volume，为沙箱提供跨生命周期的持
 
 ```bash
 pip install 'cubesandbox>=0.6.0'
+```
+
+Go 侧使用 `sdk/go` 模块：
+
+```bash
+go get github.com/tencentcloud/CubeSandbox/sdk/go
 ```
 
 须使用 **`cubesandbox`**，不可用官方 e2b Python SDK。配置 `CUBE_API_URL`、`CUBE_TEMPLATE_ID`，远程读写时还需 `CUBE_PROXY_NODE_IP`。见 [环境准备](#环境准备)。
@@ -361,7 +369,7 @@ sequenceDiagram
 
 ## SDK 用法
 
-以下示例基于 **Python SDK `cubesandbox` ≥ 0.6.0**。CubeAPI 提供 e2b 兼容的 `/volumes` REST 接口；应用侧推荐优先使用 SDK。
+以下示例基于 **Python SDK `cubesandbox` ≥ 0.6.0**，Go 示例见 [Go SDK 用法](#go-sdk-用法)。CubeAPI 提供 e2b 兼容的 `/volumes` REST 接口；应用侧推荐优先使用 SDK。
 
 ### e2b 兼容性说明
 
@@ -370,6 +378,7 @@ sequenceDiagram
 | CubeAPI `/volumes` REST | ✅ 是 | `POST/GET/DELETE /volumes`、`GET /volumes/{volumeID}` |
 | 官方 e2b Python SDK | ❌ 否 | 硬编码 e2b.cloud 后端；**勿**用于 CubeSandbox |
 | `cubesandbox` Python SDK | ✅ 是 | `Volume`、`Sandbox.create(volume_mounts={path: volume})`（e2b dict） |
+| `cubesandbox` Go SDK（`sdk/go`） | ✅ 是 | `Client.CreateVolume / ListVolumes / GetVolume / DeleteVolume`；挂载用显式结构体 `CreateOptions.VolumeMounts`（非 e2b dict） |
 | 创建时省略 `driver` | ✅ 是 | CubeMaster 取 `volume_plugins` **列表第一项** |
 | 按沙箱只读挂载 | ❌ 否 | 官方 e2b SDK 自身没有只读 Volume 挂载选项；Cube SDK 增加 `VolumeMount(volume, read_only=True)` 扩展 |
 
@@ -442,6 +451,53 @@ Volume.destroy(vol.volume_id)  # 返回 True；卷不存在时返回 False（幂
 | `volume_mounts` | e2b dict `{挂载路径: Volume \| volume_id \| name}` — key 为沙箱内路径，value 为 `Volume` 实例或 volume ID 字符串；Cube SDK 还可将 value 包装为 `VolumeMount(..., read_only=True)` 以启用只读挂载 |
 
 `driver` 写入 `t_cube_volume`，沙箱创建时经 annotation 传给 Cubelet——CubeMaster 与 Cubelet 两侧 `volume_plugins[].name` 须与之一致。
+
+### Go SDK 用法
+
+Go SDK（`sdk/go`）提供与上文等价的完整生命周期，使用与 Python 相同的环境变量：
+
+```go
+import (
+	"context"
+	"errors"
+
+	cubesandbox "github.com/tencentcloud/CubeSandbox/sdk/go"
+)
+
+client := cubesandbox.NewClient(cubesandbox.NewConfigFromEnv())
+ctx := context.Background()
+
+// ① 创建 Volume（管理面）——Driver 省略时取 volume_plugins 第一项
+volume, err := client.CreateVolume(ctx, cubesandbox.CreateVolumeOptions{Name: "my-data"})
+
+// 列出 / 单查
+volumes, err := client.ListVolumes(ctx)              // 不含 token
+volume, err = client.GetVolume(ctx, volume.VolumeID) // 含 token
+
+// ② 创建沙箱并挂载（数据面：Attach）；ReadOnly 为 Cube 只读扩展
+sb, err := client.Create(ctx, cubesandbox.CreateOptions{
+	TemplateID: "base",
+	VolumeMounts: []cubesandbox.VolumeMount{
+		{Name: volume.VolumeID, Path: "/workspace"},
+		// {Name: volume.VolumeID, Path: "/dataset", ReadOnly: true}
+	},
+})
+
+// ③ 销毁沙箱（数据面：Detach，解绑）
+err = sb.Kill(ctx)
+
+// ④ 删除 Volume（管理面：Destroy）
+if err := client.DeleteVolume(ctx, volume.VolumeID); err != nil {
+	switch {
+	case errors.Is(err, cubesandbox.ErrVolumeInUse):
+		// 仍被挂载（HTTP 409）——先销毁使用该卷的沙箱
+	case errors.Is(err, cubesandbox.ErrVolumeNotFound):
+		// 已不存在——幂等清理可忽略
+	}
+}
+```
+
+与 Python SDK 的差异：挂载参数是显式的 `[]VolumeMount{Name, Path, ReadOnly}` 结构体（非 e2b dict 映射）；删除结果通过 `ErrVolumeInUse` / `ErrVolumeNotFound` 哨兵错误用 `errors.Is` 区分。name 规则、driver 省略行为、list 不返回 token 等语义与 Python 一致。更多示例见 [`sdk/go/README.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/sdk/go/README.md)。
 
 ### 按沙箱选择访问模式
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -190,6 +190,48 @@ clones, err := sb.Clone(ctx, cubesandbox.CloneOptions{N: 3, Concurrency: 3})
 
 `Clone` snapshots the sandbox, creates `N` sandboxes from it (capped by `Concurrency`), then deletes the ephemeral snapshot. If any create fails, all successful siblings are killed and the first error is returned. `Rollback` restarts the sandbox process and drops pooled data-plane connections so the next call reconnects.
 
+## Volumes
+
+Persistent volumes survive sandbox lifecycles and are mounted at creation via `VolumeMounts`.
+
+```go
+// Driver is optional: when empty the backend uses its first configured
+// volume plugin (e2b compatible). Name is optional too — when empty the
+// server generates a UUID used as both name and volume ID.
+volume, err := client.CreateVolume(ctx, cubesandbox.CreateVolumeOptions{
+	Name:   "my-data",
+	Driver: "cos",
+}) // POST /volumes
+
+volumes, err := client.ListVolumes(ctx)         // GET /volumes (no tokens)
+volume, err = client.GetVolume(ctx, "my-data")  // GET /volumes/:id (includes token)
+
+sb, err := client.Create(ctx, cubesandbox.CreateOptions{
+	TemplateID: "base",
+	VolumeMounts: []cubesandbox.VolumeMount{
+		{Name: "my-data", Path: "/workspace"},
+		{Name: "shared-cache", Path: "/cache", ReadOnly: true},
+	},
+})
+
+err = client.DeleteVolume(ctx, "my-data") // DELETE /volumes/:id
+```
+
+Deleting a volume does not auto-detach it: destroy the sandboxes using it first, otherwise the server refuses with an error matching `ErrVolumeInUse`. A delete of a missing volume matches `ErrVolumeNotFound`, so idempotent cleanup can ignore that case:
+
+```go
+if err := client.DeleteVolume(ctx, "my-data"); err != nil {
+	switch {
+	case errors.Is(err, cubesandbox.ErrVolumeInUse):
+		// still mounted — destroy the sandboxes using it first
+	case errors.Is(err, cubesandbox.ErrVolumeNotFound):
+		// already gone
+	default:
+		return err
+	}
+}
+```
+
 ## L7 Egress Policy
 
 ```go

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -166,6 +166,13 @@ func (c *Client) createPayload(opts CreateOptions) (map[string]any, error) {
 		payload["network"] = network
 	}
 
+	if len(opts.VolumeMounts) > 0 {
+		if err := validateVolumeMounts(opts.VolumeMounts); err != nil {
+			return nil, err
+		}
+		payload["volumeMounts"] = opts.VolumeMounts
+	}
+
 	for key, value := range opts.Extra {
 		payload[key] = value
 	}

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -17,12 +17,18 @@ const (
 	apiErrorKindAuthentication   = "authentication"
 	apiErrorKindSandboxNotFound  = "sandbox_not_found"
 	apiErrorKindTemplateNotFound = "template_not_found"
+	apiErrorKindVolumeNotFound   = "volume_not_found"
+	apiErrorKindVolumeInUse      = "volume_in_use"
 )
 
 var (
 	ErrAuthentication   = errors.New("cubesandbox: authentication failed")
 	ErrSandboxNotFound  = errors.New("cubesandbox: sandbox not found")
 	ErrTemplateNotFound = errors.New("cubesandbox: template not found")
+	ErrVolumeNotFound   = errors.New("cubesandbox: volume not found")
+	// ErrVolumeInUse matches the HTTP 409 the server returns when deleting a
+	// volume that is still mounted by one or more sandboxes.
+	ErrVolumeInUse = errors.New("cubesandbox: volume is still in use")
 )
 
 // APIError describes an HTTP error returned by the CubeSandbox API.
@@ -53,6 +59,10 @@ func (e *APIError) Is(target error) bool {
 		return e.Kind == apiErrorKindSandboxNotFound
 	case ErrTemplateNotFound:
 		return e.Kind == apiErrorKindTemplateNotFound
+	case ErrVolumeNotFound:
+		return e.Kind == apiErrorKindVolumeNotFound
+	case ErrVolumeInUse:
+		return e.Kind == apiErrorKindVolumeInUse
 	default:
 		return false
 	}
@@ -75,16 +85,36 @@ func apiErrorFromStatus(statusCode int, message string) *APIError {
 	case http.StatusUnauthorized, http.StatusForbidden:
 		kind = apiErrorKindAuthentication
 	case http.StatusNotFound:
-		if strings.Contains(lowerMessage, "template") {
+		switch {
+		case strings.Contains(lowerMessage, "template"):
 			kind = apiErrorKindTemplateNotFound
-		} else {
+		// Match the exact server phrasing ("volume not found: <id>" from
+		// CubeMaster's volume handlers) rather than the bare word "volume",
+		// so a sandbox-related 404 that merely mentions a volume cannot be
+		// misclassified as ErrVolumeNotFound.
+		case strings.Contains(lowerMessage, "volume not found"):
+			kind = apiErrorKindVolumeNotFound
+		default:
 			kind = apiErrorKindSandboxNotFound
+		}
+	case http.StatusConflict:
+		// CubeMaster refuses to delete a mounted volume with
+		// "volume <id> is in use by <n> node(s); ..." relayed as HTTP 409.
+		// This mapping is coupled to that wording (handleDeleteVolume in
+		// CubeMaster) — keep the two in sync. If the server rewords the
+		// message, errors.Is(err, ErrVolumeInUse) degrades to false and the
+		// error surfaces as a generic 409 APIError. The duplicate-name 409
+		// ("volume already exists") intentionally stays generic.
+		if strings.Contains(lowerMessage, "volume") && strings.Contains(lowerMessage, "in use") {
+			kind = apiErrorKindVolumeInUse
 		}
 	}
 	if kind == apiErrorKindAPI && strings.Contains(lowerMessage, "not found") {
 		switch {
 		case strings.Contains(lowerMessage, "template"):
 			kind = apiErrorKindTemplateNotFound
+		case strings.Contains(lowerMessage, "volume not found"):
+			kind = apiErrorKindVolumeNotFound
 		case strings.Contains(lowerMessage, "sandbox"):
 			kind = apiErrorKindSandboxNotFound
 		}

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -66,7 +66,11 @@ type CreateOptions struct {
 	Metadata            map[string]string
 	AllowInternetAccess *bool
 	Network             NetworkOptions
-	Extra               map[string]any
+	// VolumeMounts attaches existing persistent volumes at creation. Each
+	// mount's Name must be an existing volumeID (see Client.CreateVolume) and
+	// Path a clean absolute path inside the sandbox.
+	VolumeMounts []VolumeMount
+	Extra        map[string]any
 }
 
 // DurationPtr returns a pointer to d. It is a convenience for optional

--- a/sdk/go/volume.go
+++ b/sdk/go/volume.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubesandbox
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// MaxVolumeNameLen mirrors CubeAPI's `MAX_VOLUME_NAME_LEN` enforced in
+// `CubeAPI/src/handlers/volumes.rs`. Validating client-side turns an opaque
+// HTTP 400 into a clean error at the call site.
+const MaxVolumeNameLen = 128
+
+// volumeNameRe mirrors the `^[a-zA-Z0-9_-]+$` rule enforced by CubeAPI for
+// volume names. Volume IDs use the same character class (named volumes have
+// volume_id == name; unnamed ones get a UUID, which also matches).
+var volumeNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// VolumeInfo describes a CubeSandbox persistent volume.
+type VolumeInfo struct {
+	// VolumeID is the stable identifier of the volume. It equals the
+	// user-provided name, or an auto-generated UUID for unnamed volumes.
+	VolumeID string `json:"volumeID"`
+	// Name is the human-readable display name.
+	Name string `json:"name"`
+	// Token is the optional auth token issued by the volume plugin. It is
+	// empty when the plugin does not issue one, and always empty for entries
+	// returned by ListVolumes (tokens are only surfaced on create/get-single).
+	// It is a data-plane credential: String/GoString mask it, so read the
+	// field directly when the actual value is needed.
+	Token string `json:"token"`
+}
+
+// String masks Token so the credential never leaks into logs, %v/%+v
+// formatting, or error text — mirroring the Python SDK's VolumeInfo repr.
+func (v VolumeInfo) String() string {
+	token := ""
+	if v.Token != "" {
+		token = "***"
+	}
+	return fmt.Sprintf("VolumeInfo{VolumeID:%q, Name:%q, Token:%q}", v.VolumeID, v.Name, token)
+}
+
+// GoString masks Token for %#v as well, which bypasses String.
+func (v VolumeInfo) GoString() string {
+	return v.String()
+}
+
+// CreateVolumeOptions contains options for CreateVolume.
+type CreateVolumeOptions struct {
+	// Name is an optional volume identifier. When provided it must match
+	// ^[a-zA-Z0-9_-]+$ and be at most MaxVolumeNameLen characters. When empty
+	// the server generates a UUID and uses it as both name and volume ID.
+	Name string
+	// Driver optionally pins a configured volume plugin (matches a
+	// volume_plugins[].name entry in the CubeMaster config, e.g. "cos" or
+	// "nfs"). When empty the field is not sent and the backend falls back to
+	// its first configured plugin (e2b-compatible behavior).
+	Driver string
+}
+
+// CreateVolume creates a new persistent volume via POST /volumes.
+func (c *Client) CreateVolume(ctx context.Context, opts CreateVolumeOptions) (*VolumeInfo, error) {
+	if err := validateVolumeName(opts.Name); err != nil {
+		return nil, err
+	}
+	payload := map[string]any{"name": opts.Name}
+	if opts.Driver != "" {
+		payload["driver"] = opts.Driver
+	}
+	var volume VolumeInfo
+	if err := c.doJSON(ctx, http.MethodPost, "/volumes", payload, &volume, http.StatusOK, http.StatusCreated); err != nil {
+		return nil, err
+	}
+	return &volume, nil
+}
+
+// ListVolumes lists all volumes via GET /volumes. Tokens are only surfaced on
+// create/get-single, so VolumeInfo.Token is always empty in list results.
+func (c *Client) ListVolumes(ctx context.Context) ([]VolumeInfo, error) {
+	var volumes []VolumeInfo
+	if err := c.doJSON(ctx, http.MethodGet, "/volumes", nil, &volumes, http.StatusOK); err != nil {
+		return nil, err
+	}
+	return volumes, nil
+}
+
+// GetVolume fetches a single volume, including its token, via
+// GET /volumes/{volumeID}. A missing volume matches ErrVolumeNotFound.
+func (c *Client) GetVolume(ctx context.Context, volumeID string) (*VolumeInfo, error) {
+	if err := validateVolumeID(volumeID); err != nil {
+		return nil, err
+	}
+	var volume VolumeInfo
+	if err := c.doJSON(ctx, http.MethodGet, "/volumes/"+url.PathEscape(volumeID), nil, &volume, http.StatusOK); err != nil {
+		return nil, err
+	}
+	return &volume, nil
+}
+
+// DeleteVolume permanently deletes a volume via DELETE /volumes/{volumeID}.
+//
+// Deleting a volume does not auto-detach it from running sandboxes: while any
+// sandbox still mounts it the server refuses with a conflict that matches
+// ErrVolumeInUse. A missing volume matches ErrVolumeNotFound, so callers that
+// want e2b-style idempotent deletes can treat that case as "already gone".
+func (c *Client) DeleteVolume(ctx context.Context, volumeID string) error {
+	if err := validateVolumeID(volumeID); err != nil {
+		return err
+	}
+	return c.doJSON(ctx, http.MethodDelete, "/volumes/"+url.PathEscape(volumeID), nil, nil, http.StatusOK, http.StatusNoContent)
+}
+
+func validateVolumeName(name string) error {
+	if name == "" {
+		return nil
+	}
+	if len(name) > MaxVolumeNameLen {
+		return fmt.Errorf("volume name must be at most %d characters, got %d", MaxVolumeNameLen, len(name))
+	}
+	if !volumeNameRe.MatchString(name) {
+		return fmt.Errorf("volume name must match ^[a-zA-Z0-9_-]+$ (letters, digits, '_' and '-'), got %q", name)
+	}
+	return nil
+}
+
+// validateVolumeID rejects IDs that are unsafe to embed in a URL path.
+// Defense-in-depth against path traversal: a malicious volumeID such as
+// "../other" must not be interpolated into the request URL. The accepted
+// character class covers both named volumes and auto-generated UUIDs.
+func validateVolumeID(volumeID string) error {
+	if volumeID == "" {
+		return fmt.Errorf("volumeID must be a non-empty string")
+	}
+	if !volumeNameRe.MatchString(volumeID) {
+		return fmt.Errorf("volumeID must match ^[a-zA-Z0-9_-]+$ (letters, digits, '_' and '-'), got %q", volumeID)
+	}
+	return nil
+}
+
+// validateVolumeMounts checks CreateOptions.VolumeMounts before the request is
+// sent. Mount paths are user input forwarded to the backend, so we require a
+// clean absolute POSIX path and reject any "."/".." segment; the backend is
+// expected to validate as well.
+func validateVolumeMounts(mounts []VolumeMount) error {
+	for i, mount := range mounts {
+		if err := validateVolumeID(mount.Name); err != nil {
+			return fmt.Errorf("volumeMounts[%d]: %w", i, err)
+		}
+		if err := validateVolumeMountPath(mount.Path); err != nil {
+			return fmt.Errorf("volumeMounts[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func validateVolumeMountPath(path string) error {
+	if path == "" {
+		return fmt.Errorf("volume mount path must be a non-empty string")
+	}
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("volume mount path must be absolute (start with '/'), got %q", path)
+	}
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "." || segment == ".." {
+			return fmt.Errorf("volume mount path must not contain '.' or '..' segments, got %q", path)
+		}
+	}
+	return nil
+}

--- a/sdk/go/volume_integration_test.go
+++ b/sdk/go/volume_integration_test.go
@@ -1,0 +1,423 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package cubesandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testVolumeDriver returns the volume driver the integration tests should
+// pin, from CUBE_VOLUME_TEST_DRIVER. Empty (the default) omits the driver so
+// the backend falls back to its first configured plugin — set it to e.g.
+// "cos" to run the same suite against a specific storage backend.
+func testVolumeDriver() string {
+	return os.Getenv("CUBE_VOLUME_TEST_DRIVER")
+}
+
+// TestIntegrationVolumeLifecycle exercises the full volume feature end to end
+// against a live backend: CRUD, mounting at sandbox creation, data persistence
+// across sandbox lifecycles, read-only mounts, and in-use delete protection.
+// Requires at least one volume plugin configured in CubeMaster/Cubelet.
+func TestIntegrationVolumeLifecycle(t *testing.T) {
+	cfg := integrationConfig(t)
+	client := NewClient(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	volumeName := fmt.Sprintf("go-sdk-e2e-%d", time.Now().UnixNano())
+
+	// -- Create --
+	volume, err := client.CreateVolume(ctx, CreateVolumeOptions{Name: volumeName, Driver: testVolumeDriver()})
+	if err != nil {
+		t.Fatalf("CreateVolume returned error: %v", err)
+	}
+	t.Cleanup(func() { deleteVolumeWithRetry(t, client, volume.VolumeID) })
+	if volume.VolumeID != volumeName || volume.Name != volumeName {
+		t.Fatalf("created volume mismatch: %#v", volume)
+	}
+
+	// -- Get --
+	got, err := client.GetVolume(ctx, volume.VolumeID)
+	if err != nil {
+		t.Fatalf("GetVolume returned error: %v", err)
+	}
+	if got.VolumeID != volume.VolumeID {
+		t.Fatalf("GetVolume volumeID=%q, want %q", got.VolumeID, volume.VolumeID)
+	}
+
+	// -- List --
+	volumes, err := client.ListVolumes(ctx)
+	if err != nil {
+		t.Fatalf("ListVolumes returned error: %v", err)
+	}
+	found := false
+	for _, v := range volumes {
+		if v.VolumeID == volume.VolumeID {
+			found = true
+			if v.Token != "" {
+				t.Fatalf("list entry should not surface token: %#v", v)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("ListVolumes does not contain %q: %#v", volume.VolumeID, volumes)
+	}
+
+	// -- Missing volume maps to ErrVolumeNotFound --
+	if _, err := client.GetVolume(ctx, "go-sdk-e2e-does-not-exist"); !errors.Is(err, ErrVolumeNotFound) {
+		t.Fatalf("GetVolume missing error=%v, want ErrVolumeNotFound", err)
+	}
+
+	// -- Mount into a sandbox and write through the mount --
+	const mountPath = "/mnt/e2e-vol"
+	marker := fmt.Sprintf("volume-data-%d", time.Now().UnixNano())
+
+	first := createIntegrationSandbox(t, ctx, client, CreateOptions{
+		Timeout:      DurationPtr(2 * time.Minute),
+		Metadata:     map[string]string{"sdk": "go", "scenario": "integration-volume"},
+		VolumeMounts: []VolumeMount{{Name: volume.VolumeID, Path: mountPath}},
+	})
+
+	info, err := first.GetInfo(ctx)
+	if err != nil {
+		t.Fatalf("GetInfo returned error: %v", err)
+	}
+	if len(info.VolumeMounts) == 0 {
+		// Servers older than #696 do not return volumeMounts in sandbox info.
+		t.Logf("server does not report volumeMounts in sandbox info (pre-#696); skipping assertion")
+	} else if info.VolumeMounts[0].Name != volume.VolumeID || info.VolumeMounts[0].Path != mountPath {
+		t.Fatalf("sandbox volumeMounts mismatch: %#v", info.VolumeMounts)
+	}
+
+	write, err := first.Commands().Run(ctx,
+		fmt.Sprintf("printf %%s %s > %s/persist.txt && cat %s/persist.txt", marker, mountPath, mountPath),
+		CommandOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("write through mount returned error: %v", err)
+	}
+	if write.ExitCode != 0 || write.Stdout != marker {
+		t.Fatalf("write through mount failed: %#v", write)
+	}
+
+	// -- Deleting a mounted volume must be refused with ErrVolumeInUse --
+	err = client.DeleteVolume(ctx, volume.VolumeID)
+	if !errors.Is(err, ErrVolumeInUse) {
+		t.Fatalf("DeleteVolume while mounted error=%v, want ErrVolumeInUse", err)
+	}
+
+	// -- Data must survive the sandbox lifecycle --
+	if err := first.Kill(ctx); err != nil {
+		t.Fatalf("Kill first sandbox returned error: %v", err)
+	}
+
+	second := createIntegrationSandbox(t, ctx, client, CreateOptions{
+		Timeout:      DurationPtr(2 * time.Minute),
+		Metadata:     map[string]string{"sdk": "go", "scenario": "integration-volume-second"},
+		VolumeMounts: []VolumeMount{{Name: volume.VolumeID, Path: mountPath}},
+	})
+
+	read, err := second.Commands().Run(ctx, fmt.Sprintf("cat %s/persist.txt", mountPath),
+		CommandOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("read through mount returned error: %v", err)
+	}
+	if read.ExitCode != 0 || read.Stdout != marker {
+		t.Fatalf("volume data did not persist across sandboxes: %#v", read)
+	}
+	if err := second.Kill(ctx); err != nil {
+		t.Fatalf("Kill second sandbox returned error: %v", err)
+	}
+
+	// -- Read-only mount: reads succeed, writes are rejected --
+	// The server allows each volume to be mounted at most once per sandbox,
+	// so the read-only attachment gets its own sandbox.
+	const roPath = "/mnt/e2e-vol-ro"
+	third := createIntegrationSandbox(t, ctx, client, CreateOptions{
+		Timeout:      DurationPtr(2 * time.Minute),
+		Metadata:     map[string]string{"sdk": "go", "scenario": "integration-volume-readonly"},
+		VolumeMounts: []VolumeMount{{Name: volume.VolumeID, Path: roPath, ReadOnly: true}},
+	})
+
+	roRead, err := third.Commands().Run(ctx, fmt.Sprintf("cat %s/persist.txt", roPath),
+		CommandOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("read through read-only mount returned error: %v", err)
+	}
+	if roRead.ExitCode != 0 || roRead.Stdout != marker {
+		t.Fatalf("read-only mount read mismatch: %#v", roRead)
+	}
+	roWrite, err := third.Commands().Run(ctx, fmt.Sprintf("touch %s/should-fail.txt 2>&1", roPath),
+		CommandOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("write attempt on read-only mount returned transport error: %v", err)
+	}
+	if roWrite.ExitCode == 0 {
+		// Servers older than #1098 accept the readOnly flag but do not
+		// enforce it; treat that as a known capability gap, not a failure.
+		t.Logf("server does not enforce read-only attachments (pre-#1098); skipping assertion")
+	}
+
+	// -- After all sandboxes are gone the volume can be deleted --
+	if err := third.Kill(ctx); err != nil {
+		t.Fatalf("Kill third sandbox returned error: %v", err)
+	}
+	deleteVolumeWithRetry(t, client, volume.VolumeID)
+
+	if _, err := client.GetVolume(ctx, volume.VolumeID); !errors.Is(err, ErrVolumeNotFound) {
+		t.Fatalf("GetVolume after delete error=%v, want ErrVolumeNotFound", err)
+	}
+}
+
+// TestIntegrationCreateVolumeUnknownDriver verifies the server rejects a
+// driver that is not configured, and that the SDK surfaces it as an APIError.
+func TestIntegrationCreateVolumeUnknownDriver(t *testing.T) {
+	cfg := integrationConfig(t)
+	client := NewClient(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := client.CreateVolume(ctx, CreateVolumeOptions{
+		Name:   fmt.Sprintf("go-sdk-e2e-baddriver-%d", time.Now().UnixNano()),
+		Driver: "go-sdk-e2e-no-such-driver",
+	})
+	if err == nil {
+		t.Fatal("CreateVolume with unknown driver returned nil error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not APIError: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(apiErr.Message), "unknown driver") {
+		t.Fatalf("unexpected error message: %v", apiErr)
+	}
+}
+
+// TestIntegrationVolumeSharedByConcurrentSandboxes mounts one volume into two
+// running sandboxes at once: writes from one must be visible in the other, and
+// the volume must stay delete-protected until the last sandbox is gone.
+func TestIntegrationVolumeSharedByConcurrentSandboxes(t *testing.T) {
+	cfg := integrationConfig(t)
+	client := NewClient(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	volumeName := fmt.Sprintf("go-sdk-e2e-shared-%d", time.Now().UnixNano())
+	volume, err := client.CreateVolume(ctx, CreateVolumeOptions{Name: volumeName, Driver: testVolumeDriver()})
+	if err != nil {
+		t.Fatalf("CreateVolume returned error: %v", err)
+	}
+	t.Cleanup(func() { deleteVolumeWithRetry(t, client, volume.VolumeID) })
+
+	const mountPath = "/mnt/e2e-shared"
+	marker := fmt.Sprintf("shared-data-%d", time.Now().UnixNano())
+
+	writer := createIntegrationSandbox(t, ctx, client, CreateOptions{
+		Timeout:      DurationPtr(3 * time.Minute),
+		Metadata:     map[string]string{"sdk": "go", "scenario": "integration-volume-shared-writer"},
+		VolumeMounts: []VolumeMount{{Name: volume.VolumeID, Path: mountPath}},
+	})
+	reader := createIntegrationSandbox(t, ctx, client, CreateOptions{
+		Timeout:      DurationPtr(3 * time.Minute),
+		Metadata:     map[string]string{"sdk": "go", "scenario": "integration-volume-shared-reader"},
+		VolumeMounts: []VolumeMount{{Name: volume.VolumeID, Path: mountPath}},
+	})
+
+	write, err := writer.Commands().Run(ctx,
+		fmt.Sprintf("printf %%s %s > %s/shared.txt", marker, mountPath),
+		CommandOptions{Timeout: 30 * time.Second})
+	if err != nil || write.ExitCode != 0 {
+		t.Fatalf("write from writer sandbox failed: err=%v result=%#v", err, write)
+	}
+
+	// Cross-sandbox visibility: the write must be observable from the other
+	// running sandbox. Shared FUSE/virtiofs backends may have a small
+	// propagation delay, so poll briefly.
+	readDeadline := time.Now().Add(30 * time.Second)
+	for {
+		read, err := reader.Commands().Run(ctx, fmt.Sprintf("cat %s/shared.txt 2>/dev/null", mountPath),
+			CommandOptions{Timeout: 30 * time.Second})
+		if err != nil {
+			t.Fatalf("read from reader sandbox returned error: %v", err)
+		}
+		if read.ExitCode == 0 && read.Stdout == marker {
+			break
+		}
+		if time.Now().After(readDeadline) {
+			t.Fatalf("write not visible from concurrent sandbox: %#v", read)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	// Both sandboxes alive: delete must be refused.
+	if err := client.DeleteVolume(ctx, volume.VolumeID); !errors.Is(err, ErrVolumeInUse) {
+		t.Fatalf("DeleteVolume with two mounts error=%v, want ErrVolumeInUse", err)
+	}
+
+	// One sandbox alive: delete must still be refused.
+	if err := writer.Kill(ctx); err != nil {
+		t.Fatalf("Kill writer sandbox returned error: %v", err)
+	}
+	if err := client.DeleteVolume(ctx, volume.VolumeID); !errors.Is(err, ErrVolumeInUse) {
+		t.Fatalf("DeleteVolume with one remaining mount error=%v, want ErrVolumeInUse", err)
+	}
+
+	// Last sandbox gone: delete succeeds (retry while detach refcount settles).
+	if err := reader.Kill(ctx); err != nil {
+		t.Fatalf("Kill reader sandbox returned error: %v", err)
+	}
+	deleteVolumeWithRetry(t, client, volume.VolumeID)
+}
+
+// TestIntegrationVolumeGeneratedName creates a volume without a name: the
+// server must generate an ID usable for mounting and deletion.
+func TestIntegrationVolumeGeneratedName(t *testing.T) {
+	cfg := integrationConfig(t)
+	client := NewClient(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	volume, err := client.CreateVolume(ctx, CreateVolumeOptions{Driver: testVolumeDriver()})
+	if err != nil {
+		t.Fatalf("CreateVolume with empty name returned error: %v", err)
+	}
+	t.Cleanup(func() { deleteVolumeWithRetry(t, client, volume.VolumeID) })
+	if volume.VolumeID == "" {
+		t.Fatalf("server did not generate a volume ID: %#v", volume)
+	}
+	if volume.Name != volume.VolumeID {
+		t.Fatalf("generated name should equal volume ID: %#v", volume)
+	}
+
+	const mountPath = "/mnt/e2e-generated"
+	sb := createIntegrationSandbox(t, ctx, client, CreateOptions{
+		Timeout:      DurationPtr(2 * time.Minute),
+		Metadata:     map[string]string{"sdk": "go", "scenario": "integration-volume-generated"},
+		VolumeMounts: []VolumeMount{{Name: volume.VolumeID, Path: mountPath}},
+	})
+	run, err := sb.Commands().Run(ctx, fmt.Sprintf("printf ok > %s/gen.txt && cat %s/gen.txt", mountPath, mountPath),
+		CommandOptions{Timeout: 30 * time.Second})
+	if err != nil || run.ExitCode != 0 || run.Stdout != "ok" {
+		t.Fatalf("write/read through generated-name volume failed: err=%v result=%#v", err, run)
+	}
+	if err := sb.Kill(ctx); err != nil {
+		t.Fatalf("Kill sandbox returned error: %v", err)
+	}
+}
+
+// TestIntegrationCreateVolumeDuplicateName verifies that creating the same
+// volume name twice is rejected with a conflict that is NOT ErrVolumeInUse.
+func TestIntegrationCreateVolumeDuplicateName(t *testing.T) {
+	cfg := integrationConfig(t)
+	client := NewClient(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	volumeName := fmt.Sprintf("go-sdk-e2e-dup-%d", time.Now().UnixNano())
+	volume, err := client.CreateVolume(ctx, CreateVolumeOptions{Name: volumeName, Driver: testVolumeDriver()})
+	if err != nil {
+		t.Fatalf("CreateVolume returned error: %v", err)
+	}
+	t.Cleanup(func() { deleteVolumeWithRetry(t, client, volume.VolumeID) })
+
+	_, err = client.CreateVolume(ctx, CreateVolumeOptions{Name: volumeName, Driver: testVolumeDriver()})
+	if err == nil {
+		t.Fatal("duplicate CreateVolume returned nil error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("duplicate create error is not APIError: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(apiErr.Message), "already exists") {
+		t.Fatalf("unexpected duplicate create message: %v", apiErr)
+	}
+	if errors.Is(err, ErrVolumeInUse) {
+		t.Fatalf("duplicate create must not map to ErrVolumeInUse: %v", err)
+	}
+}
+
+// TestIntegrationVolumeSurvivesPauseResume checks that a mounted volume is
+// still readable and writable after the sandbox is paused and resumed.
+func TestIntegrationVolumeSurvivesPauseResume(t *testing.T) {
+	cfg := integrationConfig(t)
+	client := NewClient(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	volumeName := fmt.Sprintf("go-sdk-e2e-pause-%d", time.Now().UnixNano())
+	volume, err := client.CreateVolume(ctx, CreateVolumeOptions{Name: volumeName, Driver: testVolumeDriver()})
+	if err != nil {
+		t.Fatalf("CreateVolume returned error: %v", err)
+	}
+	t.Cleanup(func() { deleteVolumeWithRetry(t, client, volume.VolumeID) })
+
+	const mountPath = "/mnt/e2e-pause"
+	marker := fmt.Sprintf("pause-data-%d", time.Now().UnixNano())
+
+	sb := createIntegrationSandbox(t, ctx, client, CreateOptions{
+		Timeout:      DurationPtr(3 * time.Minute),
+		Metadata:     map[string]string{"sdk": "go", "scenario": "integration-volume-pause"},
+		VolumeMounts: []VolumeMount{{Name: volume.VolumeID, Path: mountPath}},
+	})
+
+	write, err := sb.Commands().Run(ctx,
+		fmt.Sprintf("printf %%s %s > %s/pause.txt", marker, mountPath),
+		CommandOptions{Timeout: 30 * time.Second})
+	if err != nil || write.ExitCode != 0 {
+		t.Fatalf("write before pause failed: err=%v result=%#v", err, write)
+	}
+
+	wait := true
+	if err := sb.Pause(ctx, PauseOptions{Wait: &wait, Timeout: 90 * time.Second, Interval: 2 * time.Second}); err != nil {
+		t.Fatalf("Pause returned error: %v", err)
+	}
+	resumed, err := client.Connect(ctx, sb.SandboxID)
+	if err != nil {
+		t.Fatalf("Connect after pause returned error: %v", err)
+	}
+	sb = resumed
+
+	verify, err := sb.Commands().Run(ctx,
+		fmt.Sprintf("cat %s/pause.txt && printf %%s -after >> %s/pause.txt && cat %s/pause.txt", mountPath, mountPath, mountPath),
+		CommandOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("read/write after resume returned error: %v", err)
+	}
+	if verify.ExitCode != 0 || verify.Stdout != marker+marker+"-after" {
+		t.Fatalf("volume not usable after pause/resume: %#v", verify)
+	}
+	if err := sb.Kill(ctx); err != nil {
+		t.Fatalf("Kill sandbox returned error: %v", err)
+	}
+}
+
+// deleteVolumeWithRetry deletes a volume, retrying briefly while the server
+// still reports it as in use — Cubelet reports detach-side refcount changes
+// asynchronously after a sandbox is killed. Missing volumes are fine.
+func deleteVolumeWithRetry(t *testing.T, client *Client, volumeID string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	for {
+		err := client.DeleteVolume(ctx, volumeID)
+		if err == nil || errors.Is(err, ErrVolumeNotFound) {
+			return
+		}
+		if !errors.Is(err, ErrVolumeInUse) {
+			t.Fatalf("DeleteVolume %s returned error: %v", volumeID, err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("DeleteVolume %s still in use after retries: %v", volumeID, err)
+		case <-time.After(2 * time.Second):
+		}
+	}
+}

--- a/sdk/go/volume_test.go
+++ b/sdk/go/volume_test.go
@@ -1,0 +1,397 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubesandbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCreateVolumeSendsPayloadAndParsesResponse(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/volumes" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-key" {
+			t.Fatalf("Authorization=%q", auth)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"volumeID":"my-data","name":"my-data","token":"tok-123"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, APIKey: "test-key"})
+	volume, err := client.CreateVolume(context.Background(), CreateVolumeOptions{Name: "my-data", Driver: "cos"})
+	if err != nil {
+		t.Fatalf("CreateVolume returned error: %v", err)
+	}
+	if volume.VolumeID != "my-data" || volume.Name != "my-data" || volume.Token != "tok-123" {
+		t.Fatalf("volume mismatch: %#v", volume)
+	}
+
+	assertString(t, got, "name", "my-data")
+	assertString(t, got, "driver", "cos")
+}
+
+func TestCreateVolumeOmitsDriverAndAllowsEmptyName(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"volumeID":"3e9b6f2a-0000-4000-8000-000000000000","name":"3e9b6f2a-0000-4000-8000-000000000000","token":""}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL})
+	volume, err := client.CreateVolume(context.Background(), CreateVolumeOptions{})
+	if err != nil {
+		t.Fatalf("CreateVolume returned error: %v", err)
+	}
+	if volume.VolumeID == "" || volume.Token != "" {
+		t.Fatalf("volume mismatch: %#v", volume)
+	}
+
+	// Mirror the Python SDK's wire format: name is always sent (empty string
+	// requests a server-generated UUID), driver is omitted when unset.
+	assertString(t, got, "name", "")
+	if _, ok := got["driver"]; ok {
+		t.Fatalf("driver should be omitted, got %#v", got["driver"])
+	}
+}
+
+func TestCreateVolumeValidatesName(t *testing.T) {
+	client := newNoRequestClient(t)
+	tests := []struct {
+		name       string
+		volumeName string
+	}{
+		{"too long", strings.Repeat("a", MaxVolumeNameLen+1)},
+		{"invalid characters", "my volume!"},
+		{"path separator", "a/b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := client.CreateVolume(context.Background(), CreateVolumeOptions{Name: tt.volumeName}); err == nil {
+				t.Fatalf("CreateVolume(%q) expected validation error", tt.volumeName)
+			}
+		})
+	}
+}
+
+func TestListVolumes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/volumes" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"volumeID":"vol-a","name":"vol-a"},{"volumeID":"vol-b","name":"vol-b"}]`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL})
+	volumes, err := client.ListVolumes(context.Background())
+	if err != nil {
+		t.Fatalf("ListVolumes returned error: %v", err)
+	}
+	if len(volumes) != 2 || volumes[0].VolumeID != "vol-a" || volumes[1].VolumeID != "vol-b" {
+		t.Fatalf("volumes mismatch: %#v", volumes)
+	}
+	// Tokens are only surfaced on create / get-single.
+	if volumes[0].Token != "" || volumes[1].Token != "" {
+		t.Fatalf("list entries should have empty tokens: %#v", volumes)
+	}
+}
+
+func TestGetVolumeReturnsToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/volumes/my-data" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"volumeID":"my-data","name":"my-data","token":"tok-456"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL})
+	volume, err := client.GetVolume(context.Background(), "my-data")
+	if err != nil {
+		t.Fatalf("GetVolume returned error: %v", err)
+	}
+	if volume.VolumeID != "my-data" || volume.Token != "tok-456" {
+		t.Fatalf("volume mismatch: %#v", volume)
+	}
+}
+
+func TestDeleteVolume(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/volumes/my-data" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL})
+	if err := client.DeleteVolume(context.Background(), "my-data"); err != nil {
+		t.Fatalf("DeleteVolume returned error: %v", err)
+	}
+}
+
+func TestVolumeErrorMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		target     error
+		call       func(*Client) error
+	}{
+		{
+			name:       "get volume not found",
+			statusCode: http.StatusNotFound,
+			body:       `{"message":"volume not found: my-data"}`,
+			target:     ErrVolumeNotFound,
+			call: func(c *Client) error {
+				_, err := c.GetVolume(context.Background(), "my-data")
+				return err
+			},
+		},
+		{
+			name:       "delete volume not found",
+			statusCode: http.StatusNotFound,
+			body:       `{"message":"volume not found: my-data"}`,
+			target:     ErrVolumeNotFound,
+			call: func(c *Client) error {
+				return c.DeleteVolume(context.Background(), "my-data")
+			},
+		},
+		{
+			name:       "delete volume in use",
+			statusCode: http.StatusConflict,
+			body:       `{"message":"conflict: volume my-data is in use by 2 node(s); destroy the sandboxes using it before deleting"}`,
+			target:     ErrVolumeInUse,
+			call: func(c *Client) error {
+				return c.DeleteVolume(context.Background(), "my-data")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			client := NewClient(Config{APIURL: server.URL})
+			err := tt.call(client)
+			if !errors.Is(err, tt.target) {
+				t.Fatalf("errors.Is(%v, %v)=false", err, tt.target)
+			}
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) || apiErr.StatusCode != tt.statusCode {
+				t.Fatalf("APIError mismatch: %#v", err)
+			}
+		})
+	}
+}
+
+func TestVolumeIDValidationRejectsUnsafeIDs(t *testing.T) {
+	client := newNoRequestClient(t)
+	for _, volumeID := range []string{"", "../other", "a/b", "a b", "%2e%2e"} {
+		if _, err := client.GetVolume(context.Background(), volumeID); err == nil {
+			t.Fatalf("GetVolume(%q) expected validation error", volumeID)
+		}
+		if err := client.DeleteVolume(context.Background(), volumeID); err == nil {
+			t.Fatalf("DeleteVolume(%q) expected validation error", volumeID)
+		}
+	}
+}
+
+func TestCreateWithVolumeMountsSendsPayload(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-test"))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-test"})
+	_, err := client.Create(context.Background(), CreateOptions{
+		VolumeMounts: []VolumeMount{
+			{Name: "my-data", Path: "/workspace"},
+			{Name: "shared-cache", Path: "/cache", ReadOnly: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	mounts, ok := got["volumeMounts"].([]any)
+	if !ok || len(mounts) != 2 {
+		t.Fatalf("volumeMounts=%#v", got["volumeMounts"])
+	}
+	first, ok := mounts[0].(map[string]any)
+	if !ok || first["name"] != "my-data" || first["path"] != "/workspace" {
+		t.Fatalf("volumeMounts[0]=%#v", mounts[0])
+	}
+	// Python-compatible wire format: readOnly is omitted when false.
+	if _, ok := first["readOnly"]; ok {
+		t.Fatalf("volumeMounts[0].readOnly should be omitted, got %#v", first["readOnly"])
+	}
+	second, ok := mounts[1].(map[string]any)
+	if !ok || second["name"] != "shared-cache" || second["path"] != "/cache" || second["readOnly"] != true {
+		t.Fatalf("volumeMounts[1]=%#v", mounts[1])
+	}
+}
+
+func TestCreateOmitsVolumeMountsWhenEmpty(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-test"))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-test"})
+	if _, err := client.Create(context.Background(), CreateOptions{}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if _, ok := got["volumeMounts"]; ok {
+		t.Fatalf("volumeMounts should be omitted, got %#v", got["volumeMounts"])
+	}
+}
+
+func TestCreateValidatesVolumeMounts(t *testing.T) {
+	client := newNoRequestClient(t)
+	tests := []struct {
+		name  string
+		mount VolumeMount
+	}{
+		{"empty volume name", VolumeMount{Name: "", Path: "/workspace"}},
+		{"unsafe volume name", VolumeMount{Name: "../other", Path: "/workspace"}},
+		{"empty path", VolumeMount{Name: "my-data", Path: ""}},
+		{"relative path", VolumeMount{Name: "my-data", Path: "workspace"}},
+		{"dot-dot segment", VolumeMount{Name: "my-data", Path: "/workspace/../etc"}},
+		{"dot segment", VolumeMount{Name: "my-data", Path: "/./workspace"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.Create(context.Background(), CreateOptions{
+				TemplateID:   "tpl-test",
+				VolumeMounts: []VolumeMount{tt.mount},
+			})
+			if err == nil {
+				t.Fatalf("Create with mount %#v expected validation error", tt.mount)
+			}
+		})
+	}
+}
+
+// newNoRequestClient returns a client whose backend fails the test if any
+// HTTP request is made — for asserting client-side validation short-circuits.
+func newNoRequestClient(t *testing.T) *Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	return NewClient(Config{APIURL: server.URL, TemplateID: "tpl-test"})
+}
+
+func TestVolumeInfoStringMasksToken(t *testing.T) {
+	volume := VolumeInfo{VolumeID: "my-data", Name: "my-data", Token: "tok-secret-123"}
+	for _, formatted := range []string{
+		volume.String(),
+		fmt.Sprintf("%v", volume),
+		fmt.Sprintf("%+v", volume),
+		fmt.Sprintf("%#v", volume),
+		fmt.Sprintf("%v", &volume),
+	} {
+		if strings.Contains(formatted, "tok-secret-123") {
+			t.Fatalf("token leaked into formatted output: %s", formatted)
+		}
+		if !strings.Contains(formatted, `"***"`) {
+			t.Fatalf("masked token marker missing: %s", formatted)
+		}
+		if !strings.Contains(formatted, "my-data") {
+			t.Fatalf("volume ID missing from formatted output: %s", formatted)
+		}
+	}
+
+	// An absent token renders as empty, not as the mask — mirroring Python.
+	empty := VolumeInfo{VolumeID: "no-token", Name: "no-token"}
+	if s := fmt.Sprintf("%#v", empty); strings.Contains(s, "***") {
+		t.Fatalf("empty token should not render a mask: %s", s)
+	}
+}
+
+func TestVolumeNotFoundMappingRequiresExactPhrase(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		message    string
+		target     error
+	}{
+		{
+			name:       "exact phrase maps to volume",
+			statusCode: http.StatusNotFound,
+			message:    "volume not found: my-data",
+			target:     ErrVolumeNotFound,
+		},
+		{
+			name:       "sandbox 404 mentioning a volume stays sandbox",
+			statusCode: http.StatusNotFound,
+			message:    "failed to mount volume: sandbox not found",
+			target:     ErrSandboxNotFound,
+		},
+		{
+			name:       "backend 500 with embedded volume not found",
+			statusCode: http.StatusInternalServerError,
+			message:    "CubeMaster returned error code 130404: volume not found: my-data",
+			target:     ErrVolumeNotFound,
+		},
+		{
+			name:       "conflict with different wording stays generic",
+			statusCode: http.StatusConflict,
+			message:    "volume already exists: my-data",
+			target:     nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := apiErrorFromStatus(tt.statusCode, tt.message)
+			for _, sentinel := range []error{ErrVolumeNotFound, ErrSandboxNotFound, ErrVolumeInUse} {
+				want := sentinel == tt.target
+				if got := errors.Is(err, sentinel); got != want {
+					t.Fatalf("errors.Is(%v, %v)=%v, want %v", err, sentinel, got, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1268. Adds full persistent-Volume support to the Go SDK — volume CRUD, mounting at sandbox creation via `CreateOptions.VolumeMounts`, and dedicated error handling — achieving parity with the Python SDK (#898 / #1061), plus bilingual doc updates.

## Volume API

New `Client` methods following the existing conventions (`ListSnapshots` / `DeleteSnapshot` style):

```go
func (c *Client) CreateVolume(ctx context.Context, options CreateVolumeOptions) (*VolumeInfo, error)
func (c *Client) ListVolumes(ctx context.Context) ([]VolumeInfo, error)
func (c *Client) GetVolume(ctx context.Context, volumeID string) (*VolumeInfo, error)
func (c *Client) DeleteVolume(ctx context.Context, volumeID string) error
```

- e2b-compatible defaults: `Driver` omitted from the payload when unset (backend falls back to its first configured plugin); `Name` optional (empty requests a server-generated UUID used as both name and volume ID).
- Client-side validation mirrors CubeAPI's rules — names/IDs must match `^[a-zA-Z0-9_-]+$` (max 128 chars) — and volume IDs are checked for path traversal before being interpolated into a URL.
- Tokens are only surfaced on create / get-single, matching the server contract; list entries have empty tokens.

## Sandbox mounting

`CreateOptions` gains a `VolumeMounts` field reusing the existing `VolumeMount` struct; serialization follows the existing `createPayload` pattern (omitted when empty, `readOnly` omitted when false to match the Python SDK wire format):

```go
sandbox, err := client.Create(ctx, cubesandbox.CreateOptions{
    TemplateID: "base",
    VolumeMounts: []cubesandbox.VolumeMount{
        {Name: "my-data", Path: "/workspace"},
        {Name: "shared-cache", Path: "/cache", ReadOnly: true},
    },
})
```

Mount paths are validated as clean absolute POSIX paths (no `.`/`..` segments) before the request is sent.

## Error handling

New sentinel errors wired into the existing `APIError.Is` kind mapping:

- `ErrVolumeInUse` — the HTTP 409 the server returns when deleting a volume still mounted by one or more sandboxes.
- `ErrVolumeNotFound` — volume 404s, so idempotent cleanup can `errors.Is` and ignore them.

## Other changes

- `sdk/go/README.md`: new "Volumes" section with lifecycle and `errors.Is` examples.
- `docs/guide/volume-plugin.md` + `docs/zh/guide/volume-plugin.md` (kept in sync): Go SDK rows in the capability/compatibility tables, install step, and a "Go SDK Usage" section with the full create → mount → detach → delete lifecycle.

## Testing

- **Unit tests** (`volume_test.go`, 12 cases): payload shapes and response decoding against `httptest` servers, 404/409 error mapping, validation short-circuits (no request sent on invalid input), Python-compatible `volumeMounts` wire format.
- **Integration tests** (`volume_integration_test.go`, build tag `integration`, 6 scenarios): full lifecycle with cross-sandbox data persistence, concurrent shared mounts with refcount-based delete protection, read-only attachment enforcement, pause/resume survival, server-generated UUID names, duplicate-name and unknown-driver conflicts. The volume driver is selectable via `CUBE_VOLUME_TEST_DRIVER` for backend-specific runs.
- Verified end to end on a single-node deployment built from master, against **two storage backends**: a local host-path plugin and **Tencent Cloud COS** (cosfs) — all 9 integration tests pass on both, with the #696 (volumeMounts in sandbox info) and #1098 (read-only enforcement) assertions active.
- `gofmt` / `go vet` clean; the full existing unit + integration suite passes with no regressions (112 tests).
### Results

All runs against a live single-node deployment (CubeMaster / CubeAPI / Cubelet built from master, `2b7d3b2`), with the integration build tag **enabled**:

| Backend | Suite result | Volume e2e duration |
|---|---|---|
| local host-path plugin (default driver) | **114 passed, 0 failed** (full suite incl. all integration tests) | ~13s |
| Tencent Cloud COS (cosfs, real bucket) | **6/6 volume scenarios passed** | 51.9s |

```
$ CUBE_API_URL=http://127.0.0.1:13000 \
  CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx \
  CUBE_PROXY_NODE_IP=127.0.0.1 CUBE_PROXY_PORT_HTTP=11080 \
  go test -tags integration -count=1 -v ./...

--- PASS: TestIntegrationHealthTemplateAndList (0.02s)
--- PASS: TestIntegrationSandboxExecutionCommandsFilesAndErrors (2.90s)
--- PASS: TestIntegrationPauseConnectAndResumeExecution (3.51s)
--- PASS: TestIntegrationVolumeLifecycle (5.04s)
--- PASS: TestIntegrationCreateVolumeUnknownDriver (0.00s)
--- PASS: TestIntegrationVolumeSharedByConcurrentSandboxes (3.06s)
--- PASS: TestIntegrationVolumeGeneratedName (1.61s)
--- PASS: TestIntegrationCreateVolumeDuplicateName (0.08s)
--- PASS: TestIntegrationVolumeSurvivesPauseResume (3.61s)

114 passed, 0 failed
```

Same volume scenarios re-run against Tencent Cloud COS via `CUBE_VOLUME_TEST_DRIVER=cos`:

```
$ CUBE_VOLUME_TEST_DRIVER=cos ... \
  go test -tags integration -count=1 -run 'TestIntegrationVolume|TestIntegrationCreateVolume' -v ./...

--- PASS: TestIntegrationVolumeLifecycle (15.23s)
--- PASS: TestIntegrationVolumeSharedByConcurrentSandboxes (10.99s)
--- PASS: TestIntegrationVolumeGeneratedName (8.62s)
--- PASS: TestIntegrationCreateVolumeDuplicateName (5.39s)
--- PASS: TestIntegrationVolumeSurvivesPauseResume (11.66s)

ok  github.com/tencentcloud/CubeSandbox/sdk/go  51.916s
```

The COS runs are ~3× slower than host-path, consistent with the data plane actually going through cosfs FUSE → virtiofs → object storage. No leaked resources after either run (`GET /volumes` returns `[]`, no leftover sandboxes). The #696 (volumeMounts in sandbox info) and #1098 (read-only enforcement) assertions were active in both runs — no skipped capability checks.