### PR TITLE
fix(envd): avoid separate stderr FIFO for terminal probe

### DIFF
--- a/Cubelet/services/cubebox/destroy.go
+++ b/Cubelet/services/cubebox/destroy.go
@@ -485,10 +485,12 @@ func containerExecWithOutput(ctx context.Context, ci *cubeboxstore.Container, cm
 		return nil, err
 	}
 
-	var stdout, stderr bytes.Buffer
+	var stdout bytes.Buffer
 
 	cioOpts := []cio.Opt{
-		cio.WithStreams(nil, &stdout, &stderr),
+		// A terminal merges stderr into stdout. Do not request a separate stderr
+		// FIFO because containerd does not create one for terminal IO.
+		cio.WithStreams(nil, &stdout, nil),
 		cio.WithTerminal, cio.WithFIFODir("/data/cubelet/fifo"),
 	}
 	ioCreator := cio.NewCreator(cioOpts...)
@@ -516,15 +518,15 @@ func containerExecWithOutput(ctx context.Context, ci *cubeboxstore.Container, cm
 		return nil, err
 	}
 	status := <-statusC
+	process.IO().Wait()
+
 	code, _, err := status.Result()
 	if err != nil {
 		return nil, err
 	}
 	if code != 0 {
-		return nil, fmt.Errorf("exec failed with exit code %d,stderr:%s", code, stderr.String())
+		return nil, fmt.Errorf("exec failed with exit code %d,output:%s", code, stdout.String())
 	}
-
-	process.IO().Wait()
 
 	return stdout.Bytes(), nil
 }

--- a/Cubelet/services/cubebox/envd_version.go
+++ b/Cubelet/services/cubebox/envd_version.go
@@ -65,15 +65,6 @@ func (b *boundedBuffer) String() string {
 	return b.buf.String()
 }
 
-// parseEnvdVersionFromOutput prefers semver from stdout; falls back to stderr
-// only when stdout has no match (e.g. envd logs warnings to stderr).
-func parseEnvdVersionFromOutput(stdout, stderr string) string {
-	if v := envdSemverRe.FindString(stdout); v != "" {
-		return v
-	}
-	return envdSemverRe.FindString(stderr)
-}
-
 // runProbeCall runs fn in a goroutine so a blocking containerd/shim RPC cannot
 // stall the snapshot/commit path past execCtx's deadline.
 func runProbeCall[T any](ctx context.Context, fn func() (T, error)) (T, error) {
@@ -190,10 +181,12 @@ func (s *service) collectEnvdVersion(ctx context.Context, sandboxID string) (ver
 	pspec.Args = []string{"envd", "--version"}
 
 	stdout := &boundedBuffer{limit: envdVersionOutputLimit}
-	stderr := &boundedBuffer{limit: envdVersionOutputLimit}
 	execID := envdVersionExecIDPrefix + uuid.New().String()
 	process, err := runProbeCall(execCtx, func() (containerd.Process, error) {
-		return task.Exec(execCtx, execID, pspec, cio.NewCreator(cio.WithStreams(nil, stdout, stderr), cio.WithTerminal))
+		// A terminal merges stderr into stdout. Do not request a separate stderr
+		// FIFO: containerd does not create one for terminal IO, while passfd would
+		// otherwise try to open the non-existent path when the process starts.
+		return task.Exec(execCtx, execID, pspec, cio.NewCreator(cio.WithStreams(nil, stdout, nil), cio.WithTerminal))
 	})
 	if err != nil {
 		if probeCallTimedOut(err) {
@@ -237,7 +230,7 @@ func (s *service) collectEnvdVersion(ctx context.Context, sandboxID string) (ver
 		}
 	}
 
-	version = parseEnvdVersionFromOutput(stdout.String(), stderr.String())
+	version = envdSemverRe.FindString(stdout.String())
 	if version == "" {
 		logger.Warnf("collect envd version: no semver in output")
 		return ""

--- a/Cubelet/services/cubebox/envd_version_test.go
+++ b/Cubelet/services/cubebox/envd_version_test.go
@@ -104,22 +104,6 @@ func TestRunProbeCallRecoversPanic(t *testing.T) {
 	assert.Contains(t, err.Error(), "probe exploded")
 }
 
-func TestParseEnvdVersionFromOutputPrefersStdout(t *testing.T) {
-	t.Parallel()
-
-	stdout := "envd version 1.2.3\n"
-	stderr := "WARN: noise 9.9.9\n"
-	assert.Equal(t, "1.2.3", parseEnvdVersionFromOutput(stdout, stderr))
-}
-
-func TestParseEnvdVersionFromOutputFallsBackToStderr(t *testing.T) {
-	t.Parallel()
-
-	stdout := ""
-	stderr := "WARN: starting envd 4.5.6\n"
-	assert.Equal(t, "4.5.6", parseEnvdVersionFromOutput(stdout, stderr))
-}
-
 func TestBoundedBufferEnforcesPerStreamLimit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
close #1299

The envd version probe runs with terminal IO, where stderr is merged into stdout and containerd does not create a separate stderr FIFO. Avoid passing a stderr writer so passfd does not attempt to open a non-existent path.