### PR TITLE
feat(helm): allow fixed NodePort values for CubeAPI and CubeProxy

### DIFF
--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -443,6 +443,8 @@ CubeProxy runs on the **Pod network** (no `hostNetwork`). Traffic path:
 
 TLS for `cube.app` / wildcards still terminates **inside CubeProxy**. The default Ingress annotations enable nginx-ingress SSL passthrough + HTTPS backend; override `cubeProxy.ingress.className` / `annotations` for TKE CLB or other controllers. Set `cubeProxy.ingress.enabled=false` if you manage the entrypoint yourself (keep the Service as backend).
 
+Without an Ingress / cloud LB, set `cubeProxy.service.type` / `controlPlane.api.service.type` to `NodePort` (or `LoadBalancer`) and optionally pin host ports via `cubeProxy.service.nodePorts.*` / `controlPlane.api.service.nodePort` (Kubernetes range `30000-32767`; empty keeps auto-allocation). Explicit `nodePort` values are rejected when `type` is still `ClusterIP`.
+
 When the sandbox owner is on a compute node, CubeProxy still uses Redis routing metadata to connect to the owner `HostIP:hostPort`. The chart patches the image's default nginx listeners to the configured `cubeProxy.ports.*.containerPort` values (default `80` / `443`).
 
 CubeProxy admin is reachable in-cluster at each Pod IP:`adminPort` (default `8082`) for cube-lifecycle-manager discovery; probes use the admin token header.

--- a/deploy/kubernetes/chart/runtime-values.example.yaml
+++ b/deploy/kubernetes/chart/runtime-values.example.yaml
@@ -28,7 +28,22 @@ cubeProxy:
   #   annotations:
   #     service.cloud.tencent.com/security-groups: "sg-xxxxxxxx"
   # No Ingress controller? Set cubeProxy.ingress.enabled: false and expose
-  # the ClusterIP Service yourself.
+  # the Service yourself, e.g. NodePort with fixed host ports:
+  # service:
+  #   type: NodePort
+  #   nodePorts:
+  #     http: 30080
+  #     https: 30443
+  #     grpc: 30090
+  # ingress:
+  #   enabled: false
+
+# Optional: expose CubeAPI on a fixed NodePort (with service.type=NodePort):
+# controlPlane:
+#   api:
+#     service:
+#       type: NodePort
+#       nodePort: 30030
 
 # REQUIRED: validate.yaml refuses CHANGE_ME_* sentinels from values.yaml.
 mysql:

--- a/deploy/kubernetes/chart/scripts/test-service-nodeport.sh
+++ b/deploy/kubernetes/chart/scripts/test-service-nodeport.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Guard: optional fixed Service nodePorts render only when type allows them,
+# and validate.yaml rejects ClusterIP + explicit nodePort / out-of-range values.
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+CHART_DIR="$(dirname "$SCRIPT_DIR")"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+COMMON_SETS="
+  --set-string mysql.password=test
+  --set-string mysql.rootPassword=test
+  --set-string redis.password=test
+"
+
+fail_msg() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# Default ClusterIP render must not emit nodePort fields.
+helm template nodeport-default "$CHART_DIR" $COMMON_SETS > "$TMP_DIR/default.yaml"
+if grep -E '^\s+nodePort:' "$TMP_DIR/default.yaml" >/dev/null; then
+  fail_msg "default ClusterIP render unexpectedly includes nodePort"
+fi
+
+# Explicit NodePort + fixed ports must appear on api and proxy Services.
+helm template nodeport-fixed "$CHART_DIR" $COMMON_SETS \
+  --set controlPlane.api.service.type=NodePort \
+  --set controlPlane.api.service.nodePort=30030 \
+  --set cubeProxy.service.type=NodePort \
+  --set cubeProxy.service.nodePorts.http=30080 \
+  --set cubeProxy.service.nodePorts.https=30443 \
+  --set cubeProxy.service.nodePorts.grpc=30090 \
+  --set cubeProxy.service.nodePorts.admin=30082 \
+  --set cubeProxy.ingress.enabled=false \
+  > "$TMP_DIR/fixed.yaml"
+
+awk '
+  /^kind: Service$/ { in_svc=1; name=""; component=""; next }
+  in_svc && /^  name: / { name=$2 }
+  in_svc && /app.kubernetes.io\/component: / { component=$2 }
+  in_svc && /^---$/ { in_svc=0 }
+  in_svc && name != "" && component == "api" && /nodePort: 30030/ { api_np=1 }
+  in_svc && name != "" && component == "cube-proxy" && /nodePort: 30080/ { proxy_http=1 }
+  in_svc && name != "" && component == "cube-proxy" && /nodePort: 30443/ { proxy_https=1 }
+  in_svc && name != "" && component == "cube-proxy" && /nodePort: 30090/ { proxy_grpc=1 }
+  in_svc && name != "" && component == "cube-proxy" && /nodePort: 30082/ { proxy_admin=1 }
+  END {
+    if (!api_np) { print "api nodePort 30030 missing"; exit 1 }
+    if (!proxy_http) { print "proxy http nodePort 30080 missing"; exit 1 }
+    if (!proxy_https) { print "proxy https nodePort 30443 missing"; exit 1 }
+    if (!proxy_grpc) { print "proxy grpc nodePort 30090 missing"; exit 1 }
+    if (!proxy_admin) { print "proxy admin nodePort 30082 missing"; exit 1 }
+  }
+' "$TMP_DIR/fixed.yaml" || fail_msg "fixed nodePorts not rendered as expected"
+
+# ClusterIP + explicit nodePort must fail render.
+if helm template nodeport-bad-type "$CHART_DIR" $COMMON_SETS \
+  --set controlPlane.api.service.nodePort=30030 \
+  >"$TMP_DIR/bad-type.out" 2>"$TMP_DIR/bad-type.err"; then
+  fail_msg "expected fail when ClusterIP api sets nodePort"
+fi
+grep -q 'controlPlane.api.service.nodePort requires service.type' "$TMP_DIR/bad-type.err" \
+  || fail_msg "missing api ClusterIP+nodePort guard message"
+
+if helm template nodeport-bad-proxy "$CHART_DIR" $COMMON_SETS \
+  --set cubeProxy.service.nodePorts.http=30080 \
+  >"$TMP_DIR/bad-proxy.out" 2>"$TMP_DIR/bad-proxy.err"; then
+  fail_msg "expected fail when ClusterIP proxy sets nodePorts.http"
+fi
+grep -q 'cubeProxy.service.nodePorts.http requires service.type' "$TMP_DIR/bad-proxy.err" \
+  || fail_msg "missing proxy ClusterIP+nodePort guard message"
+
+# Out-of-range nodePort must fail.
+if helm template nodeport-range "$CHART_DIR" $COMMON_SETS \
+  --set controlPlane.api.service.type=NodePort \
+  --set controlPlane.api.service.nodePort=80 \
+  >"$TMP_DIR/range.out" 2>"$TMP_DIR/range.err"; then
+  fail_msg "expected fail for api nodePort outside 30000-32767"
+fi
+grep -q 'must be in 30000-32767' "$TMP_DIR/range.err" \
+  || fail_msg "missing api nodePort range guard message"
+
+# Unknown nodePorts key must fail (typos must not silently become auto-allocation).
+if helm template nodeport-unknown-key "$CHART_DIR" $COMMON_SETS \
+  --set cubeProxy.service.type=NodePort \
+  --set cubeProxy.service.nodePorts.htttp=30080 \
+  --set cubeProxy.ingress.enabled=false \
+  >"$TMP_DIR/unknown.out" 2>"$TMP_DIR/unknown.err"; then
+  fail_msg "expected fail for unknown cubeProxy.service.nodePorts key"
+fi
+grep -q 'cubeProxy.service.nodePorts.htttp is not supported' "$TMP_DIR/unknown.err" \
+  || fail_msg "missing unknown nodePorts key guard message"
+
+echo "Service nodePort guard passed"

--- a/deploy/kubernetes/chart/templates/api.yaml
+++ b/deploy/kubernetes/chart/templates/api.yaml
@@ -125,6 +125,9 @@ spec:
     - name: http-api
       port: {{ .Values.controlPlane.api.service.port }}
       targetPort: http-api
