### PR TITLE
fix(makefile): run web fmt on host, not inside builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,8 +463,10 @@ web-sync-dev-env:
 
 # Run make fmt in each component directory that has a fmt target.
 # Components without formattable code (e.g. CubeProxy) are skipped.
-# Outside the builder, route through builder-run so agent/Makefile's
-# MUSL+SECCOMP parse-time libseccomp.a check does not fail on the host.
+# Outside the builder, Go/Rust fmt routes through builder-run so
+# agent/Makefile's MUSL+SECCOMP parse-time libseccomp.a check does not
+# fail on the host. Web fmt stays on the host: the builder image has no
+# npm (same split as fmt-check.yml).
 .PHONY: fmt
 fmt:
 ifeq ($(IN_CUBE_SANDBOX_BUILDER),1)
@@ -498,13 +500,13 @@ ifeq ($(IN_CUBE_SANDBOX_BUILDER),1)
 	@$(MAKE) -C sdk/go fmt
 	@printf '  %-8s %s\n' "FMT" "examples/cube-bench"
 	@$(MAKE) -C examples/cube-bench fmt
+else
+	@$(MAKE) builder-image
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make fmt'
 	@printf '  %-8s %s\n' "FMT" "web"
 	@if command -v npm >/dev/null 2>&1; then \
 		$(MAKE) -C web fmt; \
 	else \
-		printf '  %-8s %s\n' "SKIP" "web (npm not available)"; \
+		printf '  %-8s %s\n' "SKIP" "web (npm not available on host)"; \
 	fi
-else
-	@$(MAKE) builder-image
-	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make fmt'
 endif


### PR DESCRIPTION
## Summary

The builder image ships no npm, so the web fmt step in the `fmt` target used to fall through to a SKIP when `make fmt` was routed through `builder-run`. This change splits the two:

- **Go/Rust fmt** keeps routing through `builder-run` (avoids the agent/Makefile MUSL+SECCOMP parse-time libseccomp.a check failing on the host).
- **Web fmt** now runs on the host when npm is available, matching the split already used in `fmt-check.yml`.

## Changes

- Move web fmt out of the `IN_CUBE_SANDBOX_BUILDER` branch into the host branch.
- Update the SKIP message to clarify npm availability is checked on the host.
- Adjust the comment to describe the go/rust vs web split.

## Test

`make fmt` was verified to run go/rust fmt via the builder and web fmt (or SKIP) on the host.