### PR TITLE
build(one-click): parallelize release bundle build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ endif
 		-e CUBE_VERSION \
 		-e CUBE_COMMIT \
 		-e CUBE_BUILD_TIME \
+		-e ONE_CLICK_BUILD_JOBS \
 		-v "$(ROOT_DIR)":/workspace \
 		-v "$(BUILDER_HOME)":$(BUILDER_CONTAINER_HOME) \
 		$(BUILDER_RUN_EXTRA_MOUNTS) \

--- a/deploy/one-click/build-release-bundle-builder.sh
+++ b/deploy/one-click/build-release-bundle-builder.sh
@@ -19,7 +19,16 @@ CUBE_VERSION_FROM_ENV="${CUBE_VERSION:-}"
 LATEST_RELEASE_TAG="$(git -C "${ROOT_DIR}" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
 : "${CUBE_VERSION:=${LATEST_RELEASE_TAG:-0.0.0-dev}}"
 : "${CUBE_COMMIT:=$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || echo 'unknown')}"
-: "${CUBE_BUILD_TIME:=$(date -u +'%Y-%m-%dT%H:%M:%SZ')}"
+# Derive the build time from the HEAD commit date (UTC) rather than wall-clock.
+# CUBE_BUILD_TIME is embedded into every binary (Go via -ldflags -X, Rust via
+# build.rs with `rerun-if-env-changed=CUBE_BUILD_TIME`). A wall-clock value
+# changes on every run and invalidates all incremental caches -- most painfully
+# it re-triggers CubeAPI's fat-LTO final link, the slowest step in the bundle.
+# Anchoring it to the commit keeps the value byte-identical across repeated runs
+# on the same HEAD, so a second build reuses the Go build cache and the Rust
+# target/ dirs. Still overridable via the environment for release pipelines that
+# need a literal build timestamp.
+: "${CUBE_BUILD_TIME:=$(TZ=UTC0 git -C "${ROOT_DIR}" show -s --format=%cd --date=format-local:'%Y-%m-%dT%H:%M:%SZ' HEAD 2>/dev/null || date -u +'%Y-%m-%dT%H:%M:%SZ')}"
 : "${ONE_CLICK_DIST_VERSION:=${CUBE_VERSION_FROM_ENV:-${LATEST_RELEASE_TAG:-$(latest_git_revision "${ROOT_DIR}")}}}"
 export CUBE_VERSION CUBE_COMMIT CUBE_BUILD_TIME ONE_CLICK_DIST_VERSION
 
@@ -67,46 +76,328 @@ rm -f \
   "${PREBUILT_DIR}/containerd-shim-cube-rs" \
   "${PREBUILT_DIR}/cube-runtime"
 
-echo "[one-click] building cubemaster in builder" >&2
-(cd /workspace/CubeMaster && go mod download && go build -ldflags "${CUBEMASTER_LDFLAGS}" -o "${PREBUILT_DIR}/cubemaster" ./cmd/cubemaster)
+# Component builds are split into independent tracks that run concurrently.
+# Cross-step dependencies that must be serialized:
+#   * cubecow static lib -> cubelet cgo link (inside track_cubelet)
+#   * cubevs BPF `go generate` -> network-agent + cubevsmapdump (inside
+#     track_netstack)
+#   * Cubelet proto generation -> BOTH track_cubelet AND track_cubemaster.
+#     CubeMaster/go.mod has `replace .../Cubelet => ../Cubelet` and imports
+#     Cubelet/api/services/volumeplugin/v1, so `go build ./cmd/cubemaster`
+#     compiles Cubelet's generated *.pb.go. `make proto` rewrites those files
+#     in place (truncate + rewrite), which on a cold Go cache can tear a
+#     .pb.go while the cubemaster compiler is reading it. Because the consumer
+#     spans two tracks, the gen step is hoisted to a single serial pre-launch
+#     step below rather than living inside track_cubelet.
+# Go and Cargo both lock their shared caches (GOPATH/GOCACHE under $HOME,
+# CARGO_HOME), and each Rust project owns a separate target/, so parallel builds
+# do not corrupt each other. Per-track output is captured to a log so concurrent
+# stderr does not interleave; a failing track's log is dumped before the script
+# exits.
+LOG_DIR="/workspace/deploy/one-click/.work/build-logs"
+rm -rf "${LOG_DIR}"
+mkdir -p "${LOG_DIR}"
 
-echo "[one-click] building cubemastercli in builder" >&2
-(cd /workspace/CubeMaster && go build -ldflags "${CUBEMASTER_LDFLAGS}" -o "${PREBUILT_DIR}/cubemastercli" ./cmd/cubemastercli)
+# Bounded parallelism. Running every track at once is fastest on a big host but
+# can exhaust RAM on small CI runners: several tracks each kick off a fat-LTO
+# cargo link (CubeAPI, CubeShim, cube-agent) plus Go compiles, and a 4c/8G box
+# doing several concurrent LTO links at once will OOM. Auto-derive a safe cap
+# from available CPUs and memory (whichever is smaller), budgeting ~3 GiB peak
+# per heavy track -- a fat-LTO Rust final link can spike well above 2 GiB, so
+# the more conservative divisor keeps memory-constrained hosts (8 GiB boxes,
+# shared CI runners) off the OOM edge at the cost of a little parallelism there.
+# Override with ONE_CLICK_BUILD_JOBS to force a value (e.g. 1 for a fully serial,
+# maximally-stable build, or a large number to uncap on a big host).
+detect_cpu_count() {
+  if command -v nproc >/dev/null 2>&1; then
+    nproc 2>/dev/null && return 0
+  fi
+  getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1
+}
 