+      {{- with .Values.controlPlane.api.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
 {{- if .Values.controlPlane.api.internalLoadBalancer.enabled }}
 ---
 apiVersion: v1

--- a/deploy/kubernetes/chart/templates/proxy-service.yaml
+++ b/deploy/kubernetes/chart/templates/proxy-service.yaml
@@ -20,16 +20,28 @@ spec:
       port: {{ .Values.cubeProxy.ports.http.containerPort }}
       targetPort: http
       protocol: TCP
+      {{- with (((.Values.cubeProxy).service).nodePorts).http }}
+      nodePort: {{ . }}
+      {{- end }}
     - name: https
       port: {{ .Values.cubeProxy.ports.https.containerPort }}
       targetPort: https
       protocol: TCP
+      {{- with (((.Values.cubeProxy).service).nodePorts).https }}
+      nodePort: {{ . }}
+      {{- end }}
     - name: grpc
       port: {{ .Values.cubeProxy.ports.grpc.containerPort }}
       targetPort: grpc
       protocol: TCP
+      {{- with (((.Values.cubeProxy).service).nodePorts).grpc }}
+      nodePort: {{ . }}
+      {{- end }}
     - name: admin
       port: {{ .Values.cubeProxy.adminPort }}
       targetPort: admin
       protocol: TCP
+      {{- with (((.Values.cubeProxy).service).nodePorts).admin }}
+      nodePort: {{ . }}
+      {{- end }}
 {{- end }}

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -106,6 +106,18 @@
 {{- if and (eq (include "cube.redisBuiltinEnabled" .) "true") (hasPrefix "CHANGE_ME" (default "" .Values.redis.password)) }}
 {{- fail "redis.password still equals the CHANGE_ME_* default sentinel. Override it before deploying (or set redis.host to use external Redis)." }}
 {{- end }}
+{{- /* Fixed Service nodePorts are only valid for NodePort / LoadBalancer. */ -}}
+{{- $apiSvcType := .Values.controlPlane.api.service.type | default "ClusterIP" -}}
+{{- $apiNodePort := .Values.controlPlane.api.service.nodePort | default "" | toString -}}
+{{- if and (ne $apiNodePort "") (not (has $apiSvcType (list "NodePort" "LoadBalancer"))) }}
+{{- fail (printf "controlPlane.api.service.nodePort requires service.type NodePort or LoadBalancer (got %s)" $apiSvcType) }}
+{{- end }}
+{{- if ne $apiNodePort "" }}
+{{- $apiNP := $apiNodePort | int -}}
+{{- if or (lt $apiNP 30000) (gt $apiNP 32767) }}
+{{- fail (printf "controlPlane.api.service.nodePort must be in 30000-32767 (got %v)" $apiNodePort) }}
+{{- end }}
+{{- end }}
 {{- if eq (include "cube.proxyEnabled" .) "true" }}
 {{- if not $controlPlaneSelector }}
 {{- fail "cubeProxy.enabled=true requires placement.controlPlane.nodeSelector because CubeProxy runs on control nodes" }}
@@ -129,11 +141,29 @@
 {{- if and (eq (.Values.cubeProxy.service.type | default "ClusterIP") "LoadBalancer") (hasPrefix "CHANGE_ME" $clbSecurityGroups) }}
 {{- fail "cubeProxy.service.annotations[\"service.cloud.tencent.com/security-groups\"] still equals the CHANGE_ME_* sentinel from values-tke.yaml. Override it with your VPC security group id(s) (comma-separated), or set it to \"\" if you manage CLB security groups outside Helm." }}
 {{- end }}
+{{- $proxySvcType := .Values.cubeProxy.service.type | default "ClusterIP" -}}
+{{- $proxyNodePorts := ((.Values.cubeProxy).service).nodePorts | default dict -}}
+{{- $proxyNodePortKeys := list "http" "https" "grpc" "admin" -}}
+{{- range $name, $raw := $proxyNodePorts }}
+{{- if not (has $name $proxyNodePortKeys) }}
+{{- fail (printf "cubeProxy.service.nodePorts.%s is not supported; allowed keys: http, https, grpc, admin" $name) }}
+{{- end }}
+{{- $npStr := $raw | default "" | toString -}}
+{{- if ne $npStr "" }}
+{{- if not (has $proxySvcType (list "NodePort" "LoadBalancer")) }}
+{{- fail (printf "cubeProxy.service.nodePorts.%s requires service.type NodePort or LoadBalancer (got %s)" $name $proxySvcType) }}
+{{- end }}
+{{- $np := $npStr | int -}}
+{{- if or (lt $np 30000) (gt $np 32767) }}
+{{- fail (printf "cubeProxy.service.nodePorts.%s must be in 30000-32767 (got %v)" $name $raw) }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- if hasKey .Values.cubeProxy "sidecar" }}
 {{- fail "cubeProxy.sidecar was removed; lifecycle coordination is handled by lifecycleManager (cube-lifecycle-manager). Remove cubeProxy.sidecar from your values." }}
 {{- end }}
 {{- if hasKey .Values.cubeProxy "hostNetwork" }}
-{{- fail "cubeProxy.hostNetwork was removed; CubeProxy always runs on the Pod network behind a ClusterIP Service + Ingress. Remove cubeProxy.hostNetwork from your values." }}
+{{- fail "cubeProxy.hostNetwork was removed; CubeProxy always runs on the Pod network behind its Service (ClusterIP / NodePort / LoadBalancer; Ingress optional). Remove cubeProxy.hostNetwork from your values." }}
 {{- end }}
 {{- if and .Values.lifecycleManager.adminToken (lt (len .Values.lifecycleManager.adminToken) 16) }}
 {{- fail "lifecycleManager.adminToken must be empty for auto-generation or at least 16 characters when explicitly set" }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -270,6 +270,9 @@ controlPlane:
     service:
       type: ClusterIP
       port: 3000
+      # Optional host port when type is NodePort or LoadBalancer.
+      # Leave empty for Kubernetes auto-allocation. Must not be set for ClusterIP.
+      nodePort: ""
     internalLoadBalancer:
       enabled: false
       annotations: {}
@@ -664,6 +667,17 @@ cubeProxy:
   service:
     type: ClusterIP
     annotations: {}
+    # Optional host ports when type is NodePort or LoadBalancer (range
+    # 30000-32767). Leave empty for auto-allocation. Must not be set for
+    # ClusterIP. Typical bare-metal / no-Ingress profile:
+    #   type: NodePort
+    #   nodePorts: { http: 30080, https: 30443, grpc: 30090 }
+    # and set ingress.enabled=false.
+    nodePorts:
+      http: ""
+      https: ""
+      grpc: ""
+      admin: ""
   ingress:
     # Requires a cluster Ingress Controller. Set false to manage the entrypoint
     # yourself (still keep the ClusterIP Service as the backend).


### PR DESCRIPTION
## Summary

- Chart Services already accepted `service.type=NodePort`, but fixed host ports could not be set via values.
- Add optional `controlPlane.api.service.nodePort` and `cubeProxy.service.nodePorts.{http,https,grpc,admin}` (Kubernetes range `30000-32767`). Empty keeps auto-allocation; default remains `ClusterIP` + Ingress.
- `validate.yaml` rejects explicit `nodePort` when `type` is still `ClusterIP`, and rejects out-of-range values.
- Document the bare-metal / no-Ingress profile in chart README and `runtime-values.example.yaml`.

## Test plan

- [x] `helm lint deploy/kubernetes/chart` (with test passwords) — passed
- [x] `helm template` default render — no `nodePort` fields
- [x] `bash deploy/kubernetes/chart/scripts/test-service-nodeport.sh` — passed (fixed ports render; ClusterIP+nodePort and out-of-range fail)
- [x] Existing chart guards (`test-database-postgres-guard.sh`, `test-master-recreate-strategy-guard.sh`, `test-pvm-native-ds-gvk-guard.sh`, …) — passed on ubuntu22 with synced chart tree