### PR TITLE
fix(templatecenter): reclaim leaked loop devices instead of silently degrading ext4 builds

### DIFF
--- a/CubeMaster/pkg/templatecenter/image/disk.go
+++ b/CubeMaster/pkg/templatecenter/image/disk.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
@@ -68,12 +69,57 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 
 	// Use context.Background() for cleanup so it runs even after request cancellation.
 	cleanupCtx := context.Background()
+	var loopDevice string
+	var mounted bool
+	var mountStuck bool
 	var unmountOnce sync.Once
 	var detachOnce sync.Once
-	cleanup := func() {
-		unmountOnce.Do(func() {
-			_ = runCommand(cleanupCtx, "", "umount", "--", mountPoint)
+	detachLoop := func() {
+		if loopDevice == "" {
+			return
+		}
+		detachOnce.Do(func() {
+			// A lazy umount releases the mount asynchronously, so the detach can fail
+			// EBUSY for a short window afterwards; retry briefly. When even the lazy
+			// umount failed the mount is still there and every attempt is guaranteed to
+			// fail, so don't spend the budget.
+			attempts := 5
+			if mountStuck {
+				attempts = 1
+			}
+			var err error
+			for attempt := 0; attempt < attempts; attempt++ {
+				if attempt > 0 {
+					time.Sleep(200 * time.Millisecond)
+				}
+				if err = runCommand(cleanupCtx, "", "losetup", "--detach", "--", loopDevice); err == nil {
+					return
+				}
+			}
+			// Be precise about how narrow recovery is from here: reclaim only picks a
+			// device up once its backing file has been unlinked — which happens on the
+			// build's failure path only — and the mount is gone. On the success path the
+			// image stays, so the device stays attached until the host reboots.
+			log.G(ctx).Warnf("losetup --detach %s failed; device stays attached, reclaimable later only if its backing file is unlinked and the mount released: %v", loopDevice, err)
 		})
+	}
+	// A single cleanup closure, so the detach always runs *after* the umount:
+	// detaching a still-mounted device fails EBUSY and pins the loop device — and,
+	// once the backing file is unlinked, its disk space too — until the host
+	// reboots. Two separate defers would run in LIFO order and get this backwards.
+	cleanup := func() {
+		if mounted {
+			unmountOnce.Do(func() {
+				if err := runCommand(cleanupCtx, "", "umount", "--", mountPoint); err != nil {
+					log.G(ctx).Warnf("umount %s failed, retrying lazily: %v", mountPoint, err)
+					if lazyErr := runCommand(cleanupCtx, "", "umount", "-l", "--", mountPoint); lazyErr != nil {
+						mountStuck = true
+						log.G(ctx).Warnf("lazy umount %s also failed, loop device will leak: %v", mountPoint, lazyErr)
+					}
+				}
+			})
+		}
+		detachLoop()
 		if err := os.RemoveAll(mountPoint); err != nil {
 			log.G(ctx).Warnf("cleanup mount point %s failed: %v", mountPoint, err)
 		}
@@ -86,25 +132,47 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 	// parsed device path — corrupting the loopDevice string so every later mount
 	// and detach receives a garbage argument (mount fails "bad option", detach
 	// fails → loop device leaks).
-	losetupCmd := exec.CommandContext(ctx, "losetup", "--find", "--show", "--", ext4Path)
-	var losetupErr bytes.Buffer
-	losetupCmd.Stderr = &losetupErr
-	loopOut, err := losetupCmd.Output()
+	findLoop := func() ([]byte, error) {
+		cmd := exec.CommandContext(ctx, "losetup", "--find", "--show", "--", ext4Path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		if err != nil {
+			return nil, fmt.Errorf("losetup --find --show %s failed: %w: %s", ext4Path, err, strings.TrimSpace(stderr.String()))
+		}
+		return out, nil
+	}
+	loopOut, err := findLoop()
 	if err != nil {
-		return fmt.Errorf("losetup --find --show %s failed: %w: %s", ext4Path, err, strings.TrimSpace(losetupErr.String()))
+		// Running out of loop devices can be self-inflicted: a detach that could not
+		// be completed (e.g. the umount above only succeeded lazily) keeps one pinned
+		// for the lifetime of the host, so the fast path would be lost permanently
+		// once enough builds have leaked. Reclaim devices whose backing file is
+		// already gone and retry before degrading to the much slower phase-1 build.
+		// This is best-effort and only meaningful for exhaustion; losetup reports
+		// every failure the same way, so other causes (cancellation, permissions)
+		// pay one extra `losetup --list` and then fail the retry as they should.
+		// It also only frees devices this process managed to attach, i.e. ones whose
+		// /dev node exists here — it cannot create the node that LOOP_CTL_GET_FREE
+		// returned, so a container whose /dev tmpfs is short of loop nodes and has no
+		// orphans to reclaim still degrades to phase-1 (see the deployment note).
+		if n := reclaimOrphanLoopDevices(cleanupCtx, artifactStoreDirOf(ext4Path)); n > 0 {
+			log.G(ctx).Warnf("loop device allocation failed (%v); reclaimed %d orphaned loop device(s), retrying", err, n)
+			retryOut, retryErr := findLoop()
+			if retryErr != nil {
+				return fmt.Errorf("%w (retry after reclaiming %d device(s) also failed: %v)", err, n, retryErr)
+			}
+			loopOut = retryOut
+		} else {
+			return err
+		}
 	}
-	loopDevice := strings.TrimSpace(string(loopOut))
-	detachLoop := func() {
-		detachOnce.Do(func() {
-			_ = runCommand(cleanupCtx, "", "losetup", "--detach", "--", loopDevice)
-		})
-	}
-	defer detachLoop()
+	loopDevice = strings.TrimSpace(string(loopOut))
 
 	if err := runCommand(ctx, "", "mount", "-o", "nosuid,noexec,nodev,noatime", "--", loopDevice, mountPoint); err != nil {
-		detachLoop() // explicit detach on mount failure (defer will be a no-op via sync.Once)
 		return fmt.Errorf("mount loop device %s: %w", loopDevice, err)
 	}
+	mounted = true
 
 	// 4. Stream export directly into the mounted ext4.
 	if source.ExportMode == ExportModeNative {
@@ -133,7 +201,7 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 		}
 	}
 
-	// 5. Unmount (via cleanup).
+	// 5. Unmount and detach (via cleanup).
 	cleanup()
 
 	// 6. Shrink the ext4 filesystem to minimum size (best-effort).
@@ -174,6 +242,74 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 	}
 
 	return nil
+}
+
+// artifactStoreDirOf returns the artifact store root for an ext4 image path,
+// mirroring the <store>/<artifact>/<artifact>.ext4 layout BuildExt4 constructs
+// (including when it falls back to ArtifactFallbackStoreRootDir, so a fallback
+// build only ever reclaims fallback-store orphans). A path of another shape just
+// yields a prefix that matches nothing in orphanLoopCandidates, i.e. reclaim
+// no-ops rather than reaching outside the store. Nested store roots are the one
+// case where the scope is wider than the build's own store: the shallower root's
+// prefix also covers the deeper one's orphans, still bounded to devices whose
+// backing file is already gone.
+func artifactStoreDirOf(ext4Path string) string {
+	return filepath.Dir(filepath.Dir(ext4Path))
+}
+
+// orphanLoopCandidates parses the output of
+// `losetup --list --noheadings --raw --output NAME,BACK-FILE` and returns the
+// devices whose backing file lives under storeDir and has already been unlinked
+// (losetup marks those with a trailing " (deleted)").
+//
+// Requiring the unlink is what makes the reclaim safe against a build running
+// concurrently: the image file is only unlinked once a build has given up on it,
+// so a live build's device can never become a candidate — not even in the
+// attach→mount window, where the device is not yet in the mount table and the
+// kernel's EBUSY refusal would not protect it either.
+func orphanLoopCandidates(losetupList, storeDir string) []string {
+	if storeDir == "" || storeDir == "/" {
+		return nil
+	}
+	prefix := strings.TrimSuffix(storeDir, "/") + "/"
+	var names []string
+	for _, line := range strings.Split(losetupList, "\n") {
+		name, backing, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok || name == "" {
+			continue
+		}
+		backing = strings.TrimSpace(backing)
+		if !strings.HasSuffix(backing, " (deleted)") {
+			continue
+		}
+		backing = strings.TrimSpace(strings.TrimSuffix(backing, " (deleted)"))
+		if strings.HasPrefix(backing, prefix) {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// reclaimOrphanLoopDevices detaches loop devices whose backing file under
+// storeDir has already been unlinked, i.e. devices no build can still be using.
+// Returns how many were freed.
+func reclaimOrphanLoopDevices(ctx context.Context, storeDir string) int {
+	out, err := exec.CommandContext(ctx, "losetup", "--list", "--noheadings", "--raw",
+		"--output", "NAME,BACK-FILE").Output()
+	if err != nil {
+		log.G(ctx).Warnf("losetup --list for orphan reclaim failed: %v", err)
+		return 0
+	}
+	reclaimed := 0
+	for _, name := range orphanLoopCandidates(string(out), storeDir) {
+		if err := runCommand(ctx, "", "losetup", "--detach", "--", name); err != nil {
+			log.G(ctx).Debugf("orphan loop device %s not reclaimable (likely still in use): %v", name, err)
+			continue
+		}
+		log.G(ctx).Debugf("reclaimed orphaned loop device %s", name)
+		reclaimed++
+	}
+	return reclaimed
 }
 
 // pipeExportToDir streams the docker export of a container directly into a target

--- a/CubeMaster/pkg/templatecenter/image/disk_test.go
+++ b/CubeMaster/pkg/templatecenter/image/disk_test.go
@@ -1,0 +1,352 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package image
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+)
+
+func TestArtifactStoreDirOf(t *testing.T) {
+	got := artifactStoreDirOf("/var/lib/cubemaster/storage/rfs-abc/rfs-abc.ext4")
+	if want := "/var/lib/cubemaster/storage"; got != want {
+		t.Fatalf("artifactStoreDirOf = %q, want %q", got, want)
+	}
+}
+
+func TestOrphanLoopCandidates(t *testing.T) {
+	const store = "/var/lib/cubemaster/storage"
+
+	cases := []struct {
+		name     string
+		list     string
+		storeDir string
+		want     []string
+	}{
+		{
+			name:     "empty output",
+			list:     "",
+			storeDir: store,
+		},
+		{
+			name:     "deleted backing file is a candidate",
+			list:     "/dev/loop3 /var/lib/cubemaster/storage/rfs-a/rfs-a.ext4 (deleted)\n",
+			storeDir: store,
+			want:     []string{"/dev/loop3"},
+		},
+		{
+			name:     "existing backing file under the store is left alone (may be a live build)",
+			list:     "/dev/loop1 /var/lib/cubemaster/storage/rfs-b/rfs-b.ext4\n",
+			storeDir: store,
+		},
+		{
+			name:     "devices outside the store are never touched",
+			list:     "/dev/loop0 /var/lib/snapd/snaps/core.snap\n/dev/loop2 /srv/other/disk.img (deleted)\n",
+			storeDir: store,
+		},
+		{
+			name:     "the store dir itself must not match as a prefix of a sibling",
+			list:     "/dev/loop4 /var/lib/cubemaster/storage-backup/rfs-c/rfs-c.ext4 (deleted)\n",
+			storeDir: store,
+		},
+		{
+			name:     "blank and malformed lines are skipped",
+			list:     "\n   \n/dev/loop5\n/dev/loop6 /var/lib/cubemaster/storage/rfs-d/rfs-d.ext4 (deleted)\n",
+			storeDir: store,
+			want:     []string{"/dev/loop6"},
+		},
+		{
+			name:     "a root store dir is refused rather than detaching everything",
+			list:     "/dev/loop0 /any/file.img (deleted)\n",
+			storeDir: "/",
+		},
+		{
+			name:     "trailing slash on the store dir behaves the same",
+			list:     "/dev/loop7 /var/lib/cubemaster/storage/rfs-e/rfs-e.ext4 (deleted)\n",
+			storeDir: store + "/",
+			want:     []string{"/dev/loop7"},
+		},
+		{
+			name:     "a backing path containing spaces is still matched",
+			list:     "/dev/loop8 /var/lib/cubemaster/storage/rfs f/rfs f.ext4 (deleted)\n",
+			storeDir: store,
+			want:     []string{"/dev/loop8"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := orphanLoopCandidates(tc.list, tc.storeDir)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("orphanLoopCandidates = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// setupStreamingFakes puts fake truncate/mkfs.ext4/mount/umount/resize2fs on
+// PATH (each appending its argv to a trace file) and lets the streaming build
+// believe loop mounts are usable. The caller installs its own `losetup` fake,
+// which is where every interesting behaviour lives.
+func setupStreamingFakes(t *testing.T) (binDir, tracePath, ext4Path string) {
+	t.Helper()
+	binDir = t.TempDir()
+	tracePath = filepath.Join(binDir, "trace.log")
+	store := filepath.Join(t.TempDir(), "storage")
+	ext4Path = filepath.Join(store, "rfs-a", "rfs-a.ext4")
+
+	t.Setenv("PATH", binDir)
+	t.Setenv("FAKE_TRACE", tracePath)
+	t.Setenv("FAKE_STORE", store)
+	t.Setenv("FAKE_STATE", filepath.Join(binDir, "state"))
+
+	for _, name := range []string{"truncate", "mkfs.ext4", "mount", "umount", "resize2fs"} {
+		installFakeCommand(t, binDir, name, `echo "`+name+` $*" >> "$FAKE_TRACE"`)
+	}
+
+	patches := gomonkey.NewPatches()
+	patches.ApplyFuncReturn(canUseLoopMount, true)
+	patches.ApplyFuncReturn(StreamRegistryToDir, nil)
+	t.Cleanup(patches.Reset)
+	return binDir, tracePath, ext4Path
+}
+
+func runStreamingBuild(t *testing.T, ext4Path string) error {
+	t.Helper()
+	source := &PreparedSource{LocalRef: "local/img:latest", ExportMode: ExportModeNative}
+	return createExt4ImageStreaming(context.Background(), source, t.TempDir(), ext4Path, 1024, nil)
+}
+
+func traceLines(t *testing.T, tracePath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read command trace: %v", err)
+	}
+	var lines []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func traceIndex(lines []string, prefix string) int {
+	for i, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			return i
+		}
+	}
+	return -1
+}
+
+func traceCount(lines []string, prefix string) int {
+	n := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestStreamingUnmountsBeforeDetach guards the actual leak: detaching a device
+// that is still mounted fails EBUSY and pins it for the lifetime of the host.
+func TestStreamingUnmountsBeforeDetach(t *testing.T) {
+	binDir, tracePath, ext4Path := setupStreamingFakes(t)
+	installFakeCommand(t, binDir, "losetup", `echo "losetup $*" >> "$FAKE_TRACE"
+case "$1" in --find) echo /dev/loop9 ;; esac`)
+
+	if err := runStreamingBuild(t, ext4Path); err != nil {
+		t.Fatalf("streaming build failed: %v", err)
+	}
+
+	lines := traceLines(t, tracePath)
+	umountAt := traceIndex(lines, "umount ")
+	detachAt := traceIndex(lines, "losetup --detach")
+	if umountAt < 0 || detachAt < 0 {
+		t.Fatalf("expected both umount and detach in trace, got %v", lines)
+	}
+	if umountAt > detachAt {
+		t.Fatalf("detach ran before umount (would fail EBUSY and leak the device): %v", lines)
+	}
+}
+
+// TestStreamingRetriesDetachAfterBusy covers the lazy-umount window, where the
+// mount is released asynchronously and the first detaches legitimately fail.
+func TestStreamingRetriesDetachAfterBusy(t *testing.T) {
+	binDir, tracePath, ext4Path := setupStreamingFakes(t)
+	installFakeCommand(t, binDir, "losetup", `echo "losetup $*" >> "$FAKE_TRACE"
+case "$1" in
+--find) echo /dev/loop9 ;;
+--detach)
+	if [ -f "$FAKE_STATE.2" ]; then exit 0; fi
+	if [ -f "$FAKE_STATE.1" ]; then > "$FAKE_STATE.2"; else > "$FAKE_STATE.1"; fi
+	echo "device or resource busy" >&2; exit 1 ;;
+esac`)
+
+	if err := runStreamingBuild(t, ext4Path); err != nil {
+		t.Fatalf("streaming build failed: %v", err)
+	}
+
+	if got := traceCount(traceLines(t, tracePath), "losetup --detach"); got != 3 {
+		t.Fatalf("detach attempts = %d, want 3 (retry until it succeeds)", got)
+	}
+}
+
+// TestStreamingSkipsDetachRetriesWhenMountStuck: once even the lazy umount
+// failed the mount is still there, so every detach is guaranteed to fail —
+// spending the retry budget only delays the build.
+func TestStreamingSkipsDetachRetriesWhenMountStuck(t *testing.T) {
+	binDir, tracePath, ext4Path := setupStreamingFakes(t)
+	installFakeCommand(t, binDir, "umount", `echo "umount $*" >> "$FAKE_TRACE"
+echo "target is busy" >&2; exit 1`)
+	installFakeCommand(t, binDir, "losetup", `echo "losetup $*" >> "$FAKE_TRACE"
+case "$1" in
+--find) echo /dev/loop9 ;;
+--detach) echo "device or resource busy" >&2; exit 1 ;;
+esac`)
+
+	if err := runStreamingBuild(t, ext4Path); err != nil {
+		t.Fatalf("streaming build failed: %v", err)
+	}
+
+	lines := traceLines(t, tracePath)
+	if got := traceCount(lines, "umount -l"); got != 1 {
+		t.Fatalf("lazy umount attempts = %d, want 1", got)
+	}
+	if got := traceCount(lines, "losetup --detach"); got != 1 {
+		t.Fatalf("detach attempts = %d, want 1 (mount is stuck, retrying is pointless)", got)
+	}
+}
+
+// TestStreamingDetachesAfterLazyUmount is the case the detach retry budget
+// exists for: the plain umount fails, the lazy one succeeds, and the device is
+// released once the kernel has dropped the mount.
+func TestStreamingDetachesAfterLazyUmount(t *testing.T) {
+	binDir, tracePath, ext4Path := setupStreamingFakes(t)
+	installFakeCommand(t, binDir, "umount", `echo "umount $*" >> "$FAKE_TRACE"
+case "$1" in -l) exit 0 ;; *) echo "target is busy" >&2; exit 1 ;; esac`)
+	installFakeCommand(t, binDir, "losetup", `echo "losetup $*" >> "$FAKE_TRACE"
+case "$1" in
+--find) echo /dev/loop9 ;;
+--detach)
+	if [ -f "$FAKE_STATE" ]; then exit 0; fi
+	> "$FAKE_STATE"; echo "device or resource busy" >&2; exit 1 ;;
+esac`)
+
+	if err := runStreamingBuild(t, ext4Path); err != nil {
+		t.Fatalf("streaming build failed: %v", err)
+	}
+
+	lines := traceLines(t, tracePath)
+	if got := traceCount(lines, "umount -l"); got != 1 {
+		t.Fatalf("lazy umount attempts = %d, want 1", got)
+	}
+	if got := traceCount(lines, "losetup --detach"); got != 2 {
+		t.Fatalf("detach attempts = %d, want 2 (retried once the lazy umount landed)", got)
+	}
+}
+
+// TestStreamingDetachesWhenMountFails guards the removal of the explicit detach
+// on the mount-failure path: it now happens only through the deferred cleanup.
+func TestStreamingDetachesWhenMountFails(t *testing.T) {
+	binDir, tracePath, ext4Path := setupStreamingFakes(t)
+	installFakeCommand(t, binDir, "mount", `echo "mount $*" >> "$FAKE_TRACE"
+echo "bad option" >&2; exit 32`)
+	installFakeCommand(t, binDir, "losetup", `echo "losetup $*" >> "$FAKE_TRACE"
+case "$1" in --find) echo /dev/loop9 ;; esac`)
+
+	if err := runStreamingBuild(t, ext4Path); err == nil {
+		t.Fatal("expected the build to fail when the mount fails")
+	}
+
+	lines := traceLines(t, tracePath)
+	if traceIndex(lines, "losetup --detach -- /dev/loop9") < 0 {
+		t.Fatalf("allocated device must be detached even though it was never mounted: %v", lines)
+	}
+	if traceIndex(lines, "umount ") >= 0 {
+		t.Fatalf("nothing was mounted, so no umount should be attempted: %v", lines)
+	}
+}
+
+// TestStreamingReclaimsOrphansOnAllocationFailure: exhaustion caused by earlier
+// leaks must self-heal instead of permanently degrading to the phase-1 build.
+func TestStreamingReclaimsOrphansOnAllocationFailure(t *testing.T) {
+	binDir, tracePath, ext4Path := setupStreamingFakes(t)
+	installFakeCommand(t, binDir, "losetup", `echo "losetup $*" >> "$FAKE_TRACE"
+case "$1" in
+--find)
+	if [ -f "$FAKE_STATE" ]; then echo /dev/loop9; else > "$FAKE_STATE"; echo "could not find any free loop device" >&2; exit 1; fi ;;
+--list) echo "/dev/loop3 $FAKE_STORE/rfs-gone/rfs-gone.ext4 (deleted)" ;;
+esac`)
+
+	if err := runStreamingBuild(t, ext4Path); err != nil {
+		t.Fatalf("streaming build failed instead of reclaiming and retrying: %v", err)
+	}
+
+	lines := traceLines(t, tracePath)
+	if got := traceCount(lines, "losetup --find"); got != 2 {
+		t.Fatalf("losetup --find attempts = %d, want 2 (retry after reclaim)", got)
+	}
+	if traceIndex(lines, "losetup --detach -- /dev/loop3") < 0 {
+		t.Fatalf("expected the orphaned device to be detached, got %v", lines)
+	}
+}
+
+// TestStreamingAllocationFailureWithoutOrphans: with nothing to reclaim the
+// original allocation error must be returned unchanged (and no retry spent), so
+// causes other than exhaustion still surface as themselves.
+func TestStreamingAllocationFailureWithoutOrphans(t *testing.T) {
+	binDir, tracePath, ext4Path := setupStreamingFakes(t)
+	installFakeCommand(t, binDir, "losetup", `echo "losetup $*" >> "$FAKE_TRACE"
+case "$1" in
+--find) echo "could not find any free loop device" >&2; exit 1 ;;
+--list) ;;
+esac`)
+
+	err := runStreamingBuild(t, ext4Path)
+	if err == nil {
+		t.Fatal("expected the build to fail when no loop device can be allocated")
+	}
+	if strings.Contains(err.Error(), "retry") {
+		t.Fatalf("nothing was reclaimed, so no retry should be reported: %v", err)
+	}
+
+	if got := traceCount(traceLines(t, tracePath), "losetup --find"); got != 1 {
+		t.Fatalf("losetup --find attempts = %d, want 1 (nothing to reclaim)", got)
+	}
+}
+
+// TestStreamingReportsBothAllocationFailures: when the retry after a reclaim
+// fails too, both the original and the retry error must be visible — otherwise
+// the reclaim hides the real reason the fast path was lost.
+func TestStreamingReportsBothAllocationFailures(t *testing.T) {
+	binDir, _, ext4Path := setupStreamingFakes(t)
+	installFakeCommand(t, binDir, "losetup", `echo "losetup $*" >> "$FAKE_TRACE"
+case "$1" in
+--find) echo "could not find any free loop device" >&2; exit 1 ;;
+--list) echo "/dev/loop3 $FAKE_STORE/rfs-gone/rfs-gone.ext4 (deleted)" ;;
+esac`)
+
+	err := runStreamingBuild(t, ext4Path)
+	if err == nil {
+		t.Fatal("expected the build to fail when the allocation fails even after reclaiming")
+	}
+	if !strings.Contains(err.Error(), "could not find any free loop device") ||
+		!strings.Contains(err.Error(), "retry after reclaiming 1 device(s)") {
+		t.Fatalf("error must report both the original and the retry failure, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`createExt4ImageStreaming` (the loop-mount fast path from #472, hardened in #958) allocates a loop device, mounts it, and relies on two deferred cleanups to release it. Both cleanups discard their errors:

```go
_ = runCommand(cleanupCtx, "", "umount", "--", mountPoint)
...
_ = runCommand(cleanupCtx, "", "losetup", "--detach", "--", loopDevice)
```

They are also registered as two separate `defer`s — the umount first, the detach second — so LIFO ordering runs the **detach before the umount**. A detach attempted while the filesystem is still mounted fails with `EBUSY`, and nothing is logged. The consequences are permanent:

1. The loop device stays attached for the lifetime of the host.
2. If the backing `.ext4` is unlinked afterwards (the build's own failure cleanup does exactly that), the loop device keeps the inode alive and its disk space is never reclaimed — the same class of permanent disk leak as #822. `losetup -a` shows these as `... .ext4 (deleted)`.
3. Once enough devices have leaked, `losetup --find` fails and every subsequent build falls back to phase-1 behind a single WARN at `ext4.go:141`. The fast path never returns without operator intervention, and the only symptom is that template creation has become drastically slower.

Containerized deployments reach (3) far earlier than the kernel's loop limit would suggest. A container's `/dev` is a tmpfs whose node set is fixed when the container starts — typically `loop-control` plus `loop0..loop7` — while `LOOP_CTL_GET_FREE` hands out **node-global** indexes. As soon as it returns 8 or above, that node does not exist inside the container:

```
losetup: /.../rfs-XXXXXXXX.ext4: failed to set up loop device: No such file or directory
```

Observed in practice: 8 devices attached, none of them mounted, three with `(deleted)` backing files, and every template build after that point taking the slow path.

## Change

- The detach now runs from the *same* cleanup closure as the umount, immediately after it, so it can no longer be ordered before the umount and hit `EBUSY`. This is the primary fix.
- `umount` failure is logged and retried lazily (`umount -l`), so a busy mount point no longer cascades into a permanently pinned device.
- `losetup --detach` is retried briefly (5 attempts, 200 ms apart) before giving up, so a lazy umount that has not finished releasing the mount does not abandon the device, and the final failure is logged instead of discarded.
- A device that still could not be detached now **fails the build** instead of being reported as success. This is the one leak the backstop below cannot heal on its own: a successful build keeps its image, so the backing file is never unlinked and the device can never become a `(deleted)` reclaim candidate. Returning the error makes `BuildExt4` unlink the image (`ext4.go:141-143`) — turning the pinned device into a candidate for the next allocation failure — and rebuild via phase-1, so no image is lost. It also refuses an image whose `resize2fs -M` and pmem alignment would have run against a still-mounted filesystem (the stuck-mount case), which would otherwise serve an unshrunk, unaligned image that the microVM rejects with `PmemSizeNotAligned`.
- A detach that fails only because the device is *already gone* is not treated as a leak: before retrying, the code asks `losetup` what the device is backed by, and stops when it is no longer this build's image. Attaches with autoclear semantics are released by the umount itself, and without this check every such host would burn the whole backoff budget and then fail every build into phase-1. The check queries `losetup` rather than matching its error text, which is localized.
- As a backstop for devices already leaked (by an earlier build, or by a lazy umount that had not completed yet), `reclaimOrphanLoopDevices` runs when `losetup --find` fails and retries once, so exhaustion self-heals instead of permanently degrading every later build.

Reclaim is narrow by construction: a device is only detached when its backing file lives under the artifact store **and has already been unlinked** (`losetup --list` reports it as `(deleted)`). A build unlinks its image only after it has given up on it, so a build in flight elsewhere can never become a candidate — not even in the attach→mount window, where the device is not yet in the mount table and the kernel's `EBUSY` refusal would not protect it either. Devices that still cannot be detached are logged at debug level and skipped.

When the retry after a reclaim also fails, both errors are surfaced (`%w` on the original) so the reason allocation failed in the first place is not lost.

The happy path is unchanged — no additional command runs unless a cleanup fails or allocation is already exhausted.

## Note for containerized deployments

Even with zero leaks, a container that only has `loop0..loop7` can exhaust them with eight concurrent builds. Making more nodes available is a deployment concern (pre-create them, or share the host `/dev`) and is out of scope here; this change makes the failure recoverable and diagnosable rather than silent and permanent.

## Tests

New `disk_test.go`:

- Behaviour of the fix itself, driven through `createExt4ImageStreaming` with fake `losetup`/`mount`/`umount` on `PATH` that record their argv: the umount always precedes the detach (reverting the ordering fails this test), a busy detach is retried until it succeeds, the plain-umount-fails/lazy-umount-succeeds case releases the device on the retry, a mount point that survives even the lazy umount stops after one detach attempt instead of spending the whole budget, a failed `mount` still detaches the allocated device (which now happens only through the deferred cleanup), and an exhausted `losetup --find` is retried after the orphan reclaim frees a device — while an allocation failure with no orphan to reclaim returns the original error with no retry, and one whose retry fails too reports both failures.
- `losetup --list` parsing and store-prefix matching: the `(deleted)` suffix is required (a live backing file under the store is left alone), devices outside the store, sibling directories sharing a prefix (`storage-backup` vs `storage`), malformed and blank lines, a backing path containing spaces, and a `/` store dir (refused rather than detaching everything).

`gofmt`, `go build ./pkg/...`, `go vet ./pkg/templatecenter/image/` and the package tests (`-short`, as CI runs them) all pass.

