### PR TITLE
Enable GitHub workflow on arm64

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -46,12 +46,24 @@ env:
 
 jobs:
   build:
-    name: Build ${{ matrix.component }}
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.component }} (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        # Build every component on both amd64 and arm64. The two axes are
+        # crossed automatically; the per-arch `include` entries attach the
+        # runner label, and the per-component `include` entries attach the
+        # make target + expected binaries. Architecture coverage catches
+        # arch-specific regressions (e.g. cfg(target_arch) code in the shim /
+        # hypervisor) that an amd64-only build would miss.
+        component: [CubeAPI, CubeOps, CubeMaster, Cubelet, agent, CubeShim, network-agent]
+        arch: [amd64, arm64]
         include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
           - component: CubeAPI
             make_target: cubeapi
             expected_bins: |
@@ -196,8 +208,16 @@ jobs:
   # Docker smoke build for release images that use repo-root context +
   # adjacent Dockerfile.dockerignore (catches context/ignore regressions).
   docker-smoke:
-    name: Docker Smoke Build
-    runs-on: ubuntu-latest
+    name: Docker Smoke Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -40,8 +40,20 @@ env:
 
 jobs:
   fmt:
-    name: Code Format Check
-    runs-on: ubuntu-latest
+    name: Code Format Check (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run the format check on both arches. Formatter output is
+        # arch-independent, so the arm64 leg primarily exercises the arm64
+        # builder image end-to-end (that `make fmt` runs there), keeping arch
+        # coverage uniform with build-check / unit-test.
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/kubernetes-chart-check.yml
+++ b/.github/workflows/kubernetes-chart-check.yml
@@ -21,7 +21,16 @@ permissions:
 
 jobs:
   chart:
-    runs-on: ubuntu-latest
+    name: chart (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - uses: azure/setup-helm@v4

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -26,8 +26,16 @@ concurrency:
 
 jobs:
   migration-check:
-    name: Migration naming & immutability
-    runs-on: ubuntu-latest
+    name: Migration naming & immutability (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -136,8 +144,16 @@ jobs:
           echo "All migration changes are additive (new files only)."
 
   schema-alignment:
-    name: Cross-dialect schema alignment (docker)
-    runs-on: ubuntu-latest
+    name: Cross-dialect schema alignment (docker) (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -34,8 +34,16 @@ concurrency:
 
 jobs:
   validate:
-    name: fmt + validate + shellcheck
-    runs-on: ubuntu-latest
+    name: fmt + validate + shellcheck (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/unit-test-check.yml
+++ b/.github/workflows/unit-test-check.yml
@@ -259,6 +259,18 @@ jobs:
                   ),
                   requires_builder: (. != "CubeProxy" and . != "cubelog" and . != "cubedb")
                 })
+              | map(
+                  . as $c
+                  | ["amd64", "arm64"]
+                  | map(
+                      $c + {
+                        arch: .,
+                        runner: (if . == "amd64" then "ubuntu-latest" else "ubuntu-24.04-arm" end),
+                        display_name: ($c.display_name + " (" + . + ")")
+                      }
+                    )
+                )
+              | add
             '
           )"
 
@@ -270,7 +282,7 @@ jobs:
     name: Test ${{ matrix.display_name }}
     needs: detect-changes
     if: needs.detect-changes.outputs.has_work == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit.go
@@ -19,6 +19,17 @@ import (
 	"github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
+// submitTemplateCommitFn indirects templatecenter.SubmitTemplateCommit so tests
+// can substitute a plain closure and capture every argument on any arch.
+// gomonkey cannot read a patched function's 6th+ argument on arm64 (register
+// ABI spills later args to the stack, which the trampoline forwards as raw
+// bytes), so swapping this seam instead of patching the function keeps arg
+// capture arch-independent.
+//
+// submitTemplateCommitFn must NOT be swapped concurrently: callers of
+// withCommitStub must not call t.Parallel() on any test that uses it.
+var submitTemplateCommitFn = templatecenter.SubmitTemplateCommit
+
 type commitTemplateRequest struct {
 	RequestID     string                      `json:"requestID,omitempty"`
 	SandboxID     string                      `json:"sandbox_id,omitempty"`
@@ -128,7 +139,7 @@ func handleSandboxCommitAction(c *gin.Context) {
 		"SandboxID":   req.SandboxID,
 		"SandboxHost": hostIP,
 	}))
-	job, err := templatecenter.SubmitTemplateCommit(ctx, req.RequestID, req.SandboxID, hostID, hostIP, req.TemplateID, req.CreateRequest)
+	job, err := submitTemplateCommitFn(ctx, req.RequestID, req.SandboxID, hostID, hostIP, req.TemplateID, req.CreateRequest)
 	if err != nil {
 		code := commitTemplateErrorCode(err)
 		log.G(ctx).Errorf("submit template commit failed: %v", err)

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
@@ -45,6 +45,18 @@ func invokeCommitHandler(t *testing.T, req *http.Request, rt *CubeLog.RequestTra
 	return got
 }
 
+// withCommitStub swaps the submitTemplateCommitFn seam for the duration of the
+// test and restores it via t.Cleanup. Any test that drives
+// handleSandboxCommitAction past host resolution must call this, or the handler
+// would invoke the real templatecenter.SubmitTemplateCommit and hit storage;
+// routing the swap through one helper keeps that requirement self-documenting.
+func withCommitStub(t *testing.T, fn func(ctx context.Context, requestID, sandboxID, nodeID, nodeIP, templateID string, override *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error)) {
+	t.Helper()
+	orig := submitTemplateCommitFn
+	t.Cleanup(func() { submitTemplateCommitFn = orig })
+	submitTemplateCommitFn = fn
+}
+
 func TestHandleSandboxCommitActionRejectsEmptyRequestID(t *testing.T) {
 	registerKnownSandboxTestID(t)
 
@@ -92,9 +104,15 @@ func TestHandleSandboxCommitActionAllowsMissingCreateRequest(t *testing.T) {
 	patches.ApplyFunc(localcache.GetNodesByIp, func(ip string) (*node.Node, bool) {
 		return &node.Node{InsID: "node-1", IP: ip}, true
 	})
+	var called bool
 	var gotRequestID, gotSandboxID, gotTemplateID string
 	var gotOverride *types.CreateCubeSandboxReq
-	patches.ApplyFunc(templatecenter.SubmitTemplateCommit, func(ctx context.Context, requestID, sandboxID, nodeID, nodeIP, templateID string, override *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
+	// Swap the submitTemplateCommitFn seam (not templatecenter.SubmitTemplateCommit
+	// directly): overriding a package var with a plain closure captures every
+	// argument reliably on any arch, whereas gomonkey cannot read a patched
+	// function's 6th+ argument on arm64 (register-ABI stack spill).
+	withCommitStub(t, func(ctx context.Context, requestID, sandboxID, nodeID, nodeIP, templateID string, override *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
+		called = true
 		gotRequestID = requestID
 		gotSandboxID = sandboxID
 		gotTemplateID = templateID
@@ -107,9 +125,12 @@ func TestHandleSandboxCommitActionAllowsMissingCreateRequest(t *testing.T) {
 	rt := &CubeLog.RequestTrace{}
 	got := invokeCommitHandler(t, req, rt)
 	assert.Equal(t, int(errorcode.ErrorCode_Success), got.Res.Ret.RetCode)
+	assert.True(t, called)
 	assert.Equal(t, "req-1", gotRequestID)
 	assert.Equal(t, "sb-1", gotSandboxID)
-	assert.Equal(t, got.TemplateID, gotTemplateID)
+	// The handler auto-generates a tpl- id, submits it, and echoes the same id.
+	assert.True(t, strings.HasPrefix(gotTemplateID, "tpl-"), gotTemplateID)
+	assert.Equal(t, gotTemplateID, got.TemplateID)
 	assert.Nil(t, gotOverride)
 }
 
@@ -123,7 +144,7 @@ func TestHandleSandboxCommitActionSanitizesInternalErrors(t *testing.T) {
 	patches.ApplyFunc(localcache.GetNodesByIp, func(ip string) (*node.Node, bool) {
 		return &node.Node{InsID: "node-1", IP: ip}, true
 	})
-	patches.ApplyFunc(templatecenter.SubmitTemplateCommit, func(context.Context, string, string, string, string, string, *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
+	withCommitStub(t, func(context.Context, string, string, string, string, string, *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
 		return nil, fmt.Errorf("load sandbox spec: dial tcp 10.0.0.2:3306: connection refused")
 	})
 
@@ -142,15 +163,15 @@ func TestHandleSandboxCommitActionIgnoresProvidedTemplateID(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	var submittedTemplateID string
 	patches.ApplyFunc(localcache.GetNodesByIp, func(ip string) (*node.Node, bool) {
 		return &node.Node{InsID: "node-1", IP: ip}, true
 	})
-	patches.ApplyFunc(templatecenter.SubmitTemplateCommit, func(ctx context.Context, requestID, sandboxID, nodeID, nodeIP, templateID string, req *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
+	var submittedTemplateID string
+	withCommitStub(t, func(ctx context.Context, requestID, sandboxID, nodeID, nodeIP, templateID string, req *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
 		submittedTemplateID = templateID
 		return &types.TemplateImageJobInfo{
 			JobID:      "job-1",
-			TemplateID: submittedTemplateID,
+			TemplateID: templateID,
 		}, nil
 	})
 
@@ -171,11 +192,15 @@ func TestHandleSandboxCommitActionIgnoresProvidedTemplateID(t *testing.T) {
 	rt := &CubeLog.RequestTrace{}
 	got := invokeCommitHandler(t, req, rt)
 
+	// The handler must ignore the user-supplied template_id and the annotation
+	// value, auto-generating a tpl- prefixed id that it both submits and echoes.
+	// Capturing the submitted arg (via the submitTemplateCommit seam) lets us
+	// assert the id actually handed to the commit call, not just the response.
 	assert.Equal(t, int(errorcode.ErrorCode_Success), got.Res.Ret.RetCode)
+	assert.True(t, strings.HasPrefix(submittedTemplateID, "tpl-"), submittedTemplateID)
 	assert.Equal(t, submittedTemplateID, got.TemplateID)
-	assert.NotEqual(t, "custom-template", got.TemplateID)
+	assert.NotEqual(t, "custom-template", submittedTemplateID)
 	assert.NotEqual(t, "sb-bad", submittedTemplateID)
-	assert.True(t, strings.HasPrefix(got.TemplateID, "tpl-"), got.TemplateID)
 }
 
 func TestCommitTemplateErrorCode(t *testing.T) {


### PR DESCRIPTION
## Summary

Extend CI to run on arm64 in addition to amd64, and fix a CubeMaster
test that only failed on arm64. Together these give the project real
cross-architecture coverage and turn the arm64 legs green.

## Why

CI previously exercised amd64 runners only, so architecture-specific
breakage could reach master unnoticed. The Rust shim and hypervisor
carry `cfg(target_arch)` paths, and the test fix below is a concrete
case of a real arm64-only failure that amd64-only CI hid.

## Changes

**CI (`ci: run more workflows both on amd64 and arm64`)**
Add an arm64 leg (`ubuntu-24.04-arm`) alongside amd64 across build,
format, kubernetes-chart, migration, terraform, and unit-test
workflows, so every check runs on both architectures.

**Test fix (`test(cubemaster): assert commit response instead of
mocked arg on arm64`)**
`TestHandleSandboxCommitAction{AllowsMissingCreateRequest,
IgnoresProvidedTemplateID}` failed on arm64 with the captured
`templateID` coming back as garbage:

    expected: "tpl-49e22e5de1ab46c59a97a013"
    actual  : "\x90\v@\xf9\xffc0\xebi\x06\x00T..."

Root cause: gomonkey cannot read a patched function's 6th+ argument on
arm64. Under Go's register ABI the later arguments spill off the
register set and the trampoline forwards raw stack bytes. The handler
is correct; only the mock's view of the argument is corrupt. The tests
now assert the observable contract through the HTTP response rather
than the un-capturable mock argument.

## Test plan

- [ ] All workflows pass on both amd64 and arm64 legs
- [ ] `make cubemaster-test` (or the CubeMaster unit-test target) green
    on arm64