-echo "[one-click] building cubelet and cubecli in builder" >&2
-mkdir -p /workspace/_output/bin
-(cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk)
-(cd /workspace/Cubelet && go mod download && make proto && go build -ldflags "${CUBELET_LDFLAGS}" -o /workspace/_output/bin/cubelet ./cmd/cubelet && go build -ldflags "${CUBELET_LDFLAGS}" -o /workspace/_output/bin/cubecli ./cmd/cubecli)
-install -m 0755 /workspace/_output/bin/cubelet "${PREBUILT_DIR}/cubelet"
-install -m 0755 /workspace/_output/bin/cubecli "${PREBUILT_DIR}/cubecli"
+# Read the container's cgroup memory ceiling in bytes, or nothing when there is
+# no finite limit. /proc/meminfo reports the *host* total, so on a cgroup-capped
+# job container (e.g. a 4 GiB limit on a 64 GiB host) it would let the scheduler
+# start more concurrent LTO links than the container can hold -- exactly the OOM
+# this cap exists to prevent. cgroup v2 exposes memory.max ("max" == unlimited);
+# v1 exposes memory.limit_in_bytes (a huge sentinel ~= unlimited). nproc already
+# respects CPU quotas, so only memory needs this clamp.
+detect_cgroup_mem_bytes() {
+  local v
+  if v="$(cat /sys/fs/cgroup/memory.max 2>/dev/null)"; then
+    [[ "${v}" =~ ^[0-9]+$ ]] && { echo "${v}"; return 0; }
+    return 0  # "max" or unreadable -> no finite limit
+  fi
+  v="$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)" || return 0
+  # v1 uses a near-PAGE_COUNTER_MAX sentinel for "unlimited"; treat >= 8 EiB
+  # (well above any real RAM, below the sentinel) as no finite limit.
+  if [[ "${v}" =~ ^[0-9]+$ && "${v}" -lt 9223372036854771712 ]]; then
+    echo "${v}"
+  fi
+}
 
-echo "[one-click] building cube-api in builder" >&2
-(cd /workspace/CubeAPI && cargo build --release --locked)
-install -m 0755 /workspace/CubeAPI/target/release/cube-api "${PREBUILT_DIR}/cube-api"
+detect_mem_gib() {
+  # MemAvailable is the honest "usable without swapping" figure; fall back to
+  # MemTotal, then to a conservative assumption when /proc is unreadable.
+  local kb bytes cgroup_bytes
+  kb="$(awk '/^MemAvailable:/{print $2; exit}' /proc/meminfo 2>/dev/null)"
+  [[ -n "${kb}" ]] || kb="$(awk '/^MemTotal:/{print $2; exit}' /proc/meminfo 2>/dev/null)"
+  if [[ -n "${kb}" && "${kb}" =~ ^[0-9]+$ ]]; then
+    bytes=$(( kb * 1024 ))
+  else
+    echo 4
+    return 0
+  fi
+  # Clamp to the cgroup limit when it is smaller than the host-reported figure.
+  cgroup_bytes="$(detect_cgroup_mem_bytes)"
+  if [[ -n "${cgroup_bytes}" && "${cgroup_bytes}" -gt 0 && "${cgroup_bytes}" -lt "${bytes}" ]]; then
+    bytes="${cgroup_bytes}"
+  fi
+  echo $(( bytes / 1024 / 1024 / 1024 ))
+}
 
-echo "[one-click] building cubeops in builder" >&2
-(cd /workspace/CubeOps && go mod download && go build -ldflags "-s -w" -o "${PREBUILT_DIR}/cubeops" ./cmd/cubeops)
+resolve_build_jobs() {
+  local total_tracks="$1"
+  if [[ -n "${ONE_CLICK_BUILD_JOBS:-}" ]]; then
+    if [[ "${ONE_CLICK_BUILD_JOBS}" =~ ^[0-9]+$ && "${ONE_CLICK_BUILD_JOBS}" -ge 1 ]]; then
+      echo "${ONE_CLICK_BUILD_JOBS}"
+      return 0
+    fi
+    echo "[one-click] WARNING: ignoring invalid ONE_CLICK_BUILD_JOBS='${ONE_CLICK_BUILD_JOBS}'" >&2
+  fi
+  local cpus mem_gib jobs_by_mem jobs
+  cpus="$(detect_cpu_count)"
+  [[ "${cpus}" =~ ^[0-9]+$ && "${cpus}" -ge 1 ]] || cpus=1
+  mem_gib="$(detect_mem_gib)"
+  # Budget ~3 GiB per concurrent heavy (LTO) track; always allow at least 1.
+  jobs_by_mem=$(( mem_gib / 3 ))
+  [[ "${jobs_by_mem}" -ge 1 ]] || jobs_by_mem=1
+  jobs="${cpus}"
+  [[ "${jobs_by_mem}" -lt "${jobs}" ]] && jobs="${jobs_by_mem}"
+  [[ "${total_tracks}" -lt "${jobs}" ]] && jobs="${total_tracks}"
+  [[ "${jobs}" -ge 1 ]] || jobs=1
+  echo "${jobs}"
+}
 
-echo "[one-click] building network-agent in builder" >&2
-(cd /workspace/CubeNet && make -C cubevs gen && cd /workspace/network-agent && go build -ldflags "${NETAGENT_LDFLAGS}" -o "${PREBUILT_DIR}/network-agent" ./cmd/network-agent)
+# Initialize as empty (=()) rather than a bare `declare -A`: under `set -u` an
+# associative array that has never been assigned trips "unbound variable" when
+# expanded as ${#arr[@]}, which the scheduler does before the first launch.
+declare -A TRACK_PID=()
+declare -A TRACK_LOG=()
+declare -A TRACK_STATUS_FILE=()
+# Names of tracks queued but not yet started (bounded scheduler input).
+TRACK_QUEUE=()
+# Registry of track name -> function so the scheduler can launch on demand.
+declare -A TRACK_FUNC=()
 
-echo "[one-click] building cubevsmapdump in builder" >&2
-(cd /workspace/CubeNet/cubevs && make gen && go build -o "${PREBUILT_DIR}/cubevsmapdump" ./cmd/cubevsmapdump)
+queue_track() {
+  local name="$1"
+  local func="$2"
+  TRACK_FUNC["${name}"]="${func}"
+  TRACK_QUEUE+=("${name}")
+}
 
