### PR TITLE
docs: add CubeSandbox 0.6 deployment record and technical blog series

### DIFF
--- a/cubesandbox-logic.html
+++ b/cubesandbox-logic.html
@@ -1,0 +1,1449 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CubeSandbox 逻辑梳理 | 架构与代码路径全景</title>
+<style>
+  :root {
+    --bg: #0b1020;
+    --bg-soft: #0f1730;
+    --panel: rgba(255, 255, 255, 0.04);
+    --panel-hover: rgba(255, 255, 255, 0.07);
+    --border: rgba(255, 255, 255, 0.09);
+    --border-strong: rgba(255, 255, 255, 0.16);
+    --text: #e6eaf2;
+    --text-dim: #9aa7bd;
+    --text-faint: #6b7a93;
+    --blue: #4f8cff;
+    --cyan: #2dd4bf;
+    --purple: #a78bfa;
+    --amber: #fbbf24;
+    --red: #f87171;
+    --green: #34d399;
+    --pink: #f472b6;
+    --mono: "SFMono-Regular", "JetBrains Mono", "Fira Code", Consolas, "Liberation Mono", Menlo, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+    --radius: 14px;
+    --shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    font-family: var(--sans);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
+    font-size: 15px;
+  }
+  a { color: var(--blue); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code {
+    font-family: var(--mono);
+    font-size: 0.88em;
+    background: rgba(79, 140, 255, 0.12);
+    color: #b9d2ff;
+    padding: 2px 7px;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  pre {
+    font-family: var(--mono);
+    font-size: 13px;
+    background: #0a0f1e;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    overflow-x: auto;
+    color: #c8d3e8;
+    line-height: 1.6;
+  }
+  pre code { background: none; padding: 0; color: inherit; white-space: pre; }
+
+  /* ===== 导航栏 ===== */
+  header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    backdrop-filter: blur(14px);
+    background: rgba(11, 16, 32, 0.82);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-inner {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 0 24px;
+    height: 58px;
+    display: flex;
+    align-items: center;
+    gap: 24px;
+  }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 700;
+    font-size: 17px;
+    letter-spacing: 0.2px;
+    white-space: nowrap;
+  }
+  .brand-mark {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, var(--blue), var(--purple));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 15px;
+    font-weight: 800;
+  }
+  .nav-links {
+    display: flex;
+    gap: 4px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .nav-links::-webkit-scrollbar { display: none; }
+  .nav-links a {
+    color: var(--text-dim);
+    padding: 6px 12px;
+    border-radius: 8px;
+    font-size: 13.5px;
+    white-space: nowrap;
+    transition: all 0.15s;
+  }
+  .nav-links a:hover { color: var(--text); background: var(--panel-hover); text-decoration: none; }
+  .nav-links a.active { color: #fff; background: rgba(79, 140, 255, 0.18); }
+
+  /* ===== 主体 ===== */
+  main { max-width: 1080px; margin: 0 auto; padding: 40px 24px 100px; }
+  section { margin-bottom: 64px; }
+  .section-title {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 26px;
+    font-weight: 800;
+    margin-bottom: 8px;
+    letter-spacing: 0.3px;
+  }
+  .section-title .num {
+    font-family: var(--mono);
+    font-size: 15px;
+    color: var(--blue);
+    background: rgba(79, 140, 255, 0.14);
+    border: 1px solid rgba(79, 140, 255, 0.3);
+    border-radius: 8px;
+    padding: 3px 9px;
+  }
+  .section-sub {
+    color: var(--text-dim);
+    margin-bottom: 28px;
+    max-width: 760px;
+  }
+  h3 {
+    font-size: 19px;
+    font-weight: 700;
+    margin: 34px 0 14px;
+    padding-left: 12px;
+    border-left: 3px solid var(--blue);
+  }
+
+  /* ===== Hero ===== */
+  .hero {
+    text-align: center;
+    padding: 70px 24px 40px;
+    background:
+      radial-gradient(900px 380px at 20% -10%, rgba(79, 140, 255, 0.18), transparent 60%),
+      radial-gradient(900px 380px at 85% -10%, rgba(167, 139, 250, 0.16), transparent 60%);
+  }
+  .hero h1 {
+    font-size: 44px;
+    font-weight: 900;
+    letter-spacing: 1px;
+    background: linear-gradient(90deg, #fff, var(--blue) 45%, var(--purple));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .hero p.tagline { color: var(--text-dim); font-size: 17px; margin-top: 14px; max-width: 680px; margin-left: auto; margin-right: auto; }
+  .hero .meta { color: var(--text-faint); font-size: 12.5px; margin-top: 18px; font-family: var(--mono); }
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+    max-width: 980px;
+    margin: 40px auto 0;
+  }
+  .stat {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px 16px;
+    backdrop-filter: blur(8px);
+  }
+  .stat .v { font-size: 30px; font-weight: 900; color: var(--blue); font-family: var(--mono); }
+  .stat .k { color: var(--text-dim); font-size: 13px; margin-top: 4px; }
+
+  /* ===== 卡片网格 ===== */
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 16px; }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px 20px 22px;
+    transition: border-color 0.2s, background 0.2s, transform 0.2s;
+  }
+  .card:hover { border-color: var(--border-strong); background: var(--panel-hover); transform: translateY(-2px); }
+  .card h4 { font-size: 15.5px; margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+  .card p { color: var(--text-dim); font-size: 13.5px; }
+
+  /* ===== 组件卡片（可折叠） ===== */
+  .component {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin-bottom: 14px;
+    overflow: hidden;
+    background: var(--panel);
+  }
+  .component summary {
+    cursor: pointer;
+    padding: 18px 22px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    list-style: none;
+    user-select: none;
+    transition: background 0.15s;
+  }
+  .component summary::-webkit-details-marker { display: none; }
+  .component summary:hover { background: var(--panel-hover); }
+  .component summary .c-logo {
+    width: 40px; height: 40px;
+    border-radius: 10px;
+    flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center;
+    font-weight: 800; font-size: 15px; color: #fff;
+    font-family: var(--mono);
+  }
+  .component summary .c-name { font-weight: 700; font-size: 16px; }
+  .component summary .c-lang {
+    font-size: 11px;
+    color: var(--text-faint);
+    background: rgba(255,255,255,0.07);
+    border: 1px solid var(--border);
+    padding: 2px 8px;
+    border-radius: 20px;
+    font-family: var(--mono);
+    white-space: nowrap;
+  }
+  .component summary .c-brief { color: var(--text-dim); font-size: 13px; margin-left: auto; text-align: right; }
+  .component summary .chevron {
+    color: var(--text-faint);
+    transition: transform 0.2s;
+    font-size: 12px;
+  }
+  .component[open] summary .chevron { transform: rotate(90deg); }
+  .component-body { padding: 4px 24px 22px; border-top: 1px solid var(--border); }
+  .component-body .row { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-top: 16px; }
+  .component-body ul { padding-left: 20px; color: var(--text-dim); font-size: 13.5px; }
+  .component-body ul li { margin: 5px 0; }
+  .file-list { font-size: 12.5px; }
+  .file-list .f { font-family: var(--mono); color: #b9d2ff; word-break: break-all; }
+
+  /* ===== 架构拓扑 ===== */
+  .topo { background: var(--bg-soft); border: 1px solid var(--border); border-radius: var(--radius); padding: 28px; }
+  .topo-layer { margin-bottom: 20px; }
+  .topo-label {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 2px;
+    color: var(--text-faint);
+    text-transform: uppercase;
+    margin-bottom: 12px;
+  }
+  .topo-row { display: flex; flex-wrap: wrap; gap: 12px; }
+  .node {
+    border: 1px solid var(--border-strong);
+    border-radius: 10px;
+    padding: 10px 16px;
+    font-size: 13.5px;
+    font-weight: 600;
+    background: rgba(255,255,255,0.05);
+    text-align: center;
+    min-width: 120px;
+  }
+  .node small { display: block; font-weight: 400; color: var(--text-faint); font-size: 11px; font-family: var(--mono); margin-top: 2px; }
+  .node.accent-blue { border-color: rgba(79,140,255,0.5); background: rgba(79,140,255,0.12); }
+  .node.accent-purple { border-color: rgba(167,139,250,0.5); background: rgba(167,139,250,0.12); }
+  .node.accent-cyan { border-color: rgba(45,212,191,0.5); background: rgba(45,212,191,0.1); }
+  .node.accent-amber { border-color: rgba(251,191,36,0.5); background: rgba(251,191,36,0.1); }
+  .node.accent-pink { border-color: rgba(244,114,182,0.5); background: rgba(244,114,182,0.1); }
+  .topo-conn {
+    text-align: center;
+    color: var(--text-faint);
+    font-family: var(--mono);
+    font-size: 12px;
+    margin: 8px 0;
+    letter-spacing: 1px;
+  }
+  .legend { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 18px; color: var(--text-dim); font-size: 12.5px; }
+  .legend span { display: flex; align-items: center; gap: 6px; }
+  .swatch { width: 12px; height: 12px; border-radius: 3px; }
+
+  /* ===== 流程 / 时序 ===== */
+  .flow-step {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 0;
+    position: relative;
+    padding-bottom: 26px;
+  }
+  .flow-step::before {
+    content: "";
+    position: absolute;
+    left: 17px;
+    top: 38px;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(var(--blue), transparent);
+  }
+  .flow-step:last-child::before { display: none; }
+  .flow-step .bubble {
+    width: 36px; height: 36px;
+    border-radius: 50%;
+    background: rgba(79, 140, 255, 0.16);
+    border: 1.5px solid var(--blue);
+    color: var(--blue);
+    display: flex; align-items: center; justify-content: center;
+    font-weight: 800;
+    font-family: var(--mono);
+    font-size: 14px;
+    flex-shrink: 0;
+    position: relative;
+    z-index: 1;
+    background: #101a33;
+  }
+  .flow-step .content { flex: 1; padding-top: 4px; }
+  .flow-step .content .who { font-family: var(--mono); font-size: 12px; color: var(--text-faint); letter-spacing: 0.5px; }
+  .flow-step .content .what { font-weight: 700; font-size: 15px; margin: 2px 0 4px; }
+  .flow-step .content .detail { color: var(--text-dim); font-size: 13.5px; }
+
+  .seq-wrap { overflow-x: auto; }
+  .seq {
+    min-width: 820px;
+    background: var(--bg-soft);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 26px 20px 10px;
+  }
+  .seq-head { display: flex; justify-content: space-between; padding: 0 10px; }
+  .seq-head span { font-family: var(--mono); font-size: 12px; color: var(--text-dim); text-align: center; flex: 1; font-weight: 700; }
+  .seq-body { position: relative; margin-top: 6px; }
+  .seq-lane {
+    display: flex;
+    gap: 0;
+    height: 26px;
+    border-top: 1px dashed rgba(255,255,255,0.12);
+  }
+  .seq-lane div { flex: 1; position: relative; }
+  .msg {
+    position: absolute;
+    top: -13px;
+    white-space: nowrap;
+    font-size: 12px;
+    font-family: var(--mono);
+    border: 1px solid rgba(79,140,255,0.4);
+    background: #0e1830;
+    color: #b9d2ff;
+    padding: 3px 10px;
+    border-radius: 20px;
+    z-index: 2;
+  }
+  .seq-lane .from { left: 0; }
+
+  /* ===== 表格 ===== */
+  .tbl-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius); }
+  table { width: 100%; border-collapse: collapse; font-size: 13.5px; min-width: 640px; }
+  thead th {
+    background: rgba(79,140,255,0.1);
+    color: #bcd6ff;
+    text-align: left;
+    padding: 11px 14px;
+    font-weight: 700;
+    border-bottom: 1px solid var(--border-strong);
+    white-space: nowrap;
+  }
+  tbody td { padding: 10px 14px; border-bottom: 1px solid var(--border); color: var(--text-dim); vertical-align: top; }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr:hover { background: rgba(255,255,255,0.03); }
+  td code, th code { font-size: 0.92em; }
+  .tag {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 6px;
+    border: 1px solid var(--border-strong);
+    color: var(--text-dim);
+    white-space: nowrap;
+  }
+  .tag.go { color: #7ee7ff; border-color: rgba(126,231,255,0.4); background: rgba(126,231,255,0.08); }
+  .tag.rust { color: #ffab7e; border-color: rgba(255,171,126,0.4); background: rgba(255,171,126,0.08); }
+  .tag.lua { color: #a5f3a1; border-color: rgba(165,243,161,0.4); background: rgba(165,243,161,0.08); }
+  .tag.c { color: #ffd27e; border-color: rgba(255,210,126,0.4); background: rgba(255,210,126,0.08); }
+  .tag.ts { color: #c9b7ff; border-color: rgba(201,183,255,0.4); background: rgba(201,183,255,0.08); }
+
+  /* ===== 状态机 ===== */
+  .state-machine { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; justify-content: center; padding: 20px 0; }
+  .state {
+    border-radius: 12px;
+    padding: 14px 22px;
+    text-align: center;
+    border: 2px solid;
+    font-weight: 700;
+    min-width: 120px;
+  }
+  .state small { display: block; font-weight: 400; font-size: 11.5px; color: var(--text-faint); margin-top: 4px; }
+  .state.running { border-color: var(--green); color: var(--green); background: rgba(52,211,153,0.08); }
+  .state.pausing { border-color: var(--amber); color: var(--amber); background: rgba(251,191,36,0.08); }
+  .state.paused { border-color: var(--blue); color: var(--blue); background: rgba(79,140,255,0.08); }
+  .state.resuming { border-color: var(--cyan); color: var(--cyan); background: rgba(45,212,191,0.08); }
+  .state.terminated { border-color: var(--red); color: var(--red); background: rgba(248,113,113,0.08); }
+  .trans { color: var(--text-faint); font-size: 12px; text-align: center; max-width: 140px; line-height: 1.5; }
+  .trans b { color: var(--text-dim); }
+
+  /* ===== 提示块 ===== */
+  .note {
+    border-left: 3px solid var(--blue);
+    background: rgba(79,140,255,0.07);
+    padding: 12px 18px;
+    border-radius: 0 10px 10px 0;
+    font-size: 13.5px;
+    color: var(--text-dim);
+    margin: 16px 0;
+  }
+  .note strong { color: var(--text); }
+  .note.warn { border-color: var(--amber); background: rgba(251,191,36,0.07); }
+
+  /* ===== 目录 ===== */
+  .toc {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 10px;
+    margin-bottom: 20px;
+  }
+  .toc a {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px 16px;
+    color: var(--text-dim);
+    font-size: 13.5px;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    transition: all 0.15s;
+  }
+  .toc a:hover { border-color: var(--border-strong); color: var(--text); background: var(--panel-hover); text-decoration: none; }
+  .toc a .n { font-family: var(--mono); color: var(--blue); font-weight: 700; }
+
+  footer { border-top: 1px solid var(--border); padding: 30px 24px 50px; text-align: center; color: var(--text-faint); font-size: 12.5px; }
+  .back-top {
+    position: fixed;
+    right: 26px;
+    bottom: 26px;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(79,140,255,0.85);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    font-size: 18px;
+    box-shadow: var(--shadow);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s;
+  }
+  .back-top.show { opacity: 1; pointer-events: auto; }
+
+  @media (max-width: 720px) {
+    .hero h1 { font-size: 32px; }
+    .nav-links { display: none; }
+    .component summary .c-brief { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox 逻辑梳理</div>
+    <nav class="nav-links" id="nav">
+      <a href="#overview">概览</a>
+      <a href="#principles">设计原则</a>
+      <a href="#architecture">架构</a>
+      <a href="#components">核心组件</a>
+      <a href="#request-flow">请求链路</a>
+      <a href="#lifecycle">沙箱生命周期</a>
+      <a href="#storage">存储</a>
+      <a href="#network">网络</a>
+      <a href="#interfaces">接口</a>
+      <a href="#source-map">源码索引</a>
+    </nav>
+  </div>
+</header>
+
+<div class="hero">
+  <h1>CubeSandbox 逻辑梳理</h1>
+  <p class="tagline">一个基于 RustVMM + KVM 构建的 AI Agent 沙箱服务：毫秒级启动、硬件级隔离、E2B 兼容，以一份 HTML 全景梳理其架构设计、组件职责与核心代码路径。</p>
+  <div class="stats">
+    <div class="stat"><div class="v">&lt;60ms</div><div class="k">沙箱冷启动</div></div>
+    <div class="stat"><div class="v">&lt;5MB</div><div class="k">单沙箱额外内存开销</div></div>
+    <div class="stat"><div class="v">KVM</div><div class="k">独立内核 · 硬件级隔离</div></div>
+    <div class="stat"><div class="v">E2B</div><div class="k">SDK 兼容 · Drop-in 替换</div></div>
+  </div>
+  <div class="meta">基于仓库源码与 docs/ 文档梳理 · 2026-08-03</div>
+</div>
+
+<main>
+
+<!-- ================= 目录 ================= -->
+<section>
+  <div class="toc">
+    <a href="#overview"><span class="n">01</span> 项目概览与关键数据</a>
+    <a href="#principles"><span class="n">02</span> 设计原则</a>
+    <a href="#architecture"><span class="n">03</span> 整体架构（控制面 / 数据面）</a>
+    <a href="#components"><span class="n">04</span> 核心组件逐一拆解</a>
+    <a href="#request-flow"><span class="n">05</span> 一次 Sandbox.create() 的完整请求链路</a>
+    <a href="#lifecycle"><span class="n">06</span> 沙箱状态机与自动暂停 / 恢复</a>
+    <a href="#storage"><span class="n">07</span> 存储逻辑：CubeCoW 快照引擎</a>
+    <a href="#network"><span class="n">08</span> 网络逻辑：CubeVS / CubeEgress / CubeProxy</a>
+    <a href="#interfaces"><span class="n">09</span> 组件间接口与协议</a>
+    <a href="#source-map"><span class="n">10</span> 关键源码文件索引</a>
+  </div>
+</section>
+
+<!-- ================= 1 概览 ================= -->
+<section id="overview">
+  <div class="section-title"><span class="num">01</span> 项目概览</div>
+  <p class="section-sub">CubeSandbox 是一个多语言（Go + Rust + Web）Monorepo 沙箱服务。所有组件构建在 Docker builder 容器中完成（<code>make</code> 目标驱动），产物输出到 <code>_output/bin/</code>。</p>
+
+  <div class="grid">
+    <div class="card"><h4><span class="dot" style="background:var(--green)"></span>定位</h4><p>面向 AI Agent 场景专门构建的基础设施。不只支持"LLM 调用工具 → 沙箱执行 → 返回结果"的经典闭环，也支持在沙箱内托管长时运行的 Agent 与有状态服务（常驻开发环境、Web 服务、数据库等）。</p></div>
+    <div class="card"><h4><span class="dot" style="background:var(--blue)"></span>隔离模型</h4><p>每个沙箱是一个在 KVM MicroVM 中运行独立 Linux 内核的沙箱，不存在共享内核的逃逸面；出站流量全部经 CubeEgress L7 代理，域名必须显式放行（零信任出网）。</p></div>
+    <div class="card"><h4><span class="dot" style="background:var(--purple)"></span>性能手段</h4><p>预快照模板 + RustVMM 恢复路径实现毫秒级冷启动；内核共享与 CoW 快照（FICLONE，O(1)）让单机可运行数千实例，单沙箱额外开销 &lt;5MB。</p></div>
+    <div class="card"><h4><span class="dot" style="background:var(--amber)"></span>生态兼容</h4><p>对外暴露 E2B 兼容的 REST API 与 SDK；替换一个环境变量（API URL）即可从 E2B 云无缝切换，无需改动业务代码。</p></div>
+  </div>
+
+  <h3>组件语言矩阵</h3>
+  <div class="grid">
+    <div class="card"><h4><span class="tag go">Go</span> 控制面与节点编排</h4><p>CubeMaster（调度器）、Cubelet（节点代理）、CubeOps、cube-lifecycle-manager、network-agent、CubeNet/cubevs（eBPF 控制面）、CubeDB。</p></div>
+    <div class="card"><h4><span class="tag rust">Rust</span> 数据面核心</h4><p>CubeAPI（Axum 网关）、CubeShim（Shim v2）、hypervisor（RustVMM）、cubecow（快照引擎）、agent（沙箱内 guest agent）。</p></div>
+    <div class="card"><h4><span class="tag lua">OpenResty + Lua</span> 数据面代理</h4><p>CubeProxy（反向代理/路由）、CubeEgress（L7 出向安全代理）。</p></div>
+    <div class="card"><h4><span class="tag c">C (eBPF)</span> 内核态网络</h4><p>CubeNet 的三个 BPF 程序（CO-RE）：from_cube / from_world / from_envoy。</p></div>
+  </div>
+</section>
+
+<!-- ================= 2 设计原则 ================= -->
+<section id="principles">
+  <div class="section-title"><span class="num">02</span> 设计原则</div>
+  <p class="section-sub">这六条原则决定了整个系统的结构形态，理解它们就能理解后面所有组件的职责划分。</p>
+  <div class="grid">
+    <div class="card"><h4>Agent 优先</h4><p>生命周期语义、SDK 形态、自动暂停/恢复、极速克隆/回滚等特性为 Agent 工作负载定制，而非通用 VM 平台。</p></div>
+    <div class="card"><h4>硬件隔离</h4><p>每沙箱独立 KVM MicroVM + 独立内核；叠加 eBPF 网络隔离，隔离级别高于容器、等同物理机。</p></div>
+    <div class="card"><h4>毫秒级启动</h4><p>预快照模板 + RustVMM 恢复路径（而非冷启动引导），冷启动 &lt;60ms、50 并发下 P95 90ms。</p></div>
+    <div class="card"><h4>零信任出网</h4><p>所有出站流量经 CubeEgress L7 MITM 代理，域名白名单放行；私网/链路本地地址段被 CubeVS 默认拒绝。</p></div>
+    <div class="card"><h4>无状态控制面</h4><p>CubeAPI / CubeMaster 不保存本地状态，Redis 是元数据与生命周期事件的唯一可信源，可水平扩容。</p></div>
+    <div class="card"><h4>高效存储</h4><p>CubeCoW 借助内核 FICLONE ioctl 在 XFS reflink 上实现 O(1) 快照与克隆，零数据拷贝。</p></div>
+  </div>
+</section>
+
+<!-- ================= 3 架构 ================= -->
+<section id="architecture">
+  <div class="section-title"><span class="num">03</span> 整体架构</div>
+  <p class="section-sub">系统按"控制面 / 数据面"分层：控制面无状态、依赖 Redis 协调，可横向扩展；数据面节点本地化，负责 VM 生命周期、存储、网络与安全策略执行。</p>
+
+  <div class="topo">
+    <div class="topo-label">客户端入口</div>
+    <div class="topo-row">
+      <div class="node">客户端 / SDK<br><small>E2B 兼容 REST</small></div>
+      <div class="node">WebUI 控制台<br><small>React + Vite · :12088</small></div>
+    </div>
+
+    <div class="topo-conn">▼ HTTP（/sandboxes … 兼容 E2B）&nbsp;&nbsp;&nbsp;▼ HTTP（/opsapi/v1）</div>
+
+    <div class="topo-label">控制面 · 无状态</div>
+    <div class="topo-row">
+      <div class="node accent-blue">CubeAPI<br><small>Rust · E2B REST 网关</small></div>
+      <div class="node accent-blue">CubeMaster<br><small>Go · 调度编排</small></div>
+      <div class="node accent-amber">cube-lifecycle-manager<br><small>Go · 自动暂停/恢复</small></div>
+      <div class="node accent-blue">CubeOps<br><small>Go · 运维 API</small></div>
+      <div class="node accent-pink">Redis<br><small>元数据 / 事件流 / 路由表</small></div>
+    </div>
+
+    <div class="topo-conn">▼ gRPC（CubeboxMgr / Images）&nbsp;&nbsp;◀── Redis Stream 生命周期事件 ──▶</div>
+
+    <div class="topo-label">数据面 · 每计算节点</div>
+    <div class="topo-row">
+      <div class="node accent-blue">Cubelet<br><small>Go · 节点调度 + containerd 插件</small></div>
+      <div class="node accent-cyan">network-agent<br><small>Go · TAP / IPAM / 策略下发</small></div>
+      <div class="node accent-blue">CubeProxy<br><small>OpenResty · 反代路由</small></div>
+      <div class="node accent-blue">CubeEgress<br><small>OpenResty · L7 出向代理</small></div>
+    </div>
+
+    <div class="topo-conn">▼ containerd Shim v2（ttRPC）</div>
+
+    <div class="topo-row">
+      <div class="node accent-purple">CubeShim<br><small>Rust · Shim v2 实现</small></div>
+      <div class="node accent-amber">CubeCoW<br><small>Rust · FICLONE 快照</small></div>
+      <div class="node accent-cyan">CubeVS<br><small>eBPF · 内核态虚拟交换机</small></div>
+    </div>
+
+    <div class="topo-conn">▼ 进程内 mpsc（ApiRequest）&nbsp;&nbsp;&nbsp;▼ cgo / C ABI</div>
+
+    <div class="topo-row">
+      <div class="node accent-purple">CubeHypervisor<br><small>RustVMM + KVM</small></div>
+      <div class="node accent-purple">guest agent<br><small>Rust · 沙箱内 init + ttRPC</small></div>
+    </div>
+
+    <div class="topo-conn">▼ vsock ttRPC</div>
+
+    <div class="topo-row">
+      <div class="node">MicroVM（沙箱）<br><small>独立内核 · TAP 直连 · virtio</small></div>
+    </div>
+
+    <div class="legend">
+      <span><span class="swatch" style="background:var(--blue)"></span>控制面 / 编排</span>
+      <span><span class="swatch" style="background:var(--purple)"></span>虚拟化层</span>
+      <span><span class="swatch" style="background:var(--cyan)"></span>网络数据面</span>
+      <span><span class="swatch" style="background:var(--amber)"></span>存储 / 生命周期</span>
+      <span><span class="swatch" style="background:var(--pink)"></span>共享状态</span>
+    </div>
+  </div>
+
+  <div class="note"><strong>注意一个易混淆点：</strong>README 架构图把 CubeAPI → CubeMaster 标为 gRPC，但当前实现中 CubeAPI 通过 <strong>HTTP/JSON</strong>（reqwest）调用 CubeMaster 的 <code>/cube/*</code> 路由；CubeMaster → Cubelet 才是 gRPC（服务端在 Cubelet，proto 定义在 CubeMaster <code>api/</code> 下共享）。</div>
+
+  <h3>控制面 vs 数据面</h3>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>层</th><th>组件</th><th>职责</th></tr></thead>
+      <tbody>
+        <tr><td><b>控制面</b></td><td>CubeAPI、CubeMaster、WebUI、CubeOps、Redis</td><td>API 网关、调度、状态协调、运维控制台</td></tr>
+        <tr><td><b>数据面</b></td><td>Cubelet、CubeShim、CubeHypervisor、CubeCoW、CubeVS、CubeEgress、CubeProxy、network-agent、guest agent</td><td>VM 生命周期、存储、网络、安全策略执行、请求路由</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ================= 4 核心组件 ================= -->
+<section id="components">
+  <div class="section-title"><span class="num">04</span> 核心组件逐一拆解</div>
+  <p class="section-sub">每个组件给出职责、技术栈、关键代码路径与核心逻辑。点击卡片展开细节。</p>
+
+  <h3>4.1 控制面</h3>
+
+  <details class="component" open>
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#f97316,#f43f5e)">API</div>
+      <div>
+        <div class="c-name">CubeAPI</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag rust">Rust</span><span class="tag">Axum</span></div>
+      </div>
+      <div class="c-brief">E2B 兼容的 REST API 网关</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>把 E2B SDK 调用转换为对 CubeMaster 的 HTTP 调用（<code>/cube/*</code>），处理鉴权回调与 E2B 生态兼容逻辑。框架为 Axum + tokio，路由层带 <code>TimeoutLayer</code>（普通 30s、snapshot 等长路由 240s）、CORS、压缩、请求 ID。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">CubeAPI/src/main.rs</div>
+            <div class="f">src/routes.rs</div>
+            <div class="f">src/cubemaster/mod.rs</div>
+            <div class="f">src/services/{sandboxes,templates,snapshots,volumes}.rs</div>
+            <div class="f">src/middleware/{auth,rate_limit}.rs</div>
+          </div>
+        </div>
+        <div>
+          <b>核心职责</b>
+          <ul>
+            <li>E2B 兼容端点：<code>POST /sandboxes</code>、<code>GET|DELETE /sandboxes/:id</code>、<code>/logs</code>、<code>/timeout</code>、<code>/refreshes</code>、<code>/pause|/resume</code>、<code>/connect</code>、<code>/snapshots</code>、<code>/rollback</code>、<code>/templates*</code>、<code>/volumes*</code>。</li>
+            <li>环境变量黑名单校验（<code>FORBIDDEN_ENV_NAMES</code>，防 LD_PRELOAD / PYTHONPATH 注入）、出站域名校验。</li>
+            <li>错误映射：CubeMaster 130404 → 404、130409 → 409、130490（暂停中）→ 503 + Retry-After。</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#2563eb,#7c3aed)">M</div>
+      <div>
+        <div class="c-name">CubeMaster</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag go">Go</span><span class="tag">gin</span></div>
+      </div>
+      <div class="c-brief">集群级调度器与编排中枢</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>接收沙箱创建/销毁/暂停/恢复请求，依据资源可用性选择目标节点，通过 gRPC 将工作分发给 Cubelet，并把生命周期事件发布到 Redis Stream。持有节点/沙箱的本地缓存（localcache / instancecache）以支撑调度决策。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">CubeMaster/cmd/cubemaster/app/main.go</div>
+            <div class="f">pkg/scheduler/{schedule,local,init}.go</div>
+            <div class="f">pkg/selector/{filter,score,postscore,backofffilter}/</div>
+            <div class="f">pkg/service/sandbox/sandbox_{run,remove,update,timeout,exec,migrate}.go</div>
+            <div class="f">pkg/service/httpservice/cube/cube.go</div>
+            <div class="f">pkg/cubelet/actions.go + grpcconn/</div>
+            <div class="f">pkg/lifecycle/{store,schema}.go</div>
+            <div class="f">pkg/task/export.go</div>
+          </div>
+        </div>
+        <div>
+          <b>调度流水线（pkg/scheduler）</b>
+          <ol style="padding-left:20px;color:var(--text-dim);font-size:13.5px">
+            <li><code>runPreFilter</code> 预选过滤</li>
+            <li><code>runFilter</code> 并行执行：cpufilter / memfilter / diskfilter / realtimecreatelimit / template_locality（模板快照所在节点优先）</li>
+            <li><code>runScoreFilter</code> 加权打分：affinityscore / imagescore / multifactorscore / realtimescore / asyncscore</li>
+            <li><code>LeastRandomSelect</code> 从高分节点随机挑选；失败时 <code>BackoffSelect</code> 兜底</li>
+            <li><code>local.go</code>：按 instance_type 维护缓冲队列 + 每 5s 动态调整节点创建/销毁并发上限</li>
+          </ol>
+        </div>
+      </div>
+      <div class="note"><strong>它本身不是 gRPC 服务端。</strong>gRPC 服务（CubeboxMgr / Images）由 Cubelet 实现；CubeMaster 通过 <code>pkg/cubelet/actions.go</code> 以客户端身份调用。调用方法：<code>Create</code> / <code>Destroy</code> / <code>List</code> / <code>Update</code> / <code>Exec</code> / <code>AppSnapshot</code> / <code>CommitSandbox</code> / <code>RollbackSandbox</code> 等。</div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#14b8a6,#0ea5e9)">LM</div>
+      <div>
+        <div class="c-name">cube-lifecycle-manager（CLM）</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag go">Go</span></div>
+      </div>
+      <div class="c-brief">自动暂停 / 恢复的协调者</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>消费 CubeMaster 发布的 Redis Stream 生命周期事件，维护内存沙箱注册表；扫描空闲沙箱执行自动暂停/超时销毁，并把状态同步推送到所有 CubeProxy 副本；接收 CubeProxy 的恢复请求合并为单次 CubeMaster RPC。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go</div>
+            <div class="f">internal/redisstream/</div>
+            <div class="f">internal/registry/</div>
+            <div class="f">internal/sweeper/sweeper.go</div>
+            <div class="f">internal/resumer/resumer.go</div>
+            <div class="f">internal/statesync/</div>
+            <div class="f">internal/proxypush/ + discovery/</div>
+          </div>
+        </div>
+        <div>
+          <b>核心循环</b>
+          <ul>
+            <li><b>启动引导</b>：<code>HGETALL lifecycle:meta</code> 全量加载 → <code>XGROUP/XREADGROUP</code> 消费事件流增量。</li>
+            <li><b>自动暂停（sweeper）</b>：<code>idle = now − max(LastActiveMs, CreatedAt)</code> 超过 <code>timeout_seconds</code> 且 <code>auto_pause</code> → SETNX 状态锁 → 调 CubeMaster Pause → 广播 "paused"；否则超时 kill。</li>
+            <li><b>自动恢复（resumer）</b>：CubeProxy 遇 paused 沙箱 → <code>POST /internal/resume</code> → 并发合并 → CubeMaster Resume → 轮询等待 running → 回推 "running"。</li>
+            <li><b>状态同步</b>：消费 <code>OpState</code> 事件对账 Redis state 与 CubeProxy 状态。</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#eab308,#f97316)">DB</div>
+      <div>
+        <div class="c-name">CubeDB + Redis + WebUI</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag go">Go</span><span class="tag ts">React/TS</span></div>
+      </div>
+      <div class="c-brief">持久化 / 共享状态 / 控制台</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <div class="row">
+        <div>
+          <b>CubeDB（Go 共享库）</b>
+          <div class="file-list">
+            <div class="f">CubeDB/dao/ + driver/{mysql,postgres}</div>
+            <div class="f">CubeDB/migrate/（goose + SHA-256 指纹防篡改）</div>
+          </div>
+          <ul>
+            <li>被 CubeMaster 与 CubeOps 共享的 GORM 访问 + 迁移库；MySQL <code>GET_LOCK</code> 做集群级串行化。</li>
+            <li>迁移覆盖：AgentHub、节点组件版本、模板副本兼容、snapshot、volume、refresh_token、JWT secret 等。</li>
+          </ul>
+        </div>
+        <div>
+          <b>Redis 的角色（控制面唯一可信源）</b>
+          <ul>
+            <li>沙箱元数据 / 生命周期事件流（<code>cube:v1:shared:sandbox:lifecycle:*</code>）</li>
+            <li>CubeProxy 路由表（<code>cube:v1:shared:sandbox:proxy:*</code>）与节点指标</li>
+            <li>自动暂停/恢复所需的分布式锁（SETNX）</li>
+          </ul>
+        </div>
+      </div>
+      <div class="row" style="margin-top:14px">
+        <div>
+          <b>WebUI（web/，React 18 + Vite + TS + React Query + Zustand）</b>
+          <div class="file-list">
+            <div class="f">web/src/main.tsx</div>
+            <div class="f">src/lib/api.ts（api() → CubeAPI 根路径；ops() → /opsapi/v1）</div>
+            <div class="f">src/api/client.ts + generated/schema.ts（openapi-typescript）</div>
+            <div class="f">src/pages/（Overview / Sandboxes / Templates / Nodes / Versions / Network / AgentHub …）</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <h3>4.2 数据面</h3>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#10b981,#059669)">L</div>
+      <div>
+        <div class="c-name">Cubelet</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag go">Go</span><span class="tag">containerd 插件</span></div>
+      </div>
+      <div class="c-brief">节点本地调度 · 沙箱生命周期管家</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>管理单节点所有沙箱的完整生命周期（创建 → 运行 → 暂停 → 恢复 → 快照 → 销毁），以 containerd 插件形式注册（<code>io.cubelet.internal.v1.cubebox</code>），复用 containerd 的镜像/快照器/元数据。与 CubeCoW（cgo）完成 rootfs 与内存卷操作，与 network-agent 协作完成 TAP/网络策略。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">Cubelet/services/cubebox/service.go（gRPC 服务端）</div>
+            <div class="f">services/cubebox/local.go（workflow.Flow 实现）</div>
+            <div class="f">services/cubebox/{update,exec,destroy}.go</div>
+            <div class="f">plugins/workflow/engine.go（流水线引擎）</div>
+            <div class="f">config/config.toml（workflow flows 定义）</div>
+            <div class="f">pkg/cubecow/cubecow.go（cgo 绑定）</div>
+            <div class="f">pkg/store/cubebox/cubebox.go（boltdb 状态机）</div>
+          </div>
+        </div>
+        <div>
+          <b>Workflow 流水线（config.toml 定义、Step 内 Action 并行）</b>
+          <pre>init:    cleanup → cubebox → images/storage/cgroup/network/volume/netfile/store
+create:  [createid, appsnapshot]
+         → [images, volume, storage, network, netfile, cube-sandbox-store]
+         → [cgroup] → [cubebox]
+destroy: [cubebox] → [images, storage, cgroup, network, volume, netfile, store] → [cleanup]</pre>
+          <b>暂停 / 恢复</b>：通过 containerd Task API <code>task.Pause / task.Resume</code>，实际 VM 暂停/恢复由 CubeShim 完成，失败时做 <code>reconcileStatusAfterPauseError</code>。
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#8b5cf6,#6366f1)">S</div>
+      <div>
+        <div class="c-name">CubeShim</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag rust">Rust</span><span class="tag">Shim v2</span></div>
+      </div>
+      <div class="c-brief">containerd Shim v2 与 VM 之间的桥梁</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>实现 containerd Shim v2 接口（<code>TaskService</code>），负责沙箱资源准备（rootfs、内存文件、内核）、VM 启动/恢复、vsock 通信与自动暂停的原地快照。二进制名 <code>io.containerd.cube.rs</code>。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">CubeShim/shim/src/service/task_srv.rs</div>
+            <div class="f">shim/src/service/srv.rs</div>
+            <div class="f">shim/src/sandbox/sb.rs</div>
+            <div class="f">shim/src/hypervisor/cube_hypervisor.rs</div>
+            <div class="f">shim/src/snapshot/cmd.rs</div>
+          </div>
+        </div>
+        <div>
+          <b>核心逻辑</b>
+          <ul>
+            <li><b>create</b>：加载 bundle spec → 未初始化则 <code>sb.create_sandbox()</code>（启动 VM、连接 agent）→ <code>sb.create_container()</code> → 发 <code>TaskCreate</code> 事件。</li>
+            <li><b>pause/resume</b>：仅支持 pod 级（校验 <code>pod_scope</code>）→ <code>sb.pause_vm()</code>（内存快照写盘到 <code>PAUSE_VM_SNAPSHOT_BASE</code>）→ <code>resume_vm()</code>。</li>
+            <li><b>状态机</b>：<code>SandBoxState::{Normal, Paused, Exited}</code>。</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#a855f7,#d946ef)">HV</div>
+      <div>
+        <div class="c-name">CubeHypervisor</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag rust">Rust</span><span class="tag">RustVMM + KVM</span></div>
+      </div>
+      <div class="c-brief">轻量级 VMM · MicroVM 生命周期</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>基于 Cloud Hypervisor 衍生改造，管理 MicroVM 生命周期：vCPU 配置、内存区域、virtio 设备（block / net / vsock / fs）、启动、暂停、快照与恢复。seccomp 加固、系统调用面最小化。CubeShim 以<strong>进程内库</strong>方式使用（<code>VmmInstance::new</code> + mpsc <code>ApiRequest</code>）。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">hypervisor/src/lib.rs（VmmInstance 门面）</div>
+            <div class="f">hypervisor/vmm/src/api/mod.rs（ApiRequest 枚举）</div>
+            <div class="f">vmm/src/vm.rs（Migratable trait 实现）</div>
+            <div class="f">hypervisor/src/kvm/（KVM 后端 + TDX 支持）</div>
+            <div class="f">hypervisor/virtiofsd/ + devices/</div>
+          </div>
+        </div>
+        <div>
+          <b>ApiRequest 核心操作</b>
+          <div class="file-list">
+            <div class="f">VmCreate / VmBoot / VmDelete</div>
+            <div class="f">VmPauseToSnapshot(SnapshotConfig)</div>
+            <div class="f">VmResumeFromSnapshot(RestoreConfig)</div>
+            <div class="f">VmSnapshot / VmRestore / VmAddDevice / VmSetFs</div>
+            <div class="f">VmResize / VmShutdown / VmmShutdown / VmPowerButton</div>
+          </div>
+          <p style="color:var(--text-dim);font-size:13px">Vm 实现 <code>Migratable</code> trait：暂停 = 冻结 vCPU + 设备；快照 = 序列化状态（含软脏页 soft_dirty 支持，见 vm-migration/）。</p>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#0ea5e9,#06b6d4)">A</div>
+      <div>
+        <div class="c-name">guest agent（沙箱内）</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag rust">Rust</span><span class="tag">vsock ttRPC</span></div>
+      </div>
+      <div class="c-brief">沙箱内 init · 容器运行时</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>沙箱内首个进程（init），通过 vsock 暴露 ttRPC 服务，接收宿主侧（CubeShim）的沙箱/容器管理指令，内置基于 kata-rustjail 的容器运行时，可运行 OCI 容器（Agent 进程）。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">agent/src/main.rs</div>
+            <div class="f">agent/src/rpc.rs（AgentService + HealthService）</div>
+            <div class="f">agent/src/sandbox.rs</div>
+            <div class="f">agent/rustjail/（OCI 运行时）</div>
+            <div class="f">agent/libs/protocols/protos/agent.proto</div>
+          </div>
+        </div>
+        <div>
+          <b>ttRPC 接口（agent.proto）</b>
+          <ul>
+            <li>沙箱级：<code>CreateSandbox / DestroySandbox</code></li>
+            <li>容器级：<code>CreateContainer / StartContainer / ExecProcess / SignalProcess / WaitProcess / PauseContainer / ResumeContainer</code></li>
+            <li>流式 IO：<code>WriteStdin / ReadStdout / ReadStderr</code></li>
+            <li>网络：<code>UpdateInterface / UpdateRoutes / AddARPNeighbors</code></li>
+            <li>其他：<code>GetOOMEvent（OOM 监控）</code>、<code>OnlineCPUMem</code>、<code>ResizeVolume</code>、<code>CopyFile</code> 等</li>
+          </ul>
+          <div class="note">就绪通知：x86 用 I/O port <code>0x680</code>，aarch64 用 MMIO <code>0x0903_0000</code> 通知宿主侧 agent 已就绪。</div>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#f59e0b,#ef4444)">CoW</div>
+      <div>
+        <div class="c-name">CubeCoW</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag rust">Rust</span><span class="tag">XFS reflink</span></div>
+      </div>
+      <div class="c-brief">O(1) 快照 / 克隆存储引擎</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>精简配置卷管理库，通过内核 <code>FICLONE</code> ioctl 在 XFS (reflink) 上实现 O(1) 快照与克隆。对外暴露 C ABI，由 Cubelet 经 cgo 调用。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">cubecow/src/ffi.rs（C ABI）</div>
+            <div class="f">cubecow/src/engine/reflink.rs（ReflinkEngine）</div>
+            <div class="f">cubecow/include/cubecow.h</div>
+          </div>
+        </div>
+        <div>
+          <b>核心能力</b>
+          <ul>
+            <li>快照仅为元数据操作（共享 extent，零字节拷贝），扁平模型——删除任一快照不影响其他快照。</li>
+            <li>增量脏页追踪：快照仅持久化自上次快照以来的匿名（脏）内存页，未变更页继续 reflink 共享。</li>
+            <li>API：<code>create_volume / delete_volume / resize_volume / create_snapshot / activate_volume / list_snapshots / get_metrics</code>。</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#22c55e,#0d9488)">VS</div>
+      <div>
+        <div class="c-name">CubeVS（CubeNet）</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag c">eBPF</span><span class="tag go">Go</span></div>
+      </div>
+      <div class="c-brief">内核态虚拟交换机 · 沙箱网络隔离</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>三个挂在内核数据路径关键位置的 BPF 程序取代整条传统网络栈（无 iptables、无 Linux Bridge、无 OVS）：</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">CubeNet/src/mvmtap.bpf.c（from_cube）</div>
+            <div class="f">CubeNet/src/nodenic.bpf.c（from_world）</div>
+            <div class="f">CubeNet/src/localgw.bpf.c（from_envoy）</div>
+            <div class="f">CubeNet/cubevs/{cubevs,netpolicy,tap,snat,port,reaper}.go</div>
+          </div>
+        </div>
+        <div>
+          <b>三个程序</b>
+          <ul>
+            <li><code>from_cube</code>（TAP TC ingress）：策略检查、DNS 拦截、SNAT、会话创建、ARP 代理。</li>
+            <li><code>from_world</code>（宿主机网卡 TC ingress）：反向 NAT、端口映射、DNS 响应学习。</li>
+            <li><code>from_envoy</code>（cube-dev TC egress）：DNAT 到沙箱、透明代理回包、就绪探测。</li>
+          </ul>
+          <b>Go 控制面（cubevs/）</b>：Init 注入宿主常量并固定 Map；AddTAPDevice / AttachFilter / SetSNATIPs / AddPortMapping；后台回收器清理过期会话与 DNS 学习条目。
+        </div>
+      </div>
+      <div class="note"><strong>网络策略评估顺序</strong>：目标为沙箱网关（169.254.68.5）→ 放行；<code>allow_out_v2</code> 命中 → 放行；<code>deny_out</code> 命中 → 丢弃；否则默认放行。<strong>始终拒绝</strong>私网/链路本地段（10/8、127/8、169.254/16、172.16/12、192.168/16）。详情见第 08 节。</div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#84cc16,#0ea5e9)">NA</div>
+      <div>
+        <div class="c-name">network-agent</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag go">Go</span><span class="tag">SCM_RIGHTS</span></div>
+      </div>
+      <div class="c-brief">节点网络编排 · TAP 直通</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>提供 gRPC <code>NetworkAgent</code> 服务，向 Cubelet 提供网络能力：TAP 设备生命周期（经 fdserver 用 unix socket + SCM_RIGHTS 把 TAP fd 直传给 hypervisor）、IPAM、主机路由/邻居配置（cube-router）、eBPF 策略下发与 CubeEgress 规则同步。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">network-agent/api/v1/network_agent.proto</div>
+            <div class="f">internal/service/local_service.go</div>
+            <div class="f">internal/service/tap_lifecycle.go</div>
+            <div class="f">internal/fdserver/</div>
+            <div class="f">internal/cubeegress/cubeegress_push.go</div>
+          </div>
+        </div>
+        <div>
+          <b>gRPC 接口</b>
+          <ul>
+            <li><code>EnsureNetwork</code>（幂等：interfaces / routes / arp / port_mappings / CubeNetworkConfig）</li>
+            <li><code>ReleaseNetwork / ReconcileNetwork / GetNetwork / ListNetworks / Health</code></li>
+          </ul>
+          <b>CubeNetworkConfig</b>：<code>allow_internet_access</code>、<code>allow_out</code>/<code>deny_out</code> CIDR、<code>rules[]</code>（L7 egress：EgressRule{name, match{sni,host,method,path,scheme}, action{allow,audit,inject{header,secret,format}}}）。
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#ec4899,#f43f5e)">P</div>
+      <div>
+        <div class="c-name">CubeProxy</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag lua">OpenResty + Lua</span></div>
+      </div>
+      <div class="c-brief">反向代理 · 请求路由到沙箱</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>反向代理与请求路由组件，兼容 E2B 协议，把请求路由到对应沙箱。通过 Redis 注册表实时发现（由 CLM 推送 meta/state），支持多副本、零静态配置。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">CubeProxy/nginx.conf（8081 http / 8080 https + 8082 admin）</div>
+            <div class="f">lua/rewrite_phase.lua（Host 模式）</div>
+            <div class="f">lua/path_rewrite_phase.lua（Path 模式）</div>
+            <div class="f">lua/sandbox_backend.lua（后端解析）</div>
+            <div class="f">lua/sandbox_state.lua（自动恢复门禁）</div>
+          </div>
+        </div>
+        <div>
+          <b>两种路由模式</b>
+          <ul>
+            <li><b>Host 模式</b>：从 Host 头解析 <code>&lt;port&gt;-&lt;sandbox_id&gt;.&lt;domain&gt;</code> → resolve_backend 查后端 IP/端口 → 渲染 maskRequestHost（envd 49983 豁免）→ balancer 选上游。</li>
+            <li><b>Path 模式</b>：<code>/sandbox/&lt;id&gt;/&lt;port&gt;/&lt;rest&gt;</code>，保留前缀（proxy_redirect / proxy_cookie_path / X-Forwarded-Prefix）。</li>
+            <li><b>自动恢复门禁</b>（sandbox_state.lua）：rewrite 阶段查状态字典——<code>paused</code> → 捕获子请求触发 CLM 恢复并阻塞等待；<code>pausing</code> → 503 Retry-After；<code>killing/killed</code> → 410。</li>
+            <li>envd 流式端点白名单（Process/Start|Connect、Filesystem/WatchDir）关闭缓冲。</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details class="component">
+    <summary>
+      <div class="c-logo" style="background:linear-gradient(135deg,#f97316,#dc2626)">EG</div>
+      <div>
+        <div class="c-name">CubeEgress</div>
+        <div style="display:flex;gap:6px;margin-top:4px"><span class="tag lua">OpenResty + Lua</span><span class="tag">TPROXY</span></div>
+      </div>
+      <div class="c-brief">透明 L7 出向安全代理</div>
+      <div class="chevron">▶</div>
+    </summary>
+    <div class="component-body">
+      <p>部署在每台主机上的透明 L7 出网代理，通过 TPROXY 拦截每一个出站 HTTP/HTTPS 请求：域名过滤、凭据注入、访问审计。沙箱信任 CubeEgress 签发的根 CA（预置于模板），实现透明 TLS 检查。</p>
+      <div class="row">
+        <div>
+          <b>关键文件</b>
+          <div class="file-list">
+            <div class="f">CubeEgress/nginx.conf（transparent listen）</div>
+            <div class="f">lua/access_phase.lua（决策 + 注入主逻辑）</div>
+            <div class="f">lua/policy.lua（shared_dict 策略存储）</div>
+            <div class="f">lua/admin.lua（/admin/v1/ 管理 API）</div>
+            <div class="f">lua/cert_signer.lua（动态叶子证书）</div>
+          </div>
+        </div>
+        <div>
+          <b>核心机制</b>
+          <ul>
+            <li><b>TPROXY</b>：nginx 补丁为 <code>listen</code> 增加 <code>transparent</code> 关键字（IP_TRANSPARENT），accept 后用 getsockname() 取真实目的地址。</li>
+            <li><b>决策</b>（access_phase.lua <code>_M.decide</code>）：按 sandbox_ip 查策略，规则首匹配生效（sni/host/method/path/scheme）；bootstrap 未就绪默认拒绝（fail-closed）。</li>
+            <li><b>凭据注入</b>：<code>inject{header, secret, format}</code> 写入请求头（先 clear_header 防伪造），审计只记 secret_ref 指纹。</li>
+            <li><b>动态证书</b>：ssl_certificate_by_lua_block 用根 CA 按 SNI+目的 IP 签发叶子证书；上游 proxy_ssl_verify on。</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </details>
+
+</section>
+
+<!-- ================= 5 请求链路 ================= -->
+<section id="request-flow">
+  <div class="section-title"><span class="num">05</span> 一次 Sandbox.create() 的完整请求链路</div>
+  <p class="section-sub">从 SDK 调用到沙箱就绪，请求依次穿过控制面与数据面的每一层。同步路径只到"调度完成"，沙箱实际就绪通过生命周期事件异步确认。</p>
+
+  <div class="flow-step">
+    <div class="bubble">1</div>
+    <div class="content">
+      <div class="who">Client / SDK</div>
+      <div class="what">POST /sandboxes（兼容 E2B）</div>
+      <div class="detail">携带 template、timeout、lifecycle（on_timeout / auto_resume）、env_vars、network 等参数。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">2</div>
+    <div class="content">
+      <div class="who">CubeAPI（Rust/Axum）</div>
+      <div class="what">鉴权 + 参数校验 → HTTP 转发 CubeMaster</div>
+      <div class="detail">中间件做鉴权回调与限流；<code>services/sandboxes.rs</code> 校验环境变量黑名单、出站域名；错误映射 130404→404 / 130409→409 / 130490→503。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">3</div>
+    <div class="content">
+      <div class="who">CubeMaster（Go）</div>
+      <div class="what">调度器选择目标节点</div>
+      <div class="detail"><code>pkg/service/sandbox/sandbox_run.go</code> 触发 <code>scheduler.Select</code>：预选 → 并行 filter（cpu/mem/disk/实时创建上限/模板本地性）→ 加权打分 → 随机挑选；失败走 BackoffSelect。本地缓存（localcache/instancecache）提供节点与模板分布数据。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">4</div>
+    <div class="content">
+      <div class="who">CubeMaster → Cubelet（gRPC）</div>
+      <div class="what">RunCubeSandbox</div>
+      <div class="detail"><code>pkg/cubelet/actions.go</code> 经连接池（grpcconn）发起 <code>CubeboxMgr.Create</code>，请求携带 volumes、containers、exposed_ports、runtime_handler、instance_type、network_type、cube_network_config（L7 出站规则）。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">5</div>
+    <div class="content">
+      <div class="who">Cubelet（Go）</div>
+      <div class="what">Workflow：prepare rootfs → 交给 containerd</div>
+      <div class="detail"><code>services/cubebox/local.go</code> 驱动 workflow：createid 分配 → CubeCoW 从模板卷克隆 rootfs（FICLONE）与内存快照 → storage/cgroup/network 准备 → <code>containerd.NewContainer</code> + <code>WithRuntime(io.containerd.cube.rs)</code> 创建容器 → Task 启动驱动 shim。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">6</div>
+    <div class="content">
+      <div class="who">CubeShim（Rust，Shim v2）</div>
+      <div class="what">Create + Start → 启动 VM</div>
+      <div class="detail"><code>task_srv.rs</code> 收到 containerd Task 请求 → <code>sb.create_sandbox()</code>：<code>launch_vmm</code>（hypervisor 库启动 VMM 线程）→ <code>create_vm</code> + <code>restore_vm</code>（从模板内存快照恢复）→ 连接 guest agent → agent.create_sandbox → watch_oom / monitor_vm。vsock 就绪后回 Task 已启动。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">7</div>
+    <div class="content">
+      <div class="who">Cubelet → network-agent → CubeVS / CubeEgress</div>
+      <div class="what">AddTAPDevice + AttachFilter + 策略下发</div>
+      <div class="detail">network-agent 创建/直通 TAP fd（SCM_RIGHTS），CubeVS 注册 TAP 并挂 from_cube TC 过滤器；把 allow/deny/DNS 域名推入 eBPF Map；L7 egress 规则推送到 CubeEgress admin API。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">8</div>
+    <div class="content">
+      <div class="who">CubeMaster → Redis → CLM → CubeProxy</div>
+      <div class="what">发布生命周期事件，注册路由，返回结果</div>
+      <div class="detail">CubeMaster <code>pkg/lifecycle/store.go</code> 写 meta（HSET）+ <code>XADD events</code>；CLM 消费后把 sandbox 路由/状态推送给所有 CubeProxy；最终 201 返回 sandbox_id 与元数据给客户端。CubeProxy 路由表就绪后，客户端即可通过 <code>&lt;port&gt;-&lt;sandbox_id&gt;.&lt;domain&gt;</code> 或 <code>/sandbox/&lt;id&gt;/&lt;port&gt;</code> 访问沙箱内服务。</div>
+    </div>
+  </div>
+
+  <div class="note warn"><strong>执行链路（数据面）</strong>：沙箱内代码执行时，agent（vsock ttRPC）接收宿主侧 ExecProcess/流式 IO 指令，运行 OCI 容器；沙箱进程的 IO 经 virtio + agent 流式转发回 CubeProxy/客户端。</div>
+</section>
+
+<!-- ================= 6 生命周期 ================= -->
+<section id="lifecycle">
+  <div class="section-title"><span class="num">06</span> 沙箱状态机与自动暂停 / 恢复</div>
+  <p class="section-sub">沙箱是系统的核心运行单元。五个状态 + 两个驱动参数（timeout 与 on_timeout）构成完整的生命周期管理。CLM 是自动化的中枢。</p>
+
+  <div class="state-machine">
+    <div class="state running">running<small>运行中 · 占用 CPU/内存</small></div>
+    <div class="trans"><b>timeout & on_timeout=pause</b><br>（空闲超时）</div>
+    <div class="state pausing">pausing<small>瞬时 · 保存 VM 快照中</small></div>
+    <div class="trans"><b>快照完成</b></div>
+    <div class="state paused">paused<small>内存落盘 · 零 CPU/内存占用</small></div>
+  </div>
+  <div class="state-machine" style="margin-top:0">
+    <div class="state running">running</div>
+    <div class="trans"><b>timeout & on_timeout=kill</b><br>或显式 kill()</div>
+    <div class="state terminated">terminated<small>不可恢复</small></div>
+    <div class="trans"></div>
+    <div class="state paused">paused</div>
+    <div class="trans"><b>kill() / DELETE</b><br>（内部先恢复再销毁）</div>
+    <div class="state terminated">terminated</div>
+  </div>
+
+  <h3>自动暂停 / 恢复的完整时序</h3>
+  <div class="flow-step">
+    <div class="bubble">1</div>
+    <div class="content">
+      <div class="who">CubeMaster</div>
+      <div class="what">创建沙箱时登记生命周期 meta</div>
+      <div class="detail">写 <code>HSET cube:v1:shared:sandbox:lifecycle:meta</code>（timeout_seconds / auto_pause / auto_resume）+ <code>XADD events</code>。CLM 启动时 HGETALL 全量引导 registry，之后 XREADGROUP 增量消费。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">2</div>
+    <div class="content">
+      <div class="who">CLM · sweeper</div>
+      <div class="what">扫描空闲沙箱，触发自动暂停 / 超时销毁</div>
+      <div class="detail"><code>idle = now − max(LastActiveMs, CreatedAt)</code>；<code>auto_pause=true</code> → tryPause（SETNX 状态锁防并发 → 通知 CubeProxy → CubeMaster Pause RPC → 写 paused 并广播）；否则超时 kill（KillReasonTimeout）。BootstrapWarmup 防止重启误暂停。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">3</div>
+    <div class="content">
+      <div class="who">CubeMaster → Cubelet → CubeShim</div>
+      <div class="what">执行暂停（内存快照落盘）</div>
+      <div class="detail">Cubelet <code>task.Pause</code> → shim <code>sb.pause_vm()</code>：把 VM 内存写快照到 <code>PAUSE_VM_SNAPSHOT_BASE/{id}</code>，随后 <code>VmPauseToSnapshot</code>。paused 状态物理上释放 CPU/内存。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">4</div>
+    <div class="content">
+      <div class="who">CubeProxy（数据面）</div>
+      <div class="what">请求到达 paused 沙箱 → 触发恢复</div>
+      <div class="detail">rewrite 阶段查状态字典发现 paused → 捕获子请求 <code>/_sidecar_resume</code> → CLM resumer：并发合并为单次 <code>callCubeMasterResume</code> → <code>waitForRunning</code>（轮询状态）→ 回推 running 给 CubeProxy → 阻塞中的请求继续转发，客户端无感知。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">5</div>
+    <div class="content">
+      <div class="who">CubeShim</div>
+      <div class="what">从快照恢复 VM</div>
+      <div class="detail"><code>sb.resume_vm()</code> → <code>VmResumeFromSnapshot</code>；恢复成功后获得全新 timeout 计时窗口（"恢复 → 使用 → 再次空闲 → 再次暂停"循环无缝持续）。</div>
+    </div>
+  </div>
+
+  <div class="note"><strong>删除 paused 沙箱</strong>：DELETE 会先在内部恢复运行时状态（最多 5 秒预算）再走正常销毁，不触发 resumed 生命周期事件；失败返回 409（资源准入）/ 503（操作未完成，带 Retry-After）。</div>
+  <div class="note"><strong>暂停资源释放（quota.paused_resource_release_ratio）</strong>：默认 0 = 暂停沙箱保留完整调度配额（恢复必有保障）；=1 全部释放（最大化密度、恢复尽力而为）；0~1 之间折中。节点级配置在 <code>Cubelet/config/config.toml</code>。恢复时触发本地实时准入检查，不满足返回 409 带配额诊断。</div>
+</section>
+
+<!-- ================= 7 存储 ================= -->
+<section id="storage">
+  <div class="section-title"><span class="num">07</span> 存储逻辑：CubeCoW 快照引擎</div>
+  <p class="section-sub">所有 rootfs 与内存卷操作（创建、克隆、快照、删除）由 Cubelet 通过 CubeCoW 完成。核心是内核 FICLONE 提供的 O(1) reflink 语义。</p>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>阶段</th><th>做什么</th><th>技术</th></tr></thead>
+      <tbody>
+        <tr><td><b>模板创建</b></td><td>OCI 镜像 → Buildkit → rootfs + 冷启动一次 → 内存快照 → 注册为模板（只读基础）</td><td>Buildkit + CubeCoW</td></tr>
+        <tr><td><b>沙箱启动</b></td><td>Cubelet 克隆模板的 rootfs 与内存卷（O(1) 零拷贝），CubeShim 从内存快照恢复 VM</td><td><code>FICLONE</code> + <code>restore_vm</code></td></tr>
+        <tr><td><b>增量快照</b></td><td>仅写入匿名（脏）内存页，未变更页 reflink 共享上一快照</td><td>脏页追踪 + reflink</td></tr>
+        <tr><td><b>回滚 / 克隆</b></td><td>回滚 = 丢弃当前状态挂载历史快照；克隆 = 从任意快照 fork 出独立环境（分叉探索）</td><td><code>RollbackSandbox</code> / <code>CommitSandbox</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <pre>模板（只读基础）
+  └── FICLONE ──→ 沙箱 rootfs 卷 (CoW)
+                      ├── FICLONE ──→ 快照 A
+                      ├── FICLONE ──→ 快照 B（只存脏页）
+                      └── FICLONE ──→ 克隆 1、克隆 2、…（可从任意快照 fork）</pre>
+
+  <div class="grid">
+    <div class="card"><h4>扁平快照模型</h4><p>快照之间无依赖链，删除任一快照不影响其他快照，crash-safe 且可独立挂载。</p></div>
+    <div class="card"><h4>应用层快照（AppSnapshot）</h4><p>Cubelet 提供 <code>AppSnapshot</code> RPC：创建沙箱 → 运行到目标状态 → 截图（内存+文件系统）→ 销毁，产物即新的模板/快照。</p></div>
+    <div class="card"><h4>Volume 框架</h4><p>兼容 E2B 标准；允许以插件形式自定义后端存储（CubeMaster <code>pkg/volume/plugin/{binary,rpc}</code> + refcount），Volume 独立生命周期、可跨沙箱共享。</p></div>
+    <div class="card"><h4>运行中快照</h4><p><code>CommitSandbox</code> 对运行中沙箱打快照，<code>RollbackSandbox</code> 回滚到任意已提交快照（CubeShim rollback_vm：VmDelete + VmResumeFromSnapshot，避免写盘）。</p></div>
+  </div>
+</section>
+
+<!-- ================= 8 网络 ================= -->
+<section id="network">
+  <div class="section-title"><span class="num">08</span> 网络逻辑</div>
+  <p class="section-sub">三层网络栈：CubeVS（内核态转发与策略）、CubeEgress（L7 出向安全）、CubeProxy（L7 入向路由）。整个数据面无 iptables / 无网桥 / 无 OVS。</p>
+
+  <h3>8.1 出站流量路径（沙箱 → 外部）</h3>
+  <div class="flow-step">
+    <div class="bubble">1</div>
+    <div class="content"><div class="who">沙箱进程</div><div class="what">发送报文，源 IP = 169.254.68.6（固定内部地址）</div><div class="detail">默认网关 169.254.68.5 由 from_cube 现场构造 ARP 应答（ARP 代理）。</div></div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">2</div>
+    <div class="content"><div class="who">from_cube（TAP TC ingress）</div><div class="what">策略 → 网关 → SNAT → 会话</div>
+      <div class="detail">目标为网关 → 重定向 cube-dev 交宿主机协议栈；被策略标记需 L7 检查的流量 → 重定向 cube-dev 走 CubeEgress；否则：策略评估 → DNS 拦截（域名规则学习）→ 创建/更新会话（egress_sessions + ingress_sessions）→ SNAT（jhash(sandbox_ip) % 4 确定性选 IP，端口从 30000 起水位线分配，自旋锁防碰撞）→ 重定向到宿主机网卡。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">3</div>
+    <div class="content"><div class="who">CubeEgress（L7，可选路径）</div><div class="what">透明代理：域名过滤 + 凭据注入 + 审计</div>
+      <div class="detail">TPROXY 监听 192.168.0.1:8080/8443（transparent），决策规则首匹配（sni/host/method/path/scheme），未就绪 fail-closed；通过 ssl_certificate_by_lua 按 SNI 动态签发叶子证书完成 TLS 检查；响应经 cube-dev（from_envoy 保留真实远端源 IP）回到沙箱。</div>
+    </div>
+  </div>
+
+  <h3>8.2 入站流量路径（外部 → 沙箱）</h3>
+  <div class="flow-step">
+    <div class="bubble">1</div>
+    <div class="content"><div class="who">from_world（宿主机网卡 TC ingress）</div><div class="what">会话反向 NAT / 端口映射</div>
+      <div class="detail">查 ingress_sessions 命中 → 重建沙箱侧五元组反向 DNAT → 重定向 TAP；未命中则查 remote_port_mapping[host_port] → DNAT 到沙箱监听端口。</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="bubble">2</div>
+    <div class="content"><div class="who">CubeProxy（L7 路由）</div><div class="what">把对 <code>&lt;port&gt;-&lt;sandbox_id&gt;</code> 的访问路由到沙箱后端</div>
+      <div class="detail">Host 模式解析 Host 头，Path 模式解析 <code>/sandbox/&lt;id&gt;/&lt;port&gt;/</code>；结合状态门禁支持自动恢复、503 Retry-After、410 Gone。</div>
+    </div>
+  </div>
+
+  <h3>8.3 会话跟踪与 DNS 学习</h3>
+  <div class="grid">
+    <div class="card"><h4>双 Map 会话跟踪</h4><p>egress_sessions（沙箱侧五元组 → 完整 NAT 状态）与 ingress_sessions（外部侧五元组 → 反向重建）。TCP 11 状态机按协议状态调整超时（ESTABLISHED 3h，SYN_SENT 1min…）；Go 回收器每 5s 清理，占用超 80% 告警。</p></div>
+    <div class="card"><h4>DNS 学习式域名策略</h4><p>from_cube 拦截查询（dns_allow LPM 精确/通配匹配 + dns_query_track 记录）；from_world 在响应时提取 A 记录写入 allow_out_v2（TTL 过期）。仅当沙箱配置域名规则才开启（dns_policy_flags 总闸门），否则零开销。</p></div>
+    <div class="card"><h4>端口分段规划</h4><p>10000–19999 宿主机临时端口；20000–29999 CubeProxy 访问沙箱端口；30000–65535 SNAT 源端口。避免子系统间冲突。</p></div>
+    <div class="card"><h4>策略优先级</h4><p>网关 > allow_out_v2 > deny_out > 默认放行；始终拒绝私网/链路本地段。LPM-trie 线速执行，每沙箱 Hash-of-Maps 隔离，更新不干扰他人。</p></div>
+  </div>
+</section>
+
+<!-- ================= 9 接口 ================= -->
+<section id="interfaces">
+  <div class="section-title"><span class="num">09</span> 组件间接口与协议</div>
+  <p class="section-sub">系统是多协议栈的：HTTP / gRPC / containerd ttRPC / vsock ttRPC / 进程内 mpsc / cgo / eBPF Map / Redis。</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>接口</th><th>协议</th><th>定义位置</th><th>说明</th></tr></thead>
+      <tbody>
+        <tr><td>Client → CubeAPI</td><td>HTTP/JSON（E2B 兼容 REST）</td><td><code>openapi.yml</code> + <code>CubeAPI/src/routes.rs</code></td><td>/sandboxes、/templates、/volumes、/snapshots…</td></tr>
+        <tr><td>CubeAPI → CubeMaster</td><td>HTTP/JSON</td><td><code>CubeAPI/src/cubemaster/mod.rs</code></td><td>/cube/sandbox*、/cube/snapshot*、/cube/template*、/cube/volume*</td></tr>
+        <tr><td>CubeMaster → Cubelet</td><td>gRPC</td><td><code>CubeMaster/api/services/cubebox/v1/cubebox.proto</code></td><td>CubeboxMgr.Create/Destroy/List/Update/Exec/AppSnapshot/CommitSandbox/RollbackSandbox…</td></tr>
+        <tr><td>CubeMaster → Cubelet</td><td>gRPC</td><td><code>CubeMaster/api/services/images/v1/images.proto</code></td><td>Images.CreateImage/ListImages/DestroyImage/VolumeUtils</td></tr>
+        <tr><td>Cubelet → CubeShim</td><td>containerd Shim v2（ttRPC）</td><td>containerd API + <code>CubeShim/shim/src/service/task_srv.rs</code></td><td>Create/Start/Pause/Resume/Exec…（运行时 io.containerd.cube.rs）</td></tr>
+        <tr><td>CubeShim → CubeHypervisor</td><td>进程内 mpsc</td><td><code>hypervisor/vmm/src/api/mod.rs</code></td><td>ApiRequest / ApiResponse 通道</td></tr>
+        <tr><td>CubeShim → guest agent</td><td>ttRPC over vsock</td><td><code>agent/libs/protocols/protos/agent.proto</code></td><td>CreateSandbox/ExecProcess/流式 IO/GetOOMEvent…</td></tr>
+        <tr><td>Cubelet → CubeCoW</td><td>cgo / C ABI</td><td><code>cubecow/include/cubecow.h</code> + <code>Cubelet/pkg/cubecow/cubecow.go</code></td><td>cubecow_init / create_snapshot / activate_volume…</td></tr>
+        <tr><td>Cubelet → network-agent</td><td>gRPC + SCM_RIGHTS</td><td><code>network-agent/api/v1/network_agent.proto</code> + fdserver</td><td>EnsureNetwork/ReleaseNetwork + TAP fd 直通</td></tr>
+        <tr><td>network-agent → CubeVS</td><td>eBPF Map（bpffs）</td><td><code>CubeNet/cubevs/</code></td><td>写 allow/deny/DNS 策略、会话管理</td></tr>
+        <tr><td>network-agent → CubeEgress</td><td>HTTP admin</td><td><code>CubeEgress/lua/admin.lua</code></td><td>/admin/v1/policy Put/Delete（L7 egress 规则）</td></tr>
+        <tr><td>CubeMaster → Redis</td><td>RESP</td><td><code>CubeMaster/pkg/base/rediskey</code></td><td>meta/events/proxy/state/分布式锁</td></tr>
+        <tr><td>CubeMaster → CLM</td><td>Redis Stream</td><td><code>CubeMaster/pkg/lifecycle/schema.go</code></td><td>XADD events（op: create/delete/update/state）</td></tr>
+        <tr><td>CLM → CubeProxy</td><td>HTTP admin（loopback）</td><td><code>CubeProxy/lua/admin_phase.lua</code></td><td>/admin/meta/upsert、/admin/state、/admin/last_active</td></tr>
+        <tr><td>CubeProxy → CLM</td><td>HTTP（数据面子请求）</td><td><code>cube-lifecycle-manager/internal/httpapi</code></td><td>POST /internal/resume（触发自动恢复）</td></tr>
+        <tr><td>CLM → CubeMaster</td><td>HTTP</td><td><code>cube-lifecycle-manager/internal/cubemasterclient</code></td><td>Pause / Resume</td></tr>
+        <tr><td>WebUI → CubeAPI / CubeOps</td><td>HTTP</td><td><code>web/src/lib/api.ts</code></td><td>根路径 E2B API + /opsapi/v1</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ================= 10 源码索引 ================= -->
+<section id="source-map">
+  <div class="section-title"><span class="num">10</span> 关键源码文件索引</div>
+  <p class="section-sub">想深入某个子系统时，从这里开始读代码。</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>关注点</th><th>入口文件</th></tr></thead>
+      <tbody>
+        <tr><td>沙箱创建控制流</td><td><code>CubeMaster/pkg/service/sandbox/sandbox_run.go</code> → <code>Cubelet/services/cubebox/local.go</code> → <code>CubeShim/shim/src/sandbox/sb.rs</code> → <code>hypervisor/vmm/src/vm.rs</code></td></tr>
+        <tr><td>调度器</td><td><code>CubeMaster/pkg/scheduler/schedule.go</code>、<code>pkg/scheduler/local.go</code>、<code>pkg/selector/filter/</code>、<code>pkg/selector/score/</code></td></tr>
+        <tr><td>暂停 / 恢复 / 回滚</td><td><code>Cubelet/services/cubebox/update.go</code>、<code>CubeShim/shim/src/sandbox/sb.rs</code>（pause_vm/resume_vm/rollback_vm）、<code>hypervisor/vmm/src/vm.rs</code>（Migratable）</td></tr>
+        <tr><td>生命周期事件</td><td><code>CubeMaster/pkg/lifecycle/{store,schema,init}.go</code>；消费端 <code>cube-lifecycle-manager/internal/{redisstream,sweeper,resumer,proxypush}</code></td></tr>
+        <tr><td>快照与克隆</td><td><code>cubecow/src/engine/reflink.rs</code>、<code>cubecow/src/ffi.rs</code>、<code>Cubelet/plugins/storage/</code>、<code>Cubelet/services/cubebox/appsnapshot.go</code></td></tr>
+        <tr><td>eBPF 数据面</td><td><code>CubeNet/src/mvmtap.bpf.c</code>、<code>CubeNet/src/nodenic.bpf.c</code>、<code>CubeNet/src/localgw.bpf.c</code>；控制面 <code>CubeNet/cubevs/</code></td></tr>
+        <tr><td>出向安全（L7）</td><td><code>CubeEgress/lua/access_phase.lua</code>、<code>CubeEgress/lua/policy.lua</code>、<code>CubeEgress/lua/cert_signer.lua</code></td></tr>
+        <tr><td>入向路由（L7）</td><td><code>CubeProxy/lua/rewrite_phase.lua</code>、<code>CubeProxy/lua/path_rewrite_phase.lua</code>、<code>CubeProxy/lua/sandbox_state.lua</code></td></tr>
+        <tr><td>沙箱内运行时</td><td><code>agent/src/rpc.rs</code>、<code>agent/src/sandbox.rs</code>、<code>agent/rustjail/src/container.rs</code></td></tr>
+        <tr><td>E2B API 网关</td><td><code>CubeAPI/src/routes.rs</code>、<code>CubeAPI/src/services/sandboxes.rs</code>、<code>CubeAPI/src/cubemaster/mod.rs</code></td></tr>
+        <tr><td>节点网络编排</td><td><code>network-agent/internal/service/tap_lifecycle.go</code>、<code>internal/service/ipam.go</code>、<code>internal/cubeegress/cubeegress_push.go</code></td></tr>
+        <tr><td>构建与开发</td><td><code>Makefile</code>（make all / make cubelet / make web-dev…）；配置 <code>CubeMaster/conf.yaml</code>、<code>Cubelet/config/config.toml</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="note"><strong>运行环境要求</strong>：沙箱运行需要 <code>/dev/kvm</code>（嵌套虚拟化）；构建在 Docker builder 容器内完成（Go 1.24 / Rust 1.89 / protoc）。Redis 是控制面运行的最低外部依赖。</div>
+</section>
+
+</main>
+
+<footer>
+  CubeSandbox 逻辑梳理 · 基于仓库源码与 docs/ 文档整理，仅作开发参考。<br>
+  组件行为以源码为准：<code>/workspace/github/CubeSandbox</code>
+</footer>
+
+<button class="back-top" id="backTop" title="返回顶部">↑</button>
+
+<script>
+  // 导航高亮 + 滚动监听
+  const nav = document.getElementById('nav');
+  const links = Array.from(nav.querySelectorAll('a'));
+  const sections = links.map(l => document.querySelector(l.getAttribute('href')));
+  const backTop = document.getElementById('backTop');
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        links.forEach(l => l.classList.toggle('active', l.getAttribute('href') === '#' + e.target.id));
+      }
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+  sections.forEach(s => s && observer.observe(s));
+
+  window.addEventListener('scroll', () => {
+    backTop.classList.toggle('show', window.scrollY > 500);
+  });
+  backTop.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+</script>
+
+</body>
+</html>

--- a/cubesandbox-tech/cubecow.html
+++ b/cubesandbox-tech/cubecow.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CubeCoW 存储引擎 · 磁盘怎么做到"一秒复制一百份"</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--amber),var(--red));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--amber));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 技术深入</div>
+    <a class="back-home" href="index.html">← 技术索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 核心技术 04 / 09</div>
+    <h1>磁盘怎么做到"一秒复制一百份"</h1>
+    <p class="lead">这篇讲 CubeCoW，CubeSandbox 的存储引擎。调度器把沙箱派到了机器上，但这台机器凭什么能"秒开"一百个同模板沙箱而不爆磁盘？答案是一个叫写时复制的古老概念，加上一个"把复杂度删到几乎为零"的设计态度。我们从头走一遍。</p>
+  </div>
+
+  <h2>一、问题：一百台电脑，不能有一百份系统盘</h2>
+
+  <p>先回到那个反复出现的场景：开发者不断敲下 <code>sandbox.create()</code>，每次都要"开一台带 Python 3.11 环境的电脑"。如果每个沙箱都完整复制一份系统盘——几个 GB——开一百个就是一百份磁盘：空间爆炸，而且复制本身耗时。而 CubeSandbox 的核心卖点是"从模板秒开"，秒开的物理前提就是：<span class="hl">创建沙箱不能真的复制数据。</span></p>
+  <p>但这一百个沙箱的系统盘内容，99.9% 是一样的——都是同一份模板。只有每个人自己的代码、下载的东西是独有的。问题于是变成：<span class="hlb">如何让一百个沙箱"共享"同一份模板的磁盘内容，各自写入时互不干扰？</span></p>
+
+  <h2>二、核心思想：写时复制，用内核现成的能力</h2>
+
+  <p>这个概念你其实早就用过——Copy-on-Write（写时复制，COW）。一间教室，老师发一本公共教材当模板，所有学生共用；谁要在书上划重点（写入），就先复印那一页，在复印件上划——其他同学仍然用原书。划重点的人越多，才会出现越多的独立拷贝。</p>
+  <p>CubeCoW 没有发明任何复杂的新东西，而是<span class="hl">直接调用 Linux 内核已有的能力</span>：一个叫 <code>FICLONE</code> 的 ioctl（ioctl 号 <code>0x40049409</code>）。它的语义是：</p>
+  <div class="codeblock">FICLONE(dst, src) = 在磁盘上登记"dst 的内容就是 src 的内容"
+                   —— 不拷贝任何字节，只加一个"引用"
+只有某一方要改动某个数据块时，内核才真正复制那一小块，
+让双方各自拥有。这就是 COW。</div>
+  <p>用这套语义，<span class="hl">"创建沙箱 = 对模板文件做一次 FICLONE"</span>，耗时与模板大小完全无关，永远是一个瞬间操作（O(1)）。这也正是 Cubelet Workflow 那篇里 storage 插件在做的：<code>storage_backend=cubecow</code> 时，卷的创建就是一次引用式克隆。</p>
+  <p>这里有一个技术选型值得停下来：为什么不直接用 dm-thin（设备映射薄卷）？dm-thin 同样提供 O(1) 快照，但要维护一个 pool 台账、一套内核 ioctl 编排，以及不小的崩溃恢复面。而 CubeCoW 的工作负载模式是"<span class="hlb">大量短命的、大镜像文件的克隆</span>"——对这种模式，xfs 的 reflink（挂在 <code>-m reflink=1</code> 布局上）在文件层就提供同样的 O(1) 语义，且每次操作就是一个文件系统事务，崩溃语义简单得多。选择 reflink，本质是选择"更小的出故障面"。</p>
+
+  <svg class="flow" viewBox="0 0 720 196" role="img" aria-label="FICLONE 克隆关系">
+    <defs>
+      <marker id="cwArr2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="196" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">一个模板 → N 个沙箱 · 创建沙箱 = 一次 FICLONE，与模板大小无关</text>
+
+    <rect x="270" y="40" width="180" height="56" rx="10" fill="rgba(251,191,36,.1)" stroke="rgba(251,191,36,.6)"/>
+    <text x="360" y="64" text-anchor="middle" class="fn">模板 vol-A 主文件</text>
+    <text x="360" y="82" text-anchor="middle" class="fd">几个 GB · 唯一一份真实字节</text>
+
+    <line x1="360" y1="96" x2="120" y2="128" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#cwArr2)"/>
+    <line x1="360" y1="96" x2="360" y2="128" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#cwArr2)"/>
+    <line x1="360" y1="96" x2="600" y2="128" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#cwArr2)"/>
+    <text x="378" y="117" class="fl">FICLONE 登记引用 · O(1)</text>
+
+    <rect x="30" y="128" width="180" height="54" rx="10" fill="rgba(251,191,36,.06)" stroke="rgba(251,191,36,.4)"/>
+    <text x="120" y="152" text-anchor="middle" class="fn">沙箱卷 1</text>
+    <text x="120" y="170" text-anchor="middle" class="fd">共享模板块 + 私有写块</text>
+    <rect x="270" y="128" width="180" height="54" rx="10" fill="rgba(251,191,36,.06)" stroke="rgba(251,191,36,.4)"/>
+    <text x="360" y="152" text-anchor="middle" class="fn">沙箱卷 2</text>
+    <text x="360" y="170" text-anchor="middle" class="fd">共享模板块 + 私有写块</text>
+    <rect x="510" y="128" width="180" height="54" rx="10" fill="rgba(251,191,36,.06)" stroke="rgba(251,191,36,.4)"/>
+    <text x="600" y="152" text-anchor="middle" class="fn">沙箱卷 3</text>
+    <text x="600" y="170" text-anchor="middle" class="fd">共享模板块 + 私有写块</text>
+  </svg>
+
+  <h2>三、三个设计取舍：把复杂度一个个删掉</h2>
+
+  <p>真正的亮点不在"用了 FICLONE"，而在围绕它做出的三个取舍。它们让这个引擎简单到几乎不可能出 bug：</p>
+
+  <h3>取舍一：快照"扁平化"——没有快照树</h3>
+  <p>很多存储系统允许"快照的快照"，形成一棵树，树越深管理越复杂。CubeCoW 选择：<span class="hl">无论从哪一层做快照，结果都落在最初那个卷的目录下。</span>目录布局是：</p>
+  <div class="codeblock">&lt;root_dir&gt;/volumes/
+    ├── &lt;vol-A&gt;/
+    │   ├── &lt;vol-A&gt;          ← 卷主文件（FICLONE 源）
+    │   ├── &lt;snap-1&gt;         ← FICLONE(&lt;vol-A&gt;)
+    │   └── &lt;snap-2&gt;         ← FICLONE(&lt;snap-1&gt;)，但扁平化落在 vol-A/ 下
+    ├── &lt;vol-B&gt;/&lt;vol-B&gt;
+    └── ...</div>
+  <p>注意 <code>snap-2</code>：它是从 <code>snap-1</code> 克隆的，但物理上仍然躺在 <code>vol-A/</code> 目录里。每个快照都记录自己的"最终源卷"，所有快照是兄弟，删除任何一个都不影响其他。<span class="hlb">代价</span>：失去快照树的分层语义；<span class="hlb">回报</span>：永远不用算"我的祖先是谁"，删除永远安全。</p>
+
+  <h3>取舍二：父卷可以先删</h3>
+  <p>一般理解是"子快照依赖父卷，父卷不能先删"。CubeCoW 的快照是独立的文件，不依赖祖先，允许"父卷先删、快照后删"。这正好服务一个真实流程：构建模板时先建临时卷，完成后删临时卷——快照安然无恙。对运维来说少了一个"先删谁后删谁"的纪律约束，就少了一类操作失误。</p>
+
+  <h3>取舍三：崩溃恢复靠"扫描目录"，而不是日志</h3>
+  <p>传统存储系统要写事务日志（WAL）才能保证崩溃后一致。CubeCoW 的选择更简单：<span class="hl">目录结构本身就是状态。</span>启动时扫一遍磁盘，就能重建全部元数据——卷列表来自 <code>readdir(volumes/)</code>，快照列表来自 <code>readdir(volumes/&lt;vol&gt;/)</code> 减掉主文件，大小来自 <code>stat</code>，创建时间来自 <code>mtime</code>。扫描器还负责清理上次崩溃留下的孤儿：空目录、FICLONE 没落地的零字节快照文件。<span class="hlb">代价</span>：要求每步操作严格先落盘再返回；<span class="hlb">回报</span>：没有日志、没有 WAL，代码少一大截。</p>
+
+  <h2>四、为什么这套设计"敢"这么简单</h2>
+
+  <p>这三个取舍成立的前提，是 CubeCoW 刻意押注在一个假设上：<span class="hl">底层文件系统（xfs）已经把它最难的部分做好了。</span>引用计数、空间回收、掉电一致性——全是内核的事。CubeCoW 只做三件事：起名字（校验名称合法性）、建目录、调 FICLONE。它甚至启动时还会探测一次底层文件系统是否真的支持 FICLONE，不支持直接拒绝启动，而不是运行到一半才炸。</p>
+  <p>也正因为"卷 = 一个普通文件"，它才能用最薄的接口暴露能力：对外是一个 <code>Engine</code> trait（create/delete/resize/list volume、snapshot 操作、激活/停用），再通过 C FFI 层（<code>ffi.rs</code> + <code>cubecow.h</code>）暴露给 Go 侧。CubeSandbox 的节点管理程序（Go 写的 Cubelet）通过 cgo 调用它——两边语言不同，但接口薄得一眼看穿。</p>
+  <div class="think">
+    <div class="q">一个反直觉的结论：越基础的基础设施，越该把"简单可靠"放在"功能强大"前面。</div>
+    <div class="a">存储引擎是沙箱数据安全的最后防线。每删掉一个复杂机制（快照树、事务日志、pool 台账），就少一类能出故障的状态。CubeCoW 的"设计审美"，是把能不做的事全都不做。</div>
+  </div>
+
+  <h2>五、收束</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>问题</th><th>选择</th><th>付出的代价</th></tr></thead>
+      <tbody>
+        <tr><td>克隆模板太贵</td><td>FICLONE 引用式克隆，O(1)</td><td>依赖底层文件系统支持 reflink</td></tr>
+        <tr><td>快照树难管理</td><td>扁平化，全部落在源卷目录</td><td>失去分层语义</td></tr>
+        <tr><td>父卷先删会悬空</td><td>快照独立，父卷可先删</td><td>无（少一条操作纪律）</td></tr>
+        <tr><td>崩溃后不一致</td><td>目录即状态，扫描自愈</td><td>每步必须严格先落盘</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="punchline">
+    <small>一句话带走</small>
+    CubeCoW = 用内核自带的 FICLONE 把"克隆模板"变成 O(1) 的瞬间操作；再配合三个删繁就简的取舍（无快照树、父卷可先删、扫描自愈），换来一个简单到几乎不会出错的存储层——而"秒开一百个沙箱"的物理基础，就在这里。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>引擎接口抽象</td><td><code>cubecow/src/engine/mod.rs</code>（Engine trait）</td></tr>
+        <tr><td>reflink 实现（FICLONE / 扫描自愈）</td><td><code>cubecow/src/engine/reflink.rs</code></td></tr>
+        <tr><td>C 接口（暴露给 Go）</td><td><code>cubecow/src/ffi.rs</code> + <code>cubecow/include/cubecow.h</code></td></tr>
+        <tr><td>Go 侧封装</td><td><code>Cubelet/pkg/cubecow/</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>CubeCoW 存储引擎 · CubeSandbox 技术深入 04/09 · 下一篇：CubeShim + CubeHypervisor——containerd 到 KVM 的最后一公里</footer>
+</body>
+</html>

--- a/cubesandbox-tech/cubeegress.html
+++ b/cubesandbox-tech/cubeegress.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CubeEgress 安全代理 · 出站流量最后的安检员</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--green),var(--cyan));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--green));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .gate{display:flex;flex-wrap:wrap;gap:6px;margin:18px 0}
+  .gate span{font-family:var(--mono);font-size:12px;padding:5px 10px;border-radius:8px;border:1px solid var(--border-strong);background:rgba(255,255,255,.03);color:var(--text-dim)}
+  .gate span.ok{border-color:rgba(52,211,153,.5);color:var(--green)}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 技术深入</div>
+    <a class="back-home" href="index.html">← 技术索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 核心技术 08 / 09</div>
+    <h1>出站流量最后的安检员</h1>
+    <p class="lead">这篇讲 CubeEgress。上一篇的 CubeVS 在 L4 管"哪些 IP 能去"，但安全往往要管到 L7——允许访问哪个域名、哪个方法、哪条路径；还要解决一个更棘手的问题：数据库密码、API Key 怎么安全地给到沙箱。CubeEgress 把这两件事都做在了沙箱之外的透明代理里。</p>
+  </div>
+
+  <h2>一、问题：L4 管不了域名，密钥也不能进沙箱</h2>
+
+  <p>CubeVS 用 eBPF 把访问控制做到了 IP 级，但它有一个边界：它看到的只是"目的 IP:端口"。管理员想表达的是"允许访问 github.com 的 API，禁止上传大文件"——这种应用语义，L4 无从判断。域名、方法、路径、TLS 里的 SNI，都是 L7 层的信息。</p>
+  <p>而另一个更麻烦的问题关于密钥。沙箱里跑着用户的代码，它要连数据库、要调云 API，就需要密码、Key。但如果把密钥直接放进沙箱镜像或环境变量——<span class="hlr">密钥就暴露给了不可信的用户代码</span>，用户把系统盘一克隆，密钥就跟着扩散了。正确做法是：<span class="hl">密钥只存在于控制面，请求发出时由代理自动注入，沙箱代码永远拿不到明文。</span></p>
+  <p>两个诉求合到一起，答案指向同一个组件：一个<span class="hl">透明的 L7 出向代理</span>，站在沙箱和互联网之间，看得见域名和方法，也握得住密钥。这就是 CubeEgress——基于 OpenResty + Lua 实现。</p>
+
+  <h2>二、机制：TPROXY——沙箱无感的透明截获</h2>
+
+  <p>关键前提是"透明"：沙箱里的程序发 HTTP/HTTPS 请求时，根本不知道流量会被拦截，代码一行都不用改。实现靠 Linux 的 TPROXY：CubeVS 判断某条流量"需要 L7 检查"（L7_REQUIRED），TPROXY 规则按目的 IP/端口把它转给 CubeEgress。CubeEgress 的 nginx 配置里是三个 server：</p>
+  <div class="codeblock">CubeEgress（OpenResty）
+├─ 8080（HTTP transparent）：listen IP:8080 transparent
+│      proxy_pass http://$server_addr:$server_port   ← 回源到 TPROXY 记录的原始目的
+├─ 8443（HTTPS transparent）：listen IP:8443 ssl transparent
+│      ssl_certificate_by_lua 按 SNI+目的IP 动态签发叶子证书
+│      proxy_ssl_verify on（校验上游证书，verify_depth 4）
+└─ 9090（Admin，loopback only）：策略 PUT/PATCH/DELETE / dump</div>
+  <p>注意一个必须解决的问题：标准 nginx 的 <code>$server_addr</code> 在 transparent listen 下拿到的是本机地址，而不是原始目的地址。CubeEgress 自带一个 OpenResty 补丁（<code>openresty/0001-nginx-support-TPROXY...</code>），让 <code>$server_addr</code> 携带 TPROXY 记录的真实目的地址，从而用变量式 proxy_pass 精确回源。HTTPS 侧则用 <code>ssl.raw_server_addr()</code> 还原目的 IP。这层"补丁"是整个透明代理能不能工作的关键——没有它，代理就不知道把请求转发给谁。</p>
+
+  <h2>三、机制：决策引擎——每个请求一次完整判断</h2>
+
+  <p>请求到达后，access 阶段执行一次完整决策，核心是 <code>_M.decide()</code>：</p>
+  <div class="codeblock">decide():
+① build_ctx()：sandbox_ip=remote_addr、sni=ssl_server_name、host（去端口）、
+               method、path=uri、dst_ip=server_addr、scheme
+② Bootstrap 门禁：策略存储的 bootstrap_status 仅 "ready"/"skipped" 放行
+     pending/unknown → fail-closed 返回 403（每 worker 每状态只 WARN 一次）
+③ sandbox_ip 为空 → deny("no_remote_addr")
+④ policy.get(sandbox_ip)：
+     └─ 出错 → deny("policy_lookup_error")
+     └─ 无策略 → deny("no_policy_for_sandbox")
+⑤ 顺序遍历 p.rules，rule_matches(r.match, ctx) 首条命中即决（first-match-wins）：
+     decision.rule_id = r.id；audit_level = r.action.audit or "metadata"
+     allow==true  → allow(decision)
+     allow==false → deny("rule_deny")
+⑥ 无规则命中 → deny("no_rule_match")（默认拒绝）</div>
+  <svg class="flow" viewBox="0 0 720 252" role="img" aria-label="CubeEgress 决策流程">
+    <defs>
+      <marker id="egArr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/></marker>
+      <marker id="egArrR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#f87171"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="252" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">decide() · 每个请求一次完整判断 · fail-closed 默认拒绝</text>
+
+    <rect x="20" y="36" width="300" height="48" rx="10" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.45)"/>
+    <text x="170" y="57" text-anchor="middle" class="fn">① build_ctx</text>
+    <text x="170" y="75" text-anchor="middle" class="fd">IP / SNI / Host / Method / Path</text>
+    <line x1="170" y1="84" x2="170" y2="98" stroke="#34d399" stroke-width="1.5" marker-end="url(#egArr)"/>
+
+    <rect x="20" y="98" width="300" height="48" rx="10" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.45)"/>
+    <text x="170" y="119" text-anchor="middle" class="fn">② 门禁 + 策略查询</text>
+    <text x="170" y="137" text-anchor="middle" class="fd">Bootstrap ready · policy.get 命中</text>
+    <line x1="320" y1="122" x2="368" y2="176" stroke="#34d399" stroke-width="1.5" marker-end="url(#egArr)"/>
+    <text x="352" y="138" class="fl">有策略</text>
+
+    <polygon points="368,176 440,146 512,176 440,206" fill="rgba(251,191,36,.1)" stroke="rgba(251,191,36,.6)" stroke-width="1.5"/>
+    <text x="440" y="174" text-anchor="middle" class="fn">命中规则？</text>
+    <text x="440" y="192" text-anchor="middle" class="fd">first-match-wins</text>
+
+    <line x1="512" y1="176" x2="560" y2="176" stroke="#34d399" stroke-width="1.5" marker-end="url(#egArr)"/>
+    <text x="534" y="168" class="fl">是</text>
+    <rect x="560" y="130" width="140" height="92" rx="10" fill="rgba(52,211,153,.1)" stroke="rgba(52,211,153,.6)"/>
+    <text x="630" y="158" text-anchor="middle" class="fn">allow</text>
+    <text x="630" y="178" text-anchor="middle" class="fd">放行</text>
+    <text x="630" y="196" text-anchor="middle" class="fd">凭证注入</text>
+    <text x="630" y="214" text-anchor="middle" class="fm">先清后注入</text>
+
+    <line x1="440" y1="206" x2="440" y2="210" stroke="#f87171" stroke-width="1.5" marker-end="url(#egArrR)"/>
+    <text x="528" y="200" class="fl">否</text>
+    <rect x="340" y="210" width="200" height="36" rx="9" fill="rgba(248,113,113,.08)" stroke="rgba(248,113,113,.5)"/>
+    <text x="440" y="232" text-anchor="middle" class="fn" style="fill:#f87171">deny · 403</text>
+    <text x="440" y="247" text-anchor="middle" class="fm">策略缺/错 · 无命中 · rule_deny</text>
+  </svg>
+  <p>两个设计取向值得记下。<span class="hlb">一是 fail-closed（默认拒绝）</span>：没有规则命中的请求直接 403——安全语义是白名单而不是黑名单；策略查询出错也拒绝，宁可服务不可用，也不放行未受控流量。<span class="hlb">二是 first-match-wins</span>：规则按顺序遍历，第一条命中的规则决定放行与否，规则之间不需要考虑"更具体优先"的排列——把"规则优先级"这个隐患直接消除。</p>
+  <p>规则匹配的字段全部可选、缺省即匹配：<code>sni</code>/<code>host</code> 用 domain_match（仅支持前导 <code>*.</code> 通配，不匹配 apex 域）、<code>method</code> 数组 any-of、<code>path</code> 尾部 <code>*</code> 前缀通配、<code>scheme</code> 等值。返回 true 当全部约束通过。</p>
+
+  <h2>四、机制：八道门禁——从握手到授权</h2>
+
+  <div class="gate">
+    <span class="ok">G1 scheme 合法</span><span>G2 TLS 握手成功</span><span>G3 SNI 匹配规则</span><span>G4 Host==SNI</span><span>G5 目的 IP 可信</span><span>G6 上游证书校验</span><span>G7 method/path 匹配</span><span>G8 策略授权</span>
+  </div>
+  <p>其中最有含金量的是 <span class="hl">G4：Host 必须等于 SNI</span>。为什么？这是防 SNI 与 Host 分离攻击：攻击者可以把"放行的域名"放在 TLS 的 SNI 里骗过代理决策，然后在 HTTP Host 头里写真正想去的域名。G4 强制两者一致，把这条绕过路径堵死。</p>
+  <p>G5/G6 是一组纵深防御：目的 IP 可信 + 上游证书由 nginx 全局 <code>proxy_ssl_verify on</code> 校验——代理自己也要防"被中间人"。整个门禁链条还有一个统一原则：<span class="hl">任何门禁失败都丢弃凭证注入</span>（请求按 allow 决定是否放行）——绝不让密钥进入一个没被完整验证过的上下文。</p>
+
+  <h2>五、机制：凭证注入——密钥永不出控制面</h2>
+
+  <p>这是 CubeEgress 的核心安全价值。策略里这样写：</p>
+  <div class="codeblock">policy: rules[].action.inject = [{ header="Authorization", secret="sk-xxx", format="${SECRET}" }]
+
+allow(decision) 里：
+① 无条件 clear_header(inj.header)      ← 先清掉沙箱自带的伪造头（防竞态）
+② inject_gates(ctx)                    ← 再走一遍门禁，失败则 dropped 并审计
+③ apply_injects：
+     pcall(ngx.req.set_header, header, rendered)   ← 渲染后注入
+     成功 → 记录 {header, secret_ref}（绝不记录值本身）
+④ 有 skipped 或 security_event → audit.write_security_event</div>
+  <p>有几个值得展开的细节。<span class="hlg">一是"先清后注入"</span>：先无条件删掉沙箱可能自带的同名请求头，再注入真实的——防止沙箱伪造一个错误的 Authorization 头抢占位置（竞态）。<span class="hlg">二是模板渲染的防御</span>：默认 format 是 <code>${SECRET}</code>，先转义 <code>%</code> 为 <code>%%</code> 再替换；如果替换 0 次则 WARN——防止策略把占位符写错（比如写成 <code>Bearer $SECRET</code>）而注入出错误值。</p>
+  <p><span class="hlg">三是密钥指纹</span>：policy.lua 在写入策略时，为每个 inject 项预计算 <code>secret_ref_synthetic</code>（sha256 前 4 字节 → "fp-xxxx"）。审计日志和管理接口只出现指纹，绝不出现明文。这样即使日志泄露，攻击者拿到的也只是"某密钥的短指纹"，而数据面判断"这次注入用的是哪把密钥"完全够用。</p>
+
+  <h2>六、机制：动态证书——透明 MITM 的底座</h2>
+
+  <p>要检查 HTTPS 流量，代理必须能解密——也就是对沙箱扮演"目标服务器"，对目标服务器扮演"合法客户端"。沙箱侧需要"看起来像真的"证书，由 CubeEgress 自带的 CA 动态签发：</p>
+  <div class="codeblock">serve(sni, dst_ip)：
+① 缓存键 = sni 或 ("ip:"..dst_ip)
+② 命中 → unpack 直接用
+③ 未命中 → resty.lock 慢路径，锁内 double-check
+     → sign_leaf(sni, dst_ip) → cache:set(…, CACHE_TTL_SEC=6天)
+     → ssl.clear_certs() + set_der_cert() + set_der_priv_key()
+
+sign_leaf：
+  ECDSA P-256，v3 证书，序列号 = now*1e6 + random
+  not_before = now−60s（时钟偏移容忍），not_after = now + 7 天
+  SAN 优先级：非 IP 的 SNI → DNS；IP 形式 SNI → IP；否则 dst_ip → IP</div>
+  <p>并发防重复签名的设计是"锁内 double-check"：缓存 miss 后先抢 resty.lock（cert_locks，5s 超时），进锁后再查一次缓存，仍然没有才签——避免同一域名被并发签出多张。证书缓存 64m、锁 8m 两个 shared dict。CA 由部署侧生成并挂载（/etc/cube/ca/），沙箱镜像和用户环境需要信任该 CA 才不会有 TLS 告警——这是所有透明 MITM 方案共同的前提成本。</p>
+
+  <h2>七、机制：策略存储与审计</h2>
+
+  <p>策略存在 shared dict：key 是沙箱源 IP，value 是策略表。有个工程细节：openresty 的 <code>get_keys()</code> 有 1024 条上限，所以用一个手工维护的 <code>__index__</code> 数组跟踪所有 IP，配一把哨兵锁保护。策略校验严格：policy_id 非空、rules 非空、rule.id 唯一、action.allow 为 boolean、inject 每项 header+secret 非空且 secret ≤ 64KiB、audit ∈ {full, metadata, none}。Admin API 只监听 127.0.0.1:9090，响应前先 redact_policy（secret → ***REDACTED***）。</p>
+  <p>下发链路：network-agent 在 EnsureNetwork 时把 CubeNetworkConfig 的 EgressRule 转成 PolicyInput 推给 CubeEgress（瞬时错误失败则打 pending 标记等重试）；CubeEgress 启动时也向 network-agent 拉取一次全量做 bootstrap。审计走 nginx 的 JSON 日志，落 <code>/data/log/cube-egress/access.jsonl</code>，记录 sandbox_ip、dst_ip、host、latency 等，门禁失败与注入丢弃事件单独写 security_event。</p>
+
+  <h2>八、收束</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>问题</th><th>设计</th><th>关键权衡</th></tr></thead>
+      <tbody>
+        <tr><td>L4 管不了域名/方法/路径</td><td>TPROXY 透明截获 + L7 决策</td><td>沙箱代码零改动</td></tr>
+        <tr><td>密钥不能进沙箱</td><td>凭证注入 + 指纹审计</td><td>密钥永不出控制面</td></tr>
+        <tr><td>策略必须白名单语义</td><td>fail-closed 默认拒绝 + first-match-wins</td><td>宁可拒，不可放</td></tr>
+        <tr><td>SNI 与 Host 分离攻击</td><td>G4 强制一致</td><td>堵死一条绕过路径</td></tr>
+        <tr><td>HTTPS 需要解密</td><td>自带 CA 动态签发 + 锁内 double-check</td><td>各端需信任该 CA</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="punchline">
+    <small>一句话带走</small>
+    CubeEgress = TPROXY 透明截获 + 默认拒绝的决策引擎 + 动态签发的 MITM + 凭证注入 + 指纹化审计——把"出站访问控制"从 IP 级提升到应用级，同时让密钥永远不落地沙箱。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>nginx 配置（三 server）</td><td><code>CubeEgress/nginx.conf</code>（8080 HTTP L107 / 8443 HTTPS L139 / 9090 admin L208）</td></tr>
+        <tr><td>决策引擎</td><td><code>CubeEgress/lua/access_phase.lua</code>（_M.decide L401 / inject_gates L184 / apply_injects L223）</td></tr>
+        <tr><td>策略存储</td><td><code>CubeEgress/lua/policy.lua</code>（fingerprint L147 / bulk_load L345）</td></tr>
+        <tr><td>证书签发</td><td><code>CubeEgress/lua/cert_signer.lua</code>（sign_leaf L97 / serve L161）</td></tr>
+        <tr><td>Admin API</td><td><code>CubeEgress/lua/admin.lua</code>（路由表 L186）</td></tr>
+        <tr><td>审计 / 脱敏</td><td><code>CubeEgress/lua/audit.lua</code>、<code>redactor.lua</code></td></tr>
+        <tr><td>TPROXY 补丁</td><td><code>CubeEgress/openresty/0001-nginx-support-TPROXY*.patch</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>CubeEgress 安全代理 · CubeSandbox 技术深入 08/09 · 下一篇：CubeProxy——请求怎么找到沙箱，又怎么叫醒它</footer>
+</body>
+</html>

--- a/cubesandbox-tech/cubelet-workflow.html
+++ b/cubesandbox-tech/cubelet-workflow.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Cubelet Workflow 引擎 · 一个沙箱，是被"流水线"制造出来的</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--blue),var(--purple));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--green));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .pipeline{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin:24px 0}
+  .pipeline .ps{border:1px solid var(--border);border-radius:12px;padding:14px;background:rgba(255,255,255,.03)}
+  .pipeline .ps .no{font-family:var(--mono);font-size:11px;color:var(--blue);margin-bottom:6px}
+  .pipeline .ps .t{font-weight:700;font-size:14.5px;margin-bottom:4px}
+  .pipeline .ps .d{font-size:12.5px;color:var(--text-dim);line-height:1.8}
+  @media(max-width:720px){.pipeline{grid-template-columns:1fr 1fr}}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 技术深入</div>
+    <a class="back-home" href="index.html">← 技术索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 核心技术 03 / 09</div>
+    <h1>一个沙箱，是被"流水线"制造出来的</h1>
+    <p class="lead">这篇讲 Cubelet 的 Workflow 引擎。创建沙箱不是一行代码，而是拉镜像、准备卷、建网络、算 cgroup、启动 VM……一长串步骤。我们把视线放到节点侧：Cubelet 是怎么把这串步骤组织成一条可扩展、可控并发、失败自愈的流水线的。</p>
+  </div>
+
+  <h2>一、问题：一个"创建沙箱"的函数，会膨胀成什么</h2>
+
+  <p>假设你是 Cubelet 的开发者，要写"创建沙箱"。你很快会发现，这不是一个函数，而是一串依赖关系明确的步骤：得先有 sandbox ID，才能建卷；卷建好，才能配网络；网络配好，才能起 cgroup；这些都好了，才能启动 VM。而每一步内部，又有多个互不依赖的子任务可以并行——比如"拉镜像"和"建网络"互不相干，让它们串行执行纯粹是浪费时间。</p>
+  <p>如果把这一切写进一个巨型函数，会怎样？函数会长到几千行，步骤顺序写死在代码里，想调整顺序要改代码，想加一种新资源类型（比如新的存储后端）要改主流程。创建时间 = 所有步骤之和，因为谁都不敢并行。</p>
+  <div class="think">
+    <div class="q">于是设计者决定：把流水线本身做成数据，让配置驱动执行。</div>
+    <div class="a">这就是 Workflow 引擎的起点——"配置即流水线"。</div>
+  </div>
+  <p>解法分成两层：一层是<span class="hl">声明式定义</span>——流水线长什么样，写在 <code>Cubelet/config/config.toml</code> 里；一层是<span class="hl">插件式执行</span>——每个步骤是一个独立的 Action 插件，实现同一个接口。调整流水线 = 改配置；加能力 = 注册新插件。引擎本身永远不需要为具体资源类型改代码。</p>
+
+  <h2>二、骨架：Flow / Step / Action 三层结构</h2>
+
+  <p>流水线有三个层次：一个 <code>Flow</code> 是一条完整的流水线（create 或 destroy）；Flow 由若干 <code>Step</code> 组成（外层数组，串行）；Step 由若干 <code>Action</code> 组成（内层数组，并行）。真实配置长这样：</p>
+  <div class="codeblock">[plugins."io.cubelet.workflow.v1.workflow".flows.create]
+  concurrent = 100
+  actions = [
+    ["createid", "appsnapshot"],               # Step1：生成 ID + 快照场景准备模板（并行）
+    ["images","volume","storage","network",
+     "netfile","cube-sandbox-store"],          # Step2：六大资源并行准备
+    ["cgroup"],                                # Step3：cgroup 资源计算与限额
+    ["cubebox"]                                # Step4：核心——创建容器并驱动 shim
+  ]
+
+[flows.destroy]
+  actions = [
+    ["cubebox"],                               # Step1：先销毁 VM/容器
+    ["images","storage","cgroup","network",
+     "volume","netfile","cube-sandbox-store"], # Step2：并行回收资源
+    ["cleanup"]                                # Step3：GC 清理
+  ]</div>
+  <p>注意到 destroy 的顺序刻意反过来了：创建时最后启动的东西，销毁时最先干掉——VM 必须先死，才能安全回收它的资源。这种顺序关系，正是"依赖"在配置里的显式表达。</p>
+
+  <svg class="flow" viewBox="0 0 720 178" role="img" aria-label="create 流水线的 Step 与 Action">
+    <defs>
+      <marker id="cwArr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="178" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">FLOWS.CREATE · 外层 Step 串行（有依赖），内层 Action 并行（无依赖）</text>
+
+    <text x="89" y="46" text-anchor="middle" class="fm">STEP 1</text>
+    <rect x="14" y="54" width="150" height="84" rx="10" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.45)"/>
+    <text x="89" y="82" text-anchor="middle" class="fn">createid + appsnapshot</text>
+    <text x="89" y="102" text-anchor="middle" class="fd">生成沙箱 ID</text>
+    <text x="89" y="118" text-anchor="middle" class="fd">模板快照就绪</text>
+    <line x1="164" y1="96" x2="192" y2="96" stroke="#34d399" stroke-width="1.5" marker-end="url(#cwArr)"/>
+
+    <text x="299" y="46" text-anchor="middle" class="fm">STEP 2 · 六大资源并行</text>
+    <rect x="204" y="54" width="190" height="84" rx="10" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.45)"/>
+    <text x="299" y="80" text-anchor="middle" class="fn" style="font-size:12.5px">images · volume · storage</text>
+    <text x="299" y="96" text-anchor="middle" class="fn" style="font-size:12.5px">network · netfile · store</text>
+    <text x="299" y="118" text-anchor="middle" class="fd">拉镜像 / 建卷 / 配网络</text>
+    <line x1="394" y1="96" x2="422" y2="96" stroke="#34d399" stroke-width="1.5" marker-end="url(#cwArr)"/>
+
+    <text x="489" y="46" text-anchor="middle" class="fm">STEP 3</text>
+    <rect x="434" y="54" width="110" height="84" rx="10" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.45)"/>
+    <text x="489" y="82" text-anchor="middle" class="fn">cgroup</text>
+    <text x="489" y="102" text-anchor="middle" class="fd">资源限额计算</text>
+    <text x="489" y="118" text-anchor="middle" class="fd">CPU / 内存配额</text>
+    <line x1="544" y1="96" x2="572" y2="96" stroke="#34d399" stroke-width="1.5" marker-end="url(#cwArr)"/>
+
+    <text x="645" y="46" text-anchor="middle" class="fm">STEP 4</text>
+    <rect x="584" y="54" width="122" height="84" rx="10" fill="rgba(52,211,153,.1)" stroke="rgba(52,211,153,.6)"/>
+    <text x="645" y="82" text-anchor="middle" class="fn">cubebox</text>
+    <text x="645" y="102" text-anchor="middle" class="fd">创建容器</text>
+    <text x="645" y="118" text-anchor="middle" class="fd">驱动 shim 起 VM</text>
+
+    <text x="24" y="162" class="fl">concurrent = 100 → 整条 Flow 的并发上限；任一个 Action 失败 → 依赖它的后续 Step 不执行，Flow 失败可重试</text>
+  </svg>
+  <p>每个 Action 是什么，一张表说清楚：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>Action</th><th>职责</th></tr></thead>
+      <tbody>
+        <tr><td><b>cubebox</b></td><td>核心：创建容器、驱动 shim、设置宿主机 cgroup 限额（services/cubebox/local.go）</td></tr>
+        <tr><td><b>createid</b></td><td>生成 sandbox ID（快照场景固定 templateID_0）</td></tr>
+        <tr><td><b>appsnapshot</b></td><td>快照恢复场景：确保 runtemplate 就绪</td></tr>
+        <tr><td><b>images</b></td><td>OCI 镜像拉取/确保（runtime_type io.containerd.cube.v2）</td></tr>
+        <tr><td><b>storage</b></td><td>CubeCoW 卷/快照准备（storage_backend=cubecow）</td></tr>
+        <tr><td><b>cgroup</b></td><td>计算资源配额（含 VM 内存开销 42MiB 等），注入 CreateContext.CgroupInfo</td></tr>
+        <tr><td><b>network</b></td><td>调用 network-agent 建网（TAP/IPAM/策略）</td></tr>
+        <tr><td><b>volume / netfile</b></td><td>外部卷插件挂载 / 沙箱网络文件（/run/vc/sbs）</td></tr>
+        <tr><td><b>cube-sandbox-store</b></td><td>containerd SandboxStore 本地存储</td></tr>
+        <tr><td><b>cleanup</b></td><td>GC 兜底清理（也是引擎的 cleanupFlow）</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>三、机制：引擎的执行规则</h2>
+
+  <p>引擎在 <code>plugins/workflow/engine.go</code>，核心抽象是 <code>Flow</code> 接口——所有 Action 和引擎本身都实现它：</p>
+  <div class="codeblock">type Flow interface {
+    ID() string
+    Init(context.Context, *InitInfo) error
+    Create(context.Context, *CreateContext) error
+    Destroy(context.Context, *DestroyContext) error
+    CleanUp(context.Context, *CleanContext) error
+}
+
+type Workflow struct {
+    Name          string
+    MaxConcurrent int64
+    Limiter       *semaphore.Limiter   // 整条流水线的并发闸门
+    Steps         []*Step
+}
+type Step struct { Name string; Actions []Flow }   // Step 内 Actions 并行</div>
+  <p>执行规则有四条，每条对应一个真实问题：</p>
+  <p><span class="hlg">① 并发闸门。</span>进入流水线前 <code>Limiter.TryAcquire()</code>，拿不到信号量直接返回 <code>ErrorCode_ConcurrentFailed</code>。为什么？创建沙箱本身吃 CPU 和磁盘 IO，如果一台节点同时被塞进上千个创建请求，大家都会因为争抢资源而集体变慢。宁可快速失败让上层重试，也不挤兑节点——这是调度器那篇讲过的"排队限流"思想在节点侧的落地。</p>
+  <p><span class="hlg">② Step 串行、Action 并行。</span>逐个 Step 调用 <code>parallelRunSteps()</code>，内部用 <code>errgroup.WithContext</code> 并发执行 Step 内所有 Action——任一失败，通过 context cancel 取消其余兄弟 Action。于是创建耗时 = 串行 Step 之和，而不是 Action 之和。</p>
+  <p><span class="hlg">③ 失败自愈。</span>Create 失败且 <code>Failover=true</code> → 异步构造 DestroyContext 走销毁流水线做现场清理（防止资源泄漏——镜像拉了、卷建了、网络开了，最后 VM 没起来，不能留着这些孤儿资源）。Destroy 失败 → 调用 <code>cleanupFlow</code> 兜底 GC。还有一种特殊错误 <code>PreConditionFailed</code> 直接短路返回、不触发 failover——比如快照场景沙箱已经存在，这是预期内的，不该走销毁。</p>
+  <p><span class="hlg">④ 插件间不直接依赖，通过上下文传数据。</span>比如 cgroup 插件把算好的 <code>*cgroupp.Info</code>（CgroupID、ResourceQuantity、UsePoolV2）塞进 <code>CreateContext.CgroupInfo</code>，cubebox 插件在 Step4 消费它来设置宿主机 cgroup 限额。上下文还提供关键判定方法：<code>IsCreateSnapshot()</code>、<code>IsRestoreSnapshot()</code>、<code>GetSnapshotTemplateID()</code>——快照场景走哪条分支，由上下文说了算。</p>
+
+  <h2>四、机制：containerd 集成——VM 也是"一个 Task"</h2>
+
+  <p>到这里你可能会问：cubebox 插件里的"创建容器"，和普通容器有什么区别？答案是：<span class="hl">在 containerd 眼里，一台 VM 就是一个 runtime 很特殊的 Task。</span>这是整个设计最聪明的地方——Cubelet 以 containerd 插件身份注册（<code>io.cubelet.internal.v1.cubebox</code>），用进程内客户端（<code>containerd.New(…, WithInMemoryServices(ic))</code>）复用 containerd 的镜像、快照器与元数据，但容器的运行时指定为 <code>io.containerd.cube.rs</code>：</p>
+  <div class="codeblock">// cube_container_create.go —— createContainers 关键步骤
+opts := []containerd.NewContainerOpts{
+    containerd.WithImageName(image),
+    containerd.WithSandbox(sandboxID),                  // 挂到沙箱（非 Pod 容器）
+    containerd.WithRuntime("io.containerd.cube.rs", nil), // 指定 cube shim 运行时
+}
+c, _ := client.NewContainer(ctx, id, cOpts...)
+task, _ := c.NewTask(ctx, ioCreater, taskOpts...)       // 创建 Task → containerd 拉起 CubeShim
+task.Start(ctx)</div>
+  <p>当 containerd 看到容器要创建 Task 时，发现 runtime type 是 <code>io.containerd.cube.rs</code>，就去启动 CubeShim 二进制（Shim v2）——后续的所有 Task 请求（Start/Pause/Resume/Exec）都走 shim。一个沙箱里，<span class="hl">第一个容器（容器 0）承载 VM 本身</span>，后续容器都是 VM 内部的 OCI 容器，由 guest agent 管理。cubebox 插件会记住 shim 暴露的 vsock 端点（<code>cubebox.Endpoint = {Address, Version}</code>），后面的一切 guest 通信都靠它。</p>
+  <p>runtime 路径本身也支持三级解析（<code>withRuntimePathOpt</code>）：OciRuntime.Path → runtemplate → annotation，优先级从高到低——这允许为不同场景注入不同的运行时模板。另外还有一个失败兜底细节：envd init 失败时走 <code>cleanupAfterEnvdInitFailure</code> 直接同步销毁，并把 Failover 置 false，防止二次销毁。</p>
+
+  <h2>五、机制：暂停/恢复——三层之间的状态收敛</h2>
+
+  <p>前面 CLM 那篇讲的自动暂停，落到节点侧就是这里：Cubelet 通过 containerd Task API 触发暂停/恢复，真正的 VM 级暂停（内存落盘）由 CubeShim 完成。难点在于——<span class="hlb">一次暂停跨越 containerd、shim、VMM 三层，任何一层半途失败，状态机都可能卡死在 pausing。</span></p>
+  <p>暂停（UpdateWithPause）的处理：</p>
+  <div class="codeblock">① 预检：IsPaused → "already paused"；IsTerminated → "not running"
+② 全部容器置 PausingAt=now，doPreStop 停止任务内进程
+③ task.Pause(ctx, 30s 超时)
+   ├─ 失败 → reconcileStatusAfterPauseError：
+   │      用全新 context.Background()+5s（不用已过期的 ctx）调 task.Status，
+   │      按 shim 真实状态收敛本地状态：
+   │        containerd.Paused → 写 PausedAt；Running/Created → 清 PausingAt；中间态不动
+   └─ 成功 → 全部容器 PausedAt=now、PausingAt=0</div>
+  <p>恢复（UpdateWithResume）在非 PAUSED 状态时：RUNNING → 幂等成功；其余 → 失败。真正执行时先做<span class="hl">资源准入检查</span>（<code>admitResume</code>，受 paused_resource_release_ratio 配额约束）——暂停期间资源可能被别的沙箱占了，恢复前得确认够不够；然后 <code>task.Resume</code>。成功后收敛状态，并<span class="hlr">作废旧的运行时快照绑定</span>：因为从 pausevm 目录恢复是"不透明恢复"，旧快照引用必须失效，否则下一次快照会基于错误的基底。</p>
+  <p>配套的兜底是 DeadGC：PausingAt 卡住超过 <code>2 × taskPauseTimeout</code>（60s），判定为卡死，走回收流程自愈。三层系统，一层一层查真实状态，是这类跨层状态机唯一的可靠收敛方式。</p>
+
+  <h2>六、机制：状态机——用时间戳推断状态</h2>
+
+  <p>每个沙箱对象持久化在 boltdb 里，它的状态不是显式枚举，而是由时间戳字段推断：</p>
+  <div class="codeblock">func (s Status) State() ContainerState {
+    if s.Unknown       { return UNKNOWN }      // 优先级从高到低
+    if s.FinishedAt!=0 { return EXITED }       // 已结束
+    if s.PausingAt!=0  { return PAUSING }      // 暂停中（瞬时态）
+    if s.PausedAt!=0   { return PAUSED }       // 已暂停
+    if s.StartedAt!=0  { return RUNNING }      // 运行中
+    if s.CreatedAt!=0  { return CREATED }      // 已创建
+    return UNKNOWN
+}</div>
+  <p>为什么用时间戳推断而不是枚举？因为状态机有中间态，而中间态天然是"时间"的产物——PausingAt 一写，就进入 pausing；成功后再写 PausedAt。字段天然保存了"什么时候进入的"，DeadGC 要判断"卡了多久"，直接读时间戳即可，不用另存一份记录。这是把"状态"和"状态发生的时间"合并存储。</p>
+
+  <h2>七、机制：快照 / 提交 / 回滚——秒级模板的根基</h2>
+
+  <p>这三个能力支撑着"模板秒开"和"任意历史回滚"，都围绕 CubeCoW 卷操作 + shim 的 snapshot 命令。</p>
+  <p><span class="hlg">AppSnapshot（创建模板）</span>是离线的一次性流程：建临时沙箱 → 从 OCI spec annotations 提取 CPU/内存/磁盘参数 → 算快照路径（<code>&lt;snapshotDir&gt;/cubebox/&lt;templateID&gt;/{cpu}C{mem}M</code>）→ 创建内存卷 → 执行 cube-runtime 的 <code>--app-snapshot --snapshot-type full</code>（采集 VM 完整内存 + 文件系统）→ 写 memory.dev、rootfs → 销毁临时沙箱 → rename 到最终路径 → 登记模板元数据。</p>
+  <p><span class="hlg">CommitSandbox</span> 是对运行中沙箱打快照：rootfs 走 <code>CommitTemplateRootfs</code>；内存走 <code>prepareCommitMemoryArtifact</code>——如果存在可解析的快照基底，就 reflink 克隆基底做 <b>soft-dirty 增量</b>（只写变化的页），否则新建空卷做 full。提交后把这次 commit 标记为新的基底。</p>
+  <p><span class="hlg">RollbackSandbox</span> 要求新代际 > 当前 rootfs 代际。构造 rollbackRestoreConfig，通过 <code>task.Update(WithAnnotations)</code> 通知 shim 执行 <code>delete_vm + resume_vm_with_config</code>——<span class="hl">丢弃当前 VM、从目标快照恢复，全程不写盘</span>。期间置 RollingBack=true 防止 DeadGC 误判。</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>快照类型</th><th>原理</th><th>用途</th></tr></thead>
+      <tbody>
+        <tr><td><b>full</b></td><td>完整内存</td><td>模板创建（一次性）</td></tr>
+        <tr><td><b>incremental</b></td><td>pagemap+kpageflags 只存 CoW 匿名页</td><td>节省空间的完整替代</td></tr>
+        <tr><td><b>soft-dirty</b></td><td>/proc/self/clear_refs + pagemap bit55</td><td>运行时提交（默认，最小化写放大）</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>八、收束</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>问题</th><th>设计</th><th>关键权衡</th></tr></thead>
+      <tbody>
+        <tr><td>创建流程冗长、顺序僵化</td><td>config.toml 声明流水线，插件注册</td><td>改流水线 = 改配置，不动代码</td></tr>
+        <tr><td>串行太慢</td><td>Step 串行、Action 并行（errgroup）</td><td>耗时 = 串行 Step 之和</td></tr>
+        <tr><td>创建风暴挤兑节点</td><td>信号量并发闸门</td><td>快速失败优于死等</td></tr>
+        <tr><td>失败后资源泄漏</td><td>failover 走销毁流水线 / cleanup GC</td><td>防孤儿资源</td></tr>
+        <tr><td>跨 containerd/shim/VMM 状态漂移</td><td>独立超时上下文 + shim 真实状态收敛 + DeadGC</td><td>以真实状态为准，不猜</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="punchline">
+    <small>一句话带走</small>
+    Cubelet 把"创建/销毁沙箱"从巨型函数重构为 config.toml 驱动的插件流水线，以 containerd 插件身份复用其生态——VM 在 containerd 眼里只是一个 runtime 为 io.containerd.cube.rs 的 Task。这也是它和 Kubernetes/containerd 生态无缝集成的根本原因。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>Flow 定义（config.toml）</td><td><code>Cubelet/config/config.toml</code></td></tr>
+        <tr><td>引擎实现</td><td><code>Cubelet/plugins/workflow/engine.go</code>、<code>plugins/workflow/plugin/plugin.go</code></td></tr>
+        <tr><td>cubebox 插件（local）</td><td><code>Cubelet/services/cubebox/local.go</code>、<code>cube_container_create.go</code></td></tr>
+        <tr><td>暂停/恢复与状态对账</td><td><code>Cubelet/services/cubebox/update.go</code></td></tr>
+        <tr><td>沙箱状态对象</td><td><code>Cubelet/pkg/store/cubebox/cubebox.go</code>、<code>status.go</code></td></tr>
+        <tr><td>快照/提交/回滚</td><td><code>Cubelet/services/cubebox/appsnapshot.go</code>、<code>template_ops.go</code>、<code>rollback.go</code></td></tr>
+        <tr><td>cgroup 资源插件</td><td><code>Cubelet/plugins/cube/internals/cgroup/</code></td></tr>
+        <tr><td>CubeCoW cgo 绑定</td><td><code>Cubelet/pkg/cubecow/cubecow.go</code>、<code>engine.go</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>Cubelet Workflow 引擎 · CubeSandbox 技术深入 03/09 · 下一篇：CubeCoW——磁盘怎么做到"一秒复制一百份"</footer>
+</body>
+</html>

--- a/cubesandbox-tech/cubeproxy.html
+++ b/cubesandbox-tech/cubeproxy.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CubeProxy 请求路由 · 请求怎么找到沙箱，又怎么叫醒它</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--blue),var(--green));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--green));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .pipeline{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin:24px 0}
+  .pipeline .ps{border:1px solid var(--border);border-radius:12px;padding:14px;background:rgba(255,255,255,.03)}
+  .pipeline .ps .no{font-family:var(--mono);font-size:11px;color:var(--blue);margin-bottom:6px}
+  .pipeline .ps .t{font-weight:700;font-size:14.5px;margin-bottom:4px}
+  .pipeline .ps .d{font-size:12.5px;color:var(--text-dim);line-height:1.8}
+  @media(max-width:720px){.pipeline{grid-template-columns:1fr 1fr}}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 技术深入</div>
+    <a class="back-home" href="index.html">← 技术索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 核心技术 09 / 09</div>
+    <h1>请求怎么找到沙箱，又怎么叫醒它</h1>
+    <p class="lead">这是九篇的收官。CubeProxy 是系统的入向大门：外部请求带着一个沙箱 ID 进来，它要路由到那台机器上的那个端口。而它还有一个更妙的职责——如果目标沙箱正在"睡觉"（被 CLM 暂停了），它不是返回错误，而是把沙箱叫醒再继续转发。我们看这条链路怎么设计。</p>
+  </div>
+
+  <h2>一、问题：入向路由的两道难题</h2>
+
+  <p>外部请求要到达沙箱，得先回答两个问题。第一，<span class="hlb">路由</span>：请求里带着沙箱 ID 和端口，怎么翻译成"哪台宿主机的哪个端口"？宿主机、沙箱的 IP 是动态分配的，路由表必须实时、可查。第二，<span class="hlb">状态</span>：沙箱可能被自动暂停了（CLM 的功劳），此时请求打到它身上会发生什么？返回"沙箱不存在"当然简单，但用户会觉得"我的沙箱怎么丢了"——体验上应该是"等一小会儿，它醒了"。</p>
+  <p>CubeProxy 的设计里，两个难题的解法是耦合的：它解析后端时顺便拿到沙箱的<span class="hl">生命周期状态</span>，然后路由前先过一道"状态门禁"——该叫醒就叫醒。我们顺着一个请求的路径走。</p>
+
+  <h2>二、入口：双模式解析</h2>
+
+  <p>CubeProxy 同时支持两种 URL 约定，方便不同场景的客户端。E2B SDK 走经典的 Host 模式：</p>
+  <div class="codeblock">Host 模式（rewrite_phase.lua）：
+Host: 80-a1b2c3d4e5f6.domain.com
+      │   └──────────┬───────────┘
+      │              └── 正则 ^(%d+)%-([^%.]+) 提取
+      │                    port="80", sandbox_id="a1b2c3d4e5f6"
+      ▼
+resolve_backend(sandbox_id, port) → route 到沙箱 IP:port，重写 Host 头</div>
+  <p>通用场景走 Path 模式：</p>
+  <div class="codeblock">Path 模式（path_rewrite_phase.lua）：
+URI: /sandbox/a1b2c3d4e5f6/80/rest/of/path
+     ├─ sandbox_id = "a1b2c3d4e5f6"
+     ├─ port       = "80"
+     └─ rest       = "/rest/of/path" → 重写为实际容器路径
+同时设置 proxy_redirect / proxy_cookie_path：让容器里的重定向/Cookie 也带
+/sandbox/&lt;id&gt;/&lt;port&gt; 前缀；X-Forwarded-Prefix：/sandbox/&lt;id&gt;/&lt;port&gt;</div>
+  <p>为什么维护两套？Host 模式对 SDK 用户最透明（URL 结构不用改），但依赖 DNS 泛解析；Path 模式适合"一个域名服务多个沙箱"或没法配置泛解析的环境。两种模式最终都汇入同一个 <code>resolve_backend</code>——解析逻辑只有一份，避免了双份维护。</p>
+
+  <svg class="flow" viewBox="0 0 720 272" role="img" aria-label="CubeProxy 请求完整旅程">
+    <defs>
+      <marker id="prArr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#4f8cff"/></marker>
+      <marker id="prArrG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/></marker>
+      <marker id="prArrA" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24"/></marker>
+      <marker id="prArrR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#f87171"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="272" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">一个外部请求的完整旅程 · 双模式 → 两级缓存 → 状态门禁</text>
+
+    <rect x="20" y="38" width="170" height="44" rx="10" fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.25)"/>
+    <text x="105" y="58" text-anchor="middle" class="fn">Host 模式</text>
+    <text x="105" y="75" text-anchor="middle" class="fm">port-id.domain</text>
+    <rect x="210" y="38" width="170" height="44" rx="10" fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.25)"/>
+    <text x="295" y="58" text-anchor="middle" class="fn">Path 模式</text>
+    <text x="295" y="75" text-anchor="middle" class="fm">/sandbox/&lt;id&gt;/&lt;port&gt;</text>
+
+    <path d="M 105 82 L 105 96 L 270 96 L 270 102" fill="none" stroke="#4f8cff" stroke-width="1.5"/>
+    <path d="M 295 82 L 295 96 L 292 96 L 292 102" fill="none" stroke="#4f8cff" stroke-width="1.5"/>
+    <line x1="270" y1="102" x2="292" y2="102" stroke="#4f8cff" stroke-width="1.5"/>
+    <line x1="292" y1="102" x2="292" y2="112" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#prArr)"/>
+
+    <rect x="120" y="112" width="260" height="48" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="250" y="133" text-anchor="middle" class="fn">resolve_backend · 两级缓存</text>
+    <text x="250" y="151" text-anchor="middle" class="fd">shared dict → Redis · IP+port+state</text>
+    <line x1="380" y1="136" x2="370" y2="160" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#prArr)"/>
+
+    <polygon points="360,164 440,132 520,164 440,196" fill="rgba(79,140,255,.1)" stroke="rgba(79,140,255,.6)" stroke-width="1.5"/>
+    <text x="440" y="162" text-anchor="middle" class="fn">状态门禁 gate</text>
+    <text x="440" y="180" text-anchor="middle" class="fd">按 state:&lt;id&gt; 分支</text>
+
+    <line x1="520" y1="164" x2="560" y2="164" stroke="#34d399" stroke-width="1.5" marker-end="url(#prArrG)"/>
+    <text x="540" y="110" class="fl">running</text>
+    <rect x="560" y="118" width="140" height="92" rx="10" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.5)"/>
+    <text x="630" y="144" text-anchor="middle" class="fn">放行</text>
+    <text x="630" y="164" text-anchor="middle" class="fd">balancer 动态选路</text>
+    <text x="630" y="184" text-anchor="middle" class="fm">set_current_peer</text>
+
+    <line x1="400" y1="180" x2="230" y2="192" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#prArrA)"/>
+    <text x="300" y="174" class="fl">paused</text>
+    <rect x="20" y="192" width="250" height="50" rx="9" fill="rgba(251,191,36,.07)" stroke="rgba(251,191,36,.5)"/>
+    <text x="145" y="211" text-anchor="middle" class="fn" style="fill:#fbbf24">paused → 自动唤醒</text>
+    <text x="145" y="228" text-anchor="middle" class="fd">子请求 _sidecar_resume → CLM 阻塞等恢复</text>
+
+    <line x1="440" y1="196" x2="345" y2="220" stroke="#64748b" stroke-width="1.5" marker-end="url(#prArr)"/>
+    <line x1="440" y1="196" x2="495" y2="220" stroke="#f87171" stroke-width="1.5" marker-end="url(#prArrR)"/>
+    <line x1="440" y1="196" x2="645" y2="220" stroke="#64748b" stroke-width="1.5" marker-end="url(#prArr)"/>
+    <rect x="280" y="220" width="130" height="44" rx="9" fill="rgba(100,116,139,.08)" stroke="rgba(100,116,139,.5)"/>
+    <text x="345" y="238" text-anchor="middle" class="fn">pausing → 503</text>
+    <text x="345" y="255" text-anchor="middle" class="fm">Retry-After</text>
+    <rect x="430" y="220" width="150" height="44" rx="9" fill="rgba(248,113,113,.08)" stroke="rgba(248,113,113,.5)"/>
+    <text x="505" y="238" text-anchor="middle" class="fn" style="fill:#f87171">killing / killed</text>
+    <text x="505" y="255" text-anchor="middle" class="fm">410 Gone</text>
+    <rect x="590" y="220" width="120" height="44" rx="9" fill="rgba(100,116,139,.08)" stroke="rgba(100,116,139,.5)"/>
+    <text x="650" y="238" text-anchor="middle" class="fn">未知 → 404</text>
+    <text x="650" y="255" text-anchor="middle" class="fm">沙箱不存在</text>
+  </svg>
+
+  <h2>三、机制：后端解析——两级缓存</h2>
+
+  <p>解析后端是"先本地、后远端"的两级：</p>
+  <div class="codeblock">resolve_backend(sandbox_id, port)：
+① 查共享字典 sandbox_backend_cache（key = sandbox_id:port）
+     ├─ 命中且未过期 → 返回 backend{ip, host_port, meta}
+     └─ 未命中/过期 → 查 Redis
+② Redis：按 sandbox_id 取 meta（HSET 结构，含 host_id/host_ip/端口映射）
+     → 组装 backend → 写回本地缓存
+③ 仍然失败 → 判定沙箱不存在 → 返回 nil（触发 404 / 门禁逻辑）</div>
+  <p>这个两级设计的动机是延迟：共享字典在进程内，查询是微秒级；Redis 在远端，每次查询都有网络往返。把热点数据缓存在本地，是典型的"以内存换延迟"。而解析结果里顺带携带的<span class="hl">生命周期状态和 last_active 水位</span>，正是下一步门禁逻辑的输入——所以解析不能只返回"地址"，必须返回"地址 + 状态"。跨多个 CubeProxy 副本时，last_active 取各副本上报的最大值（由 CLM 轮询汇总）。</p>
+
+  <h2>四、机制：状态门禁——自动恢复的最后一公里</h2>
+
+  <p>请求解析到后端后，不是直接转发，而是先过状态门禁（<code>sandbox_state.gate</code>）。这是整个"自动暂停/自动恢复"闭环里最精妙的一环：</p>
+  <div class="codeblock">sandbox_state.gate(backend)：
+根据 backend 的状态字典（state:&lt;id&gt;）分支：
+├─ running  → 放行
+├─ paused   → 触发自动恢复：
+│     ngx.location.capture("/_sidecar_resume", {args={sandbox_id=…}})
+│       → 内部子请求调用 CLM: POST /internal/resume（阻塞等待恢复完成）
+│       → 恢复成功 → 重试路由；失败 → 503
+├─ pausing  → 503 + Retry-After（马上就好）
+├─ killing / killed → 410 Gone（沙箱即将/已被销毁）
+└─ 未知    → 404</div>
+  <p>关键设计是"<span class="hlb">阻塞式恢复</span>"：请求到达一个 paused 沙箱时，数据面不返回错误，而是阻塞几百毫秒到一两秒，等 VM 从快照恢复，然后重试路由。对用户来说，这是"首次请求稍微慢了一点"，而不是"一次失败"。配合 CLM resumer 的并发合并（那篇里讲过），同一沙箱的并发请求只触发一次恢复，其余等待同一个结果。</p>
+  <p>这就是为什么整个系统敢做自动暂停：<span class="hl">暂停省的是机器的资源，用户无感是因为 CubeProxy 在门口替你等着叫醒。</span>省资源与好体验之间的鸿沟，由这个门禁补上。</p>
+
+  <h2>五、机制：动态选路——没有静态 upstream</h2>
+
+  <p>转发本身也做了一个不常见的取舍：CubeProxy 不配置静态 upstream 块，而是在 balancer 阶段动态指定每个请求的目标：</p>
+  <div class="codeblock">balancer_phase.lua（balancer_by_lua_block）：
+  从当前请求上下文取 resolve_backend 的结果
+    → balancer.set_current_peer(backend.ip, backend.host_port)
+  没有静态上游服务器，peer 完全由 Lua 每请求决定
+    → 沙箱 IP 由元数据驱动，宿主机迁移/重建后自动生效，无需 reload</div>
+  <p>为什么值得这样？如果写死 upstream 列表，沙箱 IP 一变（宿主机重建、沙箱迁移）就得 reload nginx。动态选路让 peer 完全由 Redis 里的元数据驱动——元数据变了，下一跳自然就对了，配置零维护。配合 <code>maskRequestHost</code>（request_host.lua 按 ${PORT} 模板渲染重建上游 Host 头），保证沙箱内应用看到的 Host 与其被调用端口一致——多端口服务场景下这是必需的，否则容器里拿到的主机名对不上。</p>
+
+  <h2>六、机制：注册与心跳——让自己被发现</h2>
+
+  <p>CLM 需要知道"有哪些 CubeProxy 副本"来轮询 last_active 与推送状态——靠 Redis 注册表自我宣告：</p>
+  <div class="codeblock">init_worker_phase.lua（每 worker 启动）：
+  HSET cube:v1:shared:cube_proxy:registry &lt;proxy_id&gt; {admin_url, resume_url, node_ip, started_at, version}
+  ZADD cube:v1:shared:cube_proxy:heartbeat &lt;unix_ms&gt; &lt;proxy_id&gt;
+  （心跳 TTL 15s，按 3s 周期刷新；过期成员由 CLM 的 discovery 清理）
+
+同时：
+  从 Redis 拉取沙箱 meta 建立本地缓存基线
+  admin_phase 提供：
+    POST /admin/meta/upsert    ← CLM 推送沙箱元数据
+    POST /admin/meta/delete    ← CLM 通知沙箱销毁
+    POST /admin/state          ← CLM 推送状态变化
+    GET  /admin/last_active?since=… ← CLM 轮询活跃水位（X-Cube-Admin-Token 鉴权）</div>
+  <p>三管齐下保证"任何时刻每个副本都有全量路由信息"：<span class="hl">新副本靠 bootstrap 拉全量，存量副本靠 admin 事件推送增量，故障副本靠心跳过期被剔除。</span>一个分布式系统里最经典的三个数据同步模式，在这里各司其职、互相兜底。心跳用 ZADD + TTL 15s + 3s 周期：副本活着就持续刷新自己的分数（时间戳），死了就自然过期，CLM 扫到就清理。</p>
+
+  <h2>七、收束</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>问题</th><th>设计</th><th>关键权衡</th></tr></thead>
+      <tbody>
+        <tr><td>两种客户端 URL 约定</td><td>Host 模式 + Path 模式，汇入同一解析</td><td>兼容 E2B SDK 与通用场景</td></tr>
+        <tr><td>路由表要实时</td><td>shared dict + Redis 两级缓存</td><td>内存换延迟</td></tr>
+        <tr><td>请求打到已暂停沙箱</td><td>状态门禁阻塞式唤醒</td><td>用户无感，代价是首请求延迟</td></tr>
+        <tr><td>沙箱 IP 会变</td><td>balancer 动态选路，无静态 upstream</td><td>零 reload，元数据驱动</td></tr>
+        <tr><td>多副本信息同步</td><td>bootstrap 拉全量 + 事件推增量 + 心跳剔除</td><td>三种模式各司其职</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="punchline">
+    <small>一句话带走</small>
+    CubeProxy 是双模式请求路由 + 两级后端解析 + 状态门禁驱动的自动唤醒 + balancer 动态选路 + Redis 注册表自我宣告的无状态数据面——它是 E2B 兼容的入口，也是"自动暂停"在用户请求侧的无感保障。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>nginx 主配置</td><td><code>CubeProxy/nginx.conf</code></td></tr>
+        <tr><td>Host 模式解析</td><td><code>CubeProxy/lua/rewrite_phase.lua</code></td></tr>
+        <tr><td>Path 模式解析</td><td><code>CubeProxy/lua/path_rewrite_phase.lua</code></td></tr>
+        <tr><td>后端解析（双级）</td><td><code>CubeProxy/lua/sandbox_backend.lua</code></td></tr>
+        <tr><td>状态门禁</td><td><code>CubeProxy/lua/sandbox_state.lua</code>（gate 分支）</td></tr>
+        <tr><td>动态选路</td><td><code>CubeProxy/lua/balancer_phase.lua</code></td></tr>
+        <tr><td>Admin API</td><td><code>CubeProxy/lua/admin_phase.lua</code></td></tr>
+        <tr><td>启动拉取与心跳</td><td><code>CubeProxy/lua/init_worker_phase.lua</code>、<code>proxy_registry.lua</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>CubeProxy 请求路由 · CubeSandbox 技术深入 09/09 · 到这里，一条 sandbox.create() 的完整旅程就走完了</footer>
+</body>
+</html>

--- a/cubesandbox-tech/cubevs-network.html
+++ b/cubesandbox-tech/cubevs-network.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CubeVS eBPF 网络虚拟化 · 几百个沙箱怎么共享一张网卡</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--red),var(--amber));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--red));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .pipeline{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin:24px 0}
+  .pipeline .ps{border:1px solid var(--border);border-radius:12px;padding:14px;background:rgba(255,255,255,.03)}
+  .pipeline .ps .no{font-family:var(--mono);font-size:11px;color:var(--green);margin-bottom:6px}
+  .pipeline .ps .t{font-weight:700;font-size:14.5px;margin-bottom:4px}
+  .pipeline .ps .d{font-size:12.5px;color:var(--text-dim);line-height:1.8}
+  @media(max-width:720px){.pipeline{grid-template-columns:1fr}}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 技术深入</div>
+    <a class="back-home" href="index.html">← 技术索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 核心技术 07 / 09</div>
+    <h1>几百个沙箱怎么共享一张网卡</h1>
+    <p class="lead">一篇讲 CubeVS，CubeSandbox 的网络数据面。几百个沙箱挤在一台物理机上，要同时上网、要互相隔离、要按策略控制访问——传统做法是堆 iptables 规则，规则一多就慢。CubeVS 换了一个思路：把"规则比对"换成"查表放行"，直接跑在内核的 eBPF 里。我们从头拆。</p>
+  </div>
+
+  <h2>一、问题：规则越来越多，网就越来越慢</h2>
+
+  <p>先想清楚物理现实：一台物理机上一块网卡，几百个沙箱各有一个"假的"私有 IP。每个沙箱要上网，出去必须伪装成物理机 IP（NAT）；外面要访问沙箱里的服务，又得把流量翻译回那个假 IP。同时沙箱之间必须隔离，还得按策略控制"谁能访问什么"。</p>
+  <p>传统方案是给每个沙箱配一套 iptables 规则（NAT + filter）。几百个沙箱就是几千条规则——每个包进出都要逐条比对，规则越多越慢；而且配置一下就是几秒，规则之间还会互相打架，运维噩梦。问题的本质是：<span class="hlb">"规则比对"的复杂度是 O(规则数)，它不该随沙箱数量线性增长。</span></p>
+  <div class="think">
+    <div class="q">换个思路：如果我们不改"规则"，而是改"表"呢？</div>
+    <div class="a">把策略做成一张哈希表，每个包查一次表——查表时间是 O(1)，与规则数量无关。这就是 eBPF 的查表放行。</div>
+  </div>
+
+  <h2>二、核心思想：把"逐条比对规则"换成"一次哈希查表"</h2>
+
+  <p>理解 CubeVS 只需要理解一件事：<span class="hl">它把网络策略做成了"查表放行"，而不是"逐条比对规则"。</span></p>
+  <p>实现上，策略存在 eBPF 的 map（内核里的哈希表）里；一段 eBPF 程序挂在内核网络通道的必经之路上，每个包进来先查这张表——查到了就放行 + 改地址，查不到就拦下。规则再多，也只是表里的多几行记录，查表时间恒定为一次哈希查找。而且这一切发生在内核数据路径上，<span class="hl">没有用户态介入，没有 netfilter 钩子</span>，单个包的处理是微秒级。</p>
+  <p>"外面访问沙箱"怎么处理？也是查表——查的是另一张反方向的<span class="hlb">会话登记表</span>：出向流量经过时登记一笔"谁从哪个端口出去了"，回包时按登记反向翻译回假 IP。没有登记的回包，不翻译，直接放主机栈。这套"来去都认账"的机制让沙箱间流量天然隔离：<span class="hl">没有出向会话，就永远等不到对应的入向包。</span>隔离不是靠"挡住"，而是靠"不认"。</p>
+
+  <h2>三、三条数据路径，各管一段</h2>
+
+  <svg class="flow" viewBox="0 0 720 248" role="img" aria-label="三条数据路径">
+    <defs>
+      <marker id="nvArrG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/></marker>
+      <marker id="nvArrC" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#22d3ee"/></marker>
+      <marker id="nvArrA" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="248" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">一台物理机上的三张表 · 查表放行，而非逐条比对</text>
+
+    <rect x="14" y="44" width="160" height="44" rx="10" fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.25)"/>
+    <text x="94" y="64" text-anchor="middle" class="fn">沙箱 A</text>
+    <text x="94" y="80" text-anchor="middle" class="fm">假 IP 10.x</text>
+    <rect x="14" y="108" width="160" height="44" rx="10" fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.25)"/>
+    <text x="94" y="128" text-anchor="middle" class="fn">沙箱 B</text>
+    <text x="94" y="144" text-anchor="middle" class="fm">假 IP 10.x</text>
+    <rect x="14" y="172" width="160" height="44" rx="10" fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.25)"/>
+    <text x="94" y="192" text-anchor="middle" class="fn">沙箱 C</text>
+    <text x="94" y="208" text-anchor="middle" class="fm">假 IP 10.x</text>
+
+    <rect x="250" y="32" width="200" height="196" rx="12" fill="rgba(79,140,255,.05)" stroke="rgba(79,140,255,.4)"/>
+    <text x="350" y="44" text-anchor="middle" class="fm">eBPF 门禁 · 查表</text>
+    <rect x="262" y="52" width="176" height="44" rx="9" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.45)"/>
+    <text x="350" y="71" text-anchor="middle" class="fn">允许名单 allow</text>
+    <text x="350" y="87" text-anchor="middle" class="fm">SNAT · mvmtap from_cube</text>
+    <rect x="262" y="108" width="176" height="44" rx="9" fill="rgba(34,211,238,.08)" stroke="rgba(34,211,238,.45)"/>
+    <text x="350" y="127" text-anchor="middle" class="fn">会话登记 sessions</text>
+    <text x="350" y="143" text-anchor="middle" class="fm">回译 · nodenic from_world</text>
+    <rect x="262" y="164" width="176" height="44" rx="9" fill="rgba(251,191,36,.08)" stroke="rgba(251,191,36,.45)"/>
+    <text x="350" y="183" text-anchor="middle" class="fn">端口映射 ports</text>
+    <text x="350" y="199" text-anchor="middle" class="fm">DNAT · localgw from_envoy</text>
+
+    <rect x="520" y="44" width="186" height="96" rx="10" fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.25)"/>
+    <text x="613" y="84" text-anchor="middle" class="fn">外网 / 物理网卡</text>
+    <text x="613" y="104" text-anchor="middle" class="fm">NIC · 进出都过它</text>
+    <rect x="520" y="164" width="186" height="52" rx="10" fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.25)"/>
+    <text x="613" y="184" text-anchor="middle" class="fn">开发环境</text>
+    <text x="613" y="202" text-anchor="middle" class="fm">用户访问入口</text>
+
+    <line x1="174" y1="66" x2="250" y2="66" stroke="#34d399" stroke-width="1.5" marker-end="url(#nvArrG)"/>
+    <line x1="450" y1="66" x2="520" y2="66" stroke="#34d399" stroke-width="1.5" marker-end="url(#nvArrG)"/>
+    <line x1="520" y1="108" x2="450" y2="130" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#nvArrC)"/>
+    <line x1="250" y1="130" x2="174" y2="130" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#nvArrC)"/>
+    <line x1="520" y1="190" x2="450" y2="194" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#nvArrA)"/>
+    <line x1="250" y1="194" x2="174" y2="194" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#nvArrA)"/>
+
+    <text x="24" y="236" class="fl">PATH① 出门 SNAT</text>
+    <text x="220" y="236" class="fl">PATH② 回家 会话回译</text>
+    <text x="450" y="236" class="fl">PATH③ 访客 DNAT</text>
+  </svg>
+
+  <p>三条路径都只干一件事：<b>查表 + 改地址 + 投递</b>。没有一条路径去"逐条比对规则"。有趣的是它们的挂载点也不同：出门和回家分别挂在 TAP 虚拟网卡和物理网卡两个方向，访客路径挂在本地网关——三个 eBPF 程序，三个挂载点，职责互不重叠，各管一段数据流。</p>
+
+  <h2>四、最精巧的设计：DNS 学习</h2>
+
+  <p>有一个问题让纯 IP 白名单几乎没法用：管理员允许沙箱访问 <code>*.example.com</code>，但沙箱实际连接的是这个域名的 IP——而 IP 会变，管理员没法预先填 IP。传统方案只能把域名流量全部交给上层代理（L7），每个请求过一遍，慢。</p>
+  <p>CubeVS 让门禁系统"自己学"：</p>
+  <div class="codeblock">① 沙箱发出 DNS 查询（请求 www.example.com 的 IP）
+     如果查询的域名在允许名单里 → 在"登记簿"上记一笔
+② DNS 响应回来 → 门禁只认登记簿里对应的响应
+     把响应的 IP 自动写进允许名单（带有效期，跟 DNS TTL 走）
+③ 之后沙箱直连这个 IP → 不再走代理，直接放行</div>
+  <p>这里最关键的是安全性：<span class="hl">"只认登记过的响应"。</span>沙箱不能伪造一个 DNS 响应，把自己想要的 IP 灌进名单——能进名单的，只有它已经获准查询的域名的真实应答。于是"放行域名"这个语义，被精确落实成了"放行该域名的真实 IP"，而 IP 的变动由 DNS 响应自动跟随。一个本来需要 L7 代理才能做的事，在 L4 查表里就完成了，代价仅是拦截一下 DNS 流量。</p>
+
+  <h2>五、谁来打扫：会话与名单的回收</h2>
+
+  <p>所有表都在内核内存里，有容量上限，必须有清理机制。CubeVS 的做法是后台定期"大扫除"（<code>reaper.go</code>）：按协议超时判断逐条删除过期记录——TCP 会话超时、UDP 30 秒没回包、180 秒没再发包、DNS 学来的 IP 过了 TTL。任何查表系统都必须回答"表满了怎么办、表脏了怎么办"，这里用"周期性回收"这个最直白的答案。</p>
+  <p>另外还有一层"运维管家"：network-agent 进程负责每个沙箱虚拟网卡（TAP）的创建和销毁、端口分配、策略下发。沙箱创建时它插网卡，销毁时拔网卡，策略随沙箱生、随沙箱灭——<span class="hl">没有"僵尸规则"残留</span>。eBPF 程序处理"快"，但"规则从哪来、随什么清理"这件事，必须有这么个配套的进程管理，否则表里的记录会漏一辈子。</p>
+
+  <h2>六、收束</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>问题</th><th>设计</th><th>关键权衡</th></tr></thead>
+      <tbody>
+        <tr><td>规则随沙箱数线性膨胀</td><td>eBPF map 查表，O(1)</td><td>快，但要配套回收机制</td></tr>
+        <tr><td>沙箱间隔离</td><td>出向登记、入向认账</td><td>隔离靠"不认"而非"挡"</td></tr>
+        <tr><td>域名白名单遇到动态 IP</td><td>DNS 学习：只认登记过的响应</td><td>L4 完成本该 L7 的事</td></tr>
+        <tr><td>表会满、会脏</td><td>reaper 定期回收</td><td>简单直白</td></tr>
+        <tr><td>规则随沙箱生灭</td><td>network-agent 管理 TAP 与策略</td><td>无僵尸规则</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="punchline">
+    <small>一句话带走</small>
+    CubeVS 用 eBPF 把 NAT 和访问控制做成"查表放行"：出门查白名单、回家按会话登记翻译、访客按端口映射投递，外加"DNS 学 IP"和"后台大扫除"两个小机制——几百个沙箱的虚拟网络，就在这张表上转起来了。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>出门路径（SNAT + 策略 + 拒绝回包）</td><td><code>CubeNet/src/mvmtap.bpf.c</code></td></tr>
+        <tr><td>回家路径（反向 NAT + DNS 学习）</td><td><code>CubeNet/src/nodenic.bpf.c</code>、<code>dns_response.h</code></td></tr>
+        <tr><td>访客路径（端口映射 DNAT）</td><td><code>CubeNet/src/localgw.bpf.c</code></td></tr>
+        <tr><td>允许名单 / 会话表结构</td><td><code>CubeNet/src/session.h</code>、<code>cubevs.h</code></td></tr>
+        <tr><td>策略下发（Go）</td><td><code>CubeNet/cubevs/netpolicy.go</code></td></tr>
+        <tr><td>后台回收</td><td><code>CubeNet/cubevs/reaper.go</code></td></tr>
+        <tr><td>网卡/端口生命周期管家</td><td><code>network-agent/internal/service/local_service.go</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>CubeVS eBPF 网络虚拟化 · CubeSandbox 技术深入 07/09 · 下一篇：CubeEgress——出站流量最后的安检员</footer>
+</body>
+</html>

--- a/cubesandbox-tech/deploy-troubleshoot/auto-resume-504.html
+++ b/cubesandbox-tech/deploy-troubleshoot/auto-resume-504.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>04 · 沙箱自己睡了，却没人能把它叫醒——auto_resume 504 之谜</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--blue),var(--purple));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--purple));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 部署排障</div>
+    <a class="back-home" href="index.html">← 排障索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 部署排障 04 / 05</div>
+    <h1>沙箱自己睡了，却没人能把它叫醒——auto_resume 504 之谜</h1>
+    <p class="lead">验证脚本的最后一项：创建一个 `lifecycle={"on_timeout":"pause","auto_resume":True}` 的沙箱，等 35 秒让它自动睡觉，再发命令把它叫醒。暂停一切正常，状态也显示 `paused`——可叫醒的命令全是 504，恢复后状态还是 `paused`。自动暂停活了，自动恢复却整条链路是死的。</p>
+  </div>
+
+  <h2>一、背景速览：沙箱的"睡眠"机制</h2>
+
+  <p>CubeSandbox 有一个省钱的杀手锏：沙箱闲置时自动"睡觉"。这需要先讲清楚几个概念。</p>
+
+  <p><span class="hlg">① 暂停不是关机。</span>沙箱有状态：<code>running</code>（运行中）、<code>paused</code>（已暂停）、<code>killed</code>（已销毁）。<span class="hl">暂停（pause）是把虚拟机的内存写盘成快照、释放 CPU/内存</span>，但磁盘镜像保留——需要时从快照恢复，几秒内回到暂停前的状态，用户无感。这和前置篇里"模板秒开"是同一个机制。</p>
+  <p><span class="hlg">② 谁决定它睡觉？</span>用户可以在创建沙箱时声明生命周期策略：<code>lifecycle={"on_timeout":"pause","auto_resume":True}</code>，含义是"空闲超时自动暂停；收到请求自动恢复"。真正执行这个策略的是 <span class="hl">CLM（cube-lifecycle-manager）</span>——一个独立部署的控制面组件，它扫描闲置沙箱、执行暂停、响应恢复请求。</p>
+  <p><span class="hlg">③ 用户请求来了，怎么把睡着的沙箱叫醒？</span>这是本篇文章的核心：用户请求先到达 <span class="hl">CubeProxy</span>（数据面）。CubeProxy 内部维护一个状态字典 <code>cube_sandbox_state</code>，记录每个沙箱当前是 running 还是 paused。请求到达时，门禁（gate）查字典：如果是 paused，就内部回调 CLM 的 <code>/internal/resume</code> 把沙箱唤醒，再继续转发。问题是——<span class="hlb">CubeProxy 的字典是谁填的？它怎么知道沙箱被暂停了？</span></p>
+
+  <h2>二、机制：自动恢复的四段接力</h2>
+
+  <p>答案是一套四段式的"接力"，每一段都依赖上一段：</p>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>接力段</th><th>实现</th><th>作用</th></tr></thead>
+      <tbody>
+        <tr><td>① 代理注册</td><td>CubeProxy <code>proxy_registry.lua</code> 心跳写 Redis</td><td>让 CLM 知道"有哪些 CubeProxy 活着、admin 端口在哪"</td></tr>
+        <tr><td>② 服务发现</td><td>CLM <code>discovery.RedisDiscovery</code> 扫描心跳</td><td>构建可推送的 proxy 端点列表（fleet）</td></tr>
+        <tr><td>③ 状态推送</td><td>CLM <code>proxypush.Client.broadcast</code> → POST <code>/admin/state</code></td><td>把 paused/running 写进每个 CubeProxy 的共享字典 <code>cube_sandbox_state</code></td></tr>
+        <tr><td>④ 请求门禁</td><td>CubeProxy <code>sandbox_state.lua</code> gate</td><td>请求到达时查字典：paused → 内部回调 CLM <code>/internal/resume</code> 叫醒沙箱</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>把这条链路想成"对讲机调度"：CubeProxy 每隔几秒通过对讲机喊一声"我在，我的 admin 端口是 X"（①）；CLM 听着对讲机记下所有在场的代理（②）；CLM 有状态变化时就拨号通知每个在场的代理"沙箱 A 暂停了"（③）；代理在请求到来时查自己的记录本决定要不要唤醒沙箱（④）。<span class="hlb">只要 ① 的心跳断了，②③④ 全部失效。</span></p>
+
+  <svg class="flow" viewBox="0 0 720 252" role="img" aria-label="自动恢复四段链路">
+    <defs>
+      <marker id="a4Arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#4f8cff"/></marker>
+      <marker id="a4ArrR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#f87171"/></marker>
+      <marker id="a4ArrG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="252" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">自动恢复四段接力 · 断点在第 ① 段：心跳写进了黑洞，②③④ 全部饿死</text>
+
+    <rect x="22" y="48" width="132" height="58" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="88" y="72" text-anchor="middle" class="fn">① proxy_registry</text>
+    <text x="88" y="90" text-anchor="middle" class="fd">心跳 → Redis</text>
+
+    <rect x="188" y="48" width="132" height="58" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="254" y="72" text-anchor="middle" class="fn">② discovery</text>
+    <text x="254" y="90" text-anchor="middle" class="fd">扫描心跳 → fleet</text>
+
+    <rect x="354" y="48" width="150" height="58" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="429" y="72" text-anchor="middle" class="fn">③ proxypush</text>
+    <text x="429" y="90" text-anchor="middle" class="fd">/admin/state 广播</text>
+
+    <rect x="538" y="48" width="158" height="58" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="617" y="72" text-anchor="middle" class="fn">④ gate 门禁</text>
+    <text x="617" y="90" text-anchor="middle" class="fd">paused → 回调唤醒</text>
+
+    <line x1="154" y1="77" x2="188" y2="77" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#a4Arr)"/>
+    <line x1="320" y1="77" x2="354" y2="77" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#a4Arr)"/>
+    <line x1="504" y1="77" x2="538" y2="77" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#a4Arr)"/>
+
+    <rect x="22" y="182" width="132" height="52" rx="10" fill="rgba(248,113,113,.07)" stroke="rgba(248,113,113,.45)"/>
+    <text x="88" y="202" text-anchor="middle" class="fn" style="fill:#f87171">写向死地址</text>
+    <text x="88" y="218" text-anchor="middle" class="fd">10.60.235.237:6379</text>
+    <line x1="88" y1="106" x2="88" y2="182" stroke="#f87171" stroke-width="1.5" marker-end="url(#a4ArrR)" stroke-dasharray="4 3"/>
+    <text x="96" y="152" class="fl">根因：IP 已过期</text>
+  </svg>
+  <div class="flow-cap">②③④ 的正常运转完全依赖 ① 的心跳成功写进 Redis；心跳断了，后面全部静默失效。</div>
+
+  <h2>三、问题：一半活着，一半死着</h2>
+
+  <div class="codeblock"># 验证脚本步骤 10
+等待 35 秒触发 auto_pause...
+[PASS] 超时后状态为 paused（当前=paused）
+发送请求触发 auto_resume...
+(attempt 1 failed: 504 Gateway Time-out)   <span class="cm"># openresty 返回</span>
+(attempt 2 failed: 504 Gateway Time-out)
+(attempt 3 failed: 504 Gateway Time-out)
+[FAIL] 自动恢复后命令执行成功</div>
+  <p>最有意思的细节：手动单独复现（新建一个同样的 auto_pause 沙箱）一切正常——暂停、恢复、命令，全都对。<span class="hl">功能本身没坏，是这个特定环境下的某条链路悄悄断了。</span></p>
+
+  <h2>四、排查：从 504 一路追到 Redis 心跳</h2>
+
+  <p>504 来自 openresty 的"upstream 超时"。逐层取证，用排除法收窄——每一步都在缩小嫌疑范围：</p>
+
+  <p><span class="hlg">第一刀：CubeProxy error.log 查 gate。</span>gate 一旦判定沙箱是 paused，就会打日志并回调 CLM。结果：该沙箱在 error.log 里 <b>0 条记录</b>。说明 gate 根本没走 resume 分支——<span class="hl">字典里没有这个沙箱的 paused 状态</span>。嫌疑：状态字典是空的。</p>
+
+  <p><span class="hlg">第二刀：CLM 日志查 resume 请求。</span>CLM 收到 <code>/internal/resume</code> 必打 <code>resume request received</code>。结果：没有。<span class="hl">CLM 根本没收到叫醒请求。</span>连起来就是：gate 放行了请求 → 请求打到已暂停的沙箱后端 → 无响应 30 秒 → 504。两刀下去，问题锁定在"gate 为什么放行"。</p>
+
+  <p><span class="hlg">第三刀：为什么会放行？</span>gate 查的是 worker 内共享字典 <code>cube_sandbox_state</code>，这个字典由 CLM 经 <code>/admin/state</code> 写入。字典空 → 没有 <code>paused</code> → gate 放行。那 CLM 推了没有？——推了，但推给了"空列表"。</p>
+
+  <p><span class="hlg">第四刀（根因）：Redis 里的注册表。</span>CLM 的 <code>broadcast</code> 每次推送前都从 fleet 取端点列表；fleet 来自 Redis 服务发现；而 Redis 里的注册表由 CubeProxy 心跳维护。查 Redis：</p>
+  <div class="codeblock">$ redis-cli KEYS "cube:v1:shared:cube_proxy:*"
+(empty array)   <span class="cm"># 一个键都没有！</span></div>
+  <p>CubeProxy 的心跳从来没写进过这个 Redis。<span class="hlb">fleet 为空 → broadcast 遍历空列表 → 静默跳过（只有 Debug 日志）→ 字典永不填充 → gate 永远放行 → 504。</span>至此，根因浮出水面：<span class="hl">心跳为什么写不进去？</span></p>
+
+  <h2>五、根因：一条"渲染时固化的 IP"</h2>
+
+  <p>CubeProxy 心跳要连的 Redis 地址，来自 Helm chart 在 <code>proxy.yaml</code> 里渲染出的环境变量。原逻辑：内置 Redis 是 headless Service + StatefulSet，chart 在渲染时用 <code>lookup</code> 读 Endpoints，把当时 Redis Pod 的 IP 写死进环境变量：</p>
+  <div class="codeblock"># 修复前：lookup 固化 Endpoints IP
+{{- $redisEps := lookup "v1" "Endpoints" ... }}
+{{- $redisRegistryHost = (index $subset.addresses 0).ip }}
+# → 渲染结果：CUBE_PROXY_REGISTRY_REDIS_HOST=10.60.235.237</div>
+  <p>而 <code>proxy_registry.lua</code> 跑在 <code>ngx.timer</code> 里，cosocket 没有 nginx resolver，只能用 IP 直连。这个 IP 是 Helm 渲染那一刻的 Redis Pod IP——之后 Redis Pod 重建，IP 变成 <code>10.60.235.240</code>，但 cube-proxy 的环境变量是静态的，心跳就永远写向那个已死掉的 <code>10.60.235.237:6379</code>。</p>
+
+  <div class="think">
+    <div class="q">为什么这么难发现？</div>
+    三个"静默"叠在一起：心跳失败只有 proxy 的 ERR 日志（在容器内文件里，不随 stdout 出）；fleet 为空时 broadcast 只打 Debug 不告警；gate 字典缺失时按"未加入生命周期"处理、放行请求。每一环都优雅地失败了，最后只有一个没有状态码意义的 504 浮出水面。
+  </div>
+
+  <h2>六、修复：让地址"活"起来</h2>
+
+  <p>修法是把"固化 IP"换成"可解析的主机名"——headless Service 的 StatefulSet Pod DNS 名 <code>cube-redis-0.cube-redis.cube-system.svc.cluster.local</code> 永远指向当前存活的 Pod，由入口脚本在启动时解析成 IP：</p>
+
+  <div class="codeblock"># chart 修复：headless 分支改用 Pod DNS 名
+{{- $redisRegistryHost = printf "%s-0.%s.%s.svc.%s" ... }}</div>
+  <div class="codeblock"># cube-proxy-entrypoint.sh：启动时 getent 解析成当前 IP
+if [ -n "${CUBE_PROXY_REGISTRY_REDIS_HOST:-}" ]; then
+  case "${CUBE_PROXY_REGISTRY_REDIS_HOST}" in
+    *[!0-9.]* )    <span class="cm"># 非纯 IP 才解析</span>
+      resolved="$(getent ahostsv4 "${CUBE_PROXY_REGISTRY_REDIS_HOST}" | awk 'NR==1 {print $1}')"
+      [ -n "${resolved}" ] && export CUBE_PROXY_REGISTRY_REDIS_HOST="${resolved}"
+      ;;
+  esac
+fi</div>
+  <p>这里"为什么不直接用 nginx resolver 在 Lua 里解析？"因为 <code>proxy_registry.lua</code> 跑在 <code>ngx.timer</code> 定时器里，Lua cosocket 没有 nginx resolver 可用，只能连一个具体的 IP。所以退而求其次：<span class="hl">入口脚本（bash，有完整 DNS 能力）在启动时把主机名解析成当前 IP</span>，再把解析结果交给 Lua。各用各的时机，各补各的短板。</p>
+  <p>现网立即修复，一条命令滚动更新：</p>
+  <div class="codeblock">kubectl set env deploy/cube-proxy -n cube-system \
+  CUBE_PROXY_REGISTRY_REDIS_HOST=cube-redis-0.cube-redis.cube-system.svc.cluster.local</div>
+
+  <h2>七、验证：链路重新点亮</h2>
+
+  <p>更新后，四个关键证据先后出现：</p>
+  <div class="codeblock"># ① Redis 有了注册表和心跳
+cube:v1:shared:cube_proxy:heartbeat
+cube:v1:shared:cube_proxy:registry
+# ② CLM 发现新代理并完成对账
+discovery: proxy joined  proxy_id=cube-proxy-6994fd99bb-7ws2z
+replay begin  entries=3
+replay done   pushed:3, failed:0
+# ③ 验证脚本
+结果: 34/34 通过, 0 失败    <span class="cm"># auto_resume 恢复如初</span></div>
+
+  <h2>八、权衡：为什么"渲染时固化"会失效</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>维度</th><th>固化 IP</th><th>可解析主机名（本次修复）</th></tr></thead>
+      <tbody>
+        <tr><td>渲染期正确性</td><td>✓ 当时一定可达</td><td>✓ DNS 解析当前值</td></tr>
+        <tr><td>运行期持久性</td><td>✗ Pod 重建即失效</td><td>✓ 永远指向存活 Pod</td></tr>
+        <tr><td>对运行环境的假设</td><td>无（纯 IP）</td><td>需有 DNS + 启动期解析（entrypoint 已实现）</td></tr>
+        <tr><td>失败可见性</td><td>静默（仅 Debug）</td><td>解析失败会立即暴露在启动日志</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>教训也清楚：<span class="hl">用 <code>lookup</code> 把集群内地址固化进 env，等于把"运行时才会变的东西"在"渲染时"定格。</span>headless Service + StatefulSet 的 Pod DNS 名是天然稳定的标识，而 <code>getent</code> 在入口脚本解析，正好补齐了 Lua cosocket 无 resolver 的短板——各用各的时机，各补各的缺口。</p>
+
+  <div class="punchline">
+    <small>一句话带走</small>
+    auto_resume 504 的根因是 CubeProxy 心跳写向了 Helm 渲染时固化的过期 Redis Pod IP，导致 CLM 服务发现 fleet 为空、状态字典永不填充、gate 永远放行；改成 StatefulSet Pod DNS 名 + 入口脚本启动期解析后，四段接力重新点亮。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>心跳注册（ngx.timer + cosocket）</td><td><code>CubeProxy/lua/proxy_registry.lua</code></td></tr>
+        <tr><td>请求门禁（paused → 回调唤醒）</td><td><code>CubeProxy/lua/sandbox_state.lua</code></td></tr>
+        <tr><td>Redis 发现与端点格式</td><td><code>cube-lifecycle-manager/internal/discovery/discovery.go</code></td></tr>
+        <tr><td>状态推送广播（空 fleet 静默）</td><td><code>cube-lifecycle-manager/internal/proxypush/client.go</code></td></tr>
+        <tr><td>admin 状态写入端点</td><td><code>CubeProxy/lua/admin_phase.lua</code></td></tr>
+        <tr><td>chart 修复与启动解析</td><td><code>deploy/kubernetes/chart/templates/proxy.yaml</code> + <code>chart/files/cube-proxy/cube-proxy-entrypoint.sh</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>部署排障 04/05 · 本系列完 · 全部排障过程见部署记录文档</footer>
+</body>
+</html>

--- a/cubesandbox-tech/deploy-troubleshoot/cubesandbox-basics.html
+++ b/cubesandbox-tech/deploy-troubleshoot/cubesandbox-basics.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>第 0 篇 · 先看懂一张地图：CubeSandbox 全景速览</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--blue),var(--purple));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--blue));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 部署排障</div>
+    <a class="back-home" href="index.html">← 排障索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 部署排障 00 / 05 · 前置篇</div>
+    <h1>先看懂一张地图：CubeSandbox 全景速览</h1>
+    <p class="lead">这一篇不是排障，是为后面四篇排障铺路。如果你第一次接触 CubeSandbox，请先花十分钟读完这篇——它回答三个问题：一个"沙箱"到底是什么、SDK 一行代码背后发生了什么、那么多组件各管什么。有了这张地图，后面每篇排障你都能立刻定位"问题出在地图的哪个角落"。</p>
+  </div>
+
+  <h2>一、一个"沙箱"，到底是什么</h2>
+
+  <p>在 CubeSandbox 里，沙箱（Sandbox）并不是 Docker 容器，而是一台<span class="hl">真正的轻量虚拟机（MicroVM）</span>。它有自己的 Linux 内核、自己的文件系统（rootfs）、自己的 IP。你调用 SDK 创建沙箱，实际上是在一台宿主机上<span class="hlb">启动了一台新的虚拟机</span>。</p>
+  <p>这台虚拟机用 PVM（Pagetable-based Virtual Machine，页表虚拟化）运行——不需要 KVM 那样的硬件辅助虚拟化，纯软件分页，所以对宿主机没有"必须开 KVM"的要求。但这也意味着：你创建沙箱的每一秒，都有真实的 CPU、内存、磁盘被一台完整的操作系统占着。</p>
+  <p>虚拟机里常驻一个叫 <code>envd</code> 的进程，监听固定的 <code>49983</code> 端口。它相当于沙箱的"操作系统代理"：你的命令执行、文件读写、进程管理等，最终都是 envd 在虚拟机里替你完成的。</p>
+
+  <div class="think">
+    <div class="q">那"秒开"是怎么做到的？</div>
+    靠模板快照。见下一节——这是理解整个系统最重要的概念。
+  </div>
+
+  <h2>二、模板：秒开沙箱的秘诀</h2>
+
+  <p>从零启动一台 Linux 虚拟机需要几十秒（加载内核、初始化系统）。CubeSandbox 的沙箱能"秒开"，秘密在 <span class="hl">模板（Template）</span>。</p>
+  <p>模板创建过程（<code>cubemastercli template create-from-image</code>）大致是：</p>
+  <div class="codeblock">① 拉取一个 OCI 镜像（Docker 镜像）
+② 把镜像转换为一个 ext4 磁盘镜像（rootfs）
+③ 用这个 rootfs 启动一台"build 沙箱"，执行镜像里预设的初始化脚本
+④ 把这台沙箱的磁盘 + 内存 打成一份快照（AppSnapshot），保存为模板</div>
+  <p>之后每次创建沙箱，都不是从零启动，而是<span class="hlb">从模板快照恢复</span>——把快照里的磁盘和内存"克隆"出来，一台"已经初始化好、正在运行"的虚拟机立刻出现在眼前。这就是秒开的原理。</p>
+  <p>代价是：模板是"死"的。rootfs 里的配置文件（比如 <code>/etc/resolv.conf</code>）在快照里就定型了，运行时很难再改。这个"静态"特性，会在排障链二（DNS）里坑你一次。</p>
+  <p>另一个关键点：模板创建时通过 <code>--expose-port</code> 声明"这个沙箱对外暴露哪些端口"。端口没声明，外界就永远连不进来——这是排障链一的伏笔。</p>
+
+  <h2>三、SDK 一行代码，背后有两条完全不同的路</h2>
+
+  <p>用 Python SDK 写一个最小示例：</p>
+  <div class="codeblock">sb = Sandbox.create(template=tpl)          <span class="cm"># ① 创建沙箱</span>
+sb.commands.run("echo hello")               <span class="cm"># ② 执行命令</span>
+sb.get_info()                               <span class="cm"># ③ 查询状态</span></div>
+  <p>这三行代码，走的是<span class="hl">两条互不相干的路</span>：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>操作</th><th>打给谁</th><th>做什么</th></tr></thead>
+      <tbody>
+        <tr><td>①③ 创建 / 查状态</td><td><b>CubeMaster 控制面</b>（CubeAPI，HTTP <code>:3000</code>）</td><td>调度、分配资源、记录元数据</td></tr>
+        <tr><td>② 执行命令</td><td><b>CubeProxy 数据面</b>（HTTP <code>:80</code>）</td><td>路由到沙箱内 envd，实时往返</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>这个区分极其重要：<span class="hlb">创建沙箱的"开关"和沙箱内命令的"水管"是两套系统。</span>一个出问题不影响另一个。排障链一就是两条路之间"端口没对上"。</p>
+
+  <h2>四、组件全景：谁在管什么</h2>
+
+  <p>把整个系统摊开，分成"控制面"和"节点数据面"两层。控制面是大脑，决定"创建哪个沙箱、什么时候暂停"；节点数据面是手脚，真的去启动虚拟机、转发流量。</p>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>层次</th><th>组件</th><th>一句话职责</th></tr></thead>
+      <tbody>
+        <tr><td rowspan="4" style="vertical-align:middle"><b>控制面</b></td><td><code>CubeMaster / CubeAPI</code></td><td>SDK 的入口；调度沙箱落到哪台节点、管理模板、处理 pause/resume</td></tr>
+        <tr><td><code>cube-lifecycle-manager</code>（CLM）</td><td>自动暂停/恢复的协调中枢：扫描闲置沙箱、状态对账</td></tr>
+        <tr><td><code>CubeProxy</code></td><td>反向代理，把 SDK 的"命令请求"路由到具体沙箱；维护沙箱状态门禁</td></tr>
+        <tr><td><code>Redis / MySQL</code></td><td>Redis：元数据、事件流、服务注册表；MySQL：持久化业务数据</td></tr>
+        <tr><td rowspan="4" style="vertical-align:middle"><b>节点数据面</b></td><td><code>cubelet</code></td><td>每台节点上的代理，管理本节点沙箱生命周期（类似 K8s 的 kubelet）</td></tr>
+        <tr><td><code>CubeShim</code> + VMM</td><td>containerd shim 与轻量虚拟机监控器，真正把虚拟机拉起来 / 暂停</td></tr>
+        <tr><td><code>CubeNet</code>（CubeVS）</td><td>eBPF 网络数据面：沙箱出向 SNAT、网络策略、DNS 学习</td></tr>
+        <tr><td><code>network-agent</code></td><td>管理虚拟网卡（tap 设备）、给沙箱分配 IP、配置 MTU</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <svg class="flow" viewBox="0 0 720 352" role="img" aria-label="CubeSandbox 系统全景">
+    <defs>
+      <marker id="b0Arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#4f8cff"/></marker>
+      <marker id="b0ArrC" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#2dd4bf"/></marker>
+      <marker id="b0ArrG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="352" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="26" class="fm">CubeSandbox 全景 · 控制面决定"做什么"，节点数据面负责"真干"</text>
+
+    <text x="40" y="60" class="fl">用户 / SDK</text>
+    <rect x="30" y="66" width="150" height="46" rx="9" fill="rgba(79,140,255,.1)" stroke="rgba(79,140,255,.6)"/>
+    <text x="105" y="84" text-anchor="middle" class="fn">SDK (Python)</text>
+    <text x="105" y="100" text-anchor="middle" class="fd">create / commands.run</text>
+
+    <rect x="300" y="52" width="150" height="46" rx="9" fill="rgba(45,212,191,.08)" stroke="rgba(45,212,191,.45)"/>
+    <text x="375" y="70" text-anchor="middle" class="fn">CubeMaster</text>
+    <text x="375" y="86" text-anchor="middle" class="fd">创建/调度/模板</text>
+    <rect x="300" y="108" width="150" height="46" rx="9" fill="rgba(45,212,191,.08)" stroke="rgba(45,212,191,.45)"/>
+    <text x="375" y="126" text-anchor="middle" class="fn">CLM</text>
+    <text x="375" y="142" text-anchor="middle" class="fd">自动暂停/恢复</text>
+    <rect x="300" y="164" width="150" height="46" rx="9" fill="rgba(45,212,191,.08)" stroke="rgba(45,212,191,.45)"/>
+    <text x="375" y="182" text-anchor="middle" class="fn">CubeProxy</text>
+    <text x="375" y="198" text-anchor="middle" class="fd">命令路由/状态门禁</text>
+    <rect x="300" y="220" width="150" height="46" rx="9" fill="rgba(45,212,191,.07)" stroke="rgba(45,212,191,.4)"/>
+    <text x="375" y="238" text-anchor="middle" class="fn">Redis / MySQL</text>
+    <text x="375" y="254" text-anchor="middle" class="fd">元数据/事件/注册表</text>
+    <text x="375" y="292" text-anchor="middle" class="fd" style="fill:#6b7a93">—— 控制面 ——</text>
+
+    <rect x="520" y="52" width="176" height="46" rx="9" fill="rgba(167,139,250,.08)" stroke="rgba(167,139,250,.45)"/>
+    <text x="608" y="70" text-anchor="middle" class="fn">cubelet</text>
+    <text x="608" y="86" text-anchor="middle" class="fd">节点沙箱生命周期</text>
+    <rect x="520" y="108" width="176" height="46" rx="9" fill="rgba(167,139,250,.08)" stroke="rgba(167,139,250,.45)"/>
+    <text x="608" y="126" text-anchor="middle" class="fn">CubeShim + VMM</text>
+    <text x="608" y="142" text-anchor="middle" class="fd">拉起/暂停虚拟机</text>
+    <rect x="520" y="164" width="176" height="46" rx="9" fill="rgba(167,139,250,.08)" stroke="rgba(167,139,250,.45)"/>
+    <text x="608" y="182" text-anchor="middle" class="fn">CubeNet (eBPF)</text>
+    <text x="608" y="198" text-anchor="middle" class="fd">SNAT/策略/DNS 学习</text>
+    <rect x="520" y="220" width="176" height="46" rx="9" fill="rgba(167,139,250,.07)" stroke="rgba(167,139,250,.4)"/>
+    <text x="608" y="238" text-anchor="middle" class="fn">network-agent</text>
+    <text x="608" y="254" text-anchor="middle" class="fd">tap 设备/IP/MTU</text>
+    <text x="608" y="292" text-anchor="middle" class="fd" style="fill:#6b7a93">—— 节点数据面 ——</text>
+
+    <rect x="520" y="300" width="176" height="32" rx="8" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.5)"/>
+    <text x="608" y="320" text-anchor="middle" class="fn" style="fill:#34d399">沙箱 (PVM 虚拟机)</text>
+
+    <line x1="180" y1="88" x2="300" y2="75" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#b0Arr)"/>
+    <line x1="180" y1="88" x2="300" y2="187" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#b0ArrC)"/>
+    <text x="238" y="106" text-anchor="middle" class="fl" style="font-size:10.5px">创建/状态</text>
+    <text x="236" y="150" text-anchor="middle" class="fl" style="font-size:10.5px">命令</text>
+    <line x1="450" y1="75" x2="520" y2="75" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#b0ArrC)"/>
+    <text x="485" y="66" text-anchor="middle" class="fl" style="font-size:10px">下发</text>
+    <line x1="450" y1="187" x2="520" y2="187" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#b0ArrC)"/>
+    <text x="485" y="179" text-anchor="middle" class="fl" style="font-size:10px">路由</text>
+    <line x1="608" y1="266" x2="608" y2="300" stroke="#34d399" stroke-width="1.5" marker-end="url(#b0ArrG)"/>
+  </svg>
+  <div class="flow-cap">本篇之后的所有排障，都能在这张图上定位：链一在 CubeProxy 路由，链二在 CubeNet 策略，链三在 CubeShim/VMM 网络配置，链四在 CubeProxy↔CLM↔Redis 的注册链路。</div>
+
+  <h2>五、一次命令执行，完整旅程</h2>
+
+  <p>把第 ② 行 <code>commands.run()</code> 展开，它实际走了这样一段路：</p>
+  <div class="codeblock">SDK
+ └─ HTTP 请求，Host 头 = &lt;sandbox_id&gt;-49983.cube.app   <span class="cm"># 虚拟域名，端口固定 49983</span>
+    └─ 到达 CubeProxy
+       └─ Lua 解析 Host：沙箱 ID = xxx，目标端口 = 49983
+          └─ 查 Redis 代理映射 …sandbox:proxy:&lt;id&gt;：49983 → 宿主端口
+             └─ 转发到节点上的宿主端口
+                └─ 经网络数据面进入沙箱的虚拟网卡
+                   └─ 沙箱内 envd（:49983）接收，执行命令，返回结果</div>
+  <p>注意 <span class="hlb">Redis 代理映射</span>这一步：沙箱在哪个节点、以哪个宿主端口暴露 <code>49983</code>，都记录在 Redis 的一个 hash 里。这一步查不到，命令就永远到达不了沙箱——排障链一正是栽在这里。</p>
+
+  <h2>六、生命周期：沙箱会"睡觉"</h2>
+
+  <p>沙箱有状态：<code>running</code>（运行中）、<code>paused</code>（暂停）、<code>killed</code>（已销毁）。<span class="hl">暂停（pause）不是关停</span>，而是把虚拟机内存写盘成快照、释放 CPU/内存，需要时再恢复（resume）——这天然复用了模板的秒开机制。</p>
+  <p>谁触发暂停？用户手动调 <code>sb.pause()</code>，或者设置 <code>lifecycle={"on_timeout":"pause","auto_resume":True}</code> 后由 CLM 自动判定"空闲超时"而暂停。谁触发恢复？用户请求到达时，CubeProxy 的"门禁"发现沙箱是 paused，会内部通知 CLM 把它唤醒。这套"睡/醒"的协作链条，就是排障链四的主战场。</p>
+
+  <h2>七、本系列排障的地图坐标</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>排障</th><th>现象一句话</th><th>根因在地图的哪</th></tr></thead>
+      <tbody>
+        <tr><td><a href="envd-port.html">01 · envd 端口</a></td><td>建沙箱成功，命令 ConnectException</td><td>CubeProxy → Redis 代理映射：模板没暴露 49983</td></tr>
+        <tr><td><a href="sandbox-dns.html">02 · 沙箱 DNS</a></td><td>公网域名解析失败</td><td>CubeNet eBPF 策略默认拒绝私网段（含 CoreDNS）</td></tr>
+        <tr><td><a href="mtu-blackhole.html">03 · MTU 黑洞</a></td><td>HTTP 通、HTTPS 超时、大文件截断</td><td>CubeShim/VMM 没把 MTU 传进虚拟机</td></tr>
+        <tr><td><a href="auto-resume-504.html">04 · auto_resume 504</a></td><td>自动暂停正常，自动恢复 504</td><td>CubeProxy 心跳写向过期 Redis IP → CLM 发现不到代理</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="punchline">
+    <small>一句话带走</small>
+    记住三件事就够：沙箱是一台由模板快照秒开的 PVM 虚拟机；创建走 CubeMaster、命令走 CubeProxy 两条独立链路；运行中沙箱还会被 CLM 自动暂停和恢复。后面每篇排障都在这三句话的延长线上。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个入口</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>SDK 客户端</td><td><code>cubesandbox/</code>（Python 包，<code>sandbox.py</code> / <code>_commands.py</code>）</td></tr>
+        <tr><td>控制面入口</td><td><code>CubeMaster/</code>、<code>cube-lifecycle-manager/</code></td></tr>
+        <tr><td>数据面路由与门禁</td><td><code>CubeProxy/lua/</code></td></tr>
+        <tr><td>节点沙箱生命周期</td><td><code>Cubelet/</code>、<code>CubeShim/</code>、<code>hypervisor/</code></td></tr>
+        <tr><td>网络数据面</td><td><code>CubeNet/</code>、<code>network-agent/</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>部署排障 00/05 · 前置篇 · 下一篇：沙箱建好了，命令却一条都跑不了</footer>
+</body>
+</html>

--- a/cubesandbox-tech/deploy-troubleshoot/envd-port.html
+++ b/cubesandbox-tech/deploy-troubleshoot/envd-port.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>01 · 沙箱建好了，命令却一条都跑不了</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--blue),var(--purple));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--cyan));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 部署排障</div>
+    <a class="back-home" href="index.html">← 排障索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 部署排障 01 / 05</div>
+    <h1>沙箱建好了，命令却一条都跑不了</h1>
+    <p class="lead">部署完 CubeSandbox，第一件事自然是拿 SDK 试试手。`Sandbox.create()` 秒回、沙箱 ID 都拿到了——可紧接着的 `commands.run('echo hi')`，直接抛出一个干巴巴的 `ConnectException`。创建成功但命令全挂，问题出在"创建"和"命令"这两条完全不同的路上。</p>
+  </div>
+
+  <h2>一、背景速览：先分清"创建"和"命令"是两条路</h2>
+
+  <p>如果你还没读前置篇，这里先补一块最重要的地图：CubeSandbox 的 SDK 调用被刻意拆成了<span class="hl">两条互不相干的网络路径</span>。</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>操作</th><th>走哪条路</th><th>依赖什么</th></tr></thead>
+      <tbody>
+        <tr><td><code>Sandbox.create()</code> / <code>get_info()</code></td><td>CubeMaster 控制面（CubeAPI，HTTP <code>:3000</code>）</td><td>模板存在、有节点能调度</td></tr>
+        <tr><td><code>commands.run()</code> / <code>files.*</code></td><td>CubeProxy 数据面（HTTP <code>:80</code>）</td><td>沙箱内 envd 端口（49983）被"暴露"</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>为什么拆开？因为这是两种完全不同的流量：创建是低频控制操作，命令是高频实时数据流。拆开后，控制面故障不影响已运行沙箱的命令通道，反之亦然。<span class="hlb">代价是：排障时必须先搞清楚当前错误是哪条路报的。</span></p>
+
+  <h2>二、机制之一：命令通道 = "虚拟域名 + 动态后端"</h2>
+
+  <p>命令请求长什么样？SDK 在 <code>cubesandbox/_commands.py</code> 里，用 <code>e2b_connect</code> 库发一个 gRPC-streaming 请求，目标是沙箱内 <code>envd</code> 进程监听的固定端口 <code>49983</code>。关键在请求的 <span class="hl">Host 头</span>：</p>
+  <div class="codeblock">ENVD_PORT = 49983   <span class="cm"># 沙箱内 envd 的固定端口，写死在 SDK 里</span>
+
+def _envd_rpc_base_url_and_headers(sandbox):
+    ...
+    headers["Host"] = sandbox.get_host(ENVD_PORT)
+    <span class="cm"># → Host: &lt;sandbox_id&gt;-49983.cube.app</span>
+    return f"http://{proxy_node_ip}:{proxy_port}", headers</div>
+  <p>这个 Host 是<span class="hl">虚拟域名</span>：格式固定为 <code>&lt;sandbox_id&gt;-&lt;端口&gt;.cube.app</code>。请求到达 CubeProxy 后，OpenResty 的 Lua 从 Host 里解出 <code>sandbox_id</code> 和 <code>49983</code>，然后查 Redis 里的一份<span class="hl">代理映射</span>（HSET 结构，key 类似 <code>…sandbox:proxy:&lt;id&gt;</code>），拿到这个沙箱"在哪个节点、以哪个宿主端口承载 49983"：</p>
+  <div class="codeblock"># Redis 里的代理映射（HSET）
+HostIP       = 192.168.4.64     <span class="cm"># 沙箱所在节点</span>
+SandboxIP    = 172.16.x.y      <span class="cm"># 沙箱自己的 IP</span>
+"49983"      = 33021           <span class="cm"># 节点上暴露 49983 的宿主端口</span></div>
+  <p>然后 CubeProxy 把请求转发到 <code>HostIP:宿主端口</code>，再经网络数据面进入沙箱，最终 envd 收到并执行。</p>
+
+  <div class="think">
+    <div class="q">那 Redis 映射里"有哪些端口"是谁决定的？</div>
+    是<span class="hlb">模板</span>。模板创建时用 <code>--expose-port</code> 声明了"这个沙箱对外暴露哪些容器端口"。沙箱是模板的克隆体，模板没暴露的端口，代理映射里就永远没有。
+  </div>
+
+  <h2>三、问题：建沙箱成功，命令却 ConnectException</h2>
+
+  <p>用脚本复现：</p>
+  <div class="codeblock">sb = Sandbox.create(template=tpl, timeout=120)   <span class="cm"># 返回 sandbox_id，正常</span>
+ec, out, err = sb.commands.run("echo hello")       <span class="cm"># 抛 ConnectException</span>
+<span class="cm"># e2b_connect.client.ConnectException: (&lt;Code.unknown: 'unknown'&gt;, '')</span></div>
+  <p><code>ConnectException</code> 没有 HTTP 状态码——不是 404、不是 500，是<span class="hl">连接层</span>的失败："TCP 握手根本没成功"。创建走 CubeMaster 成功了，说明控制面没问题；命令走 CubeProxy，问题必然出在命令这条链路的某个环节。</p>
+
+  <svg class="flow" viewBox="0 0 720 244" role="img" aria-label="命令链路断点定位">
+    <defs>
+      <marker id="p1Arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#4f8cff"/></marker>
+      <marker id="p1ArrR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#f87171"/></marker>
+      <marker id="p1ArrG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="244" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">命令链路 · 断点在第 ③ 环：Redis 映射里没有 49983</text>
+
+    <rect x="26" y="46" width="150" height="56" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="101" y="70" text-anchor="middle" class="fn">SDK</text>
+    <text x="101" y="88" text-anchor="middle" class="fd">Host: &lt;sid&gt;-49983.cube.app</text>
+
+    <rect x="216" y="46" width="140" height="56" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="286" y="70" text-anchor="middle" class="fn">CubeProxy</text>
+    <text x="286" y="88" text-anchor="middle" class="fd">解出 sid + 端口 49983</text>
+
+    <rect x="396" y="46" width="150" height="56" rx="10" fill="rgba(167,139,250,.08)" stroke="rgba(167,139,250,.45)"/>
+    <text x="471" y="70" text-anchor="middle" class="fn">Redis 代理映射</text>
+    <text x="471" y="88" text-anchor="middle" class="fd">只存了 "8000" → …</text>
+
+    <rect x="586" y="46" width="108" height="56" rx="10" fill="rgba(248,113,113,.08)" stroke="rgba(248,113,113,.5)"/>
+    <text x="640" y="70" text-anchor="middle" class="fn" style="fill:#f87171">无 49983</text>
+    <text x="640" y="88" text-anchor="middle" class="fd">后端解析失败</text>
+
+    <line x1="176" y1="74" x2="216" y2="74" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#p1Arr)"/>
+    <line x1="356" y1="74" x2="396" y2="74" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#p1Arr)"/>
+    <line x1="546" y1="74" x2="586" y2="74" stroke="#f87171" stroke-width="1.5" marker-end="url(#p1ArrR)"/>
+    <text x="566" y="122" text-anchor="middle" class="fl">metadata_map["49983"] = nil</text>
+
+    <rect x="216" y="168" width="160" height="56" rx="10" fill="rgba(52,211,153,.07)" stroke="rgba(52,211,153,.45)"/>
+    <text x="296" y="192" text-anchor="middle" class="fn" style="fill:#34d399">模板重建</text>
+    <text x="296" y="210" text-anchor="middle" class="fd">--expose-port 49983</text>
+    <line x1="330" y1="102" x2="320" y2="168" stroke="#34d399" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#p1ArrG)"/>
+    <text x="342" y="144" class="fl">修复：模板暴露 49983</text>
+  </svg>
+  <div class="flow-cap">SDK 请求 → CubeProxy → Redis 查映射 → 映射里没有 49983 → 后端解析失败 → ConnectException。修复点在"模板"这一源头。</div>
+
+  <h2>四、根因：模板暴露的端口，不是 49983</h2>
+
+  <p>第一次建模板时，命令是：</p>
+  <div class="codeblock">cubemastercli template create-from-image --image &lt;image&gt; --expose-port 8000</div>
+  <p>容器端口 <code>8000</code> 被写进模板元数据。于是沙箱创建后，Redis 代理映射里只有 <code>HostIP / SandboxIP / "8000"</code>——<span class="hlb">没有 <code>49983</code></span>。当 SDK 的请求带着 <code>Host: &lt;sid&gt;-49983.cube.app</code> 到达 CubeProxy 时，Lua 侧 <code>sandbox_backend.lua</code> 的 <code>resolve_backend(ins_id, "49983")</code> 查表，<code>metadata_map["49983"]</code> 是 nil——没有宿主端口，转发无门，连接直接失败。</p>
+  <p>为什么之前用 8000？因为模板镜像本身是个 Web 服务镜像，端口是 8000。但对 CubeSandbox 来说，<span class="hl">命令执行要求模板必须暴露 envd 端口 49983</span>——这是 SDK 与沙箱之间的"内部契约"，和镜像本身的业务端口无关。建模板时只想着业务端口，漏了内部端口，是最容易踩的坑。</p>
+
+  <h2>五、修复：重建模板，暴露 49983</h2>
+
+  <p>重建模板：</p>
+  <div class="codeblock">cubemastercli template create-from-image --image &lt;image&gt; \
+  --expose-port 49983 --writable-layer-size 20Gi</div>
+  <p>两个参数都值得说明。<code>--expose-port 49983</code> 是本次的关键；而 <code>--writable-layer-size 20Gi</code> 是 CLI 校验里的一个"必填项"——缺了它命令直接报 <code>writable-layer-size is required</code>，属于不算友好的细节。重建后重新创建沙箱，命令执行立即恢复。</p>
+
+  <h2>六、权衡：为什么是"端口即契约"</h2>
+
+  <p>这套"模板声明暴露端口 + Host 虚拟域名路由"的设计，本质是<span class="hl">把暴露面显式化</span>：沙箱默认对网络封闭，只有模板声明的端口才写入 Redis 映射、才可能被代理路由到。</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>好处</th><th>代价</th></tr></thead>
+      <tbody>
+        <tr><td>安全：一个模板只开一个端口，其余全屏蔽</td><td>排障直觉陷阱：错端口报"连接失败"，无状态码可查</td></tr>
+        <tr><td>每个端口都是显式声明的"契约"</td><td>创建与命令两套链路，配置来源（模板元数据）不同，端口不匹配时错误只浮现在命令层</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>记住这张对照表——排障链二（DNS）还会用到"模板元数据决定运行行为"这个心智。</p>
+
+  <div class="punchline">
+    <small>一句话带走</small>
+    命令执行走的是"Host 虚拟域名 → CubeProxy → Redis 端口映射"的独立链路；模板创建时漏了 <code>--expose-port 49983</code>，映射表里没有 envd 端口，命令请求自然无处可去。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>SDK 命令执行入口与 49983 常量</td><td><code>cubesandbox/_commands.py</code></td></tr>
+        <tr><td>SDK 构造 Host 虚拟域名</td><td><code>cubesandbox/sandbox.py</code>（<code>get_host</code>）</td></tr>
+        <tr><td>代理端口路由</td><td><code>CubeProxy/lua/sandbox_backend.lua</code></td></tr>
+        <tr><td>Redis 代理映射 key 结构</td><td><code>CubeProxy/lua/redis_keys.lua</code></td></tr>
+        <tr><td>模板 create-from-image 命令</td><td><code>CubeMaster/cmd/cubemastercli/commands/cubebox/template.go</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>部署排障 01/05 · 下一篇：沙箱里 DNS 全挂了——一次"安全默认值"引发的公网断连</footer>
+</body>
+</html>

--- a/cubesandbox-tech/deploy-troubleshoot/index.html
+++ b/cubesandbox-tech/deploy-troubleshoot/index.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CubeSandbox 部署排障实录</title>
+<style>
+  :root {
+    --bg: #0b1020;
+    --panel: rgba(255,255,255,0.04);
+    --panel-hover: rgba(255,255,255,0.07);
+    --border: rgba(255,255,255,0.09);
+    --border-strong: rgba(255,255,255,0.16);
+    --text: #e6eaf2;
+    --text-dim: #9aa7bd;
+    --text-faint: #6b7a93;
+    --blue: #4f8cff;
+    --cyan: #2dd4bf;
+    --purple: #a78bfa;
+    --amber: #fbbf24;
+    --red: #f87171;
+    --green: #34d399;
+    --mono: "SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans: -apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius: 14px;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: var(--sans); background: var(--bg); color: var(--text); line-height: 1.7; font-size: 15px; }
+  a { color: var(--blue); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { font-family: var(--mono); font-size: 0.88em; background: rgba(79,140,255,0.12); color: #b9d2ff; padding: 2px 7px; border-radius: 6px; white-space: nowrap; }
+
+  .hero {
+    text-align: center;
+    padding: 76px 24px 50px;
+    background:
+      radial-gradient(1000px 420px at 15% -10%, rgba(248,113,113,0.18), transparent 60%),
+      radial-gradient(1000px 420px at 85% -10%, rgba(79,140,255,0.2), transparent 60%),
+      radial-gradient(700px 300px at 50% 110%, rgba(251,191,36,0.1), transparent 60%);
+    border-bottom: 1px solid var(--border);
+  }
+  .hero .badge {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--amber);
+    border: 1px solid rgba(251,191,36,0.4);
+    background: rgba(251,191,36,0.08);
+    padding: 4px 14px;
+    border-radius: 20px;
+    margin-bottom: 20px;
+    letter-spacing: 1px;
+  }
+  .hero h1 {
+    font-size: 40px;
+    font-weight: 900;
+    background: linear-gradient(90deg,#fff,var(--blue) 45%,var(--purple));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .hero p { color: var(--text-dim); font-size: 16.5px; margin-top: 14px; max-width: 720px; margin-left: auto; margin-right: auto; }
+  .hero .back {
+    display: inline-block;
+    margin-top: 22px;
+    font-size: 13px;
+    color: var(--text-dim);
+    border: 1px solid var(--border);
+    padding: 6px 16px;
+    border-radius: 20px;
+    transition: all 0.15s;
+  }
+  .hero .back:hover { color: var(--text); border-color: var(--border-strong); text-decoration: none; }
+
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 56px 24px 90px; }
+  .section-title { font-size: 20px; font-weight: 800; margin: 48px 0 20px; padding-left: 12px; border-left: 3px solid var(--amber); }
+  .section-title:first-child { margin-top: 0; }
+
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 18px; }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 22px 22px 24px;
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.2s, border-color 0.2s, background 0.2s;
+  }
+  .card:hover { transform: translateY(-3px); border-color: var(--border-strong); background: var(--panel-hover); }
+  .card .num {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--amber);
+    background: rgba(251,191,36,0.12);
+    border: 1px solid rgba(251,191,36,0.3);
+    border-radius: 6px;
+    padding: 2px 8px;
+    align-self: flex-start;
+    margin-bottom: 12px;
+  }
+  .card h3 { font-size: 18px; margin-bottom: 6px; }
+  .card .tags { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 12px; }
+  .card p.desc { color: var(--text-dim); font-size: 13.5px; flex: 1; }
+  .card .features { color: var(--text-faint); font-size: 12.5px; margin-top: 14px; font-family: var(--mono); line-height: 2; }
+  .card .go {
+    margin-top: 16px;
+    font-size: 13.5px;
+    font-weight: 700;
+    color: var(--blue);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .card:hover .go { color: #8fb6ff; }
+  .tag {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 6px;
+    border: 1px solid var(--border-strong);
+    color: var(--text-dim);
+  }
+  .tag.go { color: #7ee7ff; border-color: rgba(126,231,255,0.4); background: rgba(126,231,255,0.08); }
+  .tag.rust { color: #ffab7e; border-color: rgba(255,171,126,0.4); background: rgba(255,171,126,0.08); }
+  .tag.lua { color: #a5f3a1; border-color: rgba(165,243,161,0.4); background: rgba(165,243,161,0.08); }
+  .tag.yaml { color: #ffd27e; border-color: rgba(255,210,126,0.4); background: rgba(255,210,126,0.08); }
+  .tag.k8s { color: #b9a3ff; border-color: rgba(185,163,255,0.4); background: rgba(185,163,255,0.08); }
+
+  .note {
+    border-left: 3px solid var(--amber);
+    background: rgba(251,191,36,0.07);
+    padding: 12px 18px;
+    border-radius: 0 10px 10px 0;
+    font-size: 13px;
+    color: var(--text-dim);
+    max-width: 720px;
+    margin: 26px auto 0;
+  }
+  .note strong { color: var(--text); }
+
+  .back-top {
+    position: fixed; right: 26px; bottom: 26px;
+    width: 44px; height: 44px; border-radius: 12px;
+    background: rgba(79,140,255,0.85); color: #fff; border: none;
+    cursor: pointer; font-size: 18px;
+    display: flex; align-items: center; justify-content: center;
+    opacity: 0; pointer-events: none; transition: opacity 0.25s;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.35);
+  }
+  .back-top.show { opacity: 1; pointer-events: auto; }
+  footer { border-top: 1px solid var(--border); padding: 34px 24px 50px; text-align: center; color: var(--text-faint); font-size: 12.5px; }
+  @media (max-width: 720px) { .hero h1 { font-size: 30px; } }
+</style>
+</head>
+<body>
+
+<div class="hero">
+  <div class="badge">CUBE SANDBOX · DEPLOY TROUBLESHOOTING</div>
+  <h1>CubeSandbox 部署排障实录</h1>
+  <p>2026-08-03 在 64_host 上部署 CubeSandbox 0.6 后，沙箱"建得起来、命令跑不动"——从命令执行、公网 DNS、到 HTTPS 握手超时、自动恢复 504，四篇排障实录，每篇从现象入手，循链路抽丝剥茧，一路修到源码层。</p>
+  <a class="back" href="../index.html">← 返回核心技术索引</a>
+</div>
+
+<div class="wrap">
+
+  <div class="section-title">前置 · 系统全景</div>
+  <div class="grid">
+    <div class="card">
+      <span class="num">00</span>
+      <h3>先看懂一张地图：CubeSandbox 全景速览</h3>
+      <div class="tags"><span class="tag">前置必读</span><span class="tag">概念</span></div>
+      <p class="desc">第一次接触 CubeSandbox？先读这篇。回答三个问题：一个"沙箱"到底是什么、SDK 一行代码背后发生了什么、那么多组件各管什么。</p>
+      <div class="features">PVM 虚拟机 · 模板快照 · envd:49983<br>CubeMaster / CubeProxy / CLM / CubeNet</div>
+      <a class="go" href="cubesandbox-basics.html">深入阅读 →</a>
+    </div>
+  </div>
+
+  <div class="section-title">沙箱访问排障 · 由浅入深</div>
+  <div class="grid">
+    <div class="card">
+      <span class="num">01</span>
+      <h3>沙箱建好了，命令却一条都跑不了</h3>
+      <div class="tags"><span class="tag go">Go</span><span class="tag">envd · E2B</span></div>
+      <p class="desc">Sandbox.create() 成功、commands.run 却抛 ConnectException——命令执行链路里"端口暴露"这一步是怎么断的。</p>
+      <div class="features">ENVD_PORT=49983 · --expose-port<br>_envd_rpc_base_url_and_headers · sandbox_backend</div>
+      <a class="go" href="envd-port.html">深入阅读 →</a>
+    </div>
+    <div class="card">
+      <span class="num">02</span>
+      <h3>沙箱里 DNS 全挂了——一次"安全默认值"引发的公网断连</h3>
+      <div class="tags"><span class="tag go">Go</span><span class="tag c">C/eBPF</span></div>
+      <p class="desc">resolv.conf 指向集群 CoreDNS，但沙箱连 DNS 查询都发不出去。一条"默认拒绝私网"的安全策略，如何变成沙箱的断网根源。</p>
+      <div class="features">alwaysDeniedSandboxCIDRs · ResolveEffectiveDNSServers<br>disable_host_netfile · template --dns</div>
+      <a class="go" href="sandbox-dns.html">深入阅读 →</a>
+    </div>
+    <div class="card">
+      <span class="num">03</span>
+      <h3>HTTP 通、HTTPS 超时、大文件截断——一次 MTU 黑洞的完整修复</h3>
+      <div class="tags"><span class="tag rust">Rust</span><span class="tag k8s">Calico</span></div>
+      <p class="desc">同样的链路，TCP 能连、HTTP 能通，HTTPS 却握手超时、1MB 下载只收到 228KB。1500 与 1450 之间藏着一个静默丢包的黑洞，而修复要动到 Rust VMM 的源码。</p>
+      <div class="features">mvm_mtu · VIRTIO_NET_F_MTU · add_nets<br>restore_nets_config · update_nets · MSS</div>
+      <a class="go" href="mtu-blackhole.html">深入阅读 →</a>
+    </div>
+    <div class="card">
+      <span class="num">04</span>
+      <h3>沙箱自己睡了，却没人能把它叫醒——auto_resume 504 之谜</h3>
+      <div class="tags"><span class="tag lua">OpenResty</span><span class="tag go">Go</span></div>
+      <p class="desc">自动暂停一切正常，自动恢复却永远 504。一条"渲染时固化的 IP"，让 CubeProxy 的心跳写进黑洞、CLM 找不到任何代理——四层链路逐层排查。</p>
+      <div class="features">proxy_registry.lua · lookup() · Redis discovery<br>StateLockTTL · /_sidecar_resume · cube_sandbox_state</div>
+      <a class="go" href="auto-resume-504.html">深入阅读 →</a>
+    </div>
+  </div>
+
+  <div class="note"><strong>阅读建议：</strong>第一次接触 CubeSandbox 的读者，请务必先读 <a href="cubesandbox-basics.html">第 0 篇《先看懂一张地图》</a>，它建立了全系统的心智模型——之后再按 01 → 04 顺序阅读，每篇排障你都能立刻定位"问题出在地图的哪个角落"。所有源码路径以仓库根目录为基准，涉及部署环境的 IP / ID 均为本次环境的历史值。</div>
+</div>
+
+<footer>
+  CubeSandbox 部署排障实录 · 源码路径基准：/workspace/github/CubeSandbox<br>
+  完整排障记录见 docs/zh/guide/kubernetes/deployment-record-2026-08-03-64host.md
+</footer>
+
+<button class="back-top" id="backTop">↑</button>
+<script>
+  const b = document.getElementById('backTop');
+  window.addEventListener('scroll', () => b.classList.toggle('show', window.scrollY > 500));
+  b.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+</script>
+</body>
+</html>

--- a/cubesandbox-tech/deploy-troubleshoot/mtu-blackhole.html
+++ b/cubesandbox-tech/deploy-troubleshoot/mtu-blackhole.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>03 · HTTP 通、HTTPS 超时、大文件截断——一次 MTU 黑洞的完整修复</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--blue),var(--purple));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--red));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 部署排障</div>
+    <a class="back-home" href="index.html">← 排障索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 部署排障 03 / 05</div>
+    <h1>HTTP 通、HTTPS 超时、大文件截断——一次 MTU 黑洞的完整修复</h1>
+    <p class="lead">DNS 修好后，沙箱能解析域名了。可诡异的事情来了：`curl http://www.baidu.com` 返回 200，`curl https://www.baidu.com` 却超时；1MB 的下载文件只收到 228KB 就断。同一台机器、同一个网络，为什么对数据大小这么"挑剔"？这题一解就是一天，最后改到了 Rust 写的虚拟化层源码里。</p>
+  </div>
+
+  <h2>一、背景速览：MTU / MSS / virtio 网卡，三块拼图</h2>
+
+  <p>在讲排障前，先建立三个概念——没有它们，后面的现象完全不可理解。</p>
+
+  <p><span class="hlg">拼图一：MTU 与 MSS。</span>MTU（Maximum Transmission Unit）是链路层能承载的最大帧。TCP 发送数据时要按 <span class="hl">MSS（最大分段大小）</span>切段，经典公式 <code>MSS = MTU − 40</code>（20 字节 IPv4 头 + 20 字节 TCP 头）。发送端通告的 MSS 来自自己网卡的 MTU。比如 MTU 1500 的网卡通告 MSS 1460。</p>
+  <p><span class="hlg">拼图二：黑洞的机制。</span>如果数据链路某一段的 MTU 比发送端通告的小，那么"太大的包"有两种命运：<span class="hlb">要么沿途设备发回 ICMP "Packet Too Big" 让发送端降速重发（健康），要么被静默丢弃（黑洞）</span>。丢弃没有任何反馈，发送端还以为包在路上，于是表现为超时/截断——这就是"黑洞"名字的由来。</p>
+  <p><span class="hlg">拼图三：沙箱的网卡是 virtio-net。</span>沙箱是一台 PVM 虚拟机，它的 <code>eth0</code> 是虚拟网卡（virtio-net），由 hypervisor（VMM）创建。virtio-net 有一个特性位 <code>VIRTIO_NET_F_MTU</code>：宿主机可以通过它告诉 guest 内核"你该用多大的 MTU"。<span class="hl">也就是说，guest 的 MTU 不是 guest 自己定的，而是宿主机传进去的。</span>这正是这次排障的突破口。</p>
+
+  <h2>二、问题：按数据大小"挑食"的网络</h2>
+
+  <p>三个观察，互相印证：</p>
+  <div class="codeblock">$ curl -s -o /dev/null -w '%{http_code}' http://www.baidu.com
+200                    <span class="cm"># HTTP 正常</span>
+$ curl -k -s -o /dev/null -m 15 https://www.baidu.com
+000                    <span class="cm"># HTTPS 握手超时</span>
+$ python3 -c 'import socket; socket.create_connection(("www.baidu.com", 443))'
+<span class="cm"># 成功 —— TCP 层是通的！</span></div>
+  <p>TCP 能连上（SYN/SYN-ACK 都是小包），说明不是路由不通；HTTP 能通（GET 响应体通常只有几 KB，被切分成若干 ≤1460 字节的段）；唯独 HTTPS 挂——TLS 握手里，ServerHello 之后紧跟的<strong>证书链</strong>是一大坨数据，动辄几 KB。为什么大段数据过不去？</p>
+  <p>再补一刀：下载 1MB 文件，只收到约 228KB 就断了。一个精确的"截断点"，强烈暗示<span class="hl">超过某一大小的数据被稳定地丢弃</span>。</p>
+
+  <h2>三、根因：1500 与 1450 之间的"静默黑洞"</h2>
+
+  <p>把这条链路上每一段的 MTU 都量一遍，答案就出来了：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>节点</th><th>MTU</th><th>可承载 TCP 载荷上限</th></tr></thead>
+      <tbody>
+        <tr><td>沙箱 guest <code>eth0</code>（virtio-net）</td><td><b>1500</b>（打包默认 <code>mvm_mtu=1500</code>）</td><td>1460（通告 MSS）</td></tr>
+        <tr><td>宿主机 tap（<code>cube-dev</code> / <code>z172.16.x.y</code>）</td><td>1500</td><td>1460</td></tr>
+        <tr><td>cube-node Pod <code>eth0</code>（Calico VXLAN）</td><td><b>1450</b></td><td>1410</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>Calico 的 VXLAN 模式要在数据帧外包一层 50 字节的 VXLAN/UDP/IP 头，所以 Pod 网络的 MTU 是 1450。于是黑洞出现：</p>
+  <p><span class="hlb">guest 按 MTU 1500 通告 MSS=1460，但数据面最多承载 1410 字节载荷。回程任何长度在 1411~1460 之间的 TCP 段，超过 Pod MTU，被 Calico 数据面静默丢弃——没有任何 ICMP 通知。</span></p>
+  <p>为什么会"半通半不通"？因为 TCP 丢包后会重传，重传的段还是 1460 大小——永远超限，永远重传，永远丢。HTTP 响应小、段少，恰好没撞上阈值；TLS 证书和大文件下载，段段 1460，撞个正着。</p>
+
+  <svg class="flow" viewBox="0 0 720 236" role="img" aria-label="MTU黑洞成因链路">
+    <defs>
+      <marker id="m3Arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#4f8cff"/></marker>
+      <marker id="m3ArrR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#f87171"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="236" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">MTU 黑洞 · 1500 与 1450 之间的 50 字节差，吞掉一切 1411~1460 的 TCP 段</text>
+
+    <rect x="24" y="48" width="160" height="60" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="104" y="72" text-anchor="middle" class="fn">沙箱 guest eth0</text>
+    <text x="104" y="90" text-anchor="middle" class="fd">MTU 1500 · 通告 MSS 1460</text>
+
+    <rect x="220" y="48" width="140" height="60" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="290" y="72" text-anchor="middle" class="fn">tap 设备</text>
+    <text x="290" y="90" text-anchor="middle" class="fd">MTU 1500</text>
+
+    <rect x="396" y="48" width="150" height="60" rx="10" fill="rgba(248,113,113,.08)" stroke="rgba(248,113,113,.5)"/>
+    <text x="471" y="72" text-anchor="middle" class="fn" style="fill:#f87171">Pod eth0 (Calico)</text>
+    <text x="471" y="90" text-anchor="middle" class="fd">MTU 1450 · 载荷上限 1410</text>
+
+    <rect x="582" y="48" width="112" height="60" rx="10" fill="rgba(248,113,113,.07)" stroke="rgba(248,113,113,.45)"/>
+    <text x="638" y="72" text-anchor="middle" class="fn" style="fill:#f87171">1411~1460</text>
+    <text x="638" y="90" text-anchor="middle" class="fd">段被静默丢弃</text>
+
+    <line x1="184" y1="78" x2="220" y2="78" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#m3Arr)"/>
+    <line x1="360" y1="78" x2="396" y2="78" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#m3Arr)"/>
+    <line x1="546" y1="78" x2="582" y2="78" stroke="#f87171" stroke-width="1.5" marker-end="url(#m3ArrR)"/>
+    <text x="566" y="124" text-anchor="middle" class="fl">超出 1450 → 吞</text>
+
+    <rect x="220" y="170" width="150" height="54" rx="10" fill="rgba(52,211,153,.07)" stroke="rgba(52,211,153,.45)"/>
+    <text x="295" y="192" text-anchor="middle" class="fn" style="fill:#34d399">修复：guest MTU 1450</text>
+    <text x="295" y="209" text-anchor="middle" class="fd">MSS 1410 ≤ 1410 上限</text>
+    <rect x="412" y="170" width="150" height="54" rx="10" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.5)"/>
+    <text x="487" y="192" text-anchor="middle" class="fn" style="fill:#34d399">数据面正常转发</text>
+    <text x="487" y="209" text-anchor="middle" class="fd">不再有段被吞</text>
+    <line x1="370" y1="120" x2="370" y2="170" stroke="#34d399" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#m3Arr)"/>
+    <line x1="412" y1="197" x2="482" y2="197" stroke="#34d399" stroke-width="1.5" marker-end="url(#m3Arr)"/>
+  </svg>
+  <div class="flow-cap">上排是问题链路：guest 通告 MSS 1460，超过 Pod 数据面 1410 的上限；下排是修复：guest MTU 对齐 1450，MSS 1410 恰好不越界。</div>
+
+  <h2>四、第一层修复：让 guest 的 MTU 对齐 Pod 网络</h2>
+
+  <p>修法很直白——把沙箱的 MTU 从 1500 改成 1450。难的是"改哪里"。首先要让宿主侧的 tap 设备用 1450，这由 Helm 配置链控制：</p>
+  <div class="codeblock"># values.yaml 新增参数（默认 0 = 用打包默认值）
+cubeNode:
+  network:
+    mtu: 1450</div>
+  <p>这个值经 <code>_helpers.tpl</code> 的 <code>cube.nodeComponentCommonEnv</code> 变成环境变量 <code>CUBE_SANDBOX_NETWORK_MTU</code>，再由 <code>cube-node-entrypoint.sh</code>（以及单组件部署的 <code>component-entrypoint.sh</code>）在启动时用 <code>sed</code> 把 Cubelet <code>config.toml</code> 里的 <code>mvm_mtu</code> 打补丁——并做了整型校验防止注入：</p>
+  <div class="codeblock">if [[ -n "${CUBE_SANDBOX_NETWORK_MTU:-}" && "${CUBE_SANDBOX_NETWORK_MTU}" != "0" ]]; then
+  [[ "${CUBE_SANDBOX_NETWORK_MTU}" =~ ^[0-9]+$ ]] || fail "CUBE_SANDBOX_NETWORK_MTU must be a non-negative integer"
+  sed -i "s/mvm_mtu = [0-9]\+/mvm_mtu = ${CUBE_SANDBOX_NETWORK_MTU}/" "${CUBELET_CONFIG}"
+fi</div>
+  <p>改完发现：宿主机侧全部对了——<code>cube-dev</code>、<code>z172.16.x.y</code> 的 MTU 都是 1450，network-agent 传给 Cubelet 的 <code>Interface.MTU=1450</code> 也没错。<span class="hlb">但 guest 里的 eth0 依然是 1500。</span>信息在"进入虚拟机"这一步断了——而这正是背景速览里拼图三说的：guest MTU 由宿主机通过 virtio-net 传进去，现在没人传。</p>
+
+  <h2>五、第二层修复：CubeShim 透传 MTU 到虚拟机</h2>
+
+  <p>链路是：Cubelet 把接口信息（含 MTU）发给 CubeShim，CubeShim 构造 <code>NetConfig</code> 交给 VMM（hypervisor），VMM 再通过 virtio-net 的 <code>VIRTIO_NET_F_MTU</code> 通知 guest。查源码发现，CubeShim 的 <code>add_nets</code> 构造 <code>NetConfig</code> 时根本没拷贝 MTU 字段：</p>
+  <div class="codeblock">// CubeShim/shim/src/hypervisor/config.rs — 修复前
+let mut nc: NetConfig = NetConfig {
+    id: Some(...), tap: n.name.clone(), ..Default::default()
+};
+// nc.mtu 从未被赋值 → None</div>
+  <p>修复是在两处把 MTU 显式传下去，并利用 VIRTIO_NET_F_MTU 让 guest 内核应用通告值：</p>
+  <div class="codeblock">// 修复后：add_nets（新创建路径）
+if n.mtu &gt; 0 {
+    nc.mtu = Some(n.mtu as u16);   <span class="cm">// VIRTIO_NET_F_MTU 让 guest 应用该 MTU</span>
+}
+// 修复后：restore_nets_config（快照恢复路径，CubeShim/shim/src/common/utils.rs）
+if n.mtu &gt; 0 {
+    net_config.mtu = Some(n.mtu as u16);
+}</div>
+  <p>还有第三处：<code>hypervisor/vmm/src/config.rs</code> 的 <code>update_nets</code>。它负责在 VM 状态更新（快照恢复）时把新的网络配置合并进 VM 的 <code>NetConfig</code>，但原来只复制了 <code>tap</code> 和 <code>rate_limiter_config</code>，把 MTU 丢了。这次一并补上：</p>
+  <div class="codeblock">// update_nets 修复：新增 mtu_map，恢复时按网卡 id 回填 MTU
+let mut mtu_map: HashMap&lt;String, Option&lt;u16&gt;&gt; = HashMap::default();
+// ...遍历 net_cfgs 收集 mtu ...
+for net in nets.iter_mut() {
+    if let Some(mtu) = mtu_map.get(&amp;id.clone()) { net.mtu = *mtu; }
+}</div>
+  <p>这里"快照恢复路径"为什么要单独修？因为沙箱大多从模板快照恢复，恢复时走的是 <code>update_nets</code> 合并配置——如果它丢 MTU，恢复出来的 guest 还是 1500。三条路径（新建 + 快照恢复 + 恢复合并）都得补，缺一条都会让 guest MTU 回到 1500。</p>
+
+  <h2>六、第三层：在 64_host 编译并替换 shim 二进制</h2>
+
+  <p>改动在源码，生效得重新编译。64_host 上先装齐工具链：</p>
+  <div class="codeblock">apt-get install -y build-essential libseccomp-dev libcap-ng-dev
+<span class="cm"># 首次编译曾报：error: linking with 'cc' failed: cannot find -lseccomp / -lcap-ng</span></div>
+  <div class="codeblock">cd /opt/cube-build/CubeShim
+cargo build --release
+<span class="cm"># 产出 target/release/{containerd-shim-cube-rs, cube-runtime}</span></div>
+  <p>然后替换节点上的二进制并重启 cubelet 使其加载新 shim：</p>
+  <div class="codeblock">cp -f /opt/cube-build/CubeShim/target/release/{containerd-shim-cube-rs,cube-runtime} \
+      /usr/local/services/cubetoolbox/cube-shim/bin/
+kubectl -n cube-system rollout restart ds/cube-node</div>
+
+  <h2>七、第四层（关键）：为什么模板必须重建</h2>
+
+  <p>代码改了、shim 换了，可新沙箱的 eth0 还是 1500。原因在模板创建机制：模板创建流程会先起一个"build 沙箱"跑构建，然后把它的磁盘 + 内存做成快照（AppSnapshot）。如果 build 沙箱是<strong>从旧模板的快照恢复</strong>的，那么 guest 启动走的是"快照恢复"路径——而这条路径的 MTU 透传正是我们刚在 <code>update_nets</code> 里修的那一环，旧二进制没有这个修复。</p>
+  <p>于是修复后的正确做法是：<span class="hl">重新建一个模板（不带 <code>--node</code> 让 CubeMaster 自动选健康节点），保证 build 沙箱冷启动，让新 shim 的 MTU 透传完整走一遍</span>。重建后验证：</p>
+  <div class="codeblock">$ ip link show eth0        <span class="cm"># mtu 1450 ✓</span>
+$ curl -k https://www.baidu.com   <span class="cm"># 200，TLS 握手正常 ✓</span>
+$ curl -O http://.../1MB.zip       <span class="cm"># 完整下载 ✓</span></div>
+
+  <h2>八、权衡：为什么"黑洞"如此难查</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>常见排查手段</th><th>为何失效</th></tr></thead>
+      <tbody>
+        <tr><td>ping / TCP connect</td><td>小包都能过，黑洞只吞 1411~1460 的大段</td></tr>
+        <tr><td>看各段 MTU</td><td>每一段看起来都"正常"（1500/1450 都是合法值），差异藏在跨段处</td></tr>
+        <tr><td>路由跟踪</td><td>黑洞不产生 ICMP，无从报告</td></tr>
+        <tr><td>tcpdump 抓包</td><td>能看到 SACK 重传、部分段到达——需要很强的前后对照才能定位</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>而修复本身也是三层：配置层（helm mtu 参数）解决"告诉宿主机用多少"，CubeShim/VMM 层解决"把 MTU 传进 guest"，模板层解决"让 build 沙箱冷启动走新代码"。<span class="hl">任何一层缺失，guest 的 MTU 都还是 1500。</span></p>
+
+  <div class="punchline">
+    <small>一句话带走</small>
+    MTU 黑洞的根因是 guest 通告 MSS 1460 而数据面只承载 1410；修复要贯穿三层——Helm 配置 mvm_mtu、CubeShim 的 add_nets / restore_nets_config / update_nets 透传 MTU（VIRTIO_NET_F_MTU）、重建模板让 build 沙箱冷启动走新代码。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>新建路径透传 MTU</td><td><code>CubeShim/shim/src/hypervisor/config.rs</code>（<code>add_nets</code>）</td></tr>
+        <tr><td>快照恢复路径透传 MTU</td><td><code>CubeShim/shim/src/common/utils.rs</code>（<code>restore_nets_config</code>）</td></tr>
+        <tr><td>VM 网络更新合并 MTU</td><td><code>hypervisor/vmm/src/config.rs</code>（<code>update_nets</code>）</td></tr>
+        <tr><td>helm 新增 MTU 参数</td><td><code>deploy/kubernetes/chart/values.yaml</code> + <code>templates/_helpers.tpl</code></td></tr>
+        <tr><td>启动时 patch mvm_mtu</td><td><code>deploy/kubernetes/images/scripts/cube-node-entrypoint.sh</code> / <code>component-entrypoint.sh</code></td></tr>
+        <tr><td>tap MTU 来源</td><td><code>network-agent/internal/service/tap_lifecycle.go</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>部署排障 03/05 · 下一篇：沙箱自己睡了，却没人能把它叫醒——auto_resume 504 之谜</footer>
+</body>
+</html>

--- a/cubesandbox-tech/deploy-troubleshoot/sandbox-dns.html
+++ b/cubesandbox-tech/deploy-troubleshoot/sandbox-dns.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>02 · 沙箱里 DNS 全挂了——一次"安全默认值"引发的公网断连</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--blue),var(--purple));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--amber));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 部署排障</div>
+    <a class="back-home" href="index.html">← 排障索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 部署排障 02 / 05</div>
+    <h1>沙箱里 DNS 全挂了——一次"安全默认值"引发的公网断连</h1>
+    <p class="lead">上一篇修通了命令执行，下一个测试是公网访问。`curl http://www.baidu.com` 通了，可 `getent hosts www.baidu.com` 直接失败——沙箱连域名都解析不了，又何谈访问。看起来再普通不过的 DNS 问题，背后是一个"安全默认值"和一张你完全看不见的 eBPF 拒绝表。</p>
+  </div>
+
+  <h2>一、背景速览：沙箱不是 Pod，它的网走另一条路</h2>
+
+  <p>如果你熟悉 Kubernetes，会习惯性认为"容器里 DNS 配 CoreDNS 天经地义"。但 CubeSandbox 的沙箱<span class="hl">不是 K8s Pod</span>——它是一台 PVM 虚拟机，它的网络不经过 CNI，而是走一条由 <span class="hl">CubeNet（CubeVS）eBPF 数据面</span>控制的独立通路。</p>
+  <p>这条通路大致是这样：</p>
+  <div class="codeblock">沙箱内应用
+  └─ 虚拟网卡 eth0（virtio-net）
+     └─ 宿主 tap 设备（如 cube-dev / z172.16.x.y）
+        └─ eBPF 数据面（CubeVS）
+           ├─ 出向：SNAT + 网络策略检查（允许/拒绝/限流）
+           └─ 入向：反向 NAT + 端口映射</div>
+  <p>所有沙箱的出向流量都必须经过 eBPF 里的<span class="hl">策略引擎</span>。策略引擎里有"允许出网段"的名单，也有一张"永远拒绝"的名单。下一节我们看的就是后者。</p>
+
+  <h2>二、问题：域名解析失败，但"看起来一切正常"</h2>
+
+  <p>沙箱里执行：</p>
+  <div class="codeblock">$ cat /etc/resolv.conf
+nameserver 10.50.0.10        <span class="cm"># 集群 CoreDNS 的 ClusterIP</span>
+$ getent hosts www.baidu.com
+<span class="cm"># 无输出，exit code 非 0 —— 解析失败</span></div>
+  <p>把 <code>10.50.0.10</code> 换到宿主机（或宿主 Pod）里的 DNS，同一个域名秒回。也就是说：<span class="hlb">不是 DNS 服务器挂了，是沙箱到 DNS 服务器这条路不通。</span></p>
+  <p>这引出一个先要回答的问题：<span class="hl">沙箱的 resolv.conf 是谁写的？为什么是 10.50.0.10？</span></p>
+
+  <h2>三、机制之一：沙箱的 resolv.conf 是谁写的</h2>
+
+  <p>Cubelet（节点代理）在创建沙箱时，由 <code>netfile.go</code> 的 <code>CreateNetfiles</code> 生成容器的网络文件（resolv.conf / hosts 等）。DNS 服务器的选择走 <code>ResolveEffectiveDNSServers</code>，生效顺序是：</p>
+  <div class="codeblock">① 请求里显式的 dns_config.servers   <span class="cm"># 最优先</span>
+② 配置里的 default_dns_servers        <span class="cm"># 兜底</span></div>
+  <p>K8s 部署默认把沙箱 DNS 设为"跟随节点"（<code>followNodeDns: true</code>），于是 resolv.conf 里就写进了节点所在集群的 CoreDNS ClusterIP <code>10.50.0.10</code>。这一步在 K8s 里很正常——<span class="hlb">问题出在"沙箱不是 Pod"：它到 CoreDNS 的路，被自己的策略引擎堵死了。</span></p>
+
+  <h2>四、机制之二：数据面的"默认拒绝私网"</h2>
+
+  <p>回到 eBPF 策略引擎。出向策略里有一张<span class="hl">硬编码、永远拒绝</span>的私网段表，写在 <code>CubeNet/cubevs/netpolicy.go</code>：</p>
+  <div class="codeblock">var alwaysDeniedSandboxCIDRs = []string{
+    "10.0.0.0/8",
+    "127.0.0.0/8",
+    "169.254.0.0/16",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+}</div>
+  <p>这是一条<span class="hl">安全默认值</span>：沙箱默认不许访问任何私网地址，防止一台被入侵的沙箱横向扫描集群内部机器。但它有个致命副作用——<span class="hlb">集群 CoreDNS 的 ClusterIP 10.50.0.10 恰好落在 <code>10.0.0.0/8</code> 里。</span>沙箱发往 <code>10.50.0.10:53</code> 的 DNS 查询 UDP 包，在数据面被静默丢弃，DNS 请求石沉大海。</p>
+
+  <div class="think">
+    <div class="q">这个安全默认值能被绕过吗？</div>
+    不该绕，也不需要绕。正确做法是别让沙箱依赖集群内部 DNS——给沙箱配公网 DNS（8.8.8.8 / 223.5.5.5），公网地址不在拒绝表里，查询正常放行。
+  </div>
+
+  <svg class="flow" viewBox="0 0 720 252" role="img" aria-label="沙箱DNS查询路径与修复">
+    <defs>
+      <marker id="d2Arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#4f8cff"/></marker>
+      <marker id="d2ArrR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#f87171"/></marker>
+      <marker id="d2ArrG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="252" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">沙箱 DNS 查询 · 上：指向 CoreDNS 被拒；下：指向公网 DNS 放行</text>
+
+    <rect x="26" y="48" width="140" height="56" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="96" y="72" text-anchor="middle" class="fn">沙箱内 getent</text>
+    <text x="96" y="90" text-anchor="middle" class="fd">nameserver 10.50.0.10</text>
+
+    <rect x="206" y="48" width="150" height="56" rx="10" fill="rgba(248,113,113,.08)" stroke="rgba(248,113,113,.5)"/>
+    <text x="281" y="72" text-anchor="middle" class="fn" style="fill:#f87171">eBPF 策略</text>
+    <text x="281" y="90" text-anchor="middle" class="fd">10.0.0.0/8 → 拒绝</text>
+
+    <rect x="396" y="48" width="150" height="56" rx="10" fill="rgba(248,113,113,.07)" stroke="rgba(248,113,113,.45)"/>
+    <text x="471" y="72" text-anchor="middle" class="fn" style="fill:#f87171">CoreDNS 10.50.0.10</text>
+    <text x="471" y="90" text-anchor="middle" class="fd">查询到不了</text>
+
+    <line x1="166" y1="76" x2="206" y2="76" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#d2Arr)"/>
+    <line x1="356" y1="76" x2="396" y2="76" stroke="#f87171" stroke-width="1.5" marker-end="url(#d2ArrR)"/>
+    <text x="376" y="124" text-anchor="middle" class="fl">UDP:53 被丢</text>
+
+    <rect x="26" y="180" width="140" height="56" rx="10" fill="rgba(52,211,153,.07)" stroke="rgba(52,211,153,.45)"/>
+    <text x="96" y="204" text-anchor="middle" class="fn" style="fill:#34d399">沙箱内 getent</text>
+    <text x="96" y="222" text-anchor="middle" class="fd">nameserver 8.8.8.8</text>
+    <rect x="206" y="180" width="150" height="56" rx="10" fill="rgba(52,211,153,.07)" stroke="rgba(52,211,153,.45)"/>
+    <text x="281" y="204" text-anchor="middle" class="fn" style="fill:#34d399">eBPF 策略</text>
+    <text x="281" y="222" text-anchor="middle" class="fd">公网 → 放行</text>
+    <rect x="396" y="180" width="150" height="56" rx="10" fill="rgba(52,211,153,.08)" stroke="rgba(52,211,153,.5)"/>
+    <text x="471" y="204" text-anchor="middle" class="fn" style="fill:#34d399">8.8.8.8</text>
+    <text x="471" y="222" text-anchor="middle" class="fd">可达</text>
+    <line x1="96" y1="104" x2="96" y2="180" stroke="#34d399" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#d2ArrG)"/>
+    <line x1="166" y1="208" x2="206" y2="208" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#d2Arr)"/>
+    <line x1="356" y1="208" x2="396" y2="208" stroke="#34d399" stroke-width="1.5" marker-end="url(#d2ArrG)"/>
+    <text x="128" y="150" class="fl">修复：DNS 指向公网</text>
+  </svg>
+  <div class="flow-cap">同一张 eBPF 策略：私网目标被 alwaysDeniedSandboxCIDRs 拒掉，公网目标放行。修复的核心是"让沙箱的 DNS 指向公网"。</div>
+
+  <h2>五、机制之三：为什么改了配置却不生效</h2>
+
+  <p>第一反应自然是去改部署参数，在 <code>runtime-values.yaml</code> 里把沙箱 DNS 指到公网：</p>
+  <div class="codeblock">cubeNode:
+  dns:
+    sandbox:
+      followNodeDns: false
+      nameservers:
+        - 8.8.8.8
+        - 223.5.5.5</div>
+  <p>这个配置确实生效了：Cubelet 的 <code>dynamicconf/conf.yaml</code> 里 <code>default_dns_servers</code> 被更新。但沙箱里的 resolv.conf 依旧是 10.50.0.10。原因藏在一个开关里——<code>disable_host_netfile: true</code>。</p>
+  <p>在 <code>netfile_plugin.go</code> 里，<code>Create</code> 流程是：先 <code>cnfs.CreateNetfiles(...)</code> 生成 DNS 内容，再根据 <code>!DisableHostNetfile</code> 决定要不要 <code>WriteToHost</code>（把 resolv.conf 写进宿主侧、再挂进沙箱）。K8s 部署默认关闭了 host netfile 写入，于是 <span class="hlb">沙箱 guest 里的 resolv.conf 是模板 rootfs 里烘焙的静态文件</span>，不随 Cubelet 配置动态更新。<span class="hl">改了 cubelet 配置，对已经建好的模板无效。</span></p>
+
+  <h2>六、修复：DNS 烘焙进模板</h2>
+
+  <p>正解是把公网 DNS 直接写进模板 rootfs。模板创建命令支持 <code>--dns</code> 参数（可重复），它会把 DNS 写入容器 rootfs 的 resolv.conf：</p>
+  <div class="codeblock">cubemastercli template create-from-image --image &lt;image&gt; \
+  --expose-port 49983 --writable-layer-size 20Gi \
+  --dns 8.8.8.8 --dns 223.5.5.5</div>
+  <p>重建模板后，新沙箱的 <code>/etc/resolv.conf</code> 指向公网 DNS，域名解析立即恢复。</p>
+
+  <h2>七、权衡：安全默认值与"内网可达"的取舍</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>方案</th><th>优点</th><th>代价</th></tr></thead>
+      <tbody>
+        <tr><td>沙箱 DNS = 集群 CoreDNS</td><td>内网域名开箱即用</td><td>被 alwaysDeniedSandboxCIDRs 拒绝，外网解析全挂</td></tr>
+        <tr><td>沙箱 DNS = 公网 DNS（本次选择）</td><td>外网解析正常，符合"沙箱访问公网"场景</td><td>集群内私网域名需另行配置放行，否则被拒</td></tr>
+        <tr><td>运行时注入（Cubelet 动态写 netfile）</td><td>配置热生效、模板解耦</td><td>依赖 <code>disable_host_netfile: false</code>，K8s 部署默认关闭</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>这次排障最大的收获是一个心智校正：<span class="hl">K8s Pod 的"标准答案"（DNS 指向 CoreDNS）在 CubeSandbox 沙箱里不成立</span>——沙箱出向流量走的是 CubeNet eBPF 数据面，它默认拒绝私网段，而 CoreDNS 恰好在那张表里。安全默认值没错，错的是默认组合不适用于"沙箱访问公网"的场景。</p>
+
+  <div class="punchline">
+    <small>一句话带走</small>
+    沙箱 DNS 不能照抄 K8s Pod 的"指 CoreDNS"——CubeNet 数据面的 alwaysDeniedSandboxCIDRs 默认拒绝 10/8 等私网段，CoreDNS 正在其中；而且模板 rootfs 里的 resolv.conf 是静态的，要把公网 DNS 用 <code>--dns</code> 烘焙进模板才生效。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>默认拒绝的私网段</td><td><code>CubeNet/cubevs/netpolicy.go</code>（<code>alwaysDeniedSandboxCIDRs</code>）</td></tr>
+        <tr><td>DNS 生效顺序（请求 &gt; 默认配置）</td><td><code>Cubelet/pkg/container/netfile/netfile.go</code></td></tr>
+        <tr><td>host netfile 开关分支</td><td><code>Cubelet/plugins/cube/internals/netfile/netfile_plugin.go</code></td></tr>
+        <tr><td>K8s 沙箱 DNS 默认值</td><td><code>deploy/kubernetes/chart/values.yaml</code>（<code>cubeNode.dns.sandbox</code>）</td></tr>
+        <tr><td>模板 --dns 参数</td><td><code>CubeMaster/cmd/cubemastercli/commands/cubebox/template.go</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>部署排障 02/05 · 下一篇：HTTP 通、HTTPS 超时、大文件截断——一次 MTU 黑洞的完整修复</footer>
+</body>
+</html>

--- a/cubesandbox-tech/guest-agent.html
+++ b/cubesandbox-tech/guest-agent.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>guest agent 沙箱内运行时 · VM 里的"内应"</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--purple),var(--blue));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--purple));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 技术深入</div>
+    <a class="back-home" href="index.html">← 技术索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 核心技术 06 / 09</div>
+    <h1>VM 里的"内应"</h1>
+    <p class="lead">上一篇我们站在宿主侧看了虚拟化链路。这篇翻到墙的另一边：沙箱是一台真虚拟机，但用户要的是"容器体验"——VM 里得有人负责把宿主传来的命令翻译成真实的进程操作。这个人就是 guest agent：一个烧录进沙箱镜像、以 PID 1 身份运行的 Rust 程序。</p>
+  </div>
+
+  <h2>一、问题：VM 隔离了，但里面还得跑容器</h2>
+
+  <p>把沙箱做成 VM 有巨大的隔离收益——宿主的 CPU 漏洞、内核 bug 都无法波及 guest。但它带来一个尴尬：用户在沙箱里跑的不是虚拟机，而是容器。他们调用 <code>sandbox.files.write()</code>、<code>sandbox.commands.run()</code>，期望拿到的是"在一个 Linux 环境里操作进程"的体验。</p>
+  <p>于是需要一个"翻译层"：宿主侧传来"创建容器"，guest 里得有人真的 fork 进程、建命名空间、挂文件系统；宿主侧要读容器的 stdout，guest 里得有人把管道里的字节传出去。这个角色不能由宿主直接做——它活在 VM 里，是唯一能把"容器命令"翻译成"guest 内进程操作"的通道。<span class="hl">这就是 guest agent。</span></p>
+  <p>它与宿主的通信通道是 vsock（虚拟机专用的套接字，不经网络栈），协议是 ttRPC（一种 thrift 风格的轻量 RPC）。宿主侧的 CubeShim 就是通过它指挥整个 VM 内部的。</p>
+
+  <svg class="flow" viewBox="0 0 720 210" role="img" aria-label="宿主与 guest 的通信链路">
+    <defs>
+      <marker id="gaArr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#a78bfa"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="210" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">宿主 ↔ guest · 唯一的命令通道，把"容器操作"翻译成"进程操作"</text>
+
+    <text x="139" y="46" text-anchor="middle" class="fm">宿主 HOST</text>
+    <rect x="14" y="54" width="250" height="116" rx="12" fill="rgba(167,139,250,.06)" stroke="rgba(167,139,250,.4)"/>
+    <text x="139" y="92" text-anchor="middle" class="fn">CubeShim 进程</text>
+    <text x="139" y="112" text-anchor="middle" class="fd">Task 服务 · VMM 线程</text>
+    <text x="139" y="130" text-anchor="middle" class="fd">每个沙箱一个</text>
+    <text x="139" y="152" text-anchor="middle" class="fm">exec / stdio / pause / resume</text>
+
+    <line x1="264" y1="112" x2="456" y2="112" stroke="#a78bfa" stroke-width="1.5" marker-start="url(#gaArr)" marker-end="url(#gaArr)"/>
+    <text x="360" y="96" text-anchor="middle" class="fm">vsock · ttRPC</text>
+    <text x="360" y="134" text-anchor="middle" class="fl">0x680 端口握手 · cid=-1</text>
+
+    <text x="581" y="46" text-anchor="middle" class="fm">沙箱 VM（guest 内）</text>
+    <rect x="456" y="54" width="250" height="116" rx="12" fill="rgba(167,139,250,.06)" stroke="rgba(167,139,250,.4)"/>
+    <rect x="470" y="66" width="222" height="50" rx="9" fill="rgba(167,139,250,.1)" stroke="rgba(167,139,250,.55)"/>
+    <text x="581" y="88" text-anchor="middle" class="fn">cube-agent（PID 1）</text>
+    <text x="581" y="106" text-anchor="middle" class="fd">AgentService · HealthService</text>
+    <line x1="581" y1="116" x2="581" y2="126" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#gaArr)"/>
+    <rect x="470" y="126" width="222" height="40" rx="9" fill="rgba(167,139,250,.06)" stroke="rgba(167,139,250,.4)"/>
+    <text x="581" y="143" text-anchor="middle" class="fn">rustjail 容器</text>
+    <text x="581" y="159" text-anchor="middle" class="fd">fork + 命名空间 + OCI bundle</text>
+  </svg>
+
+  <h2>二、机制：启动——它是 VM 的 PID 1</h2>
+
+  <p>agent 被烧录进沙箱镜像，以 PID 1 启动。作为 init 进程，它先做系统级初始化，再把自己变成"服务进程"：</p>
+  <div class="codeblock">main() → real_main():
+① 日志管道（logger 任务）
+② init_mode = (getpid()==1)：
+     general_mount（基础挂载）、enable_rc_local、init_agent_as_init（挂 cgroup、设 hostname）
+③ start_sandbox(logger, config, init_mode):
+     ├─ Sandbox::new(logger)               // 建立共享 UTS/IPC 命名空间等
+     ├─ rpc::start(sandbox, vsock://-1:1024) // 注册并启动 ttRPC 服务
+     └─ 信号/uevent handler → 等待 shutdown
+④ shutdown 后 reboot VM</div>
+  <p>两种模式的分工很干净：PID 1 模式负责系统级初始化（挂载、cgroup、hostname）；非 init 模式（比如作为普通进程调试运行时）只启动 RPC 服务。监听地址 <code>vsock://-1:1024</code> 里的 cid=-1 表示"接受任意来源"，宿主的 CubeShim 随时可以连进来。</p>
+
+  <h2>三、机制：ttRPC 服务面——它的"能力清单"</h2>
+
+  <p>agent 对外暴露两个服务：AgentService（一切容器操作）和 HealthService。RPC 定义在 <code>libs/protocols/protos/agent.proto</code>。按能力分组看：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>能力分组</th><th>RPC</th></tr></thead>
+      <tbody>
+        <tr><td>沙箱生命周期</td><td>CreateSandbox / DestroySandbox</td></tr>
+        <tr><td>容器生命周期</td><td>CreateContainer / StartContainer / RemoveContainer</td></tr>
+        <tr><td>进程执行</td><td>ExecProcess / SignalProcess / WaitProcess</td></tr>
+        <tr><td>标准 IO</td><td>WriteStdin / ReadStdout / ReadStderr / CloseStdin / TtyWinResize</td></tr>
+        <tr><td>网络</td><td>UpdateInterface / UpdateRoutes / ListInterfaces / ListRoutes / AddARPNeighbors / Get-SetIPTables</td></tr>
+        <tr><td>运维</td><td>GetOOMEvent / OnlineCPUMem / MemHotplugByProbe / SetGuestDateTime / ReseedRandomDev / CopyFile / AddSwap / GetVolumeStats / ResizeVolume</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>注意一个细节：<span class="hl">这套 RPC 把"宿主发起"和"guest 执行"完全对齐</span>——宿主说"写 stdin"，agent 就真的往容器的 stdin 管道写字节；宿主说"调整窗口尺寸"，agent 就 ioctl 终端。所有容器的 I/O 都是宿主代理转发，agent 是另一端。这也是为什么上一篇文章里暂停时要先 disconnect_agent：连接一断，I/O 转发就停了，进程还在，只是没人替它说话。</p>
+  <p>create_container 的内部处理链也值得一瞥：先 add_devices 把宿主给的设备逐个挂进 guest（virtio-blk / mmio-blk / nvdimm / scsi / vfio，带冲突检测），再把宿主 PCI 地址映射注入容器环境变量；然后 add_storages 按 Storage.driver 分派到 blk/virtiofs/ephemeral/overlayfs 各 handler；接着 update_container_namespaces、setup_bundle 准备 OCI bundle；最后 <code>LinuxContainer::new → Process::new → start</code>。</p>
+
+  <h2>四、机制：就绪通知——一个"笨但可靠"的硬件握手</h2>
+
+  <p>有个绕不开的问题：宿主怎么知道"agent 已经能接请求了"？轮询 vsock 可不可行？可行，但慢、且有竞态——你得反复尝试连接，还可能误判"还没就绪"和"已崩溃"。CubeSandbox 的选择是<span class="hlb">硬件级握手</span>：agent 就绪后，写一个 I/O 端口，VMM 截获这个写动作，通知宿主。</p>
+  <div class="codeblock">// x86_64：写 I/O port 0x680，数据 0x8
+let port: u16 = 0x680;
+let data: u8 = 0x8;
+libc::ioperm(port as u64, 5, 1);            // 打开端口访问权限
+x86_64::instructions::port::Port::new(port).write(data);
+
+// aarch64：mmap /dev/mem 0x0903_0000 写 1<<3（SYS_VSOCK_SERVER）
+const SYS_CTRL_MMIO_ADDR: libc::off_t = 0x0903_0000;
+const SYS_VSOCK_SERVER: u8 = 1 << 3;</div>
+  <p>I/O port 0x680 由 VMM 的 vsock/虚拟设备模块截获——agent 一写，宿主立刻知道"vsock server 就绪了"，随后建立 ttRPC 连接。相比轮询，硬件通知<b>更快、无竞态、不依赖网络栈</b>。这是那种"用一点点硬件知识换掉一大块状态机逻辑"的设计，很符合这个项目一贯的审美。</p>
+
+  <h2>五、机制：沙箱模型——用共享命名空间实现 Pod 语义</h2>
+
+  <p>一个沙箱里可以有多个容器（K8s Pod 语义：它们共享网络、共享进程树、共享 hostname）。agent 的 <code>Sandbox</code> 结构体负责建立这套共享基础：</p>
+  <div class="codeblock">pub struct Sandbox {
+    shared_utsns: Namespace,          // 共享 UTS（hostname）
+    shared_ipcns: Namespace,          // 共享 IPC
+    sandbox_pidns: Option<Namespace>, // 可选的共享 PID 命名空间
+    containers: HashMap<String, LinuxContainer>,
+    network: Network,
+    event_tx: Option<BroadcastSender<String>>,  // OOM 等事件广播
+    sender: oneshot::Sender<i32>,                // 触发 VM 关机的通道
+    pcimap: ...,                                 // 宿主 PCI → guest PCI 映射表
+}</div>
+  <p><code>setup_shared_namespaces</code>：若沙箱未指定独立 PID 命名空间，就把首个容器的 PID ns 作为共享 PID 命名空间——所有容器"看到同一个进程树"。IPC/UTS 命名空间始终共享。这就是 Pod 语义：容器们是"同一个屋子里的室友"，而不是各自独立的房间。</p>
+  <p>OOM 处理走事件广播：cgroup manager 收到 OOM 事件后，通过 <code>event_tx</code>（BroadcastSender）广播给所有 <code>GetOOMEvent</code> 订阅者——宿主 CubeShim 的 watch_oom 正是这样拿到 OOM 并转成 TaskOOM 事件上抛的。</p>
+  <p>网络也由 agent 直接管：guest 内没有 NetworkManager，agent 通过 netlink 直接配置接口与路由，写临时 resolv.conf 后 bind-mount 到 /etc/resolv.conf。这样沙箱内看到的网络与宿主 TAP 的 IP/路由严格一致，不依赖 systemd-networkd。</p>
+
+  <h2>六、机制：rustjail——VM 内的 OCI 容器运行时</h2>
+
+  <p>容器进程本身由 rustjail 管理——一个 Rust 版的 runc（OCI runtime）。它的启动模型是经典的 fork-exec：</p>
+  <div class="codeblock">LinuxContainer::new(spec)  → 解析 OCI spec
+  → init_child()：子进程入口
+      ├─ 读父进程环境变量（配置传递）
+      ├─ join / create 命名空间
+      └─ execvp 容器 init 进程（OCI 标准启动）
+  → start(&mut self, p): FIFO 建立、I/O 与日志 pipe、join ns、execvp、更新进程表</div>
+  <p>进程模型：每容器一个 init 进程 + 若干 exec 进程，WaitProcess 轮询退出状态。I/O 经宿主转发（ttRPC 的 WriteStdin/ReadStdout），支持 TTY（TtyWinResize 同步窗口尺寸）。这里值得点一句的是：<span class="hl">这个"内应"要同时充当 init（系统守护）和容器运行时（进程管理），两者在一个进程里协调</span>——它既是"管家"又是"宿主的手"，责任很重，所以协议设计上力求薄而完整。</p>
+
+  <h2>七、机制：设备热插拔——宿主加盘，guest 自动感知</h2>
+
+  <p>沙箱创建后可以动态加磁盘/设备。链路是：宿主 <code>VmAddDevice</code> → VMM 为设备分配 PCI BDF 并注入 guest → agent 的 <code>add_device</code> 里各 handler <code>wait_for_pci_device</code>（轮询 sysfs 直到设备出现）→ <code>get_device_name_by_pci</code> 换算 host/guest PCI 地址 → 找到设备节点 → 挂载到容器指定路径。</p>
+  <p>为什么设备热插拔重要？应用快照/模板通常只有最小系统盘，用户运行时才按需挂数据盘。<span class="hl">能在不停机的情况下给运行中的沙箱加盘，是"模板 + 运行时扩展"模型的关键能力。</span>另外有个安全细节：<code>update_device_cgroup</code> 会把 VM 根分区设备加入 cgroup deny——防止容器访问 VM rootfs，这是防逃逸的一部分。</p>
+
+  <h2>八、收束</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>问题</th><th>设计</th><th>关键权衡</th></tr></thead>
+      <tbody>
+        <tr><td>VM 隔离后谁在内部执行命令</td><td>agent 以 PID 1 常驻，vsock ttRPC 通信</td><td>薄而完整的协议面</td></tr>
+        <tr><td>宿主怎么知道 agent 就绪</td><td>I/O port 0x680 硬件握手</td><td>无轮询、无竞态、不依赖网络栈</td></tr>
+        <tr><td>多容器共享进程树</td><td>共享 UTS/IPC/PID 命名空间</td><td>Pod 语义，容器是室友</td></tr>
+        <tr><td>容器进程由谁管理</td><td>rustjail（Rust 版 runc）</td><td>与 OCI 生态兼容</td></tr>
+        <tr><td>运行中加盘</td><td>PCI 热插拔 + sysfs 轮询发现</td><td>模板最小化 + 运行时扩展</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="punchline">
+    <small>一句话带走</small>
+    guest agent 是 VM 内的"内应运行时"：通过 vsock ttRPC 承接宿主控制面（沙箱/容器/设备/网络/进程/IO），以 rustjail 实现 OCI 容器，用共享命名空间实现 Pod 语义，硬件 I/O 端口做就绪握手——它是"容器体验 + VM 隔离"之间唯一的翻译层。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>启动入口</td><td><code>agent/src/main.rs</code></td></tr>
+        <tr><td>ttRPC 服务与就绪通知</td><td><code>agent/src/rpc.rs</code>（0x680 ioport L1834+）</td></tr>
+        <tr><td>沙箱结构</td><td><code>agent/src/sandbox.rs</code></td></tr>
+        <tr><td>OCI 容器运行时</td><td><code>agent/rustjail/src/container.rs</code></td></tr>
+        <tr><td>RPC 协议定义</td><td><code>agent/libs/protocols/protos/agent.proto</code></td></tr>
+        <tr><td>网络 / 挂载 / 控制台</td><td><code>agent/src/{network,mount,console}.rs</code></td></tr>
+        <tr><td>设备与 PCI</td><td><code>agent/src/{device,pci}.rs</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>guest agent 沙箱内运行时 · CubeSandbox 技术深入 06/09 · 下一篇：CubeVS——几百个沙箱怎么共享一张网卡</footer>
+</body>
+</html>

--- a/cubesandbox-tech/index.html
+++ b/cubesandbox-tech/index.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CubeSandbox 核心技术深入解读</title>
+<style>
+  :root {
+    --bg: #0b1020;
+    --panel: rgba(255,255,255,0.04);
+    --panel-hover: rgba(255,255,255,0.07);
+    --border: rgba(255,255,255,0.09);
+    --border-strong: rgba(255,255,255,0.16);
+    --text: #e6eaf2;
+    --text-dim: #9aa7bd;
+    --text-faint: #6b7a93;
+    --blue: #4f8cff;
+    --cyan: #2dd4bf;
+    --purple: #a78bfa;
+    --amber: #fbbf24;
+    --red: #f87171;
+    --green: #34d399;
+    --mono: "SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans: -apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius: 14px;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: var(--sans); background: var(--bg); color: var(--text); line-height: 1.7; font-size: 15px; }
+  a { color: var(--blue); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { font-family: var(--mono); font-size: 0.88em; background: rgba(79,140,255,0.12); color: #b9d2ff; padding: 2px 7px; border-radius: 6px; white-space: nowrap; }
+
+  .hero {
+    text-align: center;
+    padding: 76px 24px 50px;
+    background:
+      radial-gradient(1000px 420px at 15% -10%, rgba(79,140,255,0.2), transparent 60%),
+      radial-gradient(1000px 420px at 85% -10%, rgba(167,139,250,0.18), transparent 60%),
+      radial-gradient(700px 300px at 50% 110%, rgba(45,212,191,0.1), transparent 60%);
+    border-bottom: 1px solid var(--border);
+  }
+  .hero .badge {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--cyan);
+    border: 1px solid rgba(45,212,191,0.4);
+    background: rgba(45,212,191,0.08);
+    padding: 4px 14px;
+    border-radius: 20px;
+    margin-bottom: 20px;
+    letter-spacing: 1px;
+  }
+  .hero h1 {
+    font-size: 42px;
+    font-weight: 900;
+    background: linear-gradient(90deg,#fff,var(--blue) 40%,var(--purple));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .hero p { color: var(--text-dim); font-size: 16.5px; margin-top: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+  .hero .back {
+    display: inline-block;
+    margin-top: 22px;
+    font-size: 13px;
+    color: var(--text-dim);
+    border: 1px solid var(--border);
+    padding: 6px 16px;
+    border-radius: 20px;
+    transition: all 0.15s;
+  }
+  .hero .back:hover { color: var(--text); border-color: var(--border-strong); text-decoration: none; }
+
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 56px 24px 90px; }
+  .section-title { font-size: 20px; font-weight: 800; margin: 48px 0 20px; padding-left: 12px; border-left: 3px solid var(--blue); }
+  .section-title:first-child { margin-top: 0; }
+
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 18px; }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 22px 22px 24px;
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.2s, border-color 0.2s, background 0.2s;
+  }
+  .card:hover { transform: translateY(-3px); border-color: var(--border-strong); background: var(--panel-hover); }
+  .card .num {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--blue);
+    background: rgba(79,140,255,0.14);
+    border: 1px solid rgba(79,140,255,0.3);
+    border-radius: 6px;
+    padding: 2px 8px;
+    align-self: flex-start;
+    margin-bottom: 12px;
+  }
+  .card h3 { font-size: 18px; margin-bottom: 6px; }
+  .card .tags { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 12px; }
+  .card p.desc { color: var(--text-dim); font-size: 13.5px; flex: 1; }
+  .card .features { color: var(--text-faint); font-size: 12.5px; margin-top: 14px; font-family: var(--mono); line-height: 2; }
+  .card .go {
+    margin-top: 16px;
+    font-size: 13.5px;
+    font-weight: 700;
+    color: var(--blue);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .card:hover .go { color: #8fb6ff; }
+  .tag {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 6px;
+    border: 1px solid var(--border-strong);
+    color: var(--text-dim);
+  }
+  .tag.go { color: #7ee7ff; border-color: rgba(126,231,255,0.4); background: rgba(126,231,255,0.08); }
+  .tag.rust { color: #ffab7e; border-color: rgba(255,171,126,0.4); background: rgba(255,171,126,0.08); }
+  .tag.lua { color: #a5f3a1; border-color: rgba(165,243,161,0.4); background: rgba(165,243,161,0.08); }
+  .tag.c { color: #ffd27e; border-color: rgba(255,210,126,0.4); background: rgba(255,210,126,0.08); }
+
+  .note {
+    border-left: 3px solid var(--amber);
+    background: rgba(251,191,36,0.07);
+    padding: 12px 18px;
+    border-radius: 0 10px 10px 0;
+    font-size: 13px;
+    color: var(--text-dim);
+    max-width: 720px;
+    margin: 26px auto 0;
+  }
+  .note strong { color: var(--text); }
+
+  .back-top {
+    position: fixed; right: 26px; bottom: 26px;
+    width: 44px; height: 44px; border-radius: 12px;
+    background: rgba(79,140,255,0.85); color: #fff; border: none;
+    cursor: pointer; font-size: 18px;
+    display: flex; align-items: center; justify-content: center;
+    opacity: 0; pointer-events: none; transition: opacity 0.25s;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.35);
+  }
+  .back-top.show { opacity: 1; pointer-events: auto; }
+  footer { border-top: 1px solid var(--border); padding: 34px 24px 50px; text-align: center; color: var(--text-faint); font-size: 12.5px; }
+  @media (max-width: 720px) { .hero h1 { font-size: 30px; } }
+</style>
+</head>
+<body>
+
+<div class="hero">
+  <div class="badge">CUBE SANDBOX · DEEP DIVE</div>
+  <h1>CubeSandbox 核心技术深入解读</h1>
+  <p>把"一个沙箱服务"拆解成 9 项核心技术，每篇独立成册。从真实问题讲起，循着设计演进慢慢展开——机制是什么、为什么这么设计、代价是什么，一路讲到源码层。</p>
+  <a class="back" href="../cubesandbox-logic.html">← 返回总览文档（cubesandbox-logic.html）</a>
+</div>
+
+<div class="wrap">
+
+  <div class="section-title">控制面 · 调度与编排</div>
+  <div class="grid">
+    <div class="card">
+      <span class="num">01</span>
+      <h3>CubeMaster 调度器</h3>
+      <div class="tags"><span class="tag go">Go</span><span class="tag">gin + errgroup</span></div>
+      <p class="desc">集群级调度器如何用"预选 → 并行 Filter → 加权打分 → 随机挑选"的流水线选出一个节点来承载新沙箱；以及按实例类型分桶的缓冲队列如何动态限流。</p>
+      <div class="features">scheduler.Select · runFilter · runScoreFilter<br>bufferTaskMap · monitorLimit · LeastRandomSelect</div>
+      <a class="go" href="scheduler.html">深入阅读 →</a>
+    </div>
+    <div class="card">
+      <span class="num">02</span>
+      <h3>生命周期管理（cube-lifecycle-manager）</h3>
+      <div class="tags"><span class="tag go">Go</span><span class="tag">Redis Stream</span></div>
+      <p class="desc">自动暂停/自动恢复的协调中枢：消费 Redis 事件流、扫描空闲沙箱、SETNX 状态锁保证单次执行、并发恢复请求合并为单次 RPC。</p>
+      <div class="features">sweeper.tryPause · resumer.Resume<br>XREADGROUP · proxypush · statesync</div>
+      <a class="go" href="lifecycle-manager.html">深入阅读 →</a>
+    </div>
+    <div class="card">
+      <span class="num">03</span>
+      <h3>Cubelet Workflow 引擎</h3>
+      <div class="tags"><span class="tag go">Go</span><span class="tag">containerd 插件</span></div>
+      <p class="desc">节点本地沙箱生命周期的流水线引擎：config.toml 声明式定义 Step/Action，errgroup 并行执行；与 containerd API、cgroup、CubeCoW 深度集成。</p>
+      <div class="features">workflow.Engine · parallelRunSteps<br>NewContainer · task.Pause/Resume · CubeBox 状态机</div>
+      <a class="go" href="cubelet-workflow.html">深入阅读 →</a>
+    </div>
+  </div>
+
+  <div class="section-title">存储 · 虚拟化 · 沙箱内</div>
+  <div class="grid">
+    <div class="card">
+      <span class="num">04</span>
+      <h3>CubeCoW 存储引擎</h3>
+      <div class="tags"><span class="tag rust">Rust</span><span class="tag">XFS reflink</span></div>
+      <p class="desc">用内核 FICLONE ioctl 实现 O(1) 快照/克隆的卷管理库：卷目录布局、崩溃恢复索引重建、C ABI 设计与 Cubelet cgo 绑定。</p>
+      <div class="features">ReflinkEngine · ficlone() · scan_and_rebuild_index<br>cubecow_init · Box&lt;dyn Engine&gt;</div>
+      <a class="go" href="cubecow.html">深入阅读 →</a>
+    </div>
+    <div class="card">
+      <span class="num">05</span>
+      <h3>CubeShim + CubeHypervisor</h3>
+      <div class="tags"><span class="tag rust">Rust</span><span class="tag">RustVMM + KVM</span></div>
+      <p class="desc">containerd Shim v2 与 KVM VMM 之间的完整链路：沙箱创建/启动、暂停写内存快照、恢复、回滚，以及 VMM 的 ApiRequest 通信模型与脏页日志。</p>
+      <div class="features">SandBox::create_sandbox · pause_vm_cube<br>VmPauseToSnapshot · KvmDirtyLogSlot</div>
+      <a class="go" href="virtualization.html">深入阅读 →</a>
+    </div>
+    <div class="card">
+      <span class="num">06</span>
+      <h3>guest agent 沙箱内运行时</h3>
+      <div class="tags"><span class="tag rust">Rust</span><span class="tag">vsock ttRPC</span></div>
+      <p class="desc">沙箱内 init 进程：vsock ttRPC 服务、I/O port 0x680 就绪通知、共享命名空间、基于 rustjail 的 OCI 容器运行时、OOM 事件上报。</p>
+      <div class="features">rpc::start · ioport 0x680 · create_container<br>rustjail LinuxContainer · run_oom_event_monitor</div>
+      <a class="go" href="guest-agent.html">深入阅读 →</a>
+    </div>
+  </div>
+
+  <div class="section-title">网络与安全</div>
+  <div class="grid">
+    <div class="card">
+      <span class="num">07</span>
+      <h3>CubeVS eBPF 网络虚拟化</h3>
+      <div class="tags"><span class="tag c">C/eBPF</span><span class="tag go">Go</span></div>
+      <p class="desc">三个挂在内核数据路径上的 BPF 程序：沙箱出向 SNAT/策略/DNS 学习、入向反向 NAT/端口映射、网关 DNAT；以及 Go 控制面的 map 管理与会话回收。</p>
+      <div class="features">from_cube · from_world · from_envoy<br>egress_sessions · pick_snat_ip_port · session_reaper</div>
+      <a class="go" href="cubevs-network.html">深入阅读 →</a>
+    </div>
+    <div class="card">
+      <span class="num">08</span>
+      <h3>CubeEgress 安全代理</h3>
+      <div class="tags"><span class="tag lua">OpenResty + Lua</span><span class="tag">TPROXY</span></div>
+      <p class="desc">透明 L7 出向 MITM：TPROXY 拦截 → 八道门禁 → 域名过滤决策 → 凭证注入（密钥不进沙箱）→ 动态签发叶子证书 → 审计与脱敏。</p>
+      <div class="features">_M.decide · inject_gates · cert_signer<br>fail-closed · redactor · audit jsonl</div>
+      <a class="go" href="cubeegress.html">深入阅读 →</a>
+    </div>
+    <div class="card">
+      <span class="num">09</span>
+      <h3>CubeProxy 请求路由</h3>
+      <div class="tags"><span class="tag lua">OpenResty + Lua</span><span class="tag">动态 upstream</span></div>
+      <p class="desc">兼容 E2B 的反向代理：Host / Path 双路由模式、local_cache + Redis 双级后端解析、基于状态字典的自动恢复门禁与动态选路。</p>
+      <div class="features">rewrite_phase · sandbox_backend · sandbox_state.gate<br>maskRequestHost · /_sidecar_resume</div>
+      <a class="go" href="cubeproxy.html">深入阅读 →</a>
+    </div>
+  </div>
+
+  <div class="note"><strong>阅读建议：</strong>每篇文档相互独立，可直接打开对应链接。建议先读总览《cubesandbox-logic.html》建立全局观，再按"控制面 → 存储/虚拟化 → 网络与安全"的顺序逐篇深入。所有源码路径以仓库根目录为基准。</div>
+  <div class="note"><strong>延伸系列：</strong>K8s 部署后的实战排障（envd 端口、沙箱 DNS、MTU 黑洞、auto_resume 504），见 <a href="deploy-troubleshoot/index.html">《CubeSandbox 部署排障实录》</a>。</div>
+</div>
+
+<footer>
+  CubeSandbox 核心技术深入解读 · 源码路径基准：/workspace/github/CubeSandbox<br>
+  组件行为以源码为准，文档仅作开发参考
+</footer>
+
+<button class="back-top" id="backTop">↑</button>
+<script>
+  const b = document.getElementById('backTop');
+  window.addEventListener('scroll', () => b.classList.toggle('show', window.scrollY > 500));
+  b.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+</script>
+</body>
+</html>

--- a/cubesandbox-tech/lifecycle-manager.html
+++ b/cubesandbox-tech/lifecycle-manager.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>生命周期管理 · 一台闲置的沙箱，怎么自己学会"睡觉"</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--blue),var(--purple));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--cyan));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .pipeline{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin:24px 0}
+  .pipeline .ps{border:1px solid var(--border);border-radius:12px;padding:14px;background:rgba(255,255,255,.03)}
+  .pipeline .ps .no{font-family:var(--mono);font-size:11px;color:var(--blue);margin-bottom:6px}
+  .pipeline .ps .t{font-weight:700;font-size:14.5px;margin-bottom:4px}
+  .pipeline .ps .d{font-size:12.5px;color:var(--text-dim);line-height:1.8}
+  @media(max-width:720px){.pipeline{grid-template-columns:1fr 1fr}}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 技术深入</div>
+    <a class="back-home" href="index.html">← 技术索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 核心技术 02 / 09</div>
+    <h1>一台闲置的沙箱，怎么自己学会"睡觉"</h1>
+    <p class="lead">这篇讲 cube-lifecycle-manager（CLM）。我们从成本问题出发：沙箱不用的时候也在烧钱，但用户随时可能回来。CLM 的答案是把闲置沙箱"暂停"成快照、需要时再"唤醒"——而"判断何时该睡、何时该醒、醒来谁来做"，是一个分布式系统里最考验并发设计的问题之一。</p>
+  </div>
+
+  <h2>一、问题：闲置的沙箱，是纯成本</h2>
+
+  <p>沙箱的计费对象是"存在时间"，不管用户用不用。而现实里，开发者开一个沙箱，真正的使用往往只有几分钟，剩下的几个小时它都闲着——一台 VM 占着内存、占着 CPU 配额，什么也不干。</p>
+  <p>前一篇调度器里我们见过"模板秒开"：沙箱本质是"模板快照 + 内存快照"，既然创建时能从快照恢复，那暂停时把内存写回快照、恢复时再拉起来，就是一条自然的路径。于是设计目标明确了：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>需求</th><th>含义</th></tr></thead>
+      <tbody>
+        <tr><td><b>自动暂停</b></td><td>沙箱空闲超过阈值，自动把 VM 内存落盘、释放资源，只剩一份快照</td></tr>
+        <tr><td><b>自动恢复</b></td><td>用户请求到达暂停的沙箱时，从快照毫秒级唤醒，体验上"只是首请求稍慢"</td></tr>
+        <tr><td><b>收敛一致</b></td><td>手动 pause/resume（SDK 调用）与自动逻辑并存，最终状态必须一致</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>问题被翻译成一个工程任务：<span class="hl">谁来判断空闲、谁执行暂停、谁响应唤醒、如何防止多副本重复操作。</span>这就是 CLM 存在的理由。</p>
+
+  <svg class="flow" viewBox="0 0 720 228" role="img" aria-label="沙箱生命周期状态机">
+    <defs>
+      <marker id="lmArr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#2dd4bf"/></marker>
+      <marker id="lmArr2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#f87171"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="228" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="30" class="fm">沙箱生命周期状态机 · 状态即锁（SETNX 抢到才有资格操作）</text>
+
+    <rect x="30" y="44" width="180" height="54" rx="10" fill="rgba(45,212,191,.08)" stroke="rgba(45,212,191,.45)"/>
+    <text x="120" y="70" text-anchor="middle" class="fn">running</text>
+    <text x="120" y="88" text-anchor="middle" class="fd">VM 运行中，接流量</text>
+
+    <rect x="270" y="44" width="180" height="54" rx="10" fill="rgba(45,212,191,.08)" stroke="rgba(45,212,191,.45)"/>
+    <text x="360" y="70" text-anchor="middle" class="fn">pausing</text>
+    <text x="360" y="88" text-anchor="middle" class="fd">SETNX 持锁，内存写盘</text>
+
+    <rect x="510" y="44" width="180" height="54" rx="10" fill="rgba(45,212,191,.1)" stroke="rgba(45,212,191,.6)"/>
+    <text x="600" y="70" text-anchor="middle" class="fn">paused</text>
+    <text x="600" y="88" text-anchor="middle" class="fd">快照态，零资源占用</text>
+
+    <line x1="210" y1="71" x2="270" y2="71" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#lmArr)"/>
+    <text x="240" y="62" text-anchor="middle" class="fl">空闲超时 → tryPause</text>
+    <line x1="450" y1="71" x2="510" y2="71" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#lmArr)"/>
+    <text x="480" y="62" text-anchor="middle" class="fl">快照写盘完成</text>
+
+    <path d="M 600 98 L 600 136 L 120 136 L 120 98" fill="none" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#lmArr)"/>
+    <text x="360" y="124" text-anchor="middle" class="fl">请求到达 / 手动 resume → tryResume（单飞合并唤醒）</text>
+
+    <rect x="270" y="168" width="170" height="44" rx="9" fill="rgba(248,113,113,.07)" stroke="rgba(248,113,113,.5)"/>
+    <text x="355" y="186" text-anchor="middle" class="fn" style="fill:#f87171">killing</text>
+    <text x="355" y="203" text-anchor="middle" class="fd">注销资源中</text>
+    <rect x="470" y="168" width="170" height="44" rx="9" fill="rgba(248,113,113,.07)" stroke="rgba(248,113,113,.5)"/>
+    <text x="555" y="186" text-anchor="middle" class="fn" style="fill:#f87171">killed</text>
+    <text x="555" y="203" text-anchor="middle" class="fd">终态，从注册表移除</text>
+    <line x1="210" y1="98" x2="318" y2="168" stroke="#f87171" stroke-width="1.5" marker-end="url(#lmArr2)"/>
+    <text x="238" y="144" class="fl">销毁 / 超时</text>
+    <line x1="440" y1="188" x2="470" y2="188" stroke="#f87171" stroke-width="1.5" marker-end="url(#lmArr2)"/>
+  </svg>
+
+  <h2>二、为什么需要一个独立组件</h2>
+
+  <p>一个自然的想法是：把扫描闲置的逻辑塞进 CubeMaster 里不就行了？但这样有两个问题。第一，CubeMaster 的主链路是请求驱动的调度，它必须保持"无状态、专注于转发"——扫描、定时、状态维护是另一种节奏，混在一起会让主链路的故障面变大。第二，"自动化策略"（多久算闲置、是否自动暂停）需要独立升级、独立扩缩容，绑在主服务里就没法单独动了。</p>
+  <p>所以 CLM 被做成一个独立的 sidecar 部署在控制面，它自己不执行暂停/恢复，而是"协调"：从 Redis 事件流里看发生了什么，向 CubeMaster 发 RPC 让它暂停/恢复，把状态推给 CubeProxy 让数据面知道"这个沙箱现在能不能接请求"。启动时，<code>main.go</code> 装配了五个内部循环，各管一摊：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>循环</th><th>职责</th></tr></thead>
+      <tbody>
+        <tr><td><code>consumeStream</code></td><td>XREADGROUP 消费生命周期事件（block 5s、count 100、出错退避 1s）</td></tr>
+        <tr><td><code>pollLastActive</code></td><td>周期轮询所有 CubeProxy 的 <code>/admin/last_active</code>，合并活跃时间戳</td></tr>
+        <tr><td><code>sweep.Run</code></td><td>空闲超时扫描，默认每 5s 一次</td></tr>
+        <tr><td><code>apiSrv.Run</code></td><td>HTTP 面：<code>/internal/resume</code>、<code>/healthz</code>、<code>/readyz</code></td></tr>
+        <tr><td><code>discSvc.Run</code></td><td>CubeProxy 副本发现（Redis 心跳注册表）</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>三、机制之一：Redis 事件流，唯一的"事实源"</h2>
+
+  <p>CLM 判断"世界上有哪些沙箱、处于什么状态"，依据不是自己去问，而是订阅一条事件流。CubeMaster 在每次创建/销毁/更新成功后，把元数据和事件写进 Redis；CLM 消费后，在内存里建起自己的注册表（registry）。</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>Redis Key</th><th>结构</th><th>说明</th></tr></thead>
+      <tbody>
+        <tr><td><code>…sandbox:lifecycle:meta</code></td><td>Hash</td><td>field=sandbox_id，value=生命周期元数据 JSON，供启动时全量引导</td></tr>
+        <tr><td><code>…sandbox:lifecycle:events</code></td><td>Stream</td><td>XADD 事件（MAXLEN ~100000），字段 op / sandbox_id / payload / ts</td></tr>
+        <tr><td><code>…sandbox:lifecycle:state:&lt;id&gt;</code></td><td>String</td><td>当前状态（paused/running/pausing…），兼作 SETNX 状态锁（第四节）</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>事件有四种 op：<code>create / delete / update / state</code>。其中 <code>state</code> 事件带 <code>StatePayload{state, actor, source}</code>——state 只允许 paused/running，actor 区分是谁改的（cubemaster 还是 clm），这为后面的"状态对账"埋下伏笔。</p>
+  <p>消费侧有几个工程细节。启动引导（bootstrap）时用 <code>HGetAll</code> 全量加载 meta，并且<span class="hl">强制以 hash 的 field 作为 sandbox_id</span>——防御脏数据，不能信 value 里可能写错的 id。消费者组用 <code>XGroupCreateMkStream</code> 创建，多副本 CLM 共享同一个消费组，事件不会重复处理；遇到 <code>BUSYGROUP</code> 错误就忽略（说明别的副本建过了）。遇到解析不了的事件，先 <code>Ack</code> 再丢弃——不处理，但也不能让它卡住整条流。</p>
+
+  <h2>四、机制之二：扫描决策——"它到底闲没闲"</h2>
+
+  <p>注册表建好了，每 5 秒 <code>sweep.Run</code> 扫一遍，找出"空闲超时"的沙箱。问题来了：<span class="hlb">怎么判定一个沙箱闲了多久？</span></p>
+  <p>活跃时间的定义是：跨所有 CubeProxy 副本取 <code>LastActiveMs</code> 的最大值，再和元数据里的创建时间取 max。为什么跨副本取 max？因为用户可能从任何一台 CubeProxy 进入，单看一台会低估活跃度。公式如下：</p>
+  <div class="codeblock">baseline = max( 各 CubeProxy 上报的 LastActiveMs, Meta.CreatedAt )
+           （若两者皆 0，回落 FirstSeenAt —— CLM 本地首次见到它的时间）
+timeout  = Meta.TimeoutSeconds
+           （nil → 集群默认；&lt; 0 → 永不暂停）
+idleFor  = nowMs − baseline
+idleFor &lt; timeout → 跳过（还没到点）</div>
+  <p>这个"空闲判定"里有三个陷阱，代码里各有对策：</p>
+  <p><span class="hlg">陷阱一：CLM 重启会误杀。</span>重启后从 HGETALL 引导进来的老沙箱，LastActiveMs 还是 0——如果立即扫描，会误判"从未活跃、立刻超时"。对策是 BootstrapWarmup：启动后 30 秒内，跳过那些"首次见到时间 ≤ 启动时间"的条目，等 pollLastActive 把真实活跃时间回填。</p>
+  <p><span class="hlg">陷阱二：状态锁可能过期。</span>扫描前先 <code>GetState</code>，若已经是 paused/pausing/killing/killed，直接跳过——避免对一个正在处理中的沙箱做无谓 RPC。</p>
+  <p><span class="hlg">陷阱三：多副本同时扫到同一个沙箱。</span>这是分布式系统最经典的竞态，解法是"状态即锁"：</p>
+  <div class="codeblock">tryPause(sid)：
+① AcquireState(sid, "pausing", TTL=60s)   // SETNX：抢到锁才继续，抢不到 = 别人在处理，直接返回
+② ProxyPush.SetState(sid, "pausing")        // 先通知 CubeProxy 门禁（失败仅告警）
+③ CubeMaster.Pause(sid)                     // POST /cube/sandbox/update {action:"pause"}
+   ├─ 404(沙箱不存在)  → 驱逐本地条目：清状态 + 删 meta + 删注册表，视为成功
+   ├─ 已处于目标态     → 落入"成功记账"（补写 paused）
+   └─ 其它错误        → 回滚：清状态锁 + 写回 running + 返回错误
+④ 成功记账：SetState(sid, "paused") + ProxyPush.SetState(sid, "paused")</div>
+  <p>销毁（tryKill）结构相同：抢 killing 锁 → 通知代理 → DELETE 沙箱（kill_reason=timeout）→ 成功后清理。这套 <span class="hl">"状态即锁"的设计把"状态表示"和"并发控制"合二为一</span>——state key 既是 CubeProxy 查询的门禁依据，也是 CLM 操作的互斥锁，TTL 兜底防止执行者崩溃后锁被永久占用。一个 key，两用，代价是必须在语义上小心设计。</p>
+
+  <h2>五、机制之三：自动恢复——十个并发请求，只唤醒一次</h2>
+
+  <p>暂停是 CLM 主动发起的，恢复则是请求驱动的：CubeProxy 数据面遇到一个 paused 沙箱的请求，回调 <code>POST /internal/resume</code>。这带来一个高并发问题：<span class="hlb">同一沙箱同时来了 10 个请求，恢复只能做一次，另外 9 个得等同一个结果。</span></p>
+  <p>解法是"单飞合并"（singleflight 模式）：CLM 内部维护一个 <code>calls[sid]</code> 表，第一个请求创建 in-flight call，后续请求发现已有 in-flight，直接 select 等它的 done 通道，共享第一个执行者的结果。恢复执行本身还要再过一道状态锁：</p>
+  <div class="codeblock">Resume(sid)：
+  锁内查 calls[sid]
+   ├─ 已有 in-flight → 等 done / ctx.Done() → 返回首个执行者的结果
+   └─ 无 → 新建 call，执行 doResume：
+        acquireResumeOwnership：SETNX "resuming" 锁
+         ├─ cur == "running"     → 幂等成功（already running）
+         ├─ cur == "pausing/resuming" → waitForRunning 等对端结果
+         └─ cur == "paused" / 不存在 → 抢锁成功，own 路径
+        AutoResume 门：!Meta.AutoResume → 放弃（必须显式 connect()）
+        callCubeMasterResume：POST /cube/sandbox/update {action:"resume"}
+          └─ 404 → 驱逐注册表；已处于目标态 → 视为成功
+        成功记账：
+          SetState("running")
+          go pushRunningState(sid)      // 独立 3s 超时 + 指数退避（100ms→200ms，3 次）
+          Registry.MergeLastActive(sid, now)   // 刷新活跃时间，防 sweeper 立刻再暂停</div>
+  <p>有两个细节值得注意。<span class="hlg">一是 waitForRunning 的轮询</span>：以 200ms 间隔轮询状态直到 running，如果状态锁在轮询中途过期（TTL 60s），返回错误而不是假装成功——宁可失败重来，不给用户一个虚假的成功。</p>
+  <p><span class="hlg">二是 MergeLastActive。</span>每次自动恢复成功后，把活跃时间刷新到当前——沙箱获得一个全新的计时窗口。于是"恢复 → 使用 → 再次空闲 → 再次暂停"的循环可以无限持续。这是 Agent 场景成本优化的核心：<span class="hl">闲置就睡，来请求就醒，睡和醒之间用户无感。</span></p>
+
+  <h2>六、机制之四：状态对账——手动与自动，收敛到同一事实</h2>
+
+  <p>除了 CLM 的自动暂停/恢复，用户也可能通过 SDK 直接调用 pause()/resume()（走 CubeMaster）。这两条路径并存，必须保证最终一致。CubeMaster 的操作成功后同样会发 <code>state</code> 事件，CLM 消费后走对账：</p>
+  <div class="codeblock">Handle(ev)：
+① 校验：op=state、state ∈ {paused, running}、注册表里有该沙箱
+② 若当前状态是 "pausing"/"resuming" → 跳过（CLM 自己的 in-flight 流程会写终态，避免竞争）
+③ 幂等：当前状态 == 新状态 → 直接返回
+④ 对账：SetState(newState) + ProxyPush.SetState(newState)
+   newState == "running" → 额外 MergeLastActive（防止刚恢复又被扫暂停）</div>
+  <p>这套设计的价值在于：<span class="hl">事件驱动 + 幂等对账，让"谁发起的操作"在最终状态上收敛一致，不依赖事件到达的时序。</span>即使事件乱序，最终也会幂等收敛到真实状态——这就是"最终一致性"在一个具体系统里的落地。</p>
+
+  <h2>七、收束：设计全景</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>问题</th><th>机制</th><th>核心权衡</th></tr></thead>
+      <tbody>
+        <tr><td>谁来判断沙箱闲了多久</td><td>事件流 + 跨副本 max 活跃时间</td><td>事实源唯一，判定可审计</td></tr>
+        <tr><td>多副本同时扫描到同一沙箱</td><td>"状态即锁"（SETNX + TTL）</td><td>状态表示与并发控制合一</td></tr>
+        <tr><td>并发请求同时唤醒一个沙箱</td><td>singleflight 合并 + 状态锁</td><td>一次恢复，N 个等待者共享结果</td></tr>
+        <tr><td>重启误杀闲置沙箱</td><td>BootstrapWarmup 30s 宽限</td><td>正确性优先于即时性</td></tr>
+        <tr><td>手动与自动操作并存</td><td>事件驱动 + 幂等对账</td><td>不依赖时序，最终收敛</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="punchline">
+    <small>一句话带走</small>
+    CLM 是一个事件驱动的"寿命管家"：Redis 流是事实源，sweeper 用 SETNX 状态锁做幂等的暂停决策，resumer 用单飞合并做请求驱动的唤醒，statesync 让手动与自动收敛一致——闲置就睡，来请求就醒，全程用户无感。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>装配与五个循环</td><td><code>cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go</code></td></tr>
+        <tr><td>Redis 键与事件 schema</td><td><code>cube-lifecycle-manager/internal/lifecycle/schema.go</code></td></tr>
+        <tr><td>流消费（XREADGROUP）</td><td><code>cube-lifecycle-manager/internal/redisstream/stream.go</code></td></tr>
+        <tr><td>注册表 Entry 语义</td><td><code>cube-lifecycle-manager/internal/registry/registry.go</code></td></tr>
+        <tr><td>自动暂停 / 超时销毁</td><td><code>cube-lifecycle-manager/internal/sweeper/sweeper.go</code></td></tr>
+        <tr><td>自动恢复（并发合并）</td><td><code>cube-lifecycle-manager/internal/resumer/resumer.go</code></td></tr>
+        <tr><td>状态对账</td><td><code>cube-lifecycle-manager/internal/statesync/handler.go</code></td></tr>
+        <tr><td>发布端（CubeMaster 侧）</td><td><code>CubeMaster/pkg/lifecycle/{store,schema,init}.go</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>生命周期管理 CLM · CubeSandbox 技术深入 02/09 · 下一篇：Cubelet Workflow——沙箱是怎么被"流水线"制造出来的</footer>
+</body>
+</html>

--- a/cubesandbox-tech/scheduler.html
+++ b/cubesandbox-tech/scheduler.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CubeMaster 调度器 · 一台沙箱该落在哪台机器上</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--blue),var(--purple));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--blue));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .pipeline{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin:24px 0}
+  .pipeline .ps{border:1px solid var(--border);border-radius:12px;padding:14px;background:rgba(255,255,255,.03)}
+  .pipeline .ps .no{font-family:var(--mono);font-size:11px;color:var(--blue);margin-bottom:6px}
+  .pipeline .ps .t{font-weight:700;font-size:14.5px;margin-bottom:4px}
+  .pipeline .ps .d{font-size:12.5px;color:var(--text-dim);line-height:1.8}
+  @media(max-width:720px){.pipeline{grid-template-columns:1fr 1fr}}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 技术深入</div>
+    <a class="back-home" href="index.html">← 技术索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 核心技术 01 / 09</div>
+    <h1>一台沙箱，该落在哪台机器上？</h1>
+    <p class="lead">这篇讲 CubeMaster 的调度器。我们从问题出发，一层一层看它如何被逼出现在的样子：先解决"选得动"，再解决"选得对"，然后解决"扛得住"。每层的机制、以及机制背后的权衡，都会讲到代码层面。读完你应该能闭着眼画出完整的选位流水线。</p>
+  </div>
+
+  <h2>一、问题：选一台机器，难在哪</h2>
+
+  <p>你敲下 <code>sandbox.create()</code>，说"我要一台 4 核 8G 的沙箱"。后台有一百台物理机，每台上百个沙箱。系统的任务是：<span class="hl">从这一百台里挑出一台，来承载你的沙箱。</span></p>
+  <p>这个选择，要在三个维度上同时成立，缺一个就会出事：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>维度</th><th>具体问题</th><th>违反的后果</th></tr></thead>
+      <tbody>
+        <tr><td><b>资源（选得动）</b></td><td>机器剩下的 CPU/内存/磁盘，装得下这个请求</td><td>创建失败，用户重试，体验崩坏</td></tr>
+        <tr><td><b>均衡（选得对）</b></td><td>负载不能一边倒，也不能在几台机器间震荡</td><td>有的机器挤爆，有的空转，资源浪费</td></tr>
+        <tr><td><b>时效（选得快）</b></td><td>整个决策必须压缩在几十毫秒内完成</td><td>创建响应变慢，秒开变慢开</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>调度器入口是 <code>Select()</code>（<code>CubeMaster/pkg/scheduler/schedule.go</code>）。它不真正创建沙箱——创建发生在节点上的 Cubelet 进程里——它只负责"选位"。但选位的每一步，都和上面三个维度较劲。我们把调度器当作一条四段流水线来看，后面的内容都是围绕它展开的：</p>
+  <svg class="flow" viewBox="0 0 720 176" role="img" aria-label="调度器 Select 主流程与兜底路径">
+    <defs>
+      <marker id="sArr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#4f8cff"/></marker>
+      <marker id="sArrA" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="176" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="30" class="fm">SELECT() 主流程 · 一条 sandbox.create() 的选位之旅</text>
+
+    <rect x="14" y="48" width="156" height="72" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="92" y="76" text-anchor="middle" class="fn">① 预选 PreFilter</text>
+    <text x="92" y="96" text-anchor="middle" class="fd">健康 / 存活 / 未超载</text>
+    <text x="92" y="110" text-anchor="middle" class="fm">prefilter.go</text>
+    <line x1="170" y1="84" x2="188" y2="84" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#sArr)"/>
+
+    <rect x="188" y="48" width="156" height="72" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="266" y="76" text-anchor="middle" class="fn">② 五关淘汰 Filter</text>
+    <text x="266" y="96" text-anchor="middle" class="fd">cpu/mem/disk/创建数/模板</text>
+    <text x="266" y="110" text-anchor="middle" class="fm">parallelRunFilters · 全票</text>
+    <line x1="344" y1="84" x2="362" y2="84" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#sArr)"/>
+
+    <rect x="362" y="48" width="156" height="72" rx="10" fill="rgba(79,140,255,.08)" stroke="rgba(79,140,255,.45)"/>
+    <text x="440" y="76" text-anchor="middle" class="fn">③ 四路打分 Score</text>
+    <text x="440" y="96" text-anchor="middle" class="fd">亲和/镜像/实时/综合分</text>
+    <text x="440" y="110" text-anchor="middle" class="fm">runScoreFilter · 加权归一</text>
+    <line x1="518" y1="84" x2="536" y2="84" stroke="#4f8cff" stroke-width="1.5" marker-end="url(#sArr)"/>
+
+    <rect x="536" y="48" width="156" height="72" rx="10" fill="rgba(79,140,255,.1)" stroke="rgba(79,140,255,.6)"/>
+    <text x="614" y="76" text-anchor="middle" class="fn">④ 加权抽签</text>
+    <text x="614" y="96" text-anchor="middle" class="fd">Top N · 随机选一台</text>
+    <text x="614" y="110" text-anchor="middle" class="fm">LeastRandomSelect</text>
+
+    <line x1="266" y1="120" x2="266" y2="142" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#sArrA)"/>
+    <text x="278" y="137" class="fl">候选清空？</text>
+    <rect x="150" y="142" width="216" height="30" rx="8" fill="rgba(251,191,36,.07)" stroke="rgba(251,191,36,.5)"/>
+    <text x="258" y="161" text-anchor="middle" class="fn" style="fill:#fbbf24">BackoffSelect 兜底</text>
+    <line x1="366" y1="157" x2="380" y2="157" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#sArrA)"/>
+    <rect x="380" y="142" width="160" height="30" rx="8" fill="rgba(248,113,113,.07)" stroke="rgba(248,113,113,.5)"/>
+    <text x="460" y="161" text-anchor="middle" class="fn" style="fill:#f87171">返回 SelectNodesNoRes</text>
+  </svg>
+  <div class="flow-cap">带模板 ID 的请求：淘汰失败 → 直接报错返回，不走兜底（shouldSkipBackoffForTemplate）</div>
+
+  <h2>二、第一层设计：淘汰——"装不下"的直接回答</h2>
+
+  <p>最天真的做法是随机挑一台，但这会把请求砸到快满的机器上，创建失败。第一层进化由此而来：<span class="hl">先把装不下的机器淘汰掉，剩下的才叫候选。</span>淘汰在代码里叫 Filter，每一关是一个独立的函数，实现同一个接口 <code>Select(selCtx) (node.NodeList, error)</code>。五关判据如下：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>关卡</th><th>判据（淘汰条件）</th><th>出处</th></tr></thead>
+      <tbody>
+        <tr><td><b>cpuFilter</b></td><td>有效空闲 CPU ≤ 请求，或节点 CPU 利用率 ≥ 80%</td><td>filter/cpufilter.go</td></tr>
+        <tr><td><b>memFilter</b></td><td>有效空闲内存 ≤ 请求；或实时负载内存不够「请求 + 预留」</td><td>filter/memfilter.go</td></tr>
+        <tr><td><b>diskFilter</b></td><td>存储盘 / 系统盘 / 数据盘任一分区使用率 ≥ 80%</td><td>filter/diskfilter.go</td></tr>
+        <tr><td><b>realtimecreatelimit</b></td><td>正在创建数 ≥ 节点上报的创建并发上限（默认 50）</td><td>filter/realtimecreatelimit.go</td></tr>
+        <tr><td><b>template_locality</b></td><td>模板快照不在本机（第五节详述）</td><td>filter/template_locality.go</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h3>“有效空闲”背后的两个算法决定</h3>
+
+  <p>CPU 和内存两关的核心是同一个公式：</p>
+  <div class="codeblock">有效空闲 = 上报配额 × 超售比(overcommit ratio) − 已分配量
+（源码：EffectiveQuotaCpu / EffectiveQuotaMem − EffectiveAllocated，config.go）</div>
+  <p>这里有两个算法决定，值得停下来理解。</p>
+  <p>第一是<span class="hlb">超售</span>。沙箱实际用不满上报的配额——4 核的沙箱，多数时间 CPU 只用到几十个百分点。如果按上报值严格相加，一台 64 核的机器放 16 个 4 核沙箱就"满了"，剩下 80% 容量空转。超售比就是对"配额"和"实际占用"之间差距的承认：<code>有效配额 = 上报配额 × 超售比</code>。代价是风险——万一所有沙箱同时打满，物理机真的会超载，所以这个比值不能拍脑袋定，是整个集群运营中最敏感的调参点之一。</p>
+  <p>第二是<span class="hlb">"已分配量"从哪来</span>。它等于这台机器上所有沙箱承诺出去的配额之和，记录在 Redis 里，由各节点上报。这里有一个例外开关：如果 Redis 的分配记录不可信（比如节点闪断漏报），可以配置 <code>ignore_redis_allocation</code>，让调度器把已分配当作 0 来算——宁可冒险多放一点，也不让脏数据卡死整个集群。</p>
+  <p>内存关比 CPU 关多一道检查：<span class="hl">实时负载防线</span>。配额是承诺，实际占用是另一回事——节点上报的实时内存 <code>MemMBTotal − MemUsage</code>，必须能盖住「你的请求 + 预留」。预留默认 10GB，给机器留呼吸空间；小机器则按配额比例的 10% 兜底。这道防线防止的是：配额账面上有富余，但实际内存已经吃紧。</p>
+  <p>另外，五关是<span class="hl">并行执行</span>的，实现是 Go 的 <code>errgroup</code> + 计数器（<code>parallelRunFilters()</code>，schedule.go）：每个节点被某一关放行一次就记一票，最后只保留票数等于关卡总数的节点。一票否决，全票才留。</p>
+
+  <h2>三、第二层设计：打分——"装了之后会怎样"的效用评估</h2>
+
+  <p>淘汰只回答"能不能装"，但它制造了一个新问题：<span class="hlb">大家会往同一两台"最好"的机器上挤。</span>如果这些机器装得下，所有人都选它们，直到被淘汰关拦下才流向下一台——集群负载永远一边倒。</p>
+  <p>第二层进化由此而来：<span class="hl">给通过淘汰的机器打分。</span>分代表"这台机器接下你这单之后的综合处境"，越高越好。打分在 <code>runScoreFilter()</code> 完成，四路插件各有权重、各有关闭开关，不想要的路可以直接禁用。四路分是：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>插件</th><th>计算什么</th><th>作用</th></tr></thead>
+      <tbody>
+        <tr><td><b>affinityscore</b></td><td>用户偏好的机器（k8s 亲和语义换算分）</td><td>尊重用户显式意愿</td></tr>
+        <tr><td><b>imagescore</b></td><td>镜像/模板在本机缓存的命中情况</td><td>让秒开成为可能</td></tr>
+        <tr><td><b>realtimeweighted</b></td><td>实时负载因子 + 剩余资源越多分越高</td><td>负载均衡的数学化</td></tr>
+        <tr><td><b>multifactorscore</b></td><td>后台预计算的综合分，直接读取</td><td>把耗时算在选位之前</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>三个机制层面的细节，把它们讲透：</p>
+  <p><span class="hlg">① 打分本质是"效用函数"。</span>realtimeweighted 的负载均衡项写成公式就是：</p>
+  <div class="codeblock">剩余资源分 = getReciprocal(有效配额 − 已分配 − 你的请求, 有效配额)
+              —— 机器在承接你这单后剩得越多，这一项分越高</div>
+  <p>它让"空机器"天然得高分，流量就会被"没用完的地方"吸引过去，集群负载趋于均匀。注意这里减去了"你的请求"——打分评估的是承接后的处境，而不是当前处境。</p>
+  <p><span class="hlg">② imagescore 的映射曲线是有讲究的。</span>模板快照的大小从 23MB 线性映射到 80GB×容器数：快照越小、克隆越省事，分越高。低于 23MB 一律按 23MB 算（不给零分），超过上限封顶为满分。这条曲线把"模板本地性"这个产品特性，量化成了调度依据。</p>
+  <p><span class="hlg">③ 综合分是预计算的，这是"几十毫秒选位"的关键。</span>multifactorscore 背后有个后台协程 <code>loopAsyncScore()</code>：每 50ms 醒一次、按配置间隔节流，把全集群所有健康节点的综合分提前算好存进缓存。真正选位时直接读 <code>n.Score</code>，不再现场遍历一百台机器。用提前算好的代价，换选位瞬间的极致延迟——这是调度系统里非常典型的时间换空间。</p>
+  <p>最后，各路的原始分乘上自己的权重求和，再除以总权重归一化（跳过关掉的路），每台机器得到一个 0–1 之间的分，按降序排好。</p>
+
+  <h2>四、第三层设计：抽签——以及"永远选最好"为什么是错的</h2>
+
+  <p>分数排好名次，最后一步是选。这里有一个反直觉的设定：<span class="hlr">默认情况下，调度器不是选分数最高的一台，而是从高分集合里随机挑。</span></p>
+  <p>选择逻辑是 <code>LeastRandomSelect()</code>（selctx/selectcontext.go）：</p>
+  <div class="codeblock">① 取按分数排序后的前 N 名（PrioritySelectNum，默认 -1 = 全部保留）
+② 把每台机器的分放大为权重：int(Score × 1e6)
+③ 用权重构造选择器，随机抽出一个
+   选择器算法由 least_select_name 配置：
+   random  → 均匀随机（默认，忽略权重）
+   sw/rrw  → 平滑加权随机（分数越高，中选概率越大）</div>
+  <p>默认用均匀随机，是有意为之。回忆一个场景：如果"永远选最高分"，会发生什么？所有流量扑向第一名，把它打满；打满后它分数暴跌，流量再涌向新的第一名……集群在几台机器间来回震荡，永远安分不下来。而均匀随机保证流量天然散开——代价是偶尔选到次优，换来长期的均衡。</p>
+  <p>这也是集群调度领域的通识：<span class="hlb">不追求单次最优，追求整体稳定。</span>分数排序的真正用途，是给可选的加权算法提供权重依据；而默认行为刻意保守。</p>
+
+  <h2>五、兜底路径，和模板那道"不兜底"的铁律</h2>
+
+  <p>淘汰层有个兜底设计：万一五关把候选清空了，普通请求不会直接失败。调度器会走 <code>BackoffSelect()</code>：用一套更宽松的条件（跳过部分淘汰，按健康度从集群里捞一批），再 <code>rand.Intn</code> 随机挑一台顶上。宁可放宽标准，不让请求白跑一趟。</p>
+  <p>但这个兜底，在模板面前失效了。回到模板本地性：CubeSandbox 的招牌是"从模板秒开"——模板是一份打包好的 rootfs + 内存快照，新沙箱克隆一份、恢复快照，几十毫秒起。这一切的前提是：<span class="hl">模板快照就在你选中的那台机器上。</span>模板在 A 机、沙箱被派到 B 机？B 得先跨网络搬模板，你的 60ms 变成 6s。</p>
+  <p>所以模板本地性被做成一道淘汰关 <code>template_locality</code>，它按三层校验：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>校验</th><th>逻辑</th></tr></thead>
+      <tbody>
+        <tr><td>① 显式限定</td><td>请求可指定 <code>TemplateNodeScope</code>（模板只能落在哪些节点），不在范围的淘汰</td></tr>
+        <tr><td>② 镜像缓存</td><td><code>GetImageStateByNode(templateID, nodeID)</code> 查不到这份模板快照 → 淘汰</td></tr>
+        <tr><td>③ 快照可写</td><td>请求带 <code>EnforceSnapshotStorage</code> 时，要求快照存储存在且可写</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>而它的特殊之处在于兜底豁免：<code>schedule.go</code> 里 <code>shouldSkipBackoffForTemplate()</code> 规定——<span class="hlr">只要请求带模板 ID 且注册了这道关，淘汰失败就直接返回 <code>SelectNodesNoRes</code>，绝不进入 BackoffSelect。</span>逻辑是：模板都不在那台机器上，兜底挑中了也是一场注定慢 6 秒的启动。与其制造一个"能开但慢得离谱"的沙箱，不如明确告诉上层"没有合适的地方"，让上层决定报错或重试。</p>
+
+  <h2>六、最后的防线：洪峰限流，源头就把水龙头拧小</h2>
+
+  <p>前面都是"选谁"的问题。还有一个更粗鲁的：活动日一千人同时创建，请求洪水一样涌进来。如果全部立刻分派，每台机器要同时启动几百个虚拟机——启动虚拟机本身极吃 CPU 和磁盘 IO，瞬间所有创建通道堵死，已运行的沙箱跟着卡顿。这是"自己把自己挤兑死"。</p>
+  <p>解法分两层，都在 <code>pkg/scheduler/local.go</code> 和 <code>pkg/base/bufferqueue/</code>：</p>
+  <p><span class="hlg">第一层：排队桶。</span>按机器配置（instance_type）分桶，每桶一个队列，请求先入队，工人按并发上限一个一个处理。队列的数据结构是两个部件的组合：一个按入队时间戳排序的小顶堆（<code>TimeSortedQueue</code>，priority 取 <code>time.Now().UnixNano()</code>，天然先进先出），一个信号量（<code>semaphore.Weighted</code>）卡住并发。工人拿不到名额就睡 1ms 重试。为什么分桶？4 核和 32 核机器能承受的并发不同，混在一队，小机器会被大请求堵死。</p>
+  <p><span class="hlg">第二层：水位自动升降。</span>并发上限不是写死的。<code>monitorLimit()</code> 每 5 秒重算一次：</p>
+  <div class="codeblock">每节点创建上限 = max( 集群总创建并发 ÷ 健康节点数, 100 )
+全局创建并发   = ceil( 健康节点数 × 每节点上限 ÷ Master 副本数 )
+销毁并发同理，按每节点 50 计算</div>
+  <p>算出的水位和当前不同，就用 <code>SetLimit()</code> 动态改信号量。集群扩容了水位自动抬高，节点挂了自动收紧，全程无人值守。如果水位写死，活动日扩容了机器够用却仍按旧上限拒客，那才叫事故。</p>
+
+  <h2>七、收束：这条设计之路的全貌</h2>
+
+  <p>回头看，每一层设计都是被一个问题逼出来的，环环相扣：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>问题</th><th>逼出的设计</th><th>关键权衡</th></tr></thead>
+      <tbody>
+        <tr><td>随机挑会挑到快满的机器</td><td>五关并行淘汰，全票通过</td><td>超售换容量，预留防过载</td></tr>
+        <tr><td>淘汰后大家挤向"最好"的机器</td><td>四路效用分，加权归一化</td><td>预计算换选位延迟</td></tr>
+        <tr><td>"永远选最高分"导致热震荡</td><td>默认均匀随机，加权可选</td><td>稳定优先于最优</td></tr>
+        <tr><td>模板不在本机，秒开变慢开</td><td>模板本地性淘汰 + 失败不兜底</td><td>宁可拒绝，不制造慢启动</td></tr>
+        <tr><td>创建洪峰挤兑后端</td><td>分桶排队 + 水位自动升降</td><td>快速失败优于死等</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="punchline">
+    <small>一句话带走</small>
+    调度器是一条四段流水线：预选 → 五关淘汰 → 四路打分 → 抽签。它的每个部件都对应一个真实问题，而贯穿始终的设计哲学只有一句——不追求单次最优，追求整体稳定。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>调度主流程（Select + 兜底）</td><td><code>CubeMaster/pkg/scheduler/schedule.go</code></td></tr>
+        <tr><td>五道淘汰关</td><td><code>CubeMaster/pkg/selector/filter/</code></td></tr>
+        <tr><td>四路打分 + 后台预计算</td><td><code>CubeMaster/pkg/selector/score/</code></td></tr>
+        <tr><td>抽签与 Top N 选择</td><td><code>CubeMaster/pkg/scheduler/selctx/selectcontext.go</code></td></tr>
+        <tr><td>排队桶 + 动态限流</td><td><code>CubeMaster/pkg/base/bufferqueue/</code> · <code>pkg/scheduler/local.go</code></td></tr>
+        <tr><td>超售比、预留、各默认值</td><td><code>CubeMaster/pkg/base/config/config.go</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>CubeMaster 调度器 · CubeSandbox 技术深入 01/09 · 下一篇：生命周期管理——机器如何自己学会"休眠"</footer>
+</body>
+</html>

--- a/cubesandbox-tech/virtualization.html
+++ b/cubesandbox-tech/virtualization.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CubeShim + CubeHypervisor · containerd 到 KVM 的最后一公里</title>
+<style>
+  :root {
+    --bg:#0b1020; --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16);
+    --text:#e6eaf2; --text-dim:#9aa7bd; --text-faint:#6b7a93;
+    --blue:#4f8cff; --cyan:#2dd4bf; --purple:#a78bfa; --amber:#fbbf24; --red:#f87171; --green:#34d399;
+    --mono:"SFMono-Regular","JetBrains Mono","Fira Code",Consolas,Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans CJK SC",sans-serif;
+    --radius:14px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:2.05;font-size:16px}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.85em;background:rgba(79,140,255,.12);color:#b9d2ff;padding:2px 7px;border-radius:6px;white-space:nowrap}
+
+  header{position:sticky;top:0;z-index:100;backdrop-filter:blur(14px);background:rgba(11,16,32,.85);border-bottom:1px solid var(--border)}
+  .nav-inner{max-width:1120px;margin:0 auto;padding:0 24px;height:56px;display:flex;align-items:center;gap:22px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;white-space:nowrap}
+  .brand-mark{width:26px;height:26px;border-radius:8px;background:linear-gradient(135deg,var(--cyan),var(--blue));display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800}
+  .back-home{margin-left:auto;font-size:13px;color:var(--text-faint);border:1px solid var(--border);padding:5px 14px;border-radius:20px;white-space:nowrap}
+  .back-home:hover{color:var(--text);border-color:var(--border-strong);text-decoration:none}
+
+  main{max-width:740px;margin:0 auto;padding:44px 24px 96px}
+  .hero{border-bottom:1px solid var(--border);padding:12px 0 36px;margin-bottom:48px}
+  .hero .crumb{font-family:var(--mono);font-size:12px;color:var(--text-faint);letter-spacing:1px}
+  .hero h1{font-size:31px;font-weight:900;margin:14px 0 10px;line-height:1.4;background:linear-gradient(90deg,#fff,var(--cyan));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .hero .lead{font-size:16.5px;color:var(--text-dim);max-width:640px;line-height:2.1}
+
+  h2{font-size:20px;font-weight:800;margin:60px 0 4px;color:#f0f4ff;line-height:1.5}
+  h3{font-size:16px;font-weight:700;margin:28px 0 4px;color:#dbe4f5}
+  p{margin:16px 0}
+  .dim{color:var(--text-dim)}
+  .hl{color:var(--cyan);font-weight:600}
+  .hlb{color:var(--amber);font-weight:600}
+  .hlr{color:var(--red);font-weight:600}
+  .hlg{color:var(--green);font-weight:600}
+
+  .think{border-left:3px solid var(--purple);background:rgba(167,139,250,.06);padding:16px 22px;border-radius:0 10px 10px 0;margin:24px 0;color:var(--text-dim)}
+  .think .q{font-weight:700;color:var(--purple);margin-bottom:4px}
+
+  .codeblock{background:#0a0f1e;border:1px solid var(--border);border-radius:12px;padding:16px 20px;font-family:var(--mono);font-size:13px;color:#c8d3e8;overflow-x:auto;white-space:pre;line-height:1.9;margin:20px 0}
+  .codeblock .cm{color:var(--text-faint)}
+
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:20px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  thead th{background:rgba(79,140,255,.1);color:#bcd6ff;text-align:left;padding:9px 14px;font-weight:700;border-bottom:1px solid var(--border-strong)}
+  tbody td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text-dim);vertical-align:top}
+  tbody tr:last-child td{border-bottom:none}
+
+  .punchline{border:1px solid rgba(52,211,153,.4);background:rgba(52,211,153,.06);border-radius:var(--radius);padding:20px 24px;margin:30px 0;font-size:16px;line-height:2}
+  .punchline small{display:block;font-family:var(--mono);font-size:11px;color:var(--green);letter-spacing:1px;margin-bottom:8px}
+
+  footer{border-top:1px solid var(--border);padding:28px 24px 46px;text-align:center;color:var(--text-faint);font-size:13px}
+  @media(max-width:720px){.hero h1{font-size:25px}}
+  .flow{width:100%;height:auto;display:block;margin:24px 0 2px}
+  .flow .fn{fill:#eaf0fb;font-size:14px;font-weight:700;font-family:var(--sans)}
+  .flow .fd{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow .fm{fill:#6b7a93;font-size:10.5px;font-family:var(--mono)}
+  .flow .fl{fill:#9aa7bd;font-size:11.5px;font-family:var(--sans)}
+  .flow-cap{font-family:var(--mono);font-size:11px;color:var(--text-faint);letter-spacing:.6px;text-align:center;margin:6px 0 28px}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="nav-inner">
+    <div class="brand"><div class="brand-mark">C</div> CubeSandbox · 技术深入</div>
+    <a class="back-home" href="index.html">← 技术索引</a>
+  </div>
+</header>
+
+<main>
+
+  <div class="hero">
+    <div class="crumb">CUBESANDBOX · 核心技术 05 / 09</div>
+    <h1>containerd 到 KVM 的最后一公里</h1>
+    <p class="lead">这篇讲 CubeShim 与 CubeHypervisor。前一篇我们看到 Cubelet 把"启动 VM"包装成了 containerd 眼里的一个 Task——本篇要看明白：containerd 的请求到了之后，一台真正的 KVM 虚拟机是怎么被创建、暂停、落盘、再恢复的。这是整个虚拟化链路的执行末端。</p>
+  </div>
+
+  <h2>一、问题：两种语言之间的翻译层</h2>
+
+  <p>上面是 containerd，它只会说"容器"的语言：create、start、pause、resume、exec。下面是 Linux KVM，它只会说"虚拟机"的语言：KVM_CREATE_VM、KVM_RUN、内存映射。两者之间隔着巨大的语义鸿沟——containerd 说"暂停这个容器"，KVM 端要做的是"暂停 vCPU、把 VM 内存写盘、删除 VM 实例"。</p>
+  <p>CubeShim 就是这座桥。它是标准的 containerd Shim v2 进程，<span class="hl">每个沙箱一个</span>，同时持有两副面孔：对 containerd 它是个 Task 服务实现；对 KVM 它是个沙箱管理器。而"翻译"的过程还牵出一个并发模型问题——怎么让控制逻辑和 VMM 执行逻辑在同一个进程里安全地协作？看分层：</p>
+  <div class="codeblock">containerd（Cubelet 进程内）
+   │  ttrpc（shim socket）
+   ▼
+CubeShim  ──── Shim v2 进程，每个沙箱一个
+   │  SandBox：沙箱生命周期 + vsock 连接 guest agent
+   ▼
+CubeHypervisor  ── 封装 cube-hypervisor crate
+   │  send_request(ApiRequest)，通过 mpsc 通道
+   ▼
+VMM 线程（独立线程内运行事件循环）
+cube-hypervisor (VmmInstance)
+   │  vmm::Vm + hypervisor::KvmHypervisor
+   ▼
+/dev/kvm（KVM_CREATE_VM / KVM_RUN ...）</div>
+  <p>关键的设计决定是：<span class="hlb">VMM 在 shim 进程的独立线程里跑事件循环</span>，控制面与执行面通过 <code>ApiRequest</code>/<code>ApiResponse</code> 两条 mpsc 通道 + eventfd 通信，而不是直接函数调用。为什么？如果直接在控制线程里同步操作 KVM，一次慢操作（比如写盘）就会卡住整个 shim 的请求处理。异步化之后，控制线程发一条请求就继续处理别的，VMM 线程忙完了再把响应投回来。</p>
+  <p>这里还有一个更深的取舍：shim 崩溃 = VM 崩溃，生命周期强绑定。听起来像是缺陷——但反过来想，这正是"避免孤儿 VM"的保证：<span class="hl">没有 shim 就没有 VM，任何崩溃都会带着 VM 一起消失，系统里不可能出现一台没人管理的游离虚拟机。</span></p>
+
+  <h2>二、机制：沙箱创建——六步启动序列</h2>
+
+  <p>TaskService 收到 containerd 的 create 后，首次初始化沙箱并走完整启动流程：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>步骤</th><th>做什么</th></tr></thead>
+      <tbody>
+        <tr><td><b>1. start_vm</b></td><td>launch_vmm 启动 VMM 线程 → 若非"禁用快照"且非 app-snapshot-create，尝试 restore_vm（从模板快照恢复）；恢复失败仅 app-snapshot-restore 报错，否则回退 boot_vm → 等待 VsockServerReady 事件（10s 超时）</td></tr>
+        <tr><td><b>2. connect_agent</b></td><td>通过 vsock 建立到 guest 内 cube-agent 的 ttrpc 连接</td></tr>
+        <tr><td><b>3. reset_guest（恢复场景）</b></td><td>set_guest_date_time（时钟对齐）+ reseed_random_dev（重播种随机设备，防重复快照复用同一随机流）</td></tr>
+        <tr><td><b>4. 构造 CreateSandboxRequest</b></td><td>hostname（id 前 8 字符）、网络 interfaces/routes/ARP、cube_vip；按模式设 start_mode：SNAPSHOT 或 RESTORE；25s 超时</td></tr>
+        <tr><td><b>5. client.create_sandbox()</b></td><td>通知 guest agent 初始化共享命名空间、挂载存储</td></tr>
+        <tr><td><b>6. 启动监控</b></td><td>watch_oom（订阅 guest OOM 事件，转发为 TaskOOM）+ monitor_vm（轮询 try_wait_notify + 周期 agent health；收到 VmShutdown 或 agent 失联 → 置 Exited 并通知所有容器）</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>注意第 1 步的<span class="hl">回退逻辑</span>：如果是从模板恢复（restore_vm），恢复失败后不是直接放弃，而是回退到"从头启动"（boot_vm）——模板坏了，那就当普通机器冷启动，功能可用性优先。只有"app-snapshot-restore"这种必须从快照恢复的场景才允许失败。这是典型的降级策略：快照是优化，不是硬依赖。</p>
+
+  <h2>三、机制：ApiRequest——控制面与 VMM 的通信协议</h2>
+
+  <p>CubeHypervisor 的每个方法都对应一个 ApiRequest 枚举变体，VMM 线程收到后分发到 Vm 实现。这个枚举完整到可以当作"VMM 能力清单"看：</p>
+  <div class="codeblock">// hypervisor/vmm/src/api/mod.rs —— 完整枚举（节选）
+VmCreate(VmConfig) | VmBoot | VmDelete | VmInfo | VmmPing,
+VmPause | VmPauseToSnapshot(SnapshotConfig) | VmResumeFromSnapshot(RestoreConfig) | VmResume,
+VmWaitStart | VmCounters | VmShutdown | VmReboot | VmmShutdown,
+VmResize | VmResizeZone,
+VmAddDevice | VmAddUserDevice | VmRemoveDevice,
+VmAddDisk | VmAddFs | VmSetFs | VmAddPmem | VmAddNet | VmAddVdpa | VmAddVsock,
+VmSnapshot(SnapshotConfig) | VmRestore(RestoreConfig),
+VmCoredump | VmReceiveMigration | VmSendMigration | VmPowerButton</div>
+  <p>方法到请求的映射，把"暂停"这件事拆成了语义完全不同的两种：</p>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>CubeHypervisor 方法</th><th>ApiRequest</th><th>语义</th></tr></thead>
+      <tbody>
+        <tr><td>snapshot_vm</td><td>VmSnapshot</td><td>应用快照：内存落盘，VM 继续运行</td></tr>
+        <tr><td>pause_vm_cube</td><td>VmPauseToSnapshot</td><td>暂停 → 写快照 → 删除 VM（"暂停"语义）</td></tr>
+        <tr><td>resume_vm_cube</td><td>VmResumeFromSnapshot</td><td>从快照恢复 VM</td></tr>
+        <tr><td>delete_vm</td><td>VmDelete</td><td>关 VM，VMM 进程存活（之后还能恢复）</td></tr>
+        <tr><td>add_dev / remove_dev</td><td>VmAddDevice / VmRemoveDevice</td><td>设备热插拔，从响应解析 PciDeviceInfo.bdf</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>快照配置类型是 <code>SnapshotConfig{destination_url, snapshot_type, memory_vol_url}</code>，快照类型三种——full（完整内存）、incremental（pagemap+kpageflags 只存 CoW 匿名页）、soft-dirty（/proc/self/clear_refs + pagemap bit55）。快照版本号 <code>SNAPSHOT_VERSION = "1.0.3"</code>，落盘产物是 <code>config.json</code>（序列化的 VmConfig）+ <code>state.json</code>（快照状态）。这个版本号是恢复时校验的依据——版本不匹配的旧快照，宁可不恢复也不赌。</p>
+
+  <h2>四、机制：暂停 → 快照 → 恢复的完整链路</h2>
+
+  <p>CLM 自动暂停的请求，最终在这里落地。Cubelet 的 task.Pause 一路传下来：</p>
+  <div class="codeblock">TaskService::pause（要求 pod_scope 元数据，仅支持 Pod 级）
+  └─ SandBox::pause_vm
+       ├─ 状态校验（必须 Normal；有 exec 则拒绝——exec 会话还没结束）
+       ├─ disconnect_agent：停 monitor/oom，置空 client/conn
+       ├─ snapshot_path = /data/cubelet/root/pausevm/&lt;id&gt;（先 remove_dir_all 再 create）
+       ├─ ch.pause_vm_cube("file://...") → VmPauseToSnapshot
+       │     VMM 侧 = vm_pause() + vm_snapshot() + vm_delete()
+       │              （先暂停 vCPU → 保存时钟 → 内存落盘 → 删除 VM，进程存活）
+       └─ wait_notify 消费 VmShutdown 事件
+
+resume 反向：
+  TaskService::resume（要求 pod_scope + sandbox.paused）
+  └─ SandBox::resume_vm → resume_vm_with_config
+       ├─ ch.resume_vm_cube("file://...") → VmResumeFromSnapshot → vm_restore
+       │     读 config.json/state.json → 校验版本/磁盘/pmem 对齐 → 重建 VM
+       ├─ connect_agent + reset_guest
+       ├─ 每个容器 set_client（重启 wait_process 与日志转发）
+       └─ 重启 watch_oom + monitor_vm → 置 Normal</div>
+  <p>两个细节值得展开。<span class="hlg">一是暂停为什么是"写盘 + 删 VM"</span>：暂停不是把 VM 留在内存里等恢复——那资源一点没省。真正的暂停是把内存快照落到 <code>/data/cubelet/root/pausevm/&lt;id&gt;</code>，然后删掉 VM 实例，这样 VM 占的内存、vCPU 全部归还宿主机。恢复时再从快照把 VM 重建出来。这是"暂停 = 快照化"的完整语义。</p>
+  <p><span class="hlg">二是 vsock 等 I/O 的恢复</span>：恢复后 agent 连接要重建，每个容器要重新 set_client 重启 wait_process 与日志转发——因为整个 guest 是全新的进程树，宿主侧所有依赖旧连接的东西都得重来一遍。恢复的"重启一切"性质，是这类暂停方案绕不开的成本。</p>
+
+  <svg class="flow" viewBox="0 0 720 244" role="img" aria-label="暂停、恢复、回滚三岔路">
+    <defs>
+      <marker id="vArr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#2dd4bf"/></marker>
+      <marker id="vArrR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#f87171"/></marker>
+    </defs>
+    <rect x="0" y="0" width="720" height="244" rx="14" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.09)"/>
+    <text x="24" y="28" class="fm">pause / resume / rollback · 同一台 VM 的三条去路</text>
+
+    <rect x="250" y="36" width="220" height="44" rx="10" fill="rgba(45,212,191,.1)" stroke="rgba(45,212,191,.6)"/>
+    <text x="360" y="56" text-anchor="middle" class="fn">SandBox 生命周期操作</text>
+    <text x="360" y="72" text-anchor="middle" class="fd">状态机守卫（Normal / paused）</text>
+
+    <line x1="330" y1="80" x2="130" y2="96" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#vArr)"/>
+    <line x1="360" y1="80" x2="360" y2="96" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#vArr)"/>
+    <line x1="390" y1="80" x2="590" y2="96" stroke="#f87171" stroke-width="1.5" marker-end="url(#vArrR)"/>
+
+    <rect x="25" y="96" width="210" height="48" rx="10" fill="rgba(45,212,191,.08)" stroke="rgba(45,212,191,.45)"/>
+    <text x="130" y="117" text-anchor="middle" class="fn">task.Pause → pause_vm_cube</text>
+    <text x="130" y="135" text-anchor="middle" class="fd">仅 Pod 级 · 有 exec 则拒</text>
+    <rect x="255" y="96" width="210" height="48" rx="10" fill="rgba(45,212,191,.08)" stroke="rgba(45,212,191,.45)"/>
+    <text x="360" y="117" text-anchor="middle" class="fn">task.Resume → resume_vm_cube</text>
+    <text x="360" y="135" text-anchor="middle" class="fd">需 sandbox.paused</text>
+    <rect x="485" y="96" width="210" height="48" rx="10" fill="rgba(248,113,113,.08)" stroke="rgba(248,113,113,.5)"/>
+    <text x="590" y="117" text-anchor="middle" class="fn">RollbackSandbox → rollback_vm</text>
+    <text x="590" y="135" text-anchor="middle" class="fd">经 task.Update(annotations)</text>
+
+    <line x1="130" y1="144" x2="130" y2="152" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#vArr)"/>
+    <line x1="360" y1="144" x2="360" y2="152" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#vArr)"/>
+    <line x1="590" y1="144" x2="590" y2="152" stroke="#f87171" stroke-width="1.5" marker-end="url(#vArrR)"/>
+
+    <rect x="25" y="152" width="210" height="58" rx="10" fill="rgba(45,212,191,.06)" stroke="rgba(45,212,191,.4)"/>
+    <text x="130" y="173" text-anchor="middle" class="fn" style="fill:#2dd4bf">VmPauseToSnapshot</text>
+    <text x="130" y="191" text-anchor="middle" class="fd">暂停 vCPU → 保存时钟</text>
+    <text x="130" y="206" text-anchor="middle" class="fd">内存落盘 → 删除 VM</text>
+    <rect x="255" y="152" width="210" height="58" rx="10" fill="rgba(45,212,191,.06)" stroke="rgba(45,212,191,.4)"/>
+    <text x="360" y="173" text-anchor="middle" class="fn" style="fill:#2dd4bf">VmResumeFromSnapshot</text>
+    <text x="360" y="191" text-anchor="middle" class="fd">读 config/state.json 重建</text>
+    <text x="360" y="206" text-anchor="middle" class="fd">版本 / 磁盘 / pmem 对齐</text>
+    <rect x="485" y="152" width="210" height="58" rx="10" fill="rgba(248,113,113,.06)" stroke="rgba(248,113,113,.4)"/>
+    <text x="590" y="173" text-anchor="middle" class="fn" style="fill:#f87171">delete + 目标快照恢复</text>
+    <text x="590" y="191" text-anchor="middle" class="fd">delete 不写盘 · 排空陈旧</text>
+    <text x="590" y="206" text-anchor="middle" class="fd">VmShutdown 再恢复</text>
+
+    <text x="130" y="228" text-anchor="middle" class="fl">→ 内存 / vCPU 归还宿主机</text>
+    <text x="360" y="228" text-anchor="middle" class="fl">→ 重建 agent 连接，容器全重连</text>
+    <text x="590" y="228" text-anchor="middle" class="fl">→ 丢弃当前状态，回到历史</text>
+  </svg>
+
+  <h2>五、机制：回滚——"丢弃当前、回到历史"</h2>
+
+  <p>回滚与恢复看起来像，语义完全不同：恢复是"同一台机器从暂停中醒来"，回滚是<span class="hl">"丢弃当前状态、回到某个历史快照"</span>——它由 Cubelet 的 RollbackSandbox 通过 <code>task.Update(annotations)</code> 触发，对应 VMM 端：</p>
+  <div class="codeblock">rollback_vm：
+① delete_vm()          // 直接丢弃当前 VM——不写盘，省掉把内存落盘的 I/O
+② 排空 hypervisor 事件队列里的陈旧 VmShutdown
+                       // 防止新 monitor 把旧事件误判成"刚崩溃"
+③ resume_vm_with_config(Some(target_config))  // 从目标快照恢复</div>
+  <p>这里最妙的细节是第②步：delete_vm 会触发一个 VmShutdown 事件，如果不管它，重新恢复后新启动的 monitor 会读到这个陈旧事件，误以为 VM 崩了。所以回滚必须先排空事件队列，再做恢复。一个看似不起眼的步骤，防止了一个隐蔽的竞态。</p>
+
+  <h2>六、机制：KVM 后端与脏页日志</h2>
+
+  <p>hypervisor crate 通过 trait 抽象 KVM 后端。启动时打开 /dev/kvm、校验 KVM_API_VERSION，还通过 cpuid 0x40000002 检测 KVM-PV 变体。创建 VM 时做一系列 x86 准备：预取 MSR 列表、设置 identity map / TSS 地址、开启 split irq。vCPU 的 <code>run()</code> 就是 KVM_RUN 事件循环，把 IoIn/IoOut、Mmio、Shutdown/Hlt 等退出事件分发给 vm_ops。</p>
+  <p>最值得讲的是<span class="hlb">脏页日志</span>——它是增量快照和 live 迁移的基石。原理：</p>
+  <div class="codeblock">create_user_memory_region：遇到 KVM_MEM_LOG_DIRTY_PAGES flag 时，
+   先把该区域登记到 dirty_log_slots，但以 flags=0 建 region（先不记账）
+start_dirty_log：用 set_user_memory_region 重设 flags，真正开启脏页记录
+get_dirty_log：调 KVM_GET_DIRTY_LOG，拿"每页一位"的 bitmap</div>
+  <p>为什么延迟开启？因为脏页日志有性能开销——每写一个页都要在内核里置位。不开启时 zero overhead，需要做快照的那一刻才打开，快照完了再关。soft-dirty 增量快照与迁移（Send/ReceiveMigration）都依赖这份 bitmap：有了它，就知道从上次快照到现在哪些内存页变了，只序列化这些页，而不是整块内存。</p>
+
+  <h2>七、收束</h2>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>问题</th><th>设计</th><th>关键权衡</th></tr></thead>
+      <tbody>
+        <tr><td>containerd 与 KVM 语义不通</td><td>Shim v2 进程做翻译层</td><td>每沙箱一个 shim，隔离故障面</td></tr>
+        <tr><td>控制面与执行面并发</td><td>mpsc + eventfd 异步通信，VMM 独立线程</td><td>慢操作不阻塞控制线程</td></tr>
+        <tr><td>shim 崩溃后孤儿 VM</td><td>生命周期强绑定</td><td>shim 死 = VM 死，无游离 VM</td></tr>
+        <tr><td>暂停要真省资源</td><td>写盘 + 删 VM，恢复重建</td><td>恢复要重建一切连接</td></tr>
+        <tr><td>增量快照要知道改了哪些页</td><td>脏页日志，按需开启</td><td>开日志有开销，快照时才开</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="punchline">
+    <small>一句话带走</small>
+    CubeShim 是"containerd 眼里的一个 Task"与"KVM 眼里的一台 VM"之间的胶水：控制面在 shim 进程，执行面在独立 VMM 线程；暂停 = pause→snapshot→delete（内存落盘到 pausevm），恢复 = 读 config.json/state.json 重建 VM，回滚 = delete + restore 不写盘。
+  </div>
+
+  <h2>传送门：真想读代码，就这几个文件</h2>
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>想看什么</th><th>去这里</th></tr></thead>
+      <tbody>
+        <tr><td>沙箱生命周期</td><td><code>CubeShim/shim/src/sandbox/sb.rs</code>（PAUSE_VM_SNAPSHOT_BASE=/data/cubelet/root/pausevm）</td></tr>
+        <tr><td>沙箱配置解析</td><td><code>CubeShim/shim/src/sandbox/config.rs</code>（ANNO_VM_RES / ANNO_SNAPSHOT_BASE 等注解常量）</td></tr>
+        <tr><td>Hypervisor 封装</td><td><code>CubeShim/shim/src/hypervisor/cube_hypervisor.rs</code></td></tr>
+        <tr><td>Task API</td><td><code>CubeShim/shim/src/service/task_srv.rs</code></td></tr>
+        <tr><td>VmmInstance 线程</td><td><code>hypervisor/src/lib.rs</code></td></tr>
+        <tr><td>ApiRequest 枚举与处理</td><td><code>hypervisor/vmm/src/api/mod.rs</code>、<code>hypervisor/vmm/src/lib.rs</code></td></tr>
+        <tr><td>Vm 状态机与快照</td><td><code>hypervisor/vmm/src/vm.rs</code>（Pausable / Snapshottable）</td></tr>
+        <tr><td>KVM 后端</td><td><code>hypervisor/hypervisor/src/kvm/mod.rs</code></td></tr>
+        <tr><td>快照/迁移配置类型</td><td><code>hypervisor/vm-migration/src/lib.rs</code>（SnapshotType）</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</main>
+
+<footer>CubeShim + CubeHypervisor · CubeSandbox 技术深入 05/09 · 下一篇：guest agent——VM 里的"内应"</footer>
+</body>
+</html>

--- a/docs/zh/guide/kubernetes/deployment-record-2026-08-03-64host.md
+++ b/docs/zh/guide/kubernetes/deployment-record-2026-08-03-64host.md
@@ -1,0 +1,499 @@
+# CubeSandbox 0.6 K8s 部署记录（64_host）
+
+> 部署日期：2026-08-03
+> 部署方式：Helm Chart（Kubernetes 交付）
+> 控制面：`63_host`（k8s-master，192.168.4.63）
+> 计算面：`64_host`（k8s-node1，192.168.4.64，PVM 虚拟化）
+> 最终结果：`helm test` 8/8 通过，`cube` release v13 deployed；沙箱访问验证 `verify_cubesandbox.py` 34/34 通过
+
+> ::: warning 敏感信息
+> 本文档包含部署时生成的凭据（MySQL/Redis 密码、CubeProxy admin token），仅限内部部署记录使用，**请勿提交到公开仓库**。
+> :::
+
+> **目录**：一 背景与目标 · 二 环境信息 · 三 前置检查 · 四 部署前准备 · 五 部署时间线 · 六 关键问题（helm 部署） · 七 helm test 验证 · 八 Chart 修改 · 九 访问方式 · 十 注意事项 · **十一 沙箱访问验证与排障（2026-08-03 晚，含 MTU 黑洞与 auto_resume 修复）**
+
+---
+
+## 一、背景与目标
+
+在现有 K8s 集群上以 Helm Chart 方式部署 CubeSandbox 0.6：
+
+- `64_host` 无硬件虚拟化（VMware 未开启嵌套虚拟化，无 `/dev/kvm`），沙箱运行路径选择 **PVM（Pagetable-based Virtual Machine，软件虚拟化）**。
+- `64_host` 上已有 EMQX、Node-RED、gitlab-runner×3 等负载，已确认接受 PVM 安装触发节点重启造成的短暂中断。
+- `63_host` 为集群主节点（control-plane），复用为 CubeSandbox 控制面部署位置。
+
+## 二、环境信息
+
+| 项 | 值 |
+|---|---|
+| 集群版本 | Kubernetes v1.30.6 |
+| k8s-master | 192.168.4.63，Ubuntu 20.04.6 LTS，containerd 1.7.24 |
+| k8s-node1（64_host） | 192.168.4.64，Ubuntu 20.04.6 LTS，containerd 1.7.23 |
+| k8s-librax4 | 192.168.4.68，NotReady，未打 cube-node 标签，不参与 |
+| 沙箱虚拟化 | PVM（部署后 64_host 内核变为 `6.6.69-opencloudos9.cubesandbox.pvm.host-g0de43d6b3bcd`） |
+| Cubevs CIDR | `172.16.0.0/18`（preflight 校验通过） |
+| 持久化 | hostPath（集群无默认 StorageClass） |
+
+### 节点标签
+
+```bash
+kubectl label node k8s-node1 cube.tencent.com/cube-node=true
+kubectl label node k8s-node1 cube.tencent.com/allow-pvm-bootstrap=true   # 触发 PVM 内核安装
+```
+
+## 三、前置检查与结论
+
+| 检查项 | 结果 | 处理 |
+|---|---|---|
+| `/dev/kvm` / CPU `vmx/svm` | 无（VMware 未开嵌套虚拟化） | 使用 PVM |
+| cgroup v2 | 非必需；Cubelet 自动适配 v1/v2（`cgroup/local.go`） | 无需处理 |
+| 默认 StorageClass | 无（仅有 doris-be/doris-fe 的 no-provisioner） | 控制面组件改用 hostPath |
+| `kubectl` 权限（63_host root） | 需 `KUBECONFIG=/etc/kubernetes/admin.conf` | 后续命令均显式指定 |
+| XFS + loopback | 满足 | 无需处理 |
+| glibc / Docker | 满足 | 无需处理 |
+
+## 四、部署前准备
+
+### 4.1 工作目录与 chart 同步
+
+```bash
+# 在 63_host 上准备目录，从开发机同步 chart 源码
+mkdir -p /tmp/cube-deploy
+tar -czf /tmp/cube-deploy/chart.tgz -C /workspace/github/CubeSandbox deploy/kubernetes/chart
+scp -o StrictHostKeyChecking=no /tmp/cube-deploy/chart.tgz 63_host:/tmp/cube-deploy/
+ssh 63_host 'cd /tmp/cube-deploy && tar -xzf chart.tgz --overwrite'
+```
+
+### 4.2 runtime-values.yaml
+
+```yaml
+cubeProxy:
+  advertiseIP: "192.168.4.63"        # 控制面所在节点 IP
+  domain: "cube.app"
+  tls:
+    mode: selfSigned                  # 无现成证书，使用自签
+
+mysql:
+  host: ""
+  password: "58e5b968327c23458bc64d8f0b8565bf"
+  rootPassword: "bb2febc29e7c40574ea088059af5dd3d"
+  persistence:
+    hostPath: /data/mysql             # 无默认 StorageClass，改用 hostPath
+
+redis:
+  host: ""
+  password: "55168c39f049ba3bddc025ff9312e3ff"
+  persistence:
+    hostPath: /data/redis
+
+controlPlane:
+  master:
+    persistence:
+      hostPath: /data/CubeMaster/storage
+
+# k8s-master 有 node-role.kubernetes.io/control-plane:NoSchedule 污点，
+# 控制面组件需额外容忍该污点才能调度到控制面节点
+placement:
+  controlPlane:
+    tolerations:
+      - key: cube.tencent.com/control
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+
+# 64_host 是 Ubuntu（Debian 系），但 bootstrap 脚本优先尝试 rpm 包导致失败。
+# 将 rpmPath 指向不存在的路径，强制走 deb 分支安装 PVM 内核。
+bootstrap:
+  pvmHostKernel:
+    package:
+      rpmPath: /artifacts/kernel-pvm-host.rpm.unused
+```
+
+> 注意：`mysql` / `redis` 的 `persistence` 必须合并到同一 key 下，否则会覆盖前面已生成的密码（见「问题 5」）。
+
+## 五、部署执行时间线
+
+| 时间 | 动作 | 结果 |
+|---|---|---|
+| 16:08–16:10 | 生成 runtime-values.yaml，`helm template` 渲染校验 | 通过（render.out 15 万字节） |
+| 16:16 | 首次 `helm install cube` | 失败：`cubevs-cidr-preflight` 预检 Job `DeadlineExceeded` |
+| 16:27 | 修复 runtime-values.yaml 密码覆盖问题 | `helm template` 通过 |
+| 16:31 | upgrade（revision 4） | 通过，PVM DaemonSet 开始工作 |
+| ~16:40 | 发现 `cube-node-pvm` init `CrashLoopBackOff`（rpm not found） | 修复 rpmPath |
+| 16:46 | upgrade（revision 5） | 通过 |
+| 16:51 | upgrade（revision 6，`--no-hooks`） | 绕过 `cube-pvm-preflight` 鸡生蛋问题，完成 PVM 内核安装 |
+| ~16:55 | 64_host 因 PVM 内核安装重启，内核切换到 `6.6.69-...pvm.host-...` | 节点 Ready |
+| 16:58–17:37 | upgrade（revision 7–12） | 逐步修复 helm test 各问题 |
+| 17:54 | upgrade（revision 13） | deployed |
+| 17:59 | `helm test`（helm-test9.log） | **8/8 Succeeded** |
+
+## 六、关键问题与修复
+
+### 问题 1：`kubectl` 认证失败
+
+- 现象：`kubectl get nodes` 报 `the server has asked for the client to provide credentials`。
+- 原因：当前用户本地 kubeconfig 未配置正确凭据。
+- 修复：后续所有命令显式使用 `export KUBECONFIG=/etc/kubernetes/admin.conf`。
+
+### 问题 2：无默认 StorageClass，PVC 无法绑定
+
+- 现象：`kubectl get storageclass` 仅有 `doris-be` / `doris-fe`（no-provisioner），无默认类。
+- 影响：MySQL、Redis、CubeMaster 的 PVC 会一直 Pending。
+- 修复：runtime-values.yaml 中为 `mysql.persistence`、`redis.persistence`、`controlPlane.master.persistence` 显式配置 `hostPath`。
+
+### 问题 3：`cubevs-cidr-preflight` Job 超时（DeadlineExceeded）
+
+- 现象：首次 install 预检 Job 无法调度。
+- 原因：master 节点带默认污点 `node-role.kubernetes.io/control-plane:NoSchedule`，Job Pod 无容忍。
+- 修复：runtime-values.yaml 增加 `placement.controlPlane.tolerations`（容忍 `cube.tencent.com/control` 与 `node-role.kubernetes.io/control-plane`）。
+
+### 问题 4：`cube-node-pvm` init 容器 CrashLoopBackOff（rpm not found）
+
+- 现象：`/bin/sh: 1: rpm: not found`。
+- 原因：`pvm-host-bootstrap.sh` 在 `rpmPath` 有值时优先使用 rpm，即便目标是 Debian 系系统。
+- 修复：runtime-values.yaml 将 `bootstrap.pvmHostKernel.package.rpmPath` 指向不存在的路径（`/artifacts/kernel-pvm-host.rpm.unused`），强制脚本走 deb 分支。
+
+### 问题 5：`helm template` 密码校验失败
+
+- 现象：`mysql.password / mysql.rootPassword still equal the CHANGE_ME_* default sentinel`。
+- 原因：runtime-values.yaml 中 `mysql` / `redis` 的 `persistence` 被写成并列的重复 key，覆盖了前面生成的密码。
+- 修复：将 `persistence` 合并进 `mysql` / `redis` 各自的 key 下。
+
+### 问题 6：`cube-pvm-preflight` 预检 Job 阻塞（鸡生蛋）
+
+- 现象：`cube-pvm-preflight`（pre-upgrade hook）校验 PVM 就绪时，内核尚未被 DaemonSet 安装，hook 失败。
+- 修复：首次安装 PVM 内核时使用 `helm upgrade --no-hooks` 跳过 preflight，让 `cube-node-pvm` DaemonSet 完成内核安装后再恢复正常升级。
+
+### 问题 7：`helm test` Pod 全部 Pending
+
+- 现象：health / cubemastercli / mysql / redis / dns / node-image 测试 Pod 均为 Pending，describe 显示 `1 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }`。
+- 修复：`node-health.yaml` 中所有测试 Pod 增加 `{{- include "cube.controlPlanePlacement" . | nindent 2 }}`，使测试 Pod 可调度到 master。
+
+### 问题 8：`dns-test` 使用 busybox nslookup 失败
+
+- 现象：`nslookup cube.app` 报 `connection timed out; no servers could be reached`，但 `getent hosts` / `curl` 正常。
+- 原因：busybox nslookup 与集群 CoreDNS rewrite zone 配合不佳。
+- 修复：`dns-test` 改用 `curlimages/curl` 镜像 + `getent hosts`。
+
+### 问题 9：`health-test` / `node-image-test` curl 解析失败
+
+- 现象：`Could not resolve host: cube-master.cube-system.svc.cluster.local`，而 `curl -4` 成功。
+- 原因：CoreDNS 对无法回答的 AAAA 查询向上游转发且上游超时；curl 默认先探测 IPv6 导致失败。
+- 修复：测试脚本内定义 `curl() { command curl -4 --retry 3 --retry-all-errors --retry-delay 1 "$@"; }` 包装函数，强制 IPv4 并重试。
+
+### 问题 10：`dns-test` getent 偶发失败
+
+- 现象：同一测试偶发失败（CoreDNS 上游查询瞬时超时）。
+- 原因：`getent` 单次查询无重试，`set -e` 下直接退出。
+- 修复：`a_record()` 包装 5 次重试（每次 sleep 1s）。
+
+### 问题 11：`proxy-control-test` 根路径 400
+
+- 现象：`curl http://cube-proxy.../` 偶发 DNS 失败；HTTPS 返回 `400 {"error":"bad request"}`。
+- 原因：CubeProxy 数据面只代理沙箱流量，裸 `/` 路径本就返回 400（设计如此）；且原探针端口/域名用法错误。
+- 修复：探针改为访问 admin 健康端点 `GET /admin/healthz`，通过 `secretKeyRef` 注入 `cube-admin-token` 作为 `X-Cube-Admin-Token` 请求头，校验返回 200。
+- 补充事实：admin token 在 proxy 的 `global.conf` 中用的是 **secret 解码后的明文**（非 base64 原文）；测试 Pod 经 `secretKeyRef` 挂载时已自动解码，与 proxy 一致。
+
+## 七、验证结果（helm test，v13）
+
+```
+TEST SUITE: cube-health-test            Succeeded
+TEST SUITE: cube-cubemastercli-test     Succeeded
+TEST SUITE: cube-mysql-test             Succeeded
+TEST SUITE: cube-redis-test             Succeeded
+TEST SUITE: cube-proxy-control-test     Succeeded
+TEST SUITE: cube-dns-test               Succeeded
+TEST SUITE: cube-node-image-test        Succeeded
+TEST SUITE: cube-node-runtime-test      Succeeded
+```
+
+### 最终资源状态
+
+```bash
+$ kubectl get deploy,ds,sts -n cube-system
+deployment.apps/cube-api                1/1   1   1    # :3000 (外部 E2B SDK)
+deployment.apps/cube-cubemastercli      1/1   1   1
+deployment.apps/cube-lifecycle-manager  1/1   1   1    # :8083
+deployment.apps/cube-master             1/1   1   1    # :8089
+deployment.apps/cube-ops                1/1   1   1    # :3010 (WebUI /opsapi + SDK)
+deployment.apps/cube-proxy              1/1   1   1    # :80/443/8082
+deployment.apps/cube-webui              1/1   1   1    # :12088
+
+daemonset.apps/cube-node                1/1   # k8s-node1
+daemonset.apps/cube-node-bootstrap      1/1
+daemonset.apps/cube-node-installer      1/1
+daemonset.apps/cube-node-pvm            1/1   # 内核已装好，steady
+
+statefulset.apps/cube-mysql             1/1
+statefulset.apps/cube-redis             1/1
+```
+
+## 八、Chart 代码修改（本机工作区）
+
+仅修改 `deploy/kubernetes/chart/templates/tests/node-health.yaml`（测试探针健壮性，可保留/回退）：
+
+1. 所有测试 Pod 增加 `cube.controlPlanePlacement`，解决单主节点 + 污点场景下测试 Pod 无法调度的问题。
+2. `health-test` / `node-image-test`：新增 `curl()` 包装函数，强制 `-4` + 重试，规避 CoreDNS AAAA 上游转发超时。
+3. `dns-test`：镜像由 busybox 改为 `curlimages/curl`，解析改用 `getent`，并加 5 次重试循环。
+4. `proxy-control-test`：探针改为 `GET /admin/healthz`（带 `X-Cube-Admin-Token`），校验 HTTP 200。
+
+## 九、当前状态与访问方式
+
+所有 Service 均为 ClusterIP，集群内无现成 Ingress Controller：
+
+| Service | ClusterIP | 端口 | 说明 |
+|---|---|---|---|
+| cube-webui | 10.50.122.93 | 12088 | WebUI |
+| cube-api | 10.50.194.242 | 3000 | E2B SDK |
+| cube-ops | 10.50.250.255 | 3010 | CubeOps |
+| cube-master | 10.50.236.252 | 8089 | CubeMaster |
+| cube-proxy | 10.50.184.147 | 80/443/8082 | 沙箱流量入口 |
+| cube-lifecycle-manager | 10.50.157.246 | 8083 | 生命周期管理 |
+| cube-mysql / cube-redis | Headless | 3306/6379 | 存储 |
+
+从外部访问（临时）：
+
+```bash
+KUBECONFIG=/etc/kubernetes/admin.conf kubectl -n cube-system port-forward svc/cube-webui 12088:12088
+```
+
+沙箱域名 `*.cube.app` 已由 CoreDNS rewrite 指向 `cube-proxy` Service，集群内可访问。
+
+## 十、注意事项
+
+1. **PVM 内核不可逆**：`bootstrap.pvmHostKernel.enabled=true` 会安装宿主内核并修改 GRUB，`helm rollback` 不会撤销内核/GRUB 改动；如需回退需人工处理。
+2. **主机重启影响**：PVM 内核安装触发 64_host 重启，期间其上负载（EMQX、Node-RED、gitlab-runner）中断，已获确认接受。
+3. **k8s-librax4 NotReady**：该节点未打 cube-node 标签，不影响当前部署；如需扩容需先恢复其 Ready。
+4. **凭据安全**：MySQL/Redis 密码与 admin token 均在本记录及 `runtime-values.yaml` 中，涉及敏感信息，注意保管。
+5. **升级说明**：控制面组件可滚动升级；计算面（`cube-node` Big Pod）升级会重建并中断沙箱，参考 `docs/zh/guide/kubernetes/upgrade.md`。
+
+## 附录：常用命令速查
+
+```bash
+# kubectl 认证
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+# 节点标签（扩容计算节点时）
+kubectl label node <node> cube.tencent.com/cube-node=true
+kubectl label node <node> cube.tencent.com/allow-pvm-bootstrap=true
+
+# 升级
+cd /tmp/cube-deploy
+helm upgrade cube ./deploy/kubernetes/chart -n cube-system \
+  -f deploy/kubernetes/chart/values-cn.yaml -f runtime-values.yaml \
+  --wait --timeout 30m
+
+# 绕过 preflight（仅 PVM 首次安装等场景）
+helm upgrade cube ./deploy/kubernetes/chart -n cube-system \
+  -f deploy/kubernetes/chart/values-cn.yaml -f runtime-values.yaml --no-hooks
+
+# 测试
+helm test cube -n cube-system --timeout 20m
+
+# 查看组件日志
+kubectl logs -n cube-system -l app.kubernetes.io/component=cube-node -c cubelet --tail=100
+kubectl logs -n cube-system -l app.kubernetes.io/component=cube-node-pvm -c pvm-host-bootstrap --tail=100
+```
+
+---
+
+## 十一、部署后沙箱访问验证与排障（2026-08-03 晚至 08-04）
+
+`helm test` 8/8 通过只证明控制面组件健康。沙箱的真实可用性（SDK 建沙箱、命令执行、网络、生命周期）需要额外验证。本节记录完整排障链。
+
+### 11.1 验证环境
+
+从开发机（`207_songtao`）通过 `ssh 63_host` 打通两条 `kubectl port-forward` 隧道：
+
+```bash
+export KUBECONFIG=/etc/kubernetes/admin.conf
+nohup kubectl port-forward svc/cube-api   -n cube-system 13000:3000 --address 127.0.0.1 &
+nohup kubectl port-forward svc/cube-proxy -n cube-system 18080:80   --address 127.0.0.1 &
+```
+
+> **注意**：`kubectl port-forward` 需与 `KUBECONFIG=/etc/kubernetes/admin.conf` 同时使用，否则报 `Unauthorized`；且不会在隧道对端 Pod 重建/滚动更新后自动恢复，需重新拉起。
+
+SDK 环境变量（`cubesandbox` Python SDK）：
+
+```bash
+export CUBE_API_URL="http://127.0.0.1:13000"          # 经 port-forward 到 cube-api
+export CUBE_TEMPLATE_ID="tpl-b904804bf74a478b84e3636d" # 最终使用的模板
+export CUBE_PROXY_NODE_IP="127.0.0.1"                  # 经 port-forward 到 cube-proxy
+export CUBE_PROXY_PORT_HTTP="18080"                    # 注意：SDK 默认 80，必须显式覆盖
+```
+
+### 11.2 排障链一：模板 envd 端口（命令执行 `ConnectException`）
+
+- 现象：建沙箱成功，但 `commands.run` 报 `e2b_connect.client.ConnectException: (<Code.unknown: 'unknown'>, '')`。
+- 根因：SDK 通过 `cube-proxy → 沙箱内 envd:49983` 执行命令。最初用 `cubemastercli template create-from-image --expose-port 8000` 建模板，暴露的容器端口不是 49983。
+- 修复：用 `--expose-port 49983` 重建模板。
+
+```bash
+cubemastercli --address "$CUBEMASTERCLI_ADDRESS" --port "$CUBEMASTERCLI_PORT" \
+  template create-from-image --image <image> --expose-port 49983 --writable-layer-size 20Gi
+```
+
+> `--writable-layer-size` 为必填，缺省会直接报错；`cubemastercli template render` 语法是 `--template-id <id>` 而非位置参数。
+
+### 11.3 排障链二：沙箱 DNS（公网域名无法解析）
+
+- 现象：沙箱内 `curl https://www.baidu.com` 返回 `000`，`getent hosts` 失败；沙箱内 `resolv.conf` 只有 `nameserver 10.50.0.10`（集群 CoreDNS），且该 IP 的数据面流量被丢弃。
+- 根因：CubeNet 的 `alwaysDeniedSandboxCIDRs` 默认拒绝 `10.0.0.0/8`、`172.16.0.0/12`、`192.168.0.0/16` 等私网段（安全策略），而 CoreDNS 的 ClusterIP `10.50.0.10` 恰好落在被拒段内——**沙箱 → CoreDNS 的 DNS 查询在数据面被静默丢弃**，与 `runtime-values.yaml` 里 `cubeNode.dns.sandbox` 是否生效无关。
+- 修复（两层）：
+  1. `runtime-values.yaml` 为沙箱显式配置公网 DNS（并重启 cube-node 让 cubelet 的 `dynamicconf/conf.yaml` 生效）：
+
+     ```yaml
+     cubeNode:
+       dns:
+         sandbox:
+           followNodeDns: false
+           nameservers:
+             - 8.8.8.8
+             - 223.5.5.5
+     ```
+
+  2. 模板创建时用 `--dns` 把公网 DNS 直接烘焙进 rootfs 的 `resolv.conf`（因为 Cubelet 的 `disable_host_netfile: true` 不会在运行时覆盖 guest 内静态 `resolv.conf`，仅改 cubelet 配置对已建 rootfs 无效）。
+
+     ```bash
+     cubemastercli template create-from-image --image <image> \
+       --expose-port 49983 --writable-layer-size 20Gi \
+       --dns 8.8.8.8 --dns 223.5.5.5
+     ```
+
+### 11.4 排障链三：MTU 黑洞（HTTPS 握手超时、大文件截断）
+
+这是最深的排障链，涉及 CubeShim 重编译 + 宿主机 VMM 代码修复。
+
+- 现象（三段式，层层递进）：
+  1. DNS 修好后：`curl -s http://www.baidu.com` 返回 `200`，但 `curl -k https://www.baidu.com` 返回 `000`（TLS 握手超时）。
+  2. `socket.create_connection(("www.baidu.com", 443))` 能连上（TCP 层通），说明是数据面在 TLS 交互中丢包。
+  3. 下载 `1MB.zip` 只收到约 228KB 即断——典型的**载荷超过某阈值被静默丢弃**。
+- 根因：**MTU 黑洞**。链条如下：
+  - Calico（VXLAN）下 `cube-node` Pod 的 `eth0` MTU = **1450**。
+  - 但沙箱 tap（`cube-dev` / `z172.16.x.y`）与 guest 内 `eth0` MTU = **1500**（打包默认 `mvm_mtu=1500`）。
+  - guest 通告 MSS=1460（1500−40），回程 TCP 段一旦超过 Pod MTU（1450−40=1410 有效载荷）就会被 Calico 数据面**静默丢弃**。
+  - 表现：TLS ServerHello 之后的大段（证书）到不了客户端 → 握手超时；大文件下载截断。
+- 修复（代码 + 镜像 + 节点三层）：
+
+  **a. Helm Chart 增加 MTU 参数（已合入工作区）**
+  - `deploy/kubernetes/chart/values.yaml`：新增 `cubeNode.network.mtu`（默认 `0` 表示用打包默认值）。
+  - `deploy/kubernetes/chart/templates/_helpers.tpl`：`cube.nodeComponentCommonEnv` 注入 `CUBE_SANDBOX_NETWORK_MTU`。
+  - `deploy/kubernetes/images/scripts/cube-node-entrypoint.sh` 与 `component-entrypoint.sh`：启动时用 `sed` 把 `config.toml` 里的 `mvm_mtu` 打补丁为配置值（含整型校验，防注入）。
+
+  ```yaml
+  # runtime-values.yaml 追加
+  cubeNode:
+    network:
+      mtu: 1450          # 必须与 Pod 网络 MTU（此处 Calico 1450）一致
+  ```
+
+  **b. CubeShim 透传 MTU 到虚拟机（已合入工作区，需重编译 cube-shim）**
+  - `CubeShim/shim/src/hypervisor/config.rs` `add_nets`：显式 `nc.mtu = Some(n.mtu as u16)`，使 VIRTIO_NET_F_MTU 通知 guest 应用通告 MTU。
+  - `CubeShim/shim/src/common/utils.rs` `restore_nets_config`：快照恢复路径同样透传 MTU。
+  - `hypervisor/vmm/src/config.rs` `update_nets`：补 `mtu_map`，把 MTU 从输入 `NetConfig` 正确复制到 VM 的 `NetConfig`（此前只更新 tap / rate_limiter，快照恢复会丢掉 MTU）。
+
+  **c. 64_host 编译并替换 cube-shim 二进制**
+
+  ```bash
+  # 64_host 上：缺的编译依赖先装上
+  apt-get install -y build-essential libseccomp-dev libcap-ng-dev
+
+  # 编译（CubeShim 工作区已同步到 64_host）
+  cd /opt/cube-build/CubeShim
+  cargo build --release
+
+  # 替换节点二进制（containerd-shim-cube-rs + cube-runtime）
+  /tmp/deploy-shim.sh   # 把 target/release/{containerd-shim-cube-rs,cube-runtime}
+                        # 复制到 /usr/local/services/cubetoolbox/cube-shim/bin/
+  # 重启 cubelet 容器使新 shim 生效
+  kubectl -n cube-system rollout restart ds/cube-node
+  ```
+
+  > 首次编译曾报 `error: linking with 'cc' failed: cannot find -lseccomp / -lcap-ng`，安装 `libseccomp-dev libcap-ng-dev` 后解决。
+
+  **d. 重建模板（关键！）**
+  - 模板创建流程会先起"build 沙箱"再打快照。若 build 沙箱是**从旧模板快照恢复**的，快照里的 guest `eth0` MTU 仍是 1500，新 shim 的 `update_nets` 修复恰好覆盖了这一路径。
+  - 但更稳妥的做法是重新建一个模板（不带 `--node` 让 CubeMaster 自动选节点），确保 build 沙箱冷启动，使新 shim 的 MTU 透传生效。重建后验证：
+
+    ```bash
+    # 沙箱内
+    ip link show eth0        # mtu 1450
+    curl -k https://www.baidu.com  # 200，TLS 正常
+    ```
+
+- 验证成果：guest `eth0` MTU 从 1500 → **1450** 后，HTTPS 握手与大文件下载全部恢复正常；最终模板 `tpl-b904804bf74a478b84e3636d`。
+
+### 11.5 排障链四：auto_resume 504（CubeProxy 心跳注册写向过期 Redis Pod IP）
+
+- 现象：`verify_cubesandbox.py` 步骤 10 中，auto_pause（35s 后自动暂停）正常、`get_info` 也显示 `paused`，但随后触发 auto_resume 的命令全部 `504 Gateway Time-out`（来自 openresty），恢复后状态仍 `paused`。
+- 定位（逐层排除）：
+  - 手动复现：单独建 auto_pause 沙箱 → paused → resume，一切正常。说明功能本身没坏，是**脚本运行环境特定状态**导致。
+  - CubeProxy error.log 无该沙箱 gate 记录 → gate 从未走 resume 分支（状态字典里没有该沙箱的 `paused`）。
+  - CLM 日志无对应 `resume request received` → **CLM 根本没收到 resume 请求**。
+  - `$cube_sidecar_addr = cube-lifecycle-manager.cube-system.svc.cluster.local:8083` 可从 cube-proxy 内连通（healthz 200）→ 排除链路不通。
+  - 结论：**CubeProxy 本地状态字典 `cube_sandbox_state` 从未被填充**，gate 直接放行请求到已暂停的 backend → 30s 无响应 → 504。
+- 根因：**CLM 的服务发现 fleet 为空**。
+  - CubeProxy 通过 `proxy_registry.lua`（`ngx.timer` 里用 cosocket 连 Redis）写 `cube:v1:shared:cube_proxy:*` 心跳，供 CLM 发现。
+  - 该 Redis 地址由 Helm chart 渲染时 `lookup` 固化：本环境 Redis 是 **headless Service + StatefulSet**，chart 走了 `Endpoints` 分支，把当时的 Pod IP `10.60.235.237` 硬编码进 `CUBE_PROXY_REGISTRY_REDIS_HOST`。
+  - Redis Pod 重建后 IP 变为 `10.60.235.240`，但 cube-proxy 的 env 是静态的 → 心跳一直写向**已不可达的旧地址** → Redis 里 `cube:v1:shared:cube_proxy:*` 永远不存在 → CLM `broadcast` 对空 fleet 静默跳过（仅 Debug 日志，无 warn）→ proxy 状态字典一直为空。
+- 修复（chart + 现网）：
+  1. **Chart 修复（已合入工作区）** `deploy/kubernetes/chart/templates/proxy.yaml`：headless Service 分支不再 `lookup` Endpoints IP，改为 StatefulSet Pod DNS 名：
+
+     ```yaml
+     {{- $redisRegistryHost = printf "%s-0.%s.%s.svc.%s" (include "cube.redisName" .) (include "cube.redisName" .) .Release.Namespace (include "cube.clusterDomain" .) -}}
+     ```
+
+     即 `cube-redis-0.cube-redis.cube-system.svc.cluster.local`，由 `cube-proxy-entrypoint.sh` 启动时 `getent` 解析成当前存活 IP（cosocket 无 nginx resolver，必须在启动时解析好）。
+
+  2. **现网立即修复**：
+
+     ```bash
+     kubectl set env deploy/cube-proxy -n cube-system \
+       CUBE_PROXY_REGISTRY_REDIS_HOST=cube-redis-0.cube-redis.cube-system.svc.cluster.local
+     kubectl rollout status deploy/cube-proxy -n cube-system --timeout=90s
+     ```
+
+- 验证：
+  - Redis 中出现 `cube:v1:shared:cube_proxy:registry` + `heartbeat`，心跳持续刷新。
+  - CLM 日志：`discovery: proxy joined` → `replay begin entries=3` → `replay done pushed:3, failed:0`。
+  - 复跑 `verify_cubesandbox.py`：步骤 10 auto_resume **通过**。
+
+### 11.6 验证脚本最终结果（34/34 通过）
+
+```bash
+cd /workspace/working/mega-agent/scripts/cube
+export CUBE_API_URL="http://127.0.0.1:13000"
+export CUBE_TEMPLATE_ID="tpl-b904804bf74a478b84e3636d"
+export CUBE_PROXY_NODE_IP="127.0.0.1"
+export CUBE_PROXY_PORT_HTTP="18080"
+python3 -u verify_cubesandbox.py
+```
+
+```
+结果: 34/34 通过, 0 失败
+```
+
+覆盖项：创建/销毁沙箱、基础命令（bash/python/R/node/envd）、numpy/pandas、公网 HTTP(S)+DNS+urllib、文件读写（UTF-8/emoji）、目录操作、错误处理、超时处理、pause/resume 与 writable layer 保留、auto_pause/auto_resume、envd 日志、hostPath 挂载持久化。
+
+### 11.7 本次代码修改汇总（工作区，未提交）
+
+| 文件 | 修改 |
+|---|---|
+| `CubeShim/shim/src/hypervisor/config.rs` | `add_nets` 透传 MTU（VIRTIO_NET_F_MTU） |
+| `CubeShim/shim/src/common/utils.rs` | `restore_nets_config` 快照恢复透传 MTU |
+| `hypervisor/vmm/src/config.rs` | `update_nets` 补 MTU 复制（快照恢复丢 MTU） |
+| `deploy/kubernetes/chart/values.yaml` | 新增 `cubeNode.network.mtu`（默认 0） |
+| `deploy/kubernetes/chart/templates/_helpers.tpl` | 注入 `CUBE_SANDBOX_NETWORK_MTU` 环境变量 |
+| `deploy/kubernetes/images/scripts/cube-node-entrypoint.sh` / `component-entrypoint.sh` | 启动时 patch `mvm_mtu`（含整型校验） |
+| `deploy/kubernetes/chart/templates/proxy.yaml` | CubeProxy registry 的 Redis 地址改用 StatefulSet Pod DNS 名（防 IP 过期） |
+| `deploy/kubernetes/chart/templates/tests/node-health.yaml` | 测试 Pod 增加 control-plane 容忍；curl 强制 IPv4+重试；`dns-test` 改用 `getent`；`proxy-control-test` 探 `/admin/healthz` 带 token |
+
+### 11.8 遗留与注意
+
+1. `kubectl port-forward` 不会随目标 Pod 重建自动恢复，运行验证前先确认两条隧道（13000/18080）存活。
+2. `CUBE_PROXY_PORT_HTTP` 必须显式设置：SDK 默认 `80`，指向 63_host 上的其它 nginx 而非 cube-proxy，会得到 404。
+3. 沙箱 DNS 公网化后，集群内私网域名（如内网服务）需另行在 `cubeNode.dns.sandbox` 或模板 DNS 中补充，否则会走 `alwaysDeniedSandboxCIDRs` 被拒。
+4. 本次对 CubeShim/VMM 的修改需要重新构建镜像（`deploy/kubernetes/images/build-cube-images.sh`）才能在其它节点/正式发布中生效；64_host 上为临时替换节点二进制。后续发布请将 `mvm_mtu` 配置、CubeShim MTU 透传、CubeProxy registry 修复一并合入。


### PR DESCRIPTION
## Summary

Two complementary additions for operators and newcomers:

- `docs/zh/guide/kubernetes/deployment-record-2026-08-03-64host.md` — a
  step-by-step record of deploying CubeSandbox 0.6 via Helm on a PVM
  (no-KVM) node, including four troubleshooting chapters (envd port,
  sandbox DNS, MTU blackhole, auto-resume 504) and the final sandbox
  access verification results.
- `cubesandbox-tech/` — a static HTML technical-blog series explaining
  CubeSandbox internals: virtualization, guest agent, scheduler, CLM,
  CubeProxy, CubeVS network, CubeEgress, CubeCow, plus a newbie-oriented
  deploy-troubleshoot series mapping each resolved incident to its
  underlying subsystem and code path.

All files are new; no existing docs are modified.

Assisted-by: Cursor:deepseek-v4-flash
