### PR TITLE
test(cubelet): avoid wall-clock race in multilock lifetime test

### DIFF
--- a/Cubelet/pkg/multilock/multilock_test.go
+++ b/Cubelet/pkg/multilock/multilock_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math/rand"
 	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -43,20 +45,31 @@ func TestMultiLock_Lifetime(t *testing.T) {
 	mlock := NewMultiLock(o)
 	key := "test_key"
 	l := mlock.Get(key)
+	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			l.LockAt()
 			defer l.UnlockAt()
 			_ = uuid.New().String()
 		}()
 	}
-	time.Sleep(4 * time.Second)
-	_, ok := mlock.Load(key)
-	if ok {
-		t.Errorf("Lock at key '%s' still life", key)
+	wg.Wait()
+
+	lock := l.(*rwLock)
+	atomic.StoreInt64(&lock.updateAt, time.Now().Unix()-o.ExpiredInSecond-1)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := mlock.Load(key); !ok {
+			l.LockAt()
+			l.UnlockAt()
+			return
+		}
+		time.Sleep(o.CheckInterval)
 	}
-	l.LockAt()
-	l.UnlockAt()
+	t.Fatalf("Lock at key '%s' was not removed after expiration", key)
 }
 
 func TestMultiLock_LockAt(t *testing.T) {


### PR DESCRIPTION
## Motivation

`TestMultiLock_Lifetime` can fail intermittently because it asserts asynchronous expiration cleanup after a fixed wall-clock sleep.

Lock activity is recorded with integer-second timestamps, expiration uses a strict greater-than comparison, and cleanup runs on a background ticker. As a result, a fixed four-second sleep can wake before the cleanup tick observes the lock as expired, leaving the lock in the map even though the production behavior is still within its configured timing.

The test also starts concurrent lock activity without waiting for those goroutines to finish before beginning the expiration wait, so the last activity timestamp is not a stable boundary for the assertion.

## What Changed

* Wait for all concurrent lock activity to finish before testing expiration.
* Set the package-internal activity timestamp to an unambiguously expired value.
* Wait for asynchronous cleanup with a bounded deadline instead of asserting at one exact instant.
* Keep the production lock lifetime and cleanup implementation unchanged.

## Validation

```bash
cd Cubelet
go test -short ./pkg/multilock -count=100
go test -race -short ./pkg/multilock -run '^TestMultiLock_Lifetime$' -count=20
go test -short ./pkg/...
```

All tests passed in the builder container.

## Scope

This PR only updates `Cubelet/pkg/multilock/multilock_test.go`.

It does not change production multilock behavior, lock lifetime configuration, or cleanup scheduling.