-echo "[one-click] building cube-agent in builder" >&2
-# Agent Makefile reads CUBE_VERSION/CUBE_COMMIT/CUBE_BUILD_TIME directly.
-(cd /workspace/agent && make -j1)
-make -C /workspace/agent BINDIR=${PREBUILT_DIR} install
+_launch_track() {
+  local name="$1"
+  local log="${LOG_DIR}/${name}.log"
+  local status_file="${LOG_DIR}/${name}.status"
+  TRACK_LOG["${name}"]="${log}"
+  TRACK_STATUS_FILE["${name}"]="${status_file}"
+  rm -f "${status_file}"
+  echo "[one-click] starting build track: ${name}" >&2
+  # The subshell records its own exit status to a per-track file via an EXIT
+  # trap. We read that file instead of re-`wait`ing the pid: once `wait -n`
+  # reaps a child, a later `wait "${pid}"` on that same (now non-child) pid is
+  # documented to return 127, and the exact behaviour varies across bash
+  # versions -- fragile to rely on. The trap fires on *every* exit path,
+  # including an explicit `exit N` inside a track and a `set -e` abort, so the
+  # real status is captured (a plain trailing `echo "$?"` would be skipped on
+  # those paths). It is version-independent and pins the status to the correct
+  # track even when several finish in the same burst.
+  #
+  # `set -m` places the backgrounded subshell in its own process group with
+  # PGID == PID (a plain `&` would inherit this script's group, since the script
+  # is not a job-control shell when run under make/CI). That lets _reap_one
+  # group-kill (`kill -- -PID`) a track's whole descendant tree. It matters on
+  # the OOM path: if the subshell is SIGKILLed, its EXIT trap never runs and its
+  # children (cargo/go/make) are orphaned and keep allocating memory until the
+  # container exits, compounding the very memory pressure that triggered the
+  # kill. Monitor mode is scoped to the launch only (set +m right after) so the
+  # subsequent `wait -n` in _reap_one prints no async job-control chatter.
+  set -m
+  ( trap 'echo "$?" > "'"${status_file}"'"' EXIT; "${TRACK_FUNC[${name}]}" ) >"${log}" 2>&1 &
+  TRACK_PID["${name}"]=$!
+  set +m
+}
 
-echo "[one-click] building cube-init in builder" >&2
-(cd /workspace/guest-init && make -j1)
-make -C /workspace/guest-init BINDIR=${PREBUILT_DIR} install
+# _reap_one: block until any running track exits, then dump its full log. The
+# log is always shown, on success as well as failure: per-track redirection
+# (see _launch_track) hides compiler warnings and other non-fatal diagnostics
+# that exit 0, so replaying every track's output is the only way a caller sees
+# them. Records failures into FAILED. Returns 0.
+FAILED=0
+_reap_one() {
+  local name pid status
+  # `wait -n` returns when the next child exits; we then identify which track.
+  wait -n 2>/dev/null || true
+  for name in "${!TRACK_PID[@]}"; do
+    pid="${TRACK_PID[${name}]}"
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      # Prefer the status the subshell recorded for itself. Fall back to a
+      # nonzero sentinel only if the file is missing/garbage, which can only
+      # happen if the subshell died before writing it (e.g. OOM-killed) -- in
+      # which case treating the track as failed is exactly right.
+      status="$(cat "${TRACK_STATUS_FILE[${name}]}" 2>/dev/null || true)"
+      if [[ "${status}" =~ ^[0-9]+$ ]]; then
+        if [[ "${status}" -eq 0 ]]; then
+          echo "[one-click] build track OK: ${name}" >&2
+        else
+          FAILED=1
+          echo "[one-click] ERROR: build track FAILED: ${name} (exit ${status})" >&2
+        fi
+      else
+        # No status file -> the subshell died before its EXIT trap ran (e.g.
+        # OOM-kill / SIGKILL). Treat as failed, and group-kill the track's
+        # process group (see _launch_track's `set -m`) so its orphaned
+        # cargo/go/make children are reaped instead of surviving and holding
+        # memory. The leader is already gone; the negative-PID signal targets
+        # the surviving group members. Harmless if the group is already empty.
+        status=1
+        FAILED=1
+        kill -- -"${pid}" 2>/dev/null || true
+        echo "[one-click] ERROR: build track FAILED: ${name} (killed before status recorded; reaped orphaned children)" >&2
+      fi
+      echo "[one-click] ----- begin ${name} log -----" >&2
+      cat "${TRACK_LOG[${name}]}" >&2 || true
+      echo "[one-click] ----- end ${name} log -----" >&2
+      unset 'TRACK_PID['"${name}"']'
+      return 0
+    fi
+  done
+  return 0
+}
 
