### PR TITLE
test(cubelet): avoid FIFO open race in taskio test

### DIFF
--- a/Cubelet/pkg/taskio/taskio_test.go
+++ b/Cubelet/pkg/taskio/taskio_test.go
@@ -91,6 +91,11 @@ func TestTaskIO(t *testing.T) {
 	defer Clean(context.Background(), ctnID)
 
 	expected := 10
+	ch, err := Consume(cfg.Stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
 		f, err := fifo.OpenFifo(context.Background(), cfg.Stdout, syscall.O_WRONLY, 0600)
 		if err != nil {
@@ -105,10 +110,6 @@ func TestTaskIO(t *testing.T) {
 		cio.Close()
 	}()
 
-	ch, err := Consume(cfg.Stdout)
-	if err != nil {
-		t.Fatal(err)
-	}
 	actualCnt := 0
 	for range ch {
 		actualCnt++


### PR DESCRIPTION
Open the consumer before starting the writer so the writer cannot close all FIFO write handles before the reader is connected, which could block the test until timeout.