### PR TITLE
[Bugfix] Honor snake_case CubeMaster log rotation settings

### DIFF
--- a/CubeMaster/pkg/base/config/config_test.go
+++ b/CubeMaster/pkg/base/config/config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -49,6 +50,29 @@ func TestInit(t *testing.T) {
 	gotCpu, err := resource.ParseQuantity(cubeboxConf.CpuLowerWaterMark)
 	assert.NoError(t, err)
 	assert.True(t, expectCpu.Equal(gotCpu))
+}
+
+func TestNestedLogSettingsUseSnakeCaseOnRoundTrip(t *testing.T) {
+	var cfg Config
+	err := yaml.Unmarshal([]byte("log:\n  file_size: 100\n  file_num: 10\n  enable_log_metric: true\n"), &cfg)
+	assert.NoError(t, err)
+	if !assert.NotNil(t, cfg.Log) {
+		return
+	}
+
+	assert.Equal(t, 100, cfg.Log.FileSize)
+	assert.Equal(t, 10, cfg.Log.FileNum)
+	assert.True(t, cfg.Log.EnableLogMetric)
+
+	encoded, err := yaml.Marshal(&cfg)
+	assert.NoError(t, err)
+	text := string(encoded)
+	assert.Contains(t, text, "file_size: 100")
+	assert.Contains(t, text, "file_num: 10")
+	assert.Contains(t, text, "enable_log_metric: true")
+	assert.NotContains(t, text, "fileSize:")
+	assert.NotContains(t, text, "fileNum:")
+	assert.NotContains(t, text, "enableLogMetric:")
 }
 
 func TestGetEffectiveNodeMaxMemReservedInMBFallsBackForSmallNodes(t *testing.T) {

--- a/CubeMaster/pkg/base/log/types.go
+++ b/CubeMaster/pkg/base/log/types.go
@@ -5,13 +5,48 @@
 // Package log provides log
 package log
 
+import "gopkg.in/yaml.v3"
+
 type Conf struct {
 	Region          string `yaml:"region"`
 	Cluster         string `yaml:"cluster"`
 	Module          string `yaml:"module"`
 	Path            string `yaml:"path"`
-	FileSize        int    `yaml:"fileSize"`
-	FileNum         int    `yaml:"fileNum"`
+	FileSize        int    `yaml:"file_size"`
+	FileNum         int    `yaml:"file_num"`
 	Level           string `yaml:"level"`
-	EnableLogMetric bool   `yaml:"enableLogMetric"`
+	EnableLogMetric bool   `yaml:"enable_log_metric"`
+}
+
+// UnmarshalYAML accepts the snake_case keys used by the shipped configuration
+// and the camelCase keys used by older deployments. When both spellings are
+// present, the shipped snake_case spelling takes precedence.
+func (c *Conf) UnmarshalYAML(value *yaml.Node) error {
+	type plain Conf
+	if err := value.Decode((*plain)(c)); err != nil {
+		return err
+	}
+
+	var keys struct {
+		FileSize              *int  `yaml:"file_size"`
+		FileNum               *int  `yaml:"file_num"`
+		EnableLogMetric       *bool `yaml:"enable_log_metric"`
+		LegacyFileSize        *int  `yaml:"fileSize"`
+		LegacyFileNum         *int  `yaml:"fileNum"`
+		LegacyEnableLogMetric *bool `yaml:"enableLogMetric"`
+	}
+	if err := value.Decode(&keys); err != nil {
+		return err
+	}
+
+	if keys.FileSize == nil && keys.LegacyFileSize != nil {
+		c.FileSize = *keys.LegacyFileSize
+	}
+	if keys.FileNum == nil && keys.LegacyFileNum != nil {
+		c.FileNum = *keys.LegacyFileNum
+	}
+	if keys.EnableLogMetric == nil && keys.LegacyEnableLogMetric != nil {
+		c.EnableLogMetric = *keys.LegacyEnableLogMetric
+	}
+	return nil
 }

--- a/CubeMaster/pkg/base/log/types_test.go
+++ b/CubeMaster/pkg/base/log/types_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package log
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfUnmarshalLogRotationSettings(t *testing.T) {
+	var conf Conf
+	err := yaml.Unmarshal([]byte("file_size: 100\nfile_num: 10\n"), &conf)
+	if err != nil {
+		t.Fatalf("unmarshal log config: %v", err)
+	}
+
+	if conf.FileSize != 100 {
+		t.Fatalf("FileSize = %d, want 100", conf.FileSize)
+	}
+	if conf.FileNum != 10 {
+		t.Fatalf("FileNum = %d, want 10", conf.FileNum)
+	}
+}
+
+func TestConfUnmarshalLegacyLogRotationSettings(t *testing.T) {
+	var conf Conf
+	err := yaml.Unmarshal([]byte("fileSize: 200\nfileNum: 20\n"), &conf)
+	if err != nil {
+		t.Fatalf("unmarshal legacy log config: %v", err)
+	}
+
+	if conf.FileSize != 200 {
+		t.Fatalf("FileSize = %d, want 200", conf.FileSize)
+	}
+	if conf.FileNum != 20 {
+		t.Fatalf("FileNum = %d, want 20", conf.FileNum)
+	}
+}
+
+func TestConfUnmarshalSnakeCaseTakesPrecedence(t *testing.T) {
+	var conf Conf
+	err := yaml.Unmarshal([]byte("file_size: 100\nfile_num: 10\nenable_log_metric: false\nfileSize: 200\nfileNum: 20\nenableLogMetric: true\n"), &conf)
+	if err != nil {
+		t.Fatalf("unmarshal mixed log config: %v", err)
+	}
+
+	if conf.FileSize != 100 {
+		t.Fatalf("FileSize = %d, want 100", conf.FileSize)
+	}
+	if conf.FileNum != 10 {
+		t.Fatalf("FileNum = %d, want 10", conf.FileNum)
+	}
+	if conf.EnableLogMetric {
+		t.Fatalf("EnableLogMetric = true, want false")
+	}
+}
+
+func TestConfUnmarshalLegacyLogMetricSetting(t *testing.T) {
+	var conf Conf
+	err := yaml.Unmarshal([]byte("enableLogMetric: true\n"), &conf)
+	if err != nil {
+		t.Fatalf("unmarshal legacy log metric config: %v", err)
+	}
+
+	if !conf.EnableLogMetric {
+		t.Fatalf("EnableLogMetric = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary
Fix CubeMaster log rotation settings being ignored when using the shipped configuration.

## Root cause
The shipped YAML uses `file_size` and `file_num`, but `log.Conf` used `fileSize` and `fileNum` YAML tags. `yaml.v3` therefore leaves both values at zero, so `cubelog` receives no rotation size or count.

## Changes
- use the shipped snake_case keys in the Go struct tags
- add a regression test for unmarshalling the rotation settings

Closes #1289

## Validation
- `go test ./pkg/base/log` (not run locally: the Go toolchain is unavailable in this environment)