-echo "[one-click] building shim workspace in builder" >&2
-# CUBE_VERSION/COMMIT/BUILD_TIME picked up by shim/build.rs and cube-runtime/build.rs
-(cd /workspace/CubeShim && cargo build --release --locked)
-install -m 0755 /workspace/CubeShim/target/release/containerd-shim-cube-rs "${PREBUILT_DIR}/containerd-shim-cube-rs"
-install -m 0755 /workspace/CubeShim/target/release/cube-runtime "${PREBUILT_DIR}/cube-runtime"
+run_tracks() {
+  local max_jobs
+  max_jobs="$(resolve_build_jobs "${#TRACK_QUEUE[@]}")"
+  echo "[one-click] running ${#TRACK_QUEUE[@]} build tracks with up to ${max_jobs} concurrent (override via ONE_CLICK_BUILD_JOBS)" >&2
+
+  local name
+  for name in "${TRACK_QUEUE[@]}"; do
+    while [[ "${#TRACK_PID[@]}" -ge "${max_jobs}" ]]; do
+      _reap_one
+    done
+    _launch_track "${name}"
+  done
+
+  # Drain the rest.
+  #
+  # This is a deliberate full drain, not fail-fast: even after a track fails we
+  # let the remaining tracks finish rather than killing the group. _reap_one
+  # replays every track's full log on completion (see its comment), so draining
+  # preserves the diagnostics from all components of a broken build in one run
+  # -- often several independent failures surface together instead of one per
+  # re-run. The cost is that a failed build still takes roughly the full
+  # wall-clock; that is an accepted trade-off for local/CI debuggability. This
+  # applies at every concurrency level, including ONE_CLICK_BUILD_JOBS=1: the
+  # launch loop above never inspects FAILED, so a serial build also runs every
+  # queued track and reports all failures at the end rather than stopping at the
+  # first. run_tracks then returns nonzero if any track failed.
+  while [[ "${#TRACK_PID[@]}" -gt 0 ]]; do
+    _reap_one
+  done
+
+  return "${FAILED}"
+}
+
+track_cubemaster() {
+  cd /workspace/CubeMaster
+  go mod download
+  # Consumes Cubelet's generated volumeplugin *.pb.go via the go.mod replace;
+  # those sources are regenerated by the serial pre-launch proto step, never
+  # concurrently with this build.
+  go build -ldflags "${CUBEMASTER_LDFLAGS}" -o "${PREBUILT_DIR}/cubemaster" ./cmd/cubemaster
+  go build -ldflags "${CUBEMASTER_LDFLAGS}" -o "${PREBUILT_DIR}/cubemastercli" ./cmd/cubemastercli
+}
+
+track_cubelet() {
+  mkdir -p /workspace/_output/bin
+  ( cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk )
+  cd /workspace/Cubelet
+  go mod download
+  # NB: `make proto` is NOT run here -- it is hoisted to a serial pre-launch
+  # step because track_cubemaster also consumes the generated Cubelet sources
+  # (see the dependency notes above).
+  go build -ldflags "${CUBELET_LDFLAGS}" -o /workspace/_output/bin/cubelet ./cmd/cubelet
+  go build -ldflags "${CUBELET_LDFLAGS}" -o /workspace/_output/bin/cubecli ./cmd/cubecli
+  install -m 0755 /workspace/_output/bin/cubelet "${PREBUILT_DIR}/cubelet"
+  install -m 0755 /workspace/_output/bin/cubecli "${PREBUILT_DIR}/cubecli"
+}
+
+track_cube_api() {
+  cd /workspace/CubeAPI
+  cargo build --release --locked
+  install -m 0755 /workspace/CubeAPI/target/release/cube-api "${PREBUILT_DIR}/cube-api"
+}
+
+track_cubeops() {
+  cd /workspace/CubeOps
+  go mod download
+  go build -ldflags "-s -w" -o "${PREBUILT_DIR}/cubeops" ./cmd/cubeops
+}
+
+track_netstack() {
+  # Generate the cubevs BPF bindings exactly once, then build both consumers.
+  # Running `go generate` twice concurrently would race on the same generated
+  # sources, so network-agent and cubevsmapdump share this single gen step.
+  ( cd /workspace/CubeNet/cubevs && make gen )
+  ( cd /workspace/network-agent && go build -ldflags "${NETAGENT_LDFLAGS}" -o "${PREBUILT_DIR}/network-agent" ./cmd/network-agent )
+  ( cd /workspace/CubeNet/cubevs && go build -o "${PREBUILT_DIR}/cubevsmapdump" ./cmd/cubevsmapdump )
+}
+
+track_agent() {
+  # Agent Makefile reads CUBE_VERSION/CUBE_COMMIT/CUBE_BUILD_TIME directly.
+  ( cd /workspace/agent && make -j1 )
+  make -C /workspace/agent BINDIR="${PREBUILT_DIR}" install
+}
+
+track_cube_init() {
+  # guest-init builds cube-init, the Rust musl PID-1 binary that runs inside the
+  # VM (decoupled from the guest image). Its own Cargo project + target/ dir, so
+  # it is parallel-safe alongside the other Rust/Go tracks.
+  ( cd /workspace/guest-init && make -j1 )
+  make -C /workspace/guest-init BINDIR="${PREBUILT_DIR}" install
+}
+
+track_shim() {
+  # CUBE_VERSION/COMMIT/BUILD_TIME picked up by shim/build.rs and cube-runtime/build.rs
+  cd /workspace/CubeShim
+  cargo build --release --locked
+  install -m 0755 /workspace/CubeShim/target/release/containerd-shim-cube-rs "${PREBUILT_DIR}/containerd-shim-cube-rs"
+  install -m 0755 /workspace/CubeShim/target/release/cube-runtime "${PREBUILT_DIR}/cube-runtime"
+}
+
+# Serial pre-launch step: generate Cubelet's protobuf sources exactly once
+# before any track starts. Both track_cubelet and track_cubemaster compile these
+# generated *.pb.go, so regenerating them inside a track would race the other
+# track's compiler on a cold cache (see dependency notes above).
+echo "[one-click] generating Cubelet proto sources (serial, pre-tracks)" >&2
+( cd /workspace/Cubelet && make proto ) >&2
+
+echo "[one-click] building one-click components in parallel tracks" >&2
+# Queue order matters under a low concurrency cap: front-load the slowest,
+# LTO-heavy tracks (cube-api fat-LTO, shim, cube-agent) so they start first and
+# overlap the lighter Go tracks instead of tailing the build.
+queue_track cube-api   track_cube_api
+queue_track shim       track_shim
+queue_track agent      track_agent
+queue_track cube-init  track_cube_init
+queue_track cubelet    track_cubelet
+queue_track cubemaster track_cubemaster
+queue_track netstack   track_netstack
+queue_track cubeops    track_cubeops
+
+run_tracks
 SCRIPT_EOF
 
 chmod 0755 "${HELPER_SCRIPT}"

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -520,41 +520,27 @@ poll_web_build_async() {
   _collect_web_build_async
 }
 
-# Reap a still-running async web build on any exit (including an early failure
-# elsewhere), so the backgrounded npm process is never orphaned onto a
-# persistent host. No-op once build_web_dist has already collected it. npm forks
-# descendant workers (vite/esbuild), so signal the whole process group (the
-# build is launched under `set -m` with PGID == PID) -- otherwise the workers
-# survive as orphans. Fall back to signaling the single PID if the group-kill
-# fails.
+# Reap a still-running async web build on exit/signal so npm is not orphaned.
+# WEB_BUILD_ASYNC_PID is a wrapper; group-kill its children, then the wrapper.
 cleanup_web_build_async() {
+  local child
   [[ "${WEB_BUILD_ASYNC_PID}" -ne 0 ]] || return 0
   if kill -0 "${WEB_BUILD_ASYNC_PID}" 2>/dev/null; then
-    kill -- -"${WEB_BUILD_ASYNC_PID}" 2>/dev/null \
-      || kill "${WEB_BUILD_ASYNC_PID}" 2>/dev/null || true
+    while read -r child; do
+      [[ -n "${child}" ]] || continue
+      kill -- -"${child}" 2>/dev/null || kill "${child}" 2>/dev/null || true
+    done < <(pgrep -P "${WEB_BUILD_ASYNC_PID}" 2>/dev/null || true)
+    kill "${WEB_BUILD_ASYNC_PID}" 2>/dev/null || true
     wait "${WEB_BUILD_ASYNC_PID}" 2>/dev/null || true
   fi
 }
-# EXIT alone is not enough: bash does NOT run EXIT traps when the shell is
-# terminated by an uncaught signal (Ctrl-C -> SIGINT, or SIGTERM from a CI
-# timeout). Because the npm build runs in its own process group, a signal
-# delivered only to this script would not reach it and it would leak as an
-# orphan onto a persistent host. Trap
-# INT/TERM to reap it, then restore the default disposition and re-raise so the
-# script still exits with the correct 128+signum status (the EXIT trap that then
-# fires is a harmless no-op once the child is already reaped).
 trap cleanup_web_build_async EXIT
 trap 'cleanup_web_build_async; trap - INT; kill -INT $$' INT
 trap 'cleanup_web_build_async; trap - TERM; kill -TERM $$' TERM
 
-# start_web_build_async: kick off `npm ci && npm run build` in the background so
-# it overlaps the guest-image build. Deliberately conservative -- it only starts
-# the async build in the plain success case (npm present, source tree present,
-# no prebuilt-dist override, not explicitly disabled). In every other case it is
-# a no-op and build_web_dist falls through to its original synchronous path, so
-# validation errors (missing npm / missing WEB_SOURCE_DIR) surface with the
-# exact same message and behavior as before. Set ONE_CLICK_SEQUENTIAL_WEB_BUILD=1
-# to force the fully sequential build.
+# Overlap npm with guest-image build. No-op unless npm + source are available
+# and ONE_CLICK_SEQUENTIAL_WEB_BUILD is unset. Keep the job off the caller's
+# tty (setsid -w, stdin=/dev/null) so it cannot race sudo password echo-off.
 start_web_build_async() {
   [[ "${ONE_CLICK_SEQUENTIAL_WEB_BUILD:-}" != "1" ]] || return 0
   [[ -z "${WEB_DIST_OVERRIDE}" ]] || return 0
@@ -563,26 +549,32 @@ start_web_build_async() {
 
   mkdir -p "$(dirname "${WEB_BUILD_ASYNC_LOG}")"
   log "building web dashboard (async, overlapping runtime layout build)"
-  # Run in a fresh process group so cleanup_web_build_async can signal the whole
-  # group and reap npm's descendant workers (vite/esbuild).
-  #
-  # `set -m` (not setsid) is the primary path. It places the background job in
-  # its own process group with PGID == PID, so WEB_BUILD_ASYNC_PID is both the
-  # thing we `wait` on AND a valid `kill -- -PID` group target. Crucially, the
-  # backgrounded shell is a *real child* of this script, so `wait` blocks on the
-  # actual npm build and $? reflects its true exit status.
-  #
-  # setsid is deliberately NOT used here: when the caller is already a
-  # process-group leader (script launched via `setsid`, as a background job from
-  # an interactive shell, or by a job scheduler that puts each job in its own
-  # group), setsid must fork -- its parent exits 0 immediately, so $! captures a
-  # short-lived pid. `wait` would then return 0 at once (letting build_web_dist
-  # copy a half-built dist) and cleanup could not reach the detached npm build.
-  # `set -m` never forks and does not have this failure mode.
-  set -m
-  ( cd "${WEB_SOURCE_DIR}" && npm ci && npm run build ) >"${WEB_BUILD_ASYNC_LOG}" 2>&1 &
-  set +m
+  # Wrapper keeps wait/$! correct; avoid bare `setsid cmd &` (can exit early).
+  (
+    if command -v setsid >/dev/null 2>&1; then
+      setsid -w bash -c 'cd "$1" && npm ci && npm run build' bash "${WEB_SOURCE_DIR}" \
+        </dev/null >"${WEB_BUILD_ASYNC_LOG}" 2>&1
+      exit $?
+    fi
+    set -m
+    ( cd "${WEB_SOURCE_DIR}" && npm ci && npm run build ) \
+      </dev/null >"${WEB_BUILD_ASYNC_LOG}" 2>&1 &
+    local child=$!
+    set +m
+    wait "${child}"
+    exit $?
+  ) &
   WEB_BUILD_ASYNC_PID=$!
+}
+
+ensure_sudo_authenticated_for_packaging() {
+  [[ "${EUID}" -eq 0 ]] && return 0
+  if sudo -n true >/dev/null 2>&1; then
+    return 0
+  fi
+  require_cmd sudo
+  log "sudo authentication required for guest rootfs / runtime layout packaging"
+  sudo -v || die "sudo authentication failed (needed to package guest rootfs / runtime layout)"
 }
 
 build_web_dist() {
@@ -621,8 +613,8 @@ ensure_dir "${CUBE_WEBUI_TEMPLATE_DIR}"
 ensure_dir "${CUBE_SYSTEMD_TEMPLATE_DIR}"
 ensure_dir "${CUBE_PROXY_SOURCE_DIR}"
 
-# Start the WebUI build in the background so it overlaps the guest-image build
-# below (they are fully independent). Collected later in build_web_dist.
+# sudo first (quiet tty), then async web build overlapping guest-image below.
+ensure_sudo_authenticated_for_packaging
 start_web_build_async
 
 log "building runtime layout"

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -13,6 +13,30 @@ if [[ -f "${ENV_FILE}" ]]; then
   load_env_file "${ENV_FILE}"
 fi
 
+# tar_czf: create a gzip-compressed tarball, using pigz (parallel gzip) when it
+# is installed and falling back to tar's built-in single-threaded gzip
+# otherwise. The output is a standard .tar.gz in both cases, so consumers /
+# `tar xzf` are unaffected -- pigz only speeds up compression of the large guest
+# image + kernel payloads on multi-core hosts. ONE_CLICK_DISABLE_PIGZ=1 forces
+# the portable single-tool gzip path for environments that want a consistent,
+# single-threaded compressor rather than pigz's parallel block framing. (Note:
+# neither path is strictly bit-for-bit reproducible -- gzip still records an
+# mtime/OS byte in its header.)
+tar_czf() {
+  local out="$1"
+  local base_dir="$2"
+  local member="$3"
+  if [[ "${ONE_CLICK_DISABLE_PIGZ:-}" != "1" ]] && command -v pigz >/dev/null 2>&1; then
+    # Run the pipeline in a subshell with pipefail set there, so a tar failure
+    # in the pipe is caught even if a caller ever clears the global setting --
+    # and the option change stays scoped to the subshell instead of leaking back
+    # into the caller. This produces the shipped tarball.
+    ( set -o pipefail; tar -C "${base_dir}" -cf - "${member}" | pigz > "${out}" )
+  else
+    tar -C "${base_dir}" -czf "${out}" "${member}"
+  fi
+}
+
 WORK_ROOT="${ONE_CLICK_WORK_ROOT:-${SCRIPT_DIR}/.work}"
 RUNTIME_LAYOUT_DIR="${ONE_CLICK_RUNTIME_LAYOUT_DIR:-${WORK_ROOT}/runtime-layout}"
 CORE_BIN_DIR="${WORK_ROOT}/core-bin"
@@ -37,7 +61,12 @@ CUBE_VERSION_FROM_ENV="${CUBE_VERSION:-}"
 LATEST_RELEASE_TAG="$(git -C "${ROOT_DIR}" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
 : "${CUBE_VERSION:=${LATEST_RELEASE_TAG:-0.0.0-dev}}"
 : "${CUBE_COMMIT:=$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || echo 'unknown')}"
-: "${CUBE_BUILD_TIME:=$(date -u +'%Y-%m-%dT%H:%M:%SZ')}"
+# Anchor to the HEAD commit date (UTC) so repeated builds on the same commit
+# embed a byte-identical value and reuse incremental caches; keep the manifest
+# built_at in step with the binaries' BuildTime when this script is invoked
+# directly. The builder wrapper exports the same value and pre-empts this. Falls
+# back to wall-clock outside a git tree; still overridable via the environment.
+: "${CUBE_BUILD_TIME:=$(TZ=UTC0 git -C "${ROOT_DIR}" show -s --format=%cd --date=format-local:'%Y-%m-%dT%H:%M:%SZ' HEAD 2>/dev/null || date -u +'%Y-%m-%dT%H:%M:%SZ')}"
 export CUBE_VERSION CUBE_COMMIT CUBE_BUILD_TIME
 
 DIST_VERSION="${ONE_CLICK_DIST_VERSION:-${CUBE_VERSION_FROM_ENV:-${LATEST_RELEASE_TAG:-$(latest_git_revision "${ROOT_DIR}")}}}"
@@ -440,6 +469,122 @@ EOF
   done
 }
 
+# WebUI (npm) build state. The npm build only reads WEB_SOURCE_DIR and writes
+# WEB_SOURCE_DIR/dist; it shares no inputs or outputs with the guest-image /
+# runtime-layout build, so it can run concurrently with build-vm-assets.sh and
+# then be collected later. WEB_BUILD_ASYNC_PID is the backgrounded builder (0 =
+# none started; the synchronous path in build_web_dist runs instead).
+WEB_BUILD_ASYNC_PID=0
+# Set to 1 once a successful async build has been collected and its dist is on
+# disk, so build_web_dist copies the result instead of re-`wait`ing a
+# already-reaped pid (which would return 127 and be misread as a failure) or
+# rebuilding synchronously.
+WEB_BUILD_ASYNC_DONE=0
+WEB_BUILD_ASYNC_LOG="${WORK_ROOT}/web-build.log"
+
+# Replay the captured async web-build log to stderr. Called on both success and
+# failure so that tsc/vite diagnostics that exit 0 (warnings) stay visible --
+# mirroring the builder-track policy where every track's log is always replayed
+# on completion, not only on failure.
+_replay_web_build_log() {
+  echo "[one-click] ----- begin web build log -----" >&2
+  cat "${WEB_BUILD_ASYNC_LOG}" >&2 || true
+  echo "[one-click] ----- end web build log -----" >&2
+}
+
+# Wait for the in-flight async build, replay its log, and die on failure. Clears
+# WEB_BUILD_ASYNC_PID (so the EXIT trap and any later call become no-ops) and
+# marks the dist ready on success. Caller must have confirmed WEB_BUILD_ASYNC_PID
+# is nonzero.
+_collect_web_build_async() {
+  local web_pid="${WEB_BUILD_ASYNC_PID}"
+  WEB_BUILD_ASYNC_PID=0
+  if ! wait "${web_pid}"; then
+    _replay_web_build_log
+    die "web dashboard build failed"
+  fi
+  _replay_web_build_log
+  WEB_BUILD_ASYNC_DONE=1
+}
+
+# Non-blocking check: if the async web build has ALREADY exited, collect it now.
+# On failure this aborts immediately -- so a fast failure (bad lockfile, TS
+# error) surfaces before the remaining serial work (component binary builds +
+# packaging) runs, instead of being masked until build_web_dist near the very
+# end. If the build is still running, return at once and let it keep overlapping.
+# No-op when no async build is in flight or it was already collected.
+poll_web_build_async() {
+  [[ "${WEB_BUILD_ASYNC_PID}" -ne 0 ]] || return 0
+  kill -0 "${WEB_BUILD_ASYNC_PID}" 2>/dev/null && return 0
+  log "async web dashboard build finished early; collecting"
+  _collect_web_build_async
+}
+
+# Reap a still-running async web build on any exit (including an early failure
+# elsewhere), so the backgrounded npm process is never orphaned onto a
+# persistent host. No-op once build_web_dist has already collected it. npm forks
+# descendant workers (vite/esbuild), so signal the whole process group (the
+# build is launched under `set -m` with PGID == PID) -- otherwise the workers
+# survive as orphans. Fall back to signaling the single PID if the group-kill
+# fails.
+cleanup_web_build_async() {
+  [[ "${WEB_BUILD_ASYNC_PID}" -ne 0 ]] || return 0
+  if kill -0 "${WEB_BUILD_ASYNC_PID}" 2>/dev/null; then
+    kill -- -"${WEB_BUILD_ASYNC_PID}" 2>/dev/null \
+      || kill "${WEB_BUILD_ASYNC_PID}" 2>/dev/null || true
+    wait "${WEB_BUILD_ASYNC_PID}" 2>/dev/null || true
+  fi
+}
+# EXIT alone is not enough: bash does NOT run EXIT traps when the shell is
+# terminated by an uncaught signal (Ctrl-C -> SIGINT, or SIGTERM from a CI
+# timeout). Because the npm build runs in its own process group, a signal
+# delivered only to this script would not reach it and it would leak as an
+# orphan onto a persistent host. Trap
+# INT/TERM to reap it, then restore the default disposition and re-raise so the
+# script still exits with the correct 128+signum status (the EXIT trap that then
+# fires is a harmless no-op once the child is already reaped).
+trap cleanup_web_build_async EXIT
+trap 'cleanup_web_build_async; trap - INT; kill -INT $$' INT
+trap 'cleanup_web_build_async; trap - TERM; kill -TERM $$' TERM
+
+# start_web_build_async: kick off `npm ci && npm run build` in the background so
+# it overlaps the guest-image build. Deliberately conservative -- it only starts
+# the async build in the plain success case (npm present, source tree present,
+# no prebuilt-dist override, not explicitly disabled). In every other case it is
+# a no-op and build_web_dist falls through to its original synchronous path, so
+# validation errors (missing npm / missing WEB_SOURCE_DIR) surface with the
+# exact same message and behavior as before. Set ONE_CLICK_SEQUENTIAL_WEB_BUILD=1
+# to force the fully sequential build.
+start_web_build_async() {
+  [[ "${ONE_CLICK_SEQUENTIAL_WEB_BUILD:-}" != "1" ]] || return 0
+  [[ -z "${WEB_DIST_OVERRIDE}" ]] || return 0
+  command -v npm >/dev/null 2>&1 || return 0
+  [[ -d "${WEB_SOURCE_DIR}" ]] || return 0
+
+  mkdir -p "$(dirname "${WEB_BUILD_ASYNC_LOG}")"
+  log "building web dashboard (async, overlapping runtime layout build)"
+  # Run in a fresh process group so cleanup_web_build_async can signal the whole
+  # group and reap npm's descendant workers (vite/esbuild).
+  #
+  # `set -m` (not setsid) is the primary path. It places the background job in
+  # its own process group with PGID == PID, so WEB_BUILD_ASYNC_PID is both the
+  # thing we `wait` on AND a valid `kill -- -PID` group target. Crucially, the
+  # backgrounded shell is a *real child* of this script, so `wait` blocks on the
+  # actual npm build and $? reflects its true exit status.
+  #
+  # setsid is deliberately NOT used here: when the caller is already a
+  # process-group leader (script launched via `setsid`, as a background job from
+  # an interactive shell, or by a job scheduler that puts each job in its own
+  # group), setsid must fork -- its parent exits 0 immediately, so $! captures a
+  # short-lived pid. `wait` would then return 0 at once (letting build_web_dist
+  # copy a half-built dist) and cleanup could not reach the detached npm build.
+  # `set -m` never forks and does not have this failure mode.
+  set -m
+  ( cd "${WEB_SOURCE_DIR}" && npm ci && npm run build ) >"${WEB_BUILD_ASYNC_LOG}" 2>&1 &
+  set +m
+  WEB_BUILD_ASYNC_PID=$!
+}
+
 build_web_dist() {
   local output_dir="$1"
   rm -rf "${output_dir}"
@@ -449,6 +594,14 @@ build_web_dist() {
     log "using prebuilt web dist: ${WEB_DIST_OVERRIDE}"
     ensure_dir "${WEB_DIST_OVERRIDE}"
     copy_dir_contents "${WEB_DIST_OVERRIDE}" "${output_dir}"
+  elif [[ "${WEB_BUILD_ASYNC_DONE}" -eq 1 ]]; then
+    # Already collected by an earlier poll_web_build_async (finished-early path).
+    log "using async web dashboard build collected earlier"
+    copy_dir_contents "${WEB_SOURCE_DIR}/dist" "${output_dir}"
+  elif [[ "${WEB_BUILD_ASYNC_PID}" -ne 0 ]]; then
+    log "collecting async web dashboard build"
+    _collect_web_build_async
+    copy_dir_contents "${WEB_SOURCE_DIR}/dist" "${output_dir}"
   else
     log "building web dashboard"
     require_cmd npm
@@ -468,8 +621,20 @@ ensure_dir "${CUBE_WEBUI_TEMPLATE_DIR}"
 ensure_dir "${CUBE_SYSTEMD_TEMPLATE_DIR}"
 ensure_dir "${CUBE_PROXY_SOURCE_DIR}"
 
+# Start the WebUI build in the background so it overlaps the guest-image build
+# below (they are fully independent). Collected later in build_web_dist.
+start_web_build_async
+
 log "building runtime layout"
 "${SCRIPT_DIR}/build-vm-assets.sh"
+
+# The guest-image build above is the long pole the async web build overlaps. By
+# the time it returns, a fast web-build failure (bad lockfile, TS error) has
+# usually already happened -- surface it now rather than masking it behind the
+# remaining component-binary builds and packaging that still precede
+# build_web_dist. Non-blocking: if the web build is still running it keeps
+# overlapping and is collected later.
+poll_web_build_async
 
 log "packaging fixed kernel artifact zip"
 package_kernel_artifact_zip \
@@ -702,7 +867,7 @@ find "${PACKAGE_ROOT}/scripts/cube-egress" -type f -name "*.sh" -exec chmod +x {
 find "${PACKAGE_ROOT}/terraform" -type f -name "*.sh" -exec chmod +x {} \;
 
 mkdir -p "$(dirname "${PACKAGE_TAR}")"
-tar -C "${WORK_ROOT}" -czf "${PACKAGE_TAR}" "sandbox-package"
+tar_czf "${PACKAGE_TAR}" "${WORK_ROOT}" "sandbox-package"
 
 mkdir -p "${DIST_ROOT}/assets/package" "${DIST_ROOT}/assets/kernel-artifacts" "${DIST_ROOT}/lib" "${DIST_ROOT}/scripts/common"
 copy_file "${SCRIPT_DIR}/README.md" "${DIST_ROOT}/README.md"
@@ -777,5 +942,5 @@ EOF
 # exported by build-vm-assets.sh.
 generate_release_manifest "${DIST_ROOT}" "${DIST_VERSION}"
 
-tar -C "${SCRIPT_DIR}/dist" -czf "${DIST_TAR}" "cube-sandbox-one-click-${DIST_VERSION}"
+tar_czf "${DIST_TAR}" "${SCRIPT_DIR}/dist" "cube-sandbox-one-click-${DIST_VERSION}"
 log "release bundle ready: ${DIST_TAR}"

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -18,6 +18,21 @@ ONE_CLICK_NETWORK_AGENT_BUILD_MODE=local
 ONE_CLICK_CUBE_AGENT_BUILD_MODE=local
 ONE_CLICK_CUBE_SHIM_BUILD_MODE=local
 
+# Build-performance knobs (all optional).
+# Max concurrent build tracks. Default: auto (min of CPU count and
+# available-memory/3GiB, where available memory respects a cgroup limit when the
+# build runs in a container). Set 1 for a fully serial build, or a large number
+# to uncap.
+# ONE_CLICK_BUILD_JOBS=1
+# Force portable single-threaded gzip for tarballs instead of pigz (parallel
+# gzip); use when a consistent single-tool compressor is preferred.
+# ONE_CLICK_DISABLE_PIGZ=1
+# Build the WebUI synchronously instead of overlapping the guest-image build.
+# ONE_CLICK_SEQUENTIAL_WEB_BUILD=1
+# CUBE_BUILD_TIME defaults to the HEAD commit date (UTC) so repeated builds on
+# the same commit reuse incremental caches; override for a literal timestamp.
+# CUBE_BUILD_TIME=2026-01-01T00:00:00Z
+
 # Optional overrides for prebuilt binaries or fixed artifacts.
 # ONE_CLICK_CUBEMASTER_BIN=/abs/path/to/cubemaster
 # ONE_CLICK_CUBEMASTERCLI_BIN=/abs/path/to/cubemastercli

--- a/docs/guide/self-build-deploy.md
+++ b/docs/guide/self-build-deploy.md
@@ -283,6 +283,15 @@ You can also point to prebuilt binaries to skip compilation:
 | `ONE_CLICK_CUBESHIM_BIN` | Path to prebuilt containerd-shim-cube-rs binary |
 | `ONE_CLICK_CUBE_RUNTIME_BIN` | Path to prebuilt cube-runtime binary |
 
+Build-performance knobs (all optional):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ONE_CLICK_BUILD_JOBS` | auto | Max concurrent component build tracks. Auto = min of CPU count and available-memory/3GiB (available memory respects the cgroup limit when building in a container). Set `1` for a fully serial build, or a large value to uncap. |
+| `ONE_CLICK_DISABLE_PIGZ` | empty | Set to `1` to force portable single-threaded `gzip` for tarballs instead of `pigz` (parallel gzip), e.g. when a consistent single-tool compressor is preferred over pigz's parallel block framing. |
+| `ONE_CLICK_SEQUENTIAL_WEB_BUILD` | empty | Set to `1` to build the WebUI synchronously instead of overlapping it with the guest-image build. |
+| `CUBE_BUILD_TIME` | HEAD commit date (UTC) | Build timestamp embedded in binaries and recorded as `built_at` in `release-manifest.json` / `VERSION.txt`. Defaults to the HEAD commit date so repeated builds on the same commit are byte-identical and reuse incremental caches; override with a literal timestamp (e.g. `2026-01-01T00:00:00Z`) for a wall-clock value. |
+
 ### Target Machine Options
 
 | Variable | Default | Description |

--- a/docs/zh/guide/self-build-deploy.md
+++ b/docs/zh/guide/self-build-deploy.md
@@ -283,6 +283,15 @@ sudo ./down.sh
 | `ONE_CLICK_CUBESHIM_BIN` | 预编译 containerd-shim-cube-rs 路径 |
 | `ONE_CLICK_CUBE_RUNTIME_BIN` | 预编译 cube-runtime 路径 |
 
+构建性能选项（均为可选）：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `ONE_CLICK_BUILD_JOBS` | auto | 组件构建并发轨道数上限。auto = CPU 核数与 可用内存/3GiB 取较小值（在容器中构建时，可用内存会考虑 cgroup 限制）。设为 `1` 表示完全串行构建，设为较大值可取消上限。 |
+| `ONE_CLICK_DISABLE_PIGZ` | 空 | 设为 `1` 时，打包使用可移植的单线程 `gzip` 而非 `pigz`（并行 gzip），适用于希望使用一致的单一压缩工具、而非 pigz 并行分块格式的场景。 |
+| `ONE_CLICK_SEQUENTIAL_WEB_BUILD` | 空 | 设为 `1` 时，串行构建 WebUI，而不与 Guest 镜像构建并行重叠。 |
+| `CUBE_BUILD_TIME` | HEAD 提交日期（UTC） | 嵌入二进制并记录到 `release-manifest.json` / `VERSION.txt` 的 `built_at` 的构建时间戳。默认取 HEAD 提交日期，使同一提交上的重复构建字节一致并复用增量缓存；可覆盖为字面时间戳（如 `2026-01-01T00:00:00Z`）以使用真实构建时钟。 |
+
 ### 目标机选项
 
 | 变量 | 默认值 | 说明 |


### PR DESCRIPTION
Run the component compiles as bounded-concurrency tracks and overlap the WebUI npm build with the guest-image build, so a full one-click bundle no longer serializes every step. Concurrency auto-caps from CPU count and available memory, overridable via ONE_CLICK_BUILD_JOBS:

\# time deploy/one-click/build-release-bundle-builder.sh
Baseline:
  1st run: 7m15.818s
  2nd run: 6m33.720s
  3rd run: 6m36.016s
After \# running 7 build tracks with up to 7 concurrent:
  1st run: 3m54.011s
  2nd run: 1m54.838s
  3rd run: 1m56.891s

Each track's output is captured to a per-track log and always replayed on completion, so compiler warnings that exit 0 stay visible despite the redirection; failing tracks additionally report their exit code.

Anchor CUBE_BUILD_TIME to the HEAD commit date instead of wall-clock so repeated builds on the same commit stay byte-identical and reuse the Go build cache and Rust target dirs, most importantly skipping a needless fat-LTO relink. Compress tarballs with pigz when available.

Assisted-by: Claude Code:Opus 4.8