### PR TITLE
fix(cubemaster): stop reporting node cache size as error

### DIFF
--- a/CubeMaster/pkg/localcache/node_cache.go
+++ b/CubeMaster/pkg/localcache/node_cache.go
@@ -101,9 +101,10 @@ func (l *local) loop(ctx context.Context) {
 					CubeLog.WithContext(context.Background()).Errorf("loop_all:%s", err)
 				}
 				if log.IsDebug() {
-					CubeLog.WithContext(context.Background()).Debugf("loop_all:%s", GetNodes(-1).String())
+					nodes := GetNodes(-1)
+					CubeLog.WithContext(context.Background()).Debugf("loop_all,size:%d,nodes:%s",
+						nodes.Len(), nodes.String())
 				}
-				CubeLog.WithContext(context.Background()).Errorf("loop_all,size:%d", l.cache.ItemCount())
 			}, func(panicError interface{}) {
 				checkDeadline = time.Now().Add(config.GetConfig().Common.SyncMetaDataInterval)
 				CubeLog.WithContext(context.Background()).Fatalf("loop panic:%v", panicError)


### PR DESCRIPTION
## Motivation

CubeMaster periodically reconciles node metadata into its local cache. After each reconciliation, it unconditionally logs the cache size at ERROR level, even when synchronization succeeds and all cached nodes are healthy.

This creates a recurring false error signal and makes real synchronization failures harder to distinguish from normal cache refreshes.

## Current Behavior

For example, a v0.6.0 CubeMaster emitted a log with the following relevant fields after a successful refresh:

```json
{"Version":"v0.6.0","LogLevel":"ERROR","CodeLine":"localcache/node_cache.go:106","LogContent":"loop_all,size:1"}
```

`CodeLine` points to the node-cache refresh path, while `size:1` is only the number of nodes in the local cache. Neither field indicates a synchronization failure, but ERROR-level alerting treats the message like one on every refresh interval.

## What Changed

* Include the node-cache size in the existing DEBUG snapshot.
* Stop emitting an unconditional ERROR after successful reconciliation.
* Preserve ERROR logging for actual metadata synchronization failures.

## Validation

* `go test ./pkg/localcache -count=1` passed
* CubeMaster built and ran successfully with this change.
* Three consecutive node metadata refresh cycles completed with the expected results:

  * Cached node state remained healthy.
  * Cache size appeared in the DEBUG snapshot.
  * No cache-size ERROR log was emitted.

## Scope

This PR only corrects the severity of the periodic node-cache size message.

It does not change metadata synchronization, cache contents, node health evaluation, scheduling, or refresh intervals.
