### PR TITLE
docs(agents): flag unusual PR file changes

### DIFF
--- a/.claude/agents/cube-project-reviewer.md
+++ b/.claude/agents/cube-project-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: cube-project-reviewer
-description: Use this agent to review a pull request against CubeSandbox project-specific conventions and release gates that generic reviewers miss — OCI image multi-arch support, bilingual README coverage, feature-change test coverage, unit-test gate, orphaned project wiring, upgradability, terraform/k8s deployment design, Fix regression tests, workflow/CODEOWNERS maintenance, non-English character policy, and commit-message convention.
+description: Use this agent to review a pull request against CubeSandbox project-specific conventions and release gates that generic reviewers miss — OCI image multi-arch support, bilingual README coverage, feature-change test coverage, unit-test gate, orphaned project wiring, upgradability, terraform/k8s deployment design, Fix regression tests, workflow/CODEOWNERS maintenance, non-English character policy, commit-message convention, and unusual file changes.
 tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash
 model: inherit
 ---
@@ -72,6 +72,17 @@ Flag any violation with the specific rule broken.
 
 **13. Close policy reminder**
 Remind the author to review the Issue & PR Close Policy in `CONTRIBUTING.md` (e.g. linking issues, closing semantics) so the PR follows project process.
+
+**14. Flagged file changes**
+Before focusing on the text diff, review the complete changed-file inventory supplied in the review context. If no complete inventory is available, say that this check could not be completed rather than assuming the rendered diff includes every file.
+
+Review every added, modified, renamed, and deleted path for changes that need explanation:
+- the file is unrelated to the pull request's stated purpose
+- its location or lifecycle conflicts with the repository structure, neighboring files, ignore rules, or established project conventions
+- it appears to be generated, transient, machine-local, or tool-produced output rather than an intentional source, configuration, documentation, or test input
+- its content is opaque or unavailable and the pull request does not explain why the file belongs
+
+Use paths, extensions, missing extensions, diff metadata, file size, and content-type indicators only as supporting evidence; none proves file type or intent by itself. Ask the author to remove an unintended change or explain why an intentional one belongs. State uncertainty when the available evidence is insufficient, and leave the final decision to maintainers.
 
 ## Output
 


### PR DESCRIPTION
## Motivation

This PR follows the suggestion accepted by @lkml-likexu during the review of #1304: improve the Claude auto-review guidance so unexpected files such as the `1.md` removed in #1043 or the 42 MB `CubeOps/bin/cubeops` build binary committed in #984 can be noticed before merge.

Unusual files can still be valid when intentional, so the reviewer should report the file facts and ask for justification rather than assume they must be removed.

## What Changed

- Require the CubeSandbox project reviewer to inspect the complete changed-file inventory before focusing on the rendered text diff.
- Review added, modified, renamed, and deleted paths for unrelated, misplaced, generated, transient, machine-local, tool-produced, or unexplained opaque files.
- Treat paths, extensions, diff metadata, size, and content-type indicators as supporting evidence rather than definitive proof of type or intent.
- State when the complete inventory or supporting evidence is unavailable instead of asserting that the check passed.
- Ask the author to remove unintended files or explain why intentional files belong in the pull request.

## Validation

- Verified that the auto-review context supplies a complete changed-file inventory and that the guidance fails explicitly when another review context does not.
- `git diff --check` passed.
- Confirmed that the final diff only updates `.claude/agents/cube-project-reviewer.md`.

## Scope

This PR only updates the CubeSandbox project-reviewer guidance. It does not add a deterministic workflow, change repository checks, or block intentional files.
