### PR TITLE
fix(k8s): make helm test pods schedule and probe correctly

### DIFF
--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -561,6 +561,14 @@ kubectl exec -n cube-system deploy/cube-cubemastercli -- \
 helm test cube -n cube-system --timeout 20m
 ```
 
+`helm test` pods are **IPv4-only by design**: CubeSandbox sandbox networking
+is IPv4, and the chart does not support single-stack IPv6 clusters. The
+health-test and dns-test force IPv4 lookups (`curl -4` / `getent ahostsv4`)
+because CoreDNS forwards AAAA queries for the sandbox domain (`cubeProxy.domain`,
+a non-`cluster.svc` name) to upstream, where they can stall. The dns-test image
+(`helmTest.dnsImage`) must ship musl `getent` — the default `curlimages/curl`
+image does; the shared `helmTest.image` is not used there.
+
 ## Upgrade policy
 
 `cube-node` is a native `apps/v1` DaemonSet. Bumping Big Pod runtime images

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -564,8 +564,8 @@ helm test cube -n cube-system --timeout 20m
 `helm test` pods are **IPv4-only by design**: CubeSandbox sandbox networking
 is IPv4, and the chart does not support single-stack IPv6 clusters. The
 health-test and dns-test force IPv4 lookups (`curl -4` / `getent ahostsv4`)
-because CoreDNS forwards AAAA queries for the sandbox domain (`cubeProxy.domain`,
-a non-`cluster.svc` name) to upstream, where they can stall. The dns-test image
+because IPv6 (AAAA) probes of the probed names stall in practice, delaying or
+failing resolution even when A records exist. The dns-test image
 (`helmTest.dnsImage`) must ship musl `getent` — the default `curlimages/curl`
 image does; the shared `helmTest.image` is not used there.
 

--- a/deploy/kubernetes/chart/scripts/test-helm-test-guards.sh
+++ b/deploy/kubernetes/chart/scripts/test-helm-test-guards.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+CHART_DIR="$(dirname "$SCRIPT_DIR")"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+helm template helm-guard "$CHART_DIR" \
+  --set-string mysql.password=test \
+  --set-string mysql.rootPassword=test \
+  --set-string redis.password=test \
+  > "$TMP_DIR/render.yaml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+python3 - "$TMP_DIR/render.yaml" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+docs = text.split("\n---\n")
+
+def pod_doc(name):
+    for d in docs:
+        if re.search(r"^kind: Pod$", d, re.M) and re.search(rf"^  name: {re.escape(name)}$", d, re.M):
+            return d
+    raise SystemExit(f"pod {name} not found")
+
+def check_pod(name, placement, container_image_spec):
+    d = pod_doc(name)
+    if placement == "compute":
+        if "cube.tencent.com/cube-node" not in d or "cube.tencent.com/cube-control" in d:
+            raise SystemExit(f"{name}: expected computePlacement only")
+    elif placement == "control":
+        if "cube.tencent.com/cube-control" not in d:
+            raise SystemExit(f"{name}: expected controlPlanePlacement")
+    else:
+        raise SystemExit(f"bad placement {placement}")
+    for container, expected_image_val in container_image_spec.items():
+        m = re.search(rf"- name: {container}\s*\n\s+image: (\S+)", d)
+        if not m:
+            raise SystemExit(f"{name}: container {container} missing")
+        if expected_image_val not in m.group(1):
+            raise SystemExit(f"{name}: container {container} image {m.group(1)} != expected containing {expected_image_val}")
+    print(f"OK {name} ({placement}Placement, images match)")
+
+check_pod("helm-guard-cube-health-test", "compute", {"curl": "curlimages/curl"})
+check_pod("helm-guard-cube-node-image-test", "compute", {"node-image-assets": "curlimages/curl"})
+check_pod("helm-guard-cube-node-runtime-test", "compute", {"node-runtime": "curlimages/curl"})
+check_pod("helm-guard-cube-cubemastercli-test", "control", {"cubemastercli": "cubemastercli"})
+check_pod("helm-guard-cube-mysql-test", "control", {"mysql": "mysql"})
+check_pod("helm-guard-cube-redis-test", "control", {"redis": "redis"})
+check_pod("helm-guard-cube-proxy-control-test", "control", {"proxy": "curlimages/curl"})
+check_pod("helm-guard-cube-dns-test", "control", {"dns": "curlimages/curl"})
+
+# proxy-control-test must probe /admin/healthz with the admin token from the
+# release Secret (not hardcoded).
+d = pod_doc("helm-guard-cube-proxy-control-test")
+if "/admin/healthz" not in d:
+    raise SystemExit("proxy-control-test does not probe admin healthz")
+if "CUBE_PROXY_ADMIN_TOKEN" not in d or "secretKeyRef" not in d or "cube-admin-token" not in d:
+    raise SystemExit("proxy-control-test does not source the admin token from the release Secret")
+
+# node-runtime-test must mount hostPaths read-only and drop capabilities.
+d = pod_doc("helm-guard-cube-node-runtime-test")
+if d.count("readOnly: true") < 3:
+    raise SystemExit("node-runtime-test hostPath mounts are not all read-only")
+if "allowPrivilegeEscalation: false" not in d or "drop:" not in d:
+    raise SystemExit("node-runtime-test securityContext missing privilege hardening")
+
+# dns-test must use dnsImage (curlimages/curl) and the getent path.
+d = pod_doc("helm-guard-cube-dns-test")
+if "getent ahostsv4" not in d:
+    raise SystemExit("dns-test does not use getent ahostsv4")
+
+print("helm test placement/image/probe guard passed")
+PY

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -20,6 +20,7 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- include "cube.controlPlanePlacement" . | nindent 2 }}
   serviceAccountName: {{ include "cube.fullname" . }}-test
   containers:
     - name: curl
@@ -33,6 +34,11 @@ spec:
           ca_path=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           ns={{ .Release.Namespace | quote }}
           kube_api="https://kubernetes.default.svc"
+          # CoreDNS forwards AAAA for names it does not answer and the upstream
+          # DNS times out, so plain curl (IPv6 probe) fails to resolve even when
+          # A records exist. Force IPv4 for all lookups and retry the occasional
+          # transient lookup timeout in this test.
+          curl() { command curl -4 --retry 3 --retry-all-errors --retry-delay 1 "$@"; }
           kget() {
             curl --connect-timeout 5 --max-time 20 --cacert "${ca_path}" \
               -H "Authorization: Bearer $(cat "${token_path}")" \
@@ -139,6 +145,7 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- include "cube.controlPlanePlacement" . | nindent 2 }}
   containers:
     - name: cubemastercli
       image: {{ include "cube.cubeImage" (dict "image" .Values.images.cubemastercli "context" $) | quote }}
@@ -178,6 +185,7 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- include "cube.controlPlanePlacement" . | nindent 2 }}
   containers:
     - name: mysql
       image: {{ include "cube.image" .Values.mysql.image | quote }}
@@ -214,6 +222,7 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- include "cube.controlPlanePlacement" . | nindent 2 }}
   containers:
     - name: redis
       image: {{ include "cube.image" .Values.redis.image | quote }}
@@ -257,16 +266,24 @@ spec:
       imagePullPolicy: {{ .Values.helmTest.image.pullPolicy }}
       env:
         {{- include "cube.timezoneEnv" . | nindent 8 }}
+        - name: CUBE_PROXY_ADMIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "cube.secretName" . }}
+              key: cube-admin-token
       command:
         - sh
         - -ec
         - |
-          echo '[health-test] check CubeProxy via ClusterIP Service'
-          curl --connect-timeout 5 --max-time 15 -fsS -o /dev/null \
-            "http://{{ include "cube.proxyServiceFQDN" . }}:{{ .Values.cubeProxy.ports.http.containerPort }}/" \
-            || curl --connect-timeout 5 --max-time 15 -k -fsS -o /dev/null \
-            "https://{{ include "cube.proxyServiceFQDN" . }}:{{ .Values.cubeProxy.ports.https.containerPort }}/" \
-            || { echo "cube-proxy Service unreachable"; exit 1; }
+          echo '[health-test] check CubeProxy admin healthz'
+          # The dataplane returns 400 for the bare "/" path (it only serves
+          # sandbox traffic), so probe the admin health endpoint instead.
+          # Retry to absorb transient CoreDNS lookup timeouts.
+          status="$(curl -4 --retry 3 --retry-all-errors --retry-delay 1 --connect-timeout 5 --max-time 15 -sS \
+            -H "X-Cube-Admin-Token: ${CUBE_PROXY_ADMIN_TOKEN}" \
+            -o /dev/null -w "%{http_code}" \
+            "http://{{ include "cube.proxyServiceFQDN" . }}:{{ .Values.cubeProxy.adminPort }}/admin/healthz")"
+          test "$status" = "200" || { echo "cube-proxy admin healthz status=$status"; exit 1; }
 {{- end }}
 {{ if eq (include "cube.configureClusterDNS" .) "true" }}
 ---
@@ -290,16 +307,28 @@ spec:
   {{- include "cube.controlPlanePlacement" . | nindent 2 }}
   containers:
     - name: dns
-      image: {{ include "cube.image" .Values.helmTest.dnsImage | quote }}
-      imagePullPolicy: {{ .Values.helmTest.dnsImage.pullPolicy }}
+      image: {{ include "cube.image" .Values.helmTest.image | quote }}
+      imagePullPolicy: {{ .Values.helmTest.image.pullPolicy }}
       command:
         - sh
         - -ec
         - |
           echo '[health-test] check cluster DNS for sandbox domain'
           target={{ include "cube.proxyServiceFQDN" . | quote }}
-          # busybox nslookup prints the DNS server Address first; take the last A record.
-          a_record() { nslookup "$1" | sed -n 's/^Address: \([0-9][0-9.]*\)$/\1/p' | tail -n 1; }
+          # curl image (alpine/musl) getent: reliable against CoreDNS rewrite zones
+          # (busybox nslookup times out on non-cluster.svc names in this setup).
+          # CoreDNS forwards non-cluster.svc names upstream and can hit transient
+          # timeouts, so retry the lookup before treating it as a failure.
+          a_record() {
+            for _ in 1 2 3 4 5; do
+              if ip="$(getent hosts "$1" 2>/dev/null | awk '{print $1}' | tail -n 1)" && [ -n "$ip" ]; then
+                printf '%s\n' "$ip"
+                return 0
+              fi
+              sleep 1
+            done
+            return 1
+          }
           domain_ip="$(a_record {{ $domain | quote }})"
           target_ip="$(a_record "$target")"
           test -n "$domain_ip"
@@ -339,6 +368,7 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- include "cube.controlPlanePlacement" . | nindent 2 }}
   serviceAccountName: {{ include "cube.fullname" . }}-test
   containers:
     - name: node-image-assets

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -313,8 +313,8 @@ spec:
   {{- include "cube.controlPlanePlacement" . | nindent 2 }}
   containers:
     - name: dns
-      image: {{ include "cube.image" .Values.helmTest.image | quote }}
-      imagePullPolicy: {{ .Values.helmTest.image.pullPolicy }}
+      image: {{ include "cube.image" .Values.helmTest.dnsImage | quote }}
+      imagePullPolicy: {{ .Values.helmTest.dnsImage.pullPolicy }}
       command:
         - sh
         - -ec
@@ -429,8 +429,8 @@ spec:
   {{- include "cube.computePlacement" . | nindent 2 }}
   containers:
     - name: node-runtime
-      image: {{ include "cube.image" .Values.helmTest.dnsImage | quote }}
-      imagePullPolicy: {{ .Values.helmTest.dnsImage.pullPolicy }}
+      image: {{ include "cube.image" .Values.helmTest.image | quote }}
+      imagePullPolicy: {{ .Values.helmTest.image.pullPolicy }}
       command:
         - sh
         - -ec

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -36,9 +36,10 @@ spec:
           kube_api="https://kubernetes.default.svc"
           # CoreDNS forwards AAAA for names it does not answer and the upstream
           # DNS times out, so plain curl (IPv6 probe) fails to resolve even when
-          # A records exist. Force IPv4 for all lookups and retry the occasional
-          # transient lookup timeout in this test.
-          curl() { command curl -4 --retry 3 --retry-all-errors --retry-delay 1 "$@"; }
+          # A records exist. Force IPv4 on every lookup; do NOT add a global
+          # --retry here because that would make the fail-fast health checks
+          # below retry real 5xx/timing-out endpoints for ~48s before failing.
+          curl() { command curl -4 "$@"; }
           kget() {
             curl --connect-timeout 5 --max-time 20 --cacert "${ca_path}" \
               -H "Authorization: Bearer $(cat "${token_path}")" \
@@ -278,11 +279,14 @@ spec:
           echo '[health-test] check CubeProxy admin healthz'
           # The dataplane returns 400 for the bare "/" path (it only serves
           # sandbox traffic), so probe the admin health endpoint instead.
-          # Retry to absorb transient CoreDNS lookup timeouts.
+          # Retry to absorb transient CoreDNS lookup timeouts. Under `set -e`
+          # a connection failure (curl non-zero exit) would abort before the
+          # status assertion, so capture it explicitly and print a clear error.
           status="$(curl -4 --retry 3 --retry-all-errors --retry-delay 1 --connect-timeout 5 --max-time 15 -sS \
             -H "X-Cube-Admin-Token: ${CUBE_PROXY_ADMIN_TOKEN}" \
             -o /dev/null -w "%{http_code}" \
-            "http://{{ include "cube.proxyServiceFQDN" . }}:{{ .Values.cubeProxy.adminPort }}/admin/healthz")"
+            "http://{{ include "cube.proxyServiceFQDN" . }}:{{ .Values.cubeProxy.adminPort }}/admin/healthz")" \
+            || { echo "cube-proxy admin healthz unreachable"; exit 1; }
           test "$status" = "200" || { echo "cube-proxy admin healthz status=$status"; exit 1; }
 {{- end }}
 {{ if eq (include "cube.configureClusterDNS" .) "true" }}
@@ -317,11 +321,14 @@ spec:
           target={{ include "cube.proxyServiceFQDN" . | quote }}
           # curl image (alpine/musl) getent: reliable against CoreDNS rewrite zones
           # (busybox nslookup times out on non-cluster.svc names in this setup).
+          # Use ahostsv4 so only A records are returned — getent hosts can emit
+          # both A and AAAA in a dual-stack cluster and the equality assertions
+          # below must compare the same address family.
           # CoreDNS forwards non-cluster.svc names upstream and can hit transient
           # timeouts, so retry the lookup before treating it as a failure.
           a_record() {
             for _ in 1 2 3 4 5; do
-              if ip="$(getent hosts "$1" 2>/dev/null | awk '{print $1}' | tail -n 1)" && [ -n "$ip" ]; then
+              if ip="$(getent ahostsv4 "$1" 2>/dev/null | awk 'NR==1 {print $1}')" && [ -n "$ip" ]; then
                 printf '%s\n' "$ip"
                 return 0
               fi

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -20,7 +20,7 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- include "cube.controlPlanePlacement" . | nindent 2 }}
+  {{- include "cube.computePlacement" . | nindent 2 }}
   serviceAccountName: {{ include "cube.fullname" . }}-test
   containers:
     - name: curl
@@ -39,6 +39,8 @@ spec:
           # A records exist. Force IPv4 on every lookup; do NOT add a global
           # --retry here because that would make the fail-fast health checks
           # below retry real 5xx/timing-out endpoints for ~48s before failing.
+          # Note: this test pod is IPv4-only by design (CubeSandbox sandbox
+          # networking is IPv4; the chart does not support single-stack IPv6).
           curl() { command curl -4 "$@"; }
           kget() {
             curl --connect-timeout 5 --max-time 20 --cacert "${ca_path}" \
@@ -375,7 +377,7 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- include "cube.controlPlanePlacement" . | nindent 2 }}
+  {{- include "cube.computePlacement" . | nindent 2 }}
   serviceAccountName: {{ include "cube.fullname" . }}-test
   containers:
     - name: node-image-assets

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -34,11 +34,11 @@ spec:
           ca_path=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           ns={{ .Release.Namespace | quote }}
           kube_api="https://kubernetes.default.svc"
-          # CoreDNS forwards AAAA for names it does not answer and the upstream
-          # DNS times out, so plain curl (IPv6 probe) fails to resolve even when
-          # A records exist. Force IPv4 on every lookup; do NOT add a global
-          # --retry here because that would make the fail-fast health checks
-          # below retry real 5xx/timing-out endpoints for ~48s before failing.
+          # IPv6 (AAAA) probes of the probed names stall in practice, so plain
+          # curl fails to resolve even when A records exist. Force IPv4 on
+          # every lookup; do NOT add a global --retry here because that would
+          # make the fail-fast health checks below retry real 5xx/timing-out
+          # endpoints for ~48s before failing.
           # Note: this test pod is IPv4-only by design (CubeSandbox sandbox
           # networking is IPv4; the chart does not support single-stack IPv6).
           curl() { command curl -4 "$@"; }
@@ -281,9 +281,11 @@ spec:
           echo '[health-test] check CubeProxy admin healthz'
           # The dataplane returns 400 for the bare "/" path (it only serves
           # sandbox traffic), so probe the admin health endpoint instead.
-          # Retry to absorb transient CoreDNS lookup timeouts. Under `set -e`
-          # a connection failure (curl non-zero exit) would abort before the
-          # status assertion, so capture it explicitly and print a clear error.
+          # Retry absorbs transient CoreDNS lookup timeouts; each attempt is
+          # capped at --max-time 15, so the worst case (real outage) is ~4×15s
+          # + retry backoff before this pod fails. Under `set -e` a connection
+          # failure (curl non-zero exit) would abort before the status
+          # assertion, so capture it explicitly and print a clear error.
           status="$(curl -4 --retry 3 --retry-all-errors --retry-delay 1 --connect-timeout 5 --max-time 15 -sS \
             -H "X-Cube-Admin-Token: ${CUBE_PROXY_ADMIN_TOKEN}" \
             -o /dev/null -w "%{http_code}" \
@@ -321,13 +323,16 @@ spec:
         - |
           echo '[health-test] check cluster DNS for sandbox domain'
           target={{ include "cube.proxyServiceFQDN" . | quote }}
-          # curl image (alpine/musl) getent: reliable against CoreDNS rewrite zones
-          # (busybox nslookup times out on non-cluster.svc names in this setup).
-          # Use ahostsv4 so only A records are returned — getent hosts can emit
-          # both A and AAAA in a dual-stack cluster and the equality assertions
-          # below must compare the same address family.
-          # CoreDNS forwards non-cluster.svc names upstream and can hit transient
-          # timeouts, so retry the lookup before treating it as a failure.
+          # curl image (alpine/musl) getent: reliable against CoreDNS rewrite
+          # zones (busybox nslookup times out on non-cluster.svc names in this
+          # setup). Use ahostsv4 so only A records are returned — getent hosts
+          # can emit both A and AAAA in a dual-stack cluster and the equality
+          # assertions below must compare the same address family. IPv6 (AAAA)
+          # probes of these names stall in practice, so the DNS test is
+          # IPv4-only by design.
+          # Lookups of the sandbox domain hit the chart's CoreDNS rewrite zone
+          # (cluster-dns.yaml) and can be transiently slow; retry before
+          # treating a failure as fatal.
           a_record() {
             for _ in 1 2 3 4 5; do
               if ip="$(getent ahostsv4 "$1" 2>/dev/null | awk 'NR==1 {print $1}')" && [ -n "$ip" ]; then
@@ -338,12 +343,14 @@ spec:
             done
             return 1
           }
-          domain_ip="$(a_record {{ $domain | quote }})"
-          target_ip="$(a_record "$target")"
-          test -n "$domain_ip"
-          test -n "$target_ip"
-          test "$domain_ip" = "$target_ip"
-          test -n "$(a_record {{ printf "wildcard-check.%s" $domain | quote }})"
+          # a_record exits non-zero on the last retry; under `set -e` the
+          # command substitution would abort the pod with no diagnostics, so
+          # capture explicitly and print which name failed.
+          domain_ip="$(a_record {{ $domain | quote }})" || { echo "could not resolve {{ $domain }} (A)"; exit 1; }
+          target_ip="$(a_record "$target")" || { echo "could not resolve $target (A)"; exit 1; }
+          test "$domain_ip" = "$target_ip" || { echo "DNS mismatch: {{ $domain }} -> $domain_ip, $target -> $target_ip"; exit 1; }
+          wildcard_ip="$(a_record {{ printf "wildcard-check.%s" $domain | quote }})" || { echo "could not resolve wildcard-check.{{ $domain }} (A)"; exit 1; }
+          test "$domain_ip" = "$wildcard_ip" || { echo "DNS mismatch: wildcard-check.{{ $domain }} -> $wildcard_ip, {{ $domain }} -> $domain_ip"; exit 1; }
 {{- end }}
 {{ if .Values.cubeNode.enabled }}
 ---
@@ -431,6 +438,16 @@ spec:
     - name: node-runtime
       image: {{ include "cube.image" .Values.helmTest.image | quote }}
       imagePullPolicy: {{ .Values.helmTest.image.pullPolicy }}
+      # Runs as root on purpose: it stat()s hostPath sockets that cube-node
+      # creates with root-only permissions (e.g. /data/cubelet/cubelet.sock),
+      # which a non-root image user cannot traverse. Root is safe here only
+      # because every hostPath mount is read-only and capabilities are
+      # dropped — the script itself only performs existence checks.
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
       command:
         - sh
         - -ec
@@ -446,8 +463,10 @@ spec:
           readOnly: true
         - name: data-cubelet
           mountPath: {{ .Values.hostPaths.dataCubelet }}
+          readOnly: true
         - name: tmp-cube
           mountPath: {{ .Values.hostPaths.tmpCube }}
+          readOnly: true
   volumes:
     - name: dev
       hostPath:

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -989,10 +989,16 @@ rbac:
 
 helmTest:
   enabled: true
+  # Main test image (curlimages/curl, Alpine/musl). Used by all test pods;
+  # the dns-test depends on its `getent` binary (ahostsv4 database), so do
+  # not override this with a non-Alpine image.
   image:
     repository: curlimages/curl
     tag: "8.10.1"
     pullPolicy: IfNotPresent
+  # Only used by node-runtime-test (busybox host-runtime asset checks).
+  # The dns-test intentionally uses helmTest.image instead: busybox lacks a
+  # reliable getent for the CoreDNS rewrite zones this chart configures.
   dnsImage:
     repository: busybox
     tag: "1.36"

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -989,17 +989,17 @@ rbac:
 
 helmTest:
   enabled: true
-  # Main test image (curlimages/curl, Alpine/musl). Used by all test pods;
-  # the dns-test depends on its `getent` binary (ahostsv4 database), so do
-  # not override this with a non-Alpine image.
+  # Shared test image (curlimages/curl, Alpine/musl). Used by health-test,
+  # proxy-control-test, node-image-test and node-runtime-test.
   image:
     repository: curlimages/curl
     tag: "8.10.1"
     pullPolicy: IfNotPresent
-  # Only used by node-runtime-test (busybox host-runtime asset checks).
-  # The dns-test intentionally uses helmTest.image instead: busybox lacks a
-  # reliable getent for the CoreDNS rewrite zones this chart configures.
+  # DNS test image. The dns-test resolves names through `getent ahostsv4`,
+  # so the image must ship musl's getent (curlimages/curl's Alpine base does).
+  # Keep it a separate value so operators can pin a different image for the
+  # DNS test without touching the shared test image.
   dnsImage:
-    repository: busybox
-    tag: "1.36"
+    repository: curlimages/curl
+    tag: "8.10.1"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

Fixes `helm test` so its pods schedule and probe correctly across cluster
topologies (separated control/compute nodes, control-plane-tainted masters,
compute-only `externalControlPlane` deployments).

1. **Scheduling** — test pods use the placement matching what they check:
   - control-plane component checks (`cubemastercli-test`, `mysql-test`,
     `redis-test`, `proxy-control-test`, `dns-test`) use `controlPlanePlacement`,
     consistent with the deployments they verify;
   - API/asset checks (`health-test`, `node-image-test`, `node-runtime-test`)
     use `computePlacement`, so they stay schedulable in compute-only clusters
     and land next to the `cube-node` assets they inspect.
2. **CubeProxy probe** — the dataplane returns `400` for the bare `/` path (it
   only serves sandbox traffic). `proxy-control-test` probes `/admin/healthz`
   with `X-Cube-Admin-Token`, captures the curl exit code explicitly (so
   `set -e` cannot swallow the diagnostic), and asserts HTTP 200.
3. **DNS resolution** — busybox `nslookup` times out on the CoreDNS `rewrite`
   zones for `cubeProxy.domain`, and plain `curl` stalls on IPv6 (AAAA)
   probing. `dns-test` resolves through `getent ahostsv4` (IPv4-only, no
   dual-stack ambiguity) with retries, reports which name failed, and the
   DNS-test image is a dedicated `helmTest.dnsImage` (defaults to
   `curlimages/curl`, which ships musl `getent`) so operators keep a distinct
   override for the DNS test.
4. **node-runtime-test hardening** — it stat()s root-owned hostPath sockets,
   so it runs as root deliberately, but with `allowPrivilegeEscalation: false`,
   `readOnlyRootFilesystem: true`, dropped capabilities, and all hostPaths
   mounted read-only.
5. **IPv4-only contract documented** — test pods force IPv4 lookups
   (`curl -4` / `getent ahostsv4`) by design; this matches CubeSandbox's
   IPv4-only sandbox networking and is documented in README.

## Files

- `deploy/kubernetes/chart/templates/tests/node-health.yaml`
- `deploy/kubernetes/chart/values.yaml`
- `deploy/kubernetes/chart/README.md`
- `deploy/kubernetes/chart/scripts/test-helm-test-guards.sh` (render guard)

## Test plan

- [ ] `helm test` passes on a control-plane-tainted single-node cluster
      (with `values-single-node.yaml`)
- [ ] `helm test` passes on a multi-node cluster with compute nodes
- [ ] `helm test` on a compute-only (`externalControlPlane.enabled`) cluster

Assisted-by: Cursor:deepseek-v4-flash