### PR TITLE
feat(node-sdk): add volume support 

### DIFF
--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -303,6 +303,54 @@ const clones = await sb.clone(3, { concurrency: 3 });
 `concurrency`), then deletes the ephemeral snapshot. If any create fails, all
 successful siblings are killed and the first error is re-thrown.
 
+### Volumes
+
+Persistent volumes survive sandbox lifecycles and are mounted at creation via
+the e2b-style `volumeMounts` mapping (`{ mountPath: volume }`):
+
+```ts
+import { Sandbox, Volume, VolumeMount, VolumeInUseError, VolumeNotFoundError } from "@cubesandbox/sdk";
+
+// driver is optional: when omitted the backend uses its first configured
+// volume plugin (e2b compatible). name is optional too — when omitted the
+// server generates a UUID used as both name and volume ID.
+const vol = await Volume.create({ name: "my-data", driver: "cos" }); // POST /volumes
+console.log(vol.volumeId, vol.token);
+
+const volumes = await Volume.list(); // GET /volumes (no tokens)
+const info = await Volume.getInfo("my-data"); // GET /volumes/:id (includes token)
+const reconnected = await Volume.connect("my-data"); // e2b compatible; wraps getInfo
+
+const sb = await Sandbox.create({
+  volumeMounts: {
+    "/workspace": vol, // Volume instance…
+    "/cache": "shared-cache", // …or a volume-ID string
+    "/dataset": new VolumeMount(vol, { readOnly: true }), // read-only (Cube extension)
+  },
+});
+
+await sb.kill();
+await Volume.destroy("my-data"); // DELETE /volumes/:id — true, or false when already gone
+```
+
+Deleting a volume does not auto-detach it: destroy the sandboxes using it
+first, otherwise the server refuses with a `VolumeInUseError` (HTTP 409):
+
+```ts
+try {
+  await Volume.destroy("my-data");
+} catch (err) {
+  if (err instanceof VolumeInUseError) {
+    // still mounted — destroy the sandboxes using it first
+  } else {
+    throw err;
+  }
+}
+```
+
+`VolumeInfo`'s `toString`/`console.log` output masks `token` (a data-plane
+credential) — read the field directly when the actual value is needed.
+
 ### List & health check
 
 ```ts
@@ -377,6 +425,16 @@ var**. Inline fields accepted by `create`: `apiUrl`, `proxyNodeIp`,
 | `Sandbox.health(config?)` | `GET /health` — service health check |
 | `Sandbox.listSnapshots(options?)` | `GET /snapshots` — list snapshots (paginated) |
 | `Sandbox.deleteSnapshot(snapshotId, options?)` | `DELETE /templates/:id` — delete a snapshot |
+
+### `Volume` — static methods
+
+| Method | Description |
+|---|---|
+| `Volume.create(options?)` | `POST /volumes` — create a volume (`name`/`driver` optional) |
+| `Volume.list(options?)` | `GET /volumes` — list volumes (no tokens) |
+| `Volume.getInfo(volumeId, options?)` | `GET /volumes/:id` — get one volume, includes `token` |
+| `Volume.connect(volumeId, options?)` | e2b-compatible connect (wraps `getInfo`) |
+| `Volume.destroy(volumeId, options?)` | `DELETE /volumes/:id` — `true`, or `false` when already gone |
 
 ### `Sandbox` — instance methods
 

--- a/sdk/node/src/exceptions.ts
+++ b/sdk/node/src/exceptions.ts
@@ -25,6 +25,12 @@ export class AuthenticationError extends CubeSandboxError {}
 /** Raised on an unexpected backend error (HTTP 4xx/5xx). */
 export class ApiError extends CubeSandboxError {}
 
+/** Raised when a volume is not found (HTTP 404). */
+export class VolumeNotFoundError extends CubeSandboxError {}
+
+/** Raised when deleting a volume that is still mounted by one or more sandboxes (HTTP 409). */
+export class VolumeInUseError extends CubeSandboxError {}
+
 /** Raised when a filesystem path is not found. */
 export class FilesystemNotFoundError extends CubeSandboxError {}
 

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -33,7 +33,17 @@ export {
   ApiError,
   FilesystemNotFoundError,
   PartialWriteError,
+  VolumeNotFoundError,
+  VolumeInUseError,
 } from "./exceptions.js";
+
+export {
+  Volume,
+  VolumeInfo,
+  VolumeMount,
+  MAX_VOLUME_NAME_LEN,
+  type VolumeMountsArg,
+} from "./volume.js";
 
 export {
   Commands,

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -23,6 +23,7 @@ import {
 import { Pty } from "./pty.js";
 import { createIdleTimeout, parseNdjsonStream, type RunCodeCallbacks } from "./stream.js";
 import { buildDataDispatcher, controlFetch, dataScheme } from "./transport.js";
+import { serializeVolumeMounts, type VolumeMountsArg } from "./volume.js";
 
 export const JUPYTER_PORT = 49999;
 
@@ -53,6 +54,16 @@ export interface CreateOptions {
   allowInternetAccess?: boolean;
   network?: NetworkOptions;
   lifecycle?: LifecycleOptions;
+  /**
+   * Persistent volumes to mount at creation — an e2b-style mapping of mount
+   * path → volume (a `Volume`/`VolumeInfo` instance or volume-ID string, or a
+   * `VolumeMount` wrapper for the read-only Cube extension):
+   *
+   * ```ts
+   * volumeMounts: { "/workspace": vol, "/dataset": new VolumeMount(vol2, { readOnly: true }) }
+   * ```
+   */
+  volumeMounts?: VolumeMountsArg;
   config?: Config | ConfigOptions;
   /** Extra fields forwarded verbatim into the create request body. */
   extra?: Record<string, unknown>;
@@ -393,6 +404,9 @@ export class Sandbox {
     }
     if (options.lifecycle) {
       payload.lifecycle = serializeLifecycle(options.lifecycle);
+    }
+    if (options.volumeMounts && Object.keys(options.volumeMounts).length > 0) {
+      payload.volumeMounts = serializeVolumeMounts(options.volumeMounts);
     }
     if (options.extra) {
       Object.assign(payload, options.extra);

--- a/sdk/node/src/volume.ts
+++ b/sdk/node/src/volume.ts
@@ -1,0 +1,349 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * CubeSandbox persistent-volume management.
+ *
+ * e2b-compatible: the {@link Volume} static methods mirror the e2b SDK (and
+ * the `cubesandbox` Python SDK's `Volume` class). Volumes survive sandbox
+ * lifecycles; mount them at creation via `Sandbox.create({ volumeMounts })`.
+ */
+
+import { Config, type ConfigOptions, resolveConfig } from "./config.js";
+import {
+  ApiError,
+  AuthenticationError,
+  VolumeInUseError,
+  VolumeNotFoundError,
+} from "./exceptions.js";
+import { controlFetch } from "./transport.js";
+
+/**
+ * Mirrors CubeAPI's `MAX_VOLUME_NAME_LEN` and the `^[a-zA-Z0-9_-]+$` rule
+ * enforced in `CubeAPI/src/handlers/volumes.rs`. Validating client-side turns
+ * an opaque HTTP 400 into a clean error at the call site.
+ */
+export const MAX_VOLUME_NAME_LEN = 128;
+const VOLUME_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
+const INSPECT = Symbol.for("nodejs.util.inspect.custom");
+
+function maskToken(token: string): string {
+  return token ? "***" : "";
+}
+
+/** A CubeSandbox persistent volume descriptor. */
+export class VolumeInfo {
+  /** Stable identifier (equals ``name`` or an auto-generated UUID). */
+  readonly volumeId: string;
+  /** Human-readable display name. */
+  readonly name: string;
+  /**
+   * Optional auth token issued by the volume plugin. Empty when the plugin
+   * does not issue one, and always empty for entries returned by
+   * {@link Volume.list} (tokens are only surfaced on create / get-single).
+   * It is a data-plane credential: `toString`/`console.log` mask it, so read
+   * the field directly when the actual value is needed.
+   */
+  readonly token: string;
+
+  constructor(volumeId: string, name: string, token = "") {
+    this.volumeId = volumeId;
+    this.name = name;
+    this.token = token;
+  }
+
+  static fromDict(data: Record<string, any>): VolumeInfo {
+    return new VolumeInfo(
+      data.volumeID ?? data.volume_id ?? "",
+      data.name ?? "",
+      data.token ?? "",
+    );
+  }
+
+  /** Masks the token so the credential never leaks into logs or error text. */
+  toString(): string {
+    return `VolumeInfo(volumeId=${JSON.stringify(this.volumeId)}, name=${JSON.stringify(
+      this.name,
+    )}, token=${JSON.stringify(maskToken(this.token))})`;
+  }
+
+  /** `console.log` / `util.inspect` render the masked form as well. */
+  [INSPECT](): string {
+    return this.toString();
+  }
+}
+
+/**
+ * CubeSandbox mount options for one Volume attachment.
+ *
+ * Plain {@link Volume}, {@link VolumeInfo} and volume-ID string values remain
+ * the e2b-compatible shorthand in ``volumeMounts``. Wrap a value only when
+ * Cube-specific attachment options such as ``readOnly`` are needed.
+ */
+export class VolumeMount {
+  readonly volume: Volume | VolumeInfo | string;
+  readonly readOnly: boolean;
+
+  constructor(volume: Volume | VolumeInfo | string, options: { readOnly?: boolean } = {}) {
+    this.volume = volume;
+    this.readOnly = options.readOnly ?? false;
+  }
+}
+
+/**
+ * ``Sandbox.create({ volumeMounts })`` argument — an e2b-compatible mapping of
+ * mount path → volume, with an optional {@link VolumeMount} wrapper for
+ * attachment-specific options.
+ */
+export type VolumeMountsArg = Record<string, Volume | VolumeInfo | string | VolumeMount>;
+
+function validateName(name: string): void {
+  if (!name) {
+    return;
+  }
+  if (name.length > MAX_VOLUME_NAME_LEN) {
+    throw new Error(
+      `volume name must be at most ${MAX_VOLUME_NAME_LEN} characters, got ${name.length}`,
+    );
+  }
+  if (!VOLUME_NAME_RE.test(name)) {
+    throw new Error(
+      `volume name must match ^[a-zA-Z0-9_-]+$ (letters, digits, '_' and '-'), got ${JSON.stringify(name)}`,
+    );
+  }
+}
+
+/**
+ * Reject volume IDs that are unsafe to embed in a URL path.
+ *
+ * Defense-in-depth against path traversal: a malicious ``volumeId`` such as
+ * ``../other`` must not be interpolated into the request URL. The accepted
+ * character class covers both named volumes and auto-generated UUIDs.
+ */
+function validateVolumeId(volumeId: string): string {
+  if (typeof volumeId !== "string" || !volumeId) {
+    throw new Error(`volumeId must be a non-empty string, got ${JSON.stringify(volumeId)}`);
+  }
+  if (!VOLUME_NAME_RE.test(volumeId)) {
+    throw new Error(
+      `volumeId must match ^[a-zA-Z0-9_-]+$ (letters, digits, '_' and '-'), got ${JSON.stringify(volumeId)}`,
+    );
+  }
+  return volumeId;
+}
+
+function resolveVolumeId(volume: Volume | VolumeInfo | string): string {
+  if (volume instanceof Volume || volume instanceof VolumeInfo) {
+    return volume.volumeId;
+  }
+  if (typeof volume === "string") {
+    return volume;
+  }
+  throw new Error(
+    "volumeMounts value must be a Volume, VolumeInfo, VolumeMount or volume-id string",
+  );
+}
+
+/**
+ * Validate a mount path before forwarding it to the backend: a clean absolute
+ * POSIX path with no ``.``/``..`` segments. The backend validates as well;
+ * this turns a malicious or typo'd path into a clean error at the call site.
+ */
+function validateMountPath(path: string): string {
+  if (typeof path !== "string" || !path) {
+    throw new Error(`volume mount path must be a non-empty string, got ${JSON.stringify(path)}`);
+  }
+  if (!path.startsWith("/")) {
+    throw new Error(
+      `volume mount path must be absolute (start with '/'), got ${JSON.stringify(path)}`,
+    );
+  }
+  for (const segment of path.split("/")) {
+    if (segment === "." || segment === "..") {
+      throw new Error(
+        `volume mount path must not contain '.' or '..' segments, got ${JSON.stringify(path)}`,
+      );
+    }
+  }
+  return path;
+}
+
+/**
+ * Serialize the e2b-style ``{path: volume}`` mapping into the wire format
+ * shared with the Python and Go SDKs: ``[{name, path, readOnly?}]`` with
+ * ``readOnly`` omitted when false.
+ */
+export function serializeVolumeMounts(mounts: VolumeMountsArg): Record<string, unknown>[] {
+  const serialized: Record<string, unknown>[] = [];
+  for (const [path, value] of Object.entries(mounts)) {
+    const volume = value instanceof VolumeMount ? value.volume : value;
+    const readOnly = value instanceof VolumeMount ? value.readOnly : false;
+    const item: Record<string, unknown> = {
+      name: validateVolumeId(resolveVolumeId(volume)),
+      path: validateMountPath(path),
+    };
+    if (readOnly) {
+      item.readOnly = true;
+    }
+    serialized.push(item);
+  }
+  return serialized;
+}
+
+async function checkVolumeResponse(resp: {
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+}): Promise<void> {
+  if (resp.ok) {
+    return;
+  }
+  let msg = "";
+  try {
+    const raw = (await resp.text()).trim();
+    try {
+      const body = JSON.parse(raw) as Record<string, unknown>;
+      msg =
+        (typeof body.message === "string" && body.message) ||
+        (typeof body.detail === "string" && body.detail) ||
+        raw;
+    } catch {
+      msg = raw;
+    }
+  } catch {
+    msg = "";
+  }
+  if (!msg) {
+    msg = `HTTP ${resp.status}`;
+  }
+  const code = resp.status;
+  if (code === 401 || code === 403) {
+    throw new AuthenticationError(msg, code);
+  }
+  if (code === 404) {
+    throw new VolumeNotFoundError(msg, code);
+  }
+  // CubeMaster refuses to delete a mounted volume with "volume <id> is in use
+  // by <n> node(s); ..." relayed as HTTP 409. The duplicate-name 409 ("volume
+  // already exists") intentionally stays a generic ApiError.
+  if (code === 409 && msg.toLowerCase().includes("in use")) {
+    throw new VolumeInUseError(msg, code);
+  }
+  throw new ApiError(msg, code);
+}
+
+/**
+ * Class-level helper for CubeSandbox persistent-volume management.
+ *
+ * e2b-compatible: methods mirror the e2b SDK. ``create`` and ``connect``
+ * return a live {@link Volume} instance; ``list`` and ``getInfo`` return
+ * plain {@link VolumeInfo} descriptors.
+ */
+export class Volume extends VolumeInfo {
+  private constructor(info: VolumeInfo) {
+    super(info.volumeId, info.name, info.token);
+  }
+
+  /** Masks the token, same as {@link VolumeInfo.toString}. */
+  override toString(): string {
+    return super.toString().replace("VolumeInfo(", "Volume(");
+  }
+
+  override [INSPECT](): string {
+    return this.toString();
+  }
+
+  /**
+   * POST /volumes — create a new persistent volume.
+   *
+   * e2b-compatible by default: when ``driver`` is omitted, no driver is sent
+   * and the backend falls back to its *first configured* volume plugin. Pass a
+   * non-empty ``driver`` to pin a specific plugin (a CubeSandbox extension),
+   * e.g. ``"cos"`` or ``"nfs"`` — it must match a ``volume_plugins[].name``
+   * entry in the CubeMaster config.
+   *
+   * ``name`` is optional: it must match ``^[a-zA-Z0-9_-]+$`` and be at most
+   * {@link MAX_VOLUME_NAME_LEN} characters; when omitted the server generates
+   * a UUID used as both the volume name and volume ID.
+   */
+  static async create(
+    options: { name?: string; driver?: string; config?: Config | ConfigOptions } = {},
+  ): Promise<Volume> {
+    const name = options.name ?? "";
+    validateName(name);
+    const cfg = resolveConfig(options.config);
+    const payload: Record<string, unknown> = { name };
+    if (options.driver) {
+      payload.driver = options.driver;
+    }
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/volumes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    await checkVolumeResponse(resp);
+    return new Volume(VolumeInfo.fromDict((await resp.json()) as Record<string, any>));
+  }
+
+  /**
+   * GET /volumes — list all volumes. Tokens are only surfaced on
+   * create / get-single, so ``token`` is always empty in list results.
+   */
+  static async list(
+    options: { config?: Config | ConfigOptions } = {},
+  ): Promise<VolumeInfo[]> {
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/volumes`);
+    await checkVolumeResponse(resp);
+    const data = ((await resp.json()) as Record<string, any>[]) || [];
+    return data.map((d) => VolumeInfo.fromDict(d));
+  }
+
+  /** GET /volumes/:id — fetch a single volume, including its token. */
+  static async getInfo(
+    volumeId: string,
+    options: { config?: Config | ConfigOptions } = {},
+  ): Promise<VolumeInfo> {
+    validateVolumeId(volumeId);
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/volumes/${volumeId}`);
+    await checkVolumeResponse(resp);
+    return VolumeInfo.fromDict((await resp.json()) as Record<string, any>);
+  }
+
+  /**
+   * Connect to an existing volume (e2b compatible; wraps {@link getInfo}) and
+   * return a live {@link Volume} instance.
+   */
+  static async connect(
+    volumeId: string,
+    options: { config?: Config | ConfigOptions } = {},
+  ): Promise<Volume> {
+    return new Volume(await Volume.getInfo(volumeId, options));
+  }
+
+  /**
+   * DELETE /volumes/:id — permanently delete a volume.
+   *
+   * e2b-compatible: resolves ``true`` on success and ``false`` when the volume
+   * does not exist (treated as idempotent — "already gone"). Deleting a volume
+   * does **not** auto-detach it from running sandboxes: while any sandbox
+   * still mounts it, the server refuses with a {@link VolumeInUseError}.
+   */
+  static async destroy(
+    volumeId: string,
+    options: { config?: Config | ConfigOptions } = {},
+  ): Promise<boolean> {
+    validateVolumeId(volumeId);
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/volumes/${volumeId}`, {
+      method: "DELETE",
+    });
+    if (resp.status === 404) {
+      return false;
+    }
+    await checkVolumeResponse(resp);
+    return true;
+  }
+}

--- a/sdk/node/test/volume-integration.test.ts
+++ b/sdk/node/test/volume-integration.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// End-to-end volume tests against a live CubeAPI. Skipped unless
+// CUBE_RUN_INTEGRATION="1". Requires at least one volume plugin configured in
+// CubeMaster/Cubelet; pin a specific backend with CUBE_VOLUME_TEST_DRIVER
+// (empty default lets the backend pick its first configured plugin).
+//
+// Run with, e.g.:
+//   CUBE_RUN_INTEGRATION=1 CUBE_API_URL=... CUBE_TEMPLATE_ID=... npm test
+
+import { describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import { Sandbox, Volume, VolumeInUseError, VolumeMount, VolumeNotFoundError } from "../src/index.js";
+
+const RUN_INTEGRATION = process.env.CUBE_RUN_INTEGRATION === "1";
+const DRIVER = process.env.CUBE_VOLUME_TEST_DRIVER || undefined;
+
+async function destroyWithRetry(volumeId: string, config: Config): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    try {
+      await Volume.destroy(volumeId, { config });
+      return;
+    } catch (err) {
+      // Cubelet reports detach-side refcount changes asynchronously after a
+      // sandbox is killed; retry briefly while the server says "in use".
+      if (!(err instanceof VolumeInUseError) || Date.now() > deadline) {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+}
+
+describe.skipIf(!RUN_INTEGRATION)("volume integration (live CubeAPI)", () => {
+  it(
+    "covers the full volume lifecycle: CRUD, mounting, persistence, read-only, in-use protection",
+    async () => {
+      const config = new Config();
+      const name = `node-sdk-e2e-${Date.now()}`;
+      const mountPath = "/mnt/e2e-vol";
+      const marker = `volume-data-${Date.now()}`;
+
+      // -- Create / get / list --
+      const volume = await Volume.create({ name, driver: DRIVER, config });
+      try {
+        expect(volume.volumeId).toBe(name);
+
+        const info = await Volume.getInfo(volume.volumeId, { config });
+        expect(info.volumeId).toBe(volume.volumeId);
+
+        const volumes = await Volume.list({ config });
+        const entry = volumes.find((v) => v.volumeId === volume.volumeId);
+        expect(entry).toBeDefined();
+        expect(entry?.token).toBe(""); // tokens are only surfaced on create/get-single
+
+        await expect(
+          Volume.getInfo("node-sdk-e2e-does-not-exist", { config }),
+        ).rejects.toBeInstanceOf(VolumeNotFoundError);
+
+        // -- Mount and write through the mount --
+        const first = await Sandbox.create({
+          config,
+          timeout: 120,
+          metadata: { sdk: "node", scenario: "integration-volume" },
+          volumeMounts: { [mountPath]: volume },
+        });
+        try {
+          const write = await first.commands.run(
+            `printf %s ${marker} > ${mountPath}/persist.txt && cat ${mountPath}/persist.txt`,
+          );
+          expect(write.exitCode).toBe(0);
+          expect(write.stdout).toBe(marker);
+
+          const sandboxInfo = await first.getInfo();
+          const mounts = (sandboxInfo.volumeMounts ?? []) as Array<Record<string, unknown>>;
+          expect(mounts).toHaveLength(1);
+          expect(mounts[0].name).toBe(volume.volumeId);
+          expect(mounts[0].path).toBe(mountPath);
+
+          // -- Deleting a mounted volume must be refused --
+          await expect(Volume.destroy(volume.volumeId, { config })).rejects.toBeInstanceOf(
+            VolumeInUseError,
+          );
+        } finally {
+          await first.kill();
+          first.close();
+        }
+
+        // -- Data must survive the sandbox lifecycle; read-only is enforced --
+        const second = await Sandbox.create({
+          config,
+          timeout: 120,
+          metadata: { sdk: "node", scenario: "integration-volume-readonly" },
+          volumeMounts: { [mountPath]: new VolumeMount(volume, { readOnly: true }) },
+        });
+        try {
+          const read = await second.commands.run(`cat ${mountPath}/persist.txt`);
+          expect(read.exitCode).toBe(0);
+          expect(read.stdout).toBe(marker);
+
+          const roWrite = await second.commands.run(
+            `touch ${mountPath}/should-fail.txt 2>&1`,
+          );
+          expect(roWrite.exitCode).not.toBe(0);
+        } finally {
+          await second.kill();
+          second.close();
+        }
+
+        // -- After all sandboxes are gone the volume can be deleted --
+        await destroyWithRetry(volume.volumeId, config);
+        await expect(Volume.getInfo(volume.volumeId, { config })).rejects.toBeInstanceOf(
+          VolumeNotFoundError,
+        );
+        // e2b-compatible idempotent destroy: already gone resolves false.
+        await expect(Volume.destroy(volume.volumeId, { config })).resolves.toBe(false);
+      } catch (err) {
+        await destroyWithRetry(volume.volumeId, config).catch(() => {});
+        throw err;
+      }
+    },
+    300_000,
+  );
+});

--- a/sdk/node/test/volume.test.ts
+++ b/sdk/node/test/volume.test.ts
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { inspect } from "node:util";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import {
+  ApiError,
+  AuthenticationError,
+  VolumeInUseError,
+  VolumeNotFoundError,
+} from "../src/exceptions.js";
+import {
+  MAX_VOLUME_NAME_LEN,
+  Sandbox,
+  Volume,
+  VolumeInfo,
+  VolumeMount,
+} from "../src/index.js";
+import { stubCubeEnv } from "./_env.js";
+
+stubCubeEnv();
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  headers: IncomingHttpHeaders;
+  body: Buffer;
+}
+
+interface MockResponse {
+  status?: number;
+  json?: unknown;
+  text?: string;
+}
+
+type Handler = (req: RecordedRequest) => MockResponse | Promise<MockResponse>;
+
+let server: Server;
+let port: number;
+let requests: RecordedRequest[] = [];
+let handler: Handler = () => ({ status: 200, json: {} });
+
+function setHandler(h: Handler): void {
+  handler = h;
+}
+
+function makeConfig(): Config {
+  return new Config({
+    apiUrl: `http://127.0.0.1:${port}`,
+    templateId: "tpl-test",
+    sandboxDomain: "cube.app",
+  });
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(chunk as Buffer));
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+      const recorded: RecordedRequest = {
+        method: req.method ?? "",
+        pathname: url.pathname,
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      };
+      requests.push(recorded);
+      Promise.resolve(handler(recorded)).then((mock) => {
+        const status = mock.status ?? 200;
+        if (mock.json !== undefined) {
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(mock.json));
+        } else {
+          res.writeHead(status, { "Content-Type": "text/plain" });
+          res.end(mock.text ?? "");
+        }
+      });
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+afterEach(() => {
+  requests = [];
+  handler = () => ({ status: 200, json: {} });
+});
+
+describe("Volume CRUD", () => {
+  it("create sends the payload and parses the response", async () => {
+    setHandler(() => ({
+      status: 201,
+      json: { volumeID: "my-data", name: "my-data", token: "tok-123" },
+    }));
+    const volume = await Volume.create({
+      name: "my-data",
+      driver: "cos",
+      config: makeConfig(),
+    });
+    expect(volume.volumeId).toBe("my-data");
+    expect(volume.name).toBe("my-data");
+    expect(volume.token).toBe("tok-123");
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].method).toBe("POST");
+    expect(requests[0].pathname).toBe("/volumes");
+    expect(JSON.parse(requests[0].body.toString())).toEqual({
+      name: "my-data",
+      driver: "cos",
+    });
+  });
+
+  it("create omits driver and allows an empty name", async () => {
+    setHandler(() => ({
+      status: 201,
+      json: { volumeID: "3e9b6f2a-0000-4000-8000-000000000000", name: "3e9b6f2a-0000-4000-8000-000000000000", token: "" },
+    }));
+    const volume = await Volume.create({ config: makeConfig() });
+    expect(volume.volumeId).not.toBe("");
+    expect(volume.token).toBe("");
+
+    // Mirror the Python/Go SDK wire format: name is always sent (empty string
+    // requests a server-generated UUID), driver is omitted when unset.
+    const payload = JSON.parse(requests[0].body.toString());
+    expect(payload).toEqual({ name: "" });
+  });
+
+  it("create validates the name without sending a request", async () => {
+    for (const name of ["a".repeat(MAX_VOLUME_NAME_LEN + 1), "my volume!", "a/b"]) {
+      await expect(Volume.create({ name, config: makeConfig() })).rejects.toThrow(
+        /volume name/,
+      );
+    }
+    expect(requests).toHaveLength(0);
+  });
+
+  it("list returns VolumeInfo entries without tokens", async () => {
+    setHandler(() => ({
+      status: 200,
+      json: [
+        { volumeID: "vol-a", name: "vol-a" },
+        { volumeID: "vol-b", name: "vol-b" },
+      ],
+    }));
+    const volumes = await Volume.list({ config: makeConfig() });
+    expect(volumes).toHaveLength(2);
+    expect(volumes[0]).toBeInstanceOf(VolumeInfo);
+    expect(volumes[0].volumeId).toBe("vol-a");
+    expect(volumes[1].volumeId).toBe("vol-b");
+    expect(volumes[0].token).toBe("");
+    expect(requests[0].method).toBe("GET");
+    expect(requests[0].pathname).toBe("/volumes");
+  });
+
+  it("getInfo returns the token and connect wraps it in a live Volume", async () => {
+    setHandler(() => ({
+      status: 200,
+      json: { volumeID: "my-data", name: "my-data", token: "tok-456" },
+    }));
+    const info = await Volume.getInfo("my-data", { config: makeConfig() });
+    expect(info.token).toBe("tok-456");
+    expect(requests[0].pathname).toBe("/volumes/my-data");
+
+    const volume = await Volume.connect("my-data", { config: makeConfig() });
+    expect(volume).toBeInstanceOf(Volume);
+    expect(volume.volumeId).toBe("my-data");
+    expect(volume.token).toBe("tok-456");
+  });
+
+  it("destroy resolves true on 204 and false on 404", async () => {
+    setHandler(() => ({ status: 204, text: "" }));
+    await expect(Volume.destroy("my-data", { config: makeConfig() })).resolves.toBe(true);
+    expect(requests[0].method).toBe("DELETE");
+    expect(requests[0].pathname).toBe("/volumes/my-data");
+
+    setHandler(() => ({ status: 404, json: { message: "volume not found: my-data" } }));
+    await expect(Volume.destroy("my-data", { config: makeConfig() })).resolves.toBe(false);
+  });
+
+  it("rejects unsafe volume IDs without sending a request", async () => {
+    for (const volumeId of ["", "../other", "a/b", "a b", "%2e%2e"]) {
+      await expect(Volume.getInfo(volumeId, { config: makeConfig() })).rejects.toThrow(
+        /volumeId/,
+      );
+      await expect(Volume.destroy(volumeId, { config: makeConfig() })).rejects.toThrow(
+        /volumeId/,
+      );
+    }
+    expect(requests).toHaveLength(0);
+  });
+});
+
+describe("Volume error mapping", () => {
+  it("maps 404 to VolumeNotFoundError", async () => {
+    setHandler(() => ({ status: 404, json: { message: "volume not found: my-data" } }));
+    await expect(Volume.getInfo("my-data", { config: makeConfig() })).rejects.toBeInstanceOf(
+      VolumeNotFoundError,
+    );
+  });
+
+  it("maps the in-use 409 to VolumeInUseError", async () => {
+    setHandler(() => ({
+      status: 409,
+      json: {
+        message:
+          "conflict: volume my-data is in use by 2 node(s); destroy the sandboxes using it before deleting",
+      },
+    }));
+    const err = await Volume.destroy("my-data", { config: makeConfig() }).catch((e) => e);
+    expect(err).toBeInstanceOf(VolumeInUseError);
+    expect(err.statusCode).toBe(409);
+  });
+
+  it("keeps the duplicate-name 409 a generic ApiError", async () => {
+    setHandler(() => ({ status: 409, json: { message: "volume already exists: my-data" } }));
+    const err = await Volume.create({ name: "my-data", config: makeConfig() }).catch(
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).not.toBeInstanceOf(VolumeInUseError);
+  });
+
+  it("maps 401 to AuthenticationError", async () => {
+    setHandler(() => ({ status: 401, json: { message: "bad key" } }));
+    await expect(Volume.list({ config: makeConfig() })).rejects.toBeInstanceOf(
+      AuthenticationError,
+    );
+  });
+});
+
+describe("token masking", () => {
+  it("toString and util.inspect mask the token", () => {
+    const info = new VolumeInfo("my-data", "my-data", "tok-secret-123");
+    for (const formatted of [info.toString(), `${info}`, inspect(info)]) {
+      expect(formatted).not.toContain("tok-secret-123");
+      expect(formatted).toContain("***");
+      expect(formatted).toContain("my-data");
+    }
+  });
+
+  it("renders an absent token as empty, not as the mask", () => {
+    const info = new VolumeInfo("no-token", "no-token");
+    expect(inspect(info)).not.toContain("***");
+  });
+});
+
+describe("Sandbox.create volumeMounts", () => {
+  const SANDBOX_JSON = {
+    sandboxID: "sb-test-001",
+    templateID: "tpl-test",
+    domain: "cube.app",
+    state: "running",
+  };
+
+  it("serializes the e2b mapping into the shared wire format", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_JSON }));
+    const volume = new VolumeInfo("my-data", "my-data");
+    await Sandbox.create({
+      config: makeConfig(),
+      volumeMounts: {
+        "/workspace": volume,
+        "/cache": "shared-cache",
+        "/dataset": new VolumeMount(volume, { readOnly: true }),
+      },
+    });
+    const payload = JSON.parse(requests[0].body.toString());
+    expect(payload.volumeMounts).toEqual([
+      { name: "my-data", path: "/workspace" },
+      { name: "shared-cache", path: "/cache" },
+      { name: "my-data", path: "/dataset", readOnly: true },
+    ]);
+  });
+
+  it("omits volumeMounts when not provided", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_JSON }));
+    await Sandbox.create({ config: makeConfig() });
+    const payload = JSON.parse(requests[0].body.toString());
+    expect(payload).not.toHaveProperty("volumeMounts");
+  });
+
+  it("validates mount paths and volume names without sending a request", async () => {
+    const cases: Array<Record<string, string>> = [
+      { "": "my-data" },
+      { relative: "my-data" },
+      { "/workspace/../etc": "my-data" },
+      { "/./workspace": "my-data" },
+      { "/workspace": "" },
+      { "/workspace": "../other" },
+    ];
+    for (const volumeMounts of cases) {
+      await expect(
+        Sandbox.create({ config: makeConfig(), volumeMounts }),
+      ).rejects.toThrow(/volume/);
+    }
+    expect(requests).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #1275. Adds full persistent-Volume support to the Node SDK — volume CRUD, mounting at sandbox creation via the e2b-style `volumeMounts` mapping, and dedicated error handling — completing Volume coverage across all three official SDKs, after Python (#898 / #1061) and Go (#1268 / #1269).

## Volume API

New `Volume` static methods following the Node SDK's e2b-style conventions (static class methods + options objects), mirroring the Python SDK surface:

```typescript
Volume.create(options?: { name?: string; driver?: string; config?: Config | ConfigOptions }): Promise<Volume>
Volume.list(options?: { config?: Config | ConfigOptions }): Promise<VolumeInfo[]>
Volume.getInfo(volumeId: string, options?: { config?: Config | ConfigOptions }): Promise<VolumeInfo>
Volume.connect(volumeId: string, options?: { config?: Config | ConfigOptions }): Promise<Volume>
Volume.destroy(volumeId: string, options?: { config?: Config | ConfigOptions }): Promise<boolean>
```

- e2b-compatible defaults: `driver` omitted from the payload when unset (backend falls back to its first configured plugin); `name` optional (empty requests a server-generated UUID used as both name and volume ID); `destroy` resolves `false` on 404 for e2b-style idempotent cleanup.
- Client-side validation mirrors CubeAPI's rules — names/IDs must match `^[a-zA-Z0-9_-]+$` (max 128 chars) — and volume IDs are checked for path traversal before being interpolated into a URL.
- Tokens are only surfaced on create / get-single, matching the server contract; list entries have empty tokens.
- **Token hygiene**: `VolumeInfo` masks `token` in `toString` and `util.inspect` (`console.log`) output — parity with the Python SDK's `__repr__` masking and the Go SDK's `String()`/`GoString()` — so the data-plane credential cannot leak into logs. Read the field directly when the actual value is needed.

## Sandbox mounting

`Sandbox.create` gains an e2b-style `volumeMounts` mapping (`{ mountPath: volume }`), with a `VolumeMount` wrapper for the Cube read-only extension. The wire format matches the Python/Go SDKs (`volumeMounts: [{name, path, readOnly?}]`, `readOnly` omitted when false):

```typescript
import { Sandbox, Volume, VolumeMount } from "@cubesandbox/sdk";

const vol = await Volume.create({ name: "my-data" });

const sb = await Sandbox.create({
  volumeMounts: {
    "/workspace": vol,                                   // Volume instance…
    "/cache": "shared-cache",                            // …or a volume-ID string
    "/dataset": new VolumeMount(vol, { readOnly: true }), // read-only (Cube extension)
  },
});
```

Mount paths are validated as clean absolute POSIX paths (no `.`/`..` segments) before the request is sent.

## Error handling

New error classes following the existing `exceptions.ts` conventions:

- `VolumeNotFoundError` — volume 404s.
- `VolumeInUseError` — the HTTP 409 the server returns when deleting a volume still mounted by one or more sandboxes. The duplicate-name 409 (`volume already exists`) intentionally stays a generic `ApiError`.

```typescript
try {
  await Volume.destroy("my-data");
} catch (err) {
  if (err instanceof VolumeInUseError) {
    // still mounted — destroy the sandboxes using it first
  }
}
```

## Other changes

- `sdk/node/README.md`: new "Volumes" section with the full lifecycle, read-only mounts, `VolumeInUseError` handling, and a `Volume` static-methods API-reference table.
- The shared volume-plugin guide (`docs/guide/volume-plugin.md` + zh) is intentionally **not** touched here: #1269 already modifies the same tables, so the Node SDK rows will follow in a small doc update once that lands, avoiding cross-PR conflicts.

## Testing

### Unit tests

`test/volume.test.ts` — 16 cases against a local mock HTTP server:

- Request payloads and response decoding for `create` / `list` / `getInfo` / `connect` / `destroy`, including the e2b-compatible defaults (`driver` omitted when unset, `name` always sent, `destroy` resolving `false` on 404).
- Error mapping: 404 → `VolumeNotFoundError`, in-use 409 → `VolumeInUseError`, duplicate-name 409 → generic `ApiError`, 401 → `AuthenticationError`.
- Token masking across `toString`, template-literal interpolation and `util.inspect`, plus an absent token rendering as empty rather than as the mask.
- Validation short-circuits — no request is sent for invalid names, unsafe volume IDs (`../other`, `a/b`, `%2e%2e`, …) or bad mount paths.
- `Sandbox.create` `volumeMounts` serialization in all three value forms (`Volume` instance, volume-ID string, read-only `VolumeMount` wrapper), and its absence from the payload when unused.

### End-to-end test

`test/volume-integration.test.ts` — one end-to-end lifecycle test against a live deployment, gated by `CUBE_RUN_INTEGRATION=1` (the same convention as the pre-existing `test/integration.test.ts`, so upstream CI stays green without a sandbox host). The storage backend is selectable via `CUBE_VOLUME_TEST_DRIVER`; leaving it unset lets the backend pick its first configured plugin.

It asserts, in order:

1. `create` → `getInfo` / `list`, with the token surfaced only on create and get-single.
2. An unknown volume rejects with `VolumeNotFoundError`.
3. Mount into a microVM sandbox, write through the mount, read the value back.
4. Sandbox info reports the expected `volumeMounts` (name + path).
5. Deleting a mounted volume is refused with `VolumeInUseError` (409).
6. After the first sandbox is killed, the data is still readable from a second sandbox.
7. A read-only mount serves reads but rejects writes.
8. `destroy` succeeds once no sandbox mounts the volume; destroying again resolves `false` (idempotent).

### Results

Live single-node deployment with CubeMaster / CubeAPI / Cubelet built from master (base commit `2b7d3b2`). The full suite — unit tests plus the two end-to-end tests — was run with the integration gate **enabled**, on two storage backends:

| Backend | Suite result | Duration |
|---|---|---|
| local host-path plugin (default driver) | 18 files, **204 passed, 0 skipped** | 4.7s |
| Tencent Cloud COS (cosfs, real bucket) | 18 files, **204 passed, 0 skipped** | 13.9s |

```
$ CUBE_RUN_INTEGRATION=1 CUBE_API_URL=http://127.0.0.1:13000 \
  CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx \
  CUBE_PROXY_NODE_IP=127.0.0.1 CUBE_PROXY_PORT_HTTP=11080 \
  npm test

 ✓ test/volume.test.ts (16 tests) 93ms
 ✓ test/integration.test.ts (1 test) 2589ms
   ✓ integration (live CubeAPI) > creates a sandbox, runs code and commands, writes/reads a file, then kills it
 ✓ test/volume-integration.test.ts (1 test) 3772ms
   ✓ volume integration (live CubeAPI) > covers the full volume lifecycle: CRUD, mounting, persistence, read-only, in-use protection

 Test Files  18 passed (18)
      Tests  204 passed (204)
   Duration  4.70s
```

Same command with `CUBE_VOLUME_TEST_DRIVER=cos`, exercising real object storage:

```
 ✓ test/volume-integration.test.ts (1 test) 13054ms
   ✓ volume integration (live CubeAPI) > covers the full volume lifecycle: CRUD, mounting, persistence, read-only, in-use protection

 Test Files  18 passed (18)
      Tests  204 passed (204)
   Duration  13.92s
```

The COS run is ~3.5× slower on the volume test, consistent with the data plane actually going through cosfs FUSE → virtiofs → object storage. No leaked test resources afterwards (`GET /volumes` empty, no sandboxes running).

`tsc --noEmit` is clean and the `tsup` build (ESM/CJS/DTS) succeeds. Without `CUBE_RUN_INTEGRATION=1`, `npm test` reports 202 passed / 2 skipped — the two end-to-end tests skipping by design.