### PR TITLE
test(sdk_compat): retry sandbox create on scheduler capacity errors

### DIFF
--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -6,10 +6,11 @@ same backend-neutral cases run against:
 - `cubesandbox`: the CubeSandbox Python SDK from `sdk/python`.
 - `e2b`: the E2B Python SDK (`e2b-code-interpreter` or `e2b`) against a CubeSandbox-compatible backend.
 
-The suite is opt-in. Without `--run-e2e`, pytest collection is safe and all cases
-are skipped. Live runs default to the `cubesandbox` backend so PR-gate runs stay
-small and stable. Use `SDK_E2E_BACKENDS=e2b,cubesandbox` for dual-SDK
-compatibility runs.
+The suite is opt-in. Without `--run-e2e`, pytest collection is safe and every
+live case is skipped; only hermetic pure-logic unit tests marked `framework`
+run. Live runs default to the `cubesandbox` backend so PR-gate runs stay small
+and stable. Use `SDK_E2E_BACKENDS=e2b,cubesandbox` for dual-SDK compatibility
+runs.
 
 Documentation:
 
@@ -212,6 +213,24 @@ Optional:
 - `SDK_E2E_API_TIMEOUT`: CubeAPI control-plane request timeout in seconds for
   preflight, diagnostics, and cleanup. Defaults to `5`.
 - `SDK_E2E_CREATE_TIMEOUT`: sandbox create timeout in seconds. Defaults to `120`.
+- `SDK_E2E_CREATE_CAPACITY_RETRIES`: extra sandbox-create attempts when the
+  scheduler transiently returns `no more resource` (error code `130597`),
+  giving the just-freed node time to be reclaimed. Defaults to `5`. Set to `0`
+  to disable and fail fast on the first capacity error.
+- `SDK_E2E_CREATE_CAPACITY_BACKOFF`: base backoff in seconds for capacity
+  retries; grows exponentially per attempt, with full jitter so parallel
+  workers do not retry in lockstep. Defaults to `2`.
+- `SDK_E2E_CREATE_CAPACITY_BACKOFF_MAX`: cap on the capacity-retry backoff in
+  seconds. Defaults to `30`. A value `<= 0` disables the per-delay cap (delays
+  then grow up to an internal `3600`s ceiling) — it does **not** mean "no
+  backoff", so keep it positive unless you intend uncapped growth.
+- `SDK_E2E_CREATE_CAPACITY_BUDGET`: total wall-clock seconds spent **sleeping**
+  across all capacity retries for a single create. Defaults to `90`. Set to `0`
+  to disable and rely on `RETRIES` alone. This caps only the cumulative backoff
+  sleep, not the `create()` calls themselves: each attempt can still run up to
+  `SDK_E2E_CREATE_TIMEOUT`, so a slow-to-reject scheduler can take up to roughly
+  `(RETRIES + 1) × CREATE_TIMEOUT + BUDGET` per test. On the fast-rejection path
+  (immediate HTTP 500) the budget effectively bounds per-create retry time.
 - `SDK_E2E_COMMAND_TIMEOUT`: command timeout in seconds. Defaults to `30`.
 - `SDK_E2E_RUN_CODE_TIMEOUT`: code execution timeout in seconds. Defaults to `60`.
 - `SDK_E2E_NETWORK_PROBE_TIMEOUT`: TCP probe socket timeout in seconds for

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -8,7 +8,8 @@
   的后端。
 
 测试套件默认不执行在线测试。未指定 `--run-e2e` 时，pytest 只进行安全的
-收集。默认后端是 `cubesandbox`；使用
+收集：所有在线用例都会被跳过，仅运行标记为 `framework` 的纯逻辑单元测试。
+默认后端是 `cubesandbox`；使用
 `SDK_E2E_BACKENDS=e2b,cubesandbox` 执行双后端兼容性测试。
 
 相关文档：
@@ -193,6 +194,20 @@ cp env.example .env
 - `SDK_E2E_API_TIMEOUT`：CubeAPI 控制面请求超时，用于 preflight、诊断
   和清理，默认 `5` 秒；
 - `SDK_E2E_CREATE_TIMEOUT`：创建超时，默认 `120` 秒；
+- `SDK_E2E_CREATE_CAPACITY_RETRIES`：当调度器瞬时返回 `no more resource`
+  （错误码 `130597`）时，额外重试创建 sandbox 的次数，给刚释放的节点留出回收
+  时间，默认 `5`；设为 `0` 可关闭重试、遇到容量错误即失败；
+- `SDK_E2E_CREATE_CAPACITY_BACKOFF`：容量重试的基础退避秒数，按次指数增长，
+  并加入完全抖动（full jitter），避免并行 worker 同步重试，默认 `2`；
+- `SDK_E2E_CREATE_CAPACITY_BACKOFF_MAX`：容量重试退避的上限秒数，默认 `30`；
+  取值 `<= 0` 表示关闭单次退避上限（退避将增长至内置的 `3600` 秒上限），
+  并非“无退避”，除非确实需要无上限增长，否则请保持为正值；
+- `SDK_E2E_CREATE_CAPACITY_BUDGET`：单次创建在所有容量重试中累计的**休眠**时间
+  上限（秒），默认 `90`；设为 `0` 可关闭、仅依赖 `RETRIES`。它仅约束累计退避
+  休眠，不约束 `create()` 调用本身：每次尝试仍可耗时至多 `SDK_E2E_CREATE_TIMEOUT`，
+  因此在调度器缓慢拒绝时，单个用例最坏可耗时约
+  `(RETRIES + 1) × CREATE_TIMEOUT + BUDGET`。在快速拒绝路径（立即返回 HTTP 500）
+  下，该预算可有效约束单次创建的重试时长；
 - `SDK_E2E_COMMAND_TIMEOUT`：命令超时，默认 `30` 秒；
 - `SDK_E2E_RUN_CODE_TIMEOUT`：代码执行超时，默认 `60` 秒；
 - `SDK_E2E_NETWORK_PROBE_TIMEOUT`：network policy 用例中的 TCP socket

--- a/tests/e2e/sdk_compat/adapters/__init__.py
+++ b/tests/e2e/sdk_compat/adapters/__init__.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from adapters.base import SandboxAdapter
 from adapters.cubesandbox_adapter import CubeSandboxAdapter
 from adapters.e2b_adapter import E2BAdapter
 from adapters.tracing_adapter import wrap_adapter
 from framework.config import SdkE2EConfig
+from framework.create_retry import create_with_capacity_retry
 from framework.trace import get_current_trace, summarize_create_options
 
 _ADAPTERS = {
@@ -46,6 +49,35 @@ def create_adapter(
         output=lambda result: {"sandbox_id": result.sandbox_id},
     )
     return wrap_adapter(adapter, trace)
+
+
+def create_adapter_with_capacity_retry(
+    backend: str,
+    config: SdkE2EConfig,
+    *,
+    metadata: dict[str, str] | None = None,
+    create_options: dict | None = None,
+    on_retry: Callable[[int, float, BaseException], None] | None = None,
+) -> SandboxAdapter:
+    """``create_adapter`` that retries while the scheduler is out of capacity.
+
+    Use this at success-expecting create sites so a saturated shared CI node can
+    be reclaimed instead of failing the run. Do NOT use it where a create is
+    expected to be rejected (e.g. boundary/rejection tests).
+    """
+    return create_with_capacity_retry(
+        lambda: create_adapter(
+            backend,
+            config,
+            metadata=metadata,
+            create_options=create_options,
+        ),
+        retries=config.create_capacity_retries,
+        backoff=config.create_capacity_backoff,
+        backoff_max=config.create_capacity_backoff_max,
+        total_budget=config.create_capacity_budget,
+        on_retry=on_retry,
+    )
 
 
 def connect_adapter(backend: str, sandbox_id: str, config: SdkE2EConfig) -> SandboxAdapter:
@@ -104,4 +136,10 @@ def _entry_id(entry: dict):
     return entry.get("sandbox_id")
 
 
-__all__ = ["SandboxAdapter", "connect_adapter", "create_adapter", "list_sandboxes"]
+__all__ = [
+    "SandboxAdapter",
+    "connect_adapter",
+    "create_adapter",
+    "create_adapter_with_capacity_retry",
+    "list_sandboxes",
+]

--- a/tests/e2e/sdk_compat/cases/framework/__init__.py
+++ b/tests/e2e/sdk_compat/cases/framework/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/e2e/sdk_compat/cases/framework/test_create_retry.py
+++ b/tests/e2e/sdk_compat/cases/framework/test_create_retry.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-logic unit tests for the sandbox-create capacity-retry helper.
+
+Marked ``framework`` so they run on every gate without a live environment
+(see ``conftest.pytest_collection_modifyitems``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework import create_retry
+from framework.create_retry import (
+    CAPACITY_ERROR_CODE,
+    create_with_capacity_retry,
+    is_capacity_error,
+)
+
+pytestmark = pytest.mark.framework
+
+
+class _CapacityError(Exception):
+    """Stand-in for the SDK error raised when the scheduler is out of capacity."""
+
+
+class _CodedError(Exception):
+    def __init__(self, message: str = "", *, code: object = None) -> None:
+        super().__init__(message)
+        if code is not None:
+            self.code = code
+
+
+class _ApiError(Exception):
+    """Mimics the CubeSandbox SDK ``ApiError``: only an HTTP ``status_code``.
+
+    The SDK does NOT surface CubeMaster's numeric RetCode (130597); the create
+    failure arrives as an HTTP 500 whose message is CubeMaster's ``RetMsg``, so
+    detection for that backend relies on the message markers.
+    """
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "no more resource",
+        "NO MORE RESOURCE",
+        "scheduler: SelectNodesNoRes",
+        "node is out of capacity",
+        "insufficient capacity on cluster",
+        f"scheduling failed: {CAPACITY_ERROR_CODE}",
+    ],
+)
+def test_is_capacity_error_matches_transient(message: str) -> None:
+    assert is_capacity_error(Exception(message)) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "invalid template id",
+        "unauthorized",
+        "resource exhausted",  # generic gRPC rate-limit, deliberately not retried
+        "connection refused",
+        "",
+    ],
+)
+def test_is_capacity_error_ignores_other_errors(message: str) -> None:
+    assert is_capacity_error(Exception(message)) is False
+
+
+def test_is_capacity_error_matches_numeric_code_attribute() -> None:
+    assert is_capacity_error(_CodedError("boom", code=int(CAPACITY_ERROR_CODE))) is True
+    assert is_capacity_error(_CodedError("boom", code=CAPACITY_ERROR_CODE)) is True
+
+
+def test_is_capacity_error_ignores_unrelated_code() -> None:
+    assert is_capacity_error(_CodedError("boom", code=404)) is False
+
+
+def test_is_capacity_error_matches_real_apierror_shape() -> None:
+    # The primary backend's ApiError has no capacity code, only status_code=500
+    # and CubeMaster's RetMsg text: detection must still trip on the message.
+    exc = _ApiError("create sandbox failed: no more resource", status_code=500)
+    assert is_capacity_error(exc) is True
+
+
+# The exact ApiError message the SDK raises on a saturated create, traced
+# through source (see create_retry module docstring): scheduler ErrNoRes (code
+# 130597) -> CubeMasterError::Api Display -> ApiError(500, message). Pinning the
+# real body keeps detection verified against the actual wire text, not an
+# assumed wording; note it carries BOTH the code token and the phrase.
+_REAL_SATURATED_CREATE_MESSAGE = (
+    "CubeMaster returned error code 130597: no more resource"
+)
+
+
+def test_is_capacity_error_matches_real_wire_message() -> None:
+    exc = _ApiError(_REAL_SATURATED_CREATE_MESSAGE, status_code=500)
+    assert is_capacity_error(exc) is True
+    # Even if the phrase wording ever drifts, the standalone 130597 token in the
+    # same message keeps detection tripping.
+    assert is_capacity_error(_ApiError("error code 130597", status_code=500)) is True
+
+
+def test_is_capacity_error_ignores_status_code_500() -> None:
+    # A generic 500 without capacity wording must not be retried.
+    exc = _ApiError("internal server error", status_code=500)
+    assert is_capacity_error(exc) is False
+
+
+def test_is_capacity_error_requires_code_word_boundary() -> None:
+    # 130597 embedded in a larger id must NOT be misread as the capacity code.
+    assert is_capacity_error(Exception("sandbox sbx-1305971 failed")) is False
+    assert is_capacity_error(Exception("retcode=130597 no schedulable node")) is True
+
+
+def test_backoff_delay_grows_and_is_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    # random.uniform(0, ceiling) -> return the ceiling so growth is observable.
+    monkeypatch.setattr(create_retry.random, "uniform", lambda _lo, hi: hi)
+    assert create_retry._backoff_delay(1, backoff=2, backoff_max=30) == 2
+    assert create_retry._backoff_delay(2, backoff=2, backoff_max=30) == 4
+    assert create_retry._backoff_delay(3, backoff=2, backoff_max=30) == 8
+    assert create_retry._backoff_delay(5, backoff=2, backoff_max=30) == 30  # capped
+
+
+def test_backoff_delay_uncapped_when_max_non_positive(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(create_retry.random, "uniform", lambda _lo, hi: hi)
+    assert create_retry._backoff_delay(4, backoff=1, backoff_max=0) == 8
+
+
+def test_backoff_delay_stays_within_ceiling() -> None:
+    for attempt in range(1, 6):
+        delay = create_retry._backoff_delay(attempt, backoff=2, backoff_max=30)
+        assert 0.0 <= delay <= 30
+
+
+def test_backoff_delay_uncapped_overflow_clamps_to_finite_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Uncapped (backoff_max<=0) + huge backoff overflows to inf; instead of a
+    # tight 0.0 loop the ceiling is clamped to the finite _UNCAPPED_BACKOFF_CEILING.
+    monkeypatch.setattr(create_retry.random, "uniform", lambda _lo, hi: hi)
+    delay = create_retry._backoff_delay(40, backoff=1e308, backoff_max=0)
+    assert delay == create_retry._UNCAPPED_BACKOFF_CEILING
+
+
+def test_backoff_delay_uncapped_grows_within_finite_ceiling() -> None:
+    # A large-but-finite uncapped delay stays within the internal ceiling.
+    for attempt in range(1, 40):
+        delay = create_retry._backoff_delay(attempt, backoff=2, backoff_max=0)
+        assert 0.0 <= delay <= create_retry._UNCAPPED_BACKOFF_CEILING
+
+
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(create_retry.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(create_retry.random, "uniform", lambda _lo, _hi: 0.0)
+
+
+def test_returns_on_first_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def create() -> str:
+        calls["n"] += 1
+        return "ok"
+
+    assert create_with_capacity_retry(
+        create, retries=5, backoff=2, backoff_max=30
+    ) == "ok"
+    assert calls["n"] == 1
+
+
+def test_retries_capacity_error_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_sleep(monkeypatch)
+    attempts = iter([Exception("no more resource"), Exception("no more resource")])
+
+    def create() -> str:
+        exc = next(attempts, None)
+        if exc is not None:
+            raise exc
+        return "ok"
+
+    seen: list[int] = []
+    result = create_with_capacity_retry(
+        create,
+        retries=5,
+        backoff=2,
+        backoff_max=30,
+        on_retry=lambda attempt, delay, exc: seen.append(attempt),
+    )
+    assert result == "ok"
+    assert seen == [1, 2]  # 1-based attempt numbers
+
+
+def test_non_capacity_error_raises_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def create() -> str:
+        calls["n"] += 1
+        raise ValueError("bad template")
+
+    with pytest.raises(ValueError):
+        create_with_capacity_retry(create, retries=5, backoff=2, backoff_max=30)
+    assert calls["n"] == 1  # no retry
+
+
+def test_raises_last_capacity_error_when_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def create() -> str:
+        calls["n"] += 1
+        raise _CapacityError(f"no more resource #{calls['n']}")
+
+    with pytest.raises(Exception, match="no more resource #3"):
+        create_with_capacity_retry(create, retries=2, backoff=2, backoff_max=30)
+    assert calls["n"] == 3  # first attempt + 2 retries
+
+
+def test_retries_zero_is_single_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def create() -> str:
+        calls["n"] += 1
+        raise _CapacityError("no more resource")
+
+    with pytest.raises(Exception, match="no more resource"):
+        create_with_capacity_retry(create, retries=0, backoff=2, backoff_max=30)
+    assert calls["n"] == 1
+
+
+def test_negative_retries_treated_as_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def create() -> str:
+        calls["n"] += 1
+        raise _CapacityError("no more resource")
+
+    with pytest.raises(Exception, match="no more resource"):
+        create_with_capacity_retry(create, retries=-3, backoff=2, backoff_max=30)
+    assert calls["n"] == 1
+
+
+def _deterministic_delay(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    # Return the full ceiling as the delay (no jitter) and record every sleep.
+    slept: list[float] = []
+    monkeypatch.setattr(create_retry.random, "uniform", lambda _lo, hi: hi)
+    monkeypatch.setattr(create_retry.time, "sleep", lambda seconds: slept.append(seconds))
+    return slept
+
+
+def test_total_budget_stops_before_exceeding(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Delays are 2, 4, 8, ... With a 5s budget, the loop sleeps 2 (total 2),
+    # then the next 4 would push total to 6 > 5, so it re-raises instead.
+    slept = _deterministic_delay(monkeypatch)
+    calls = {"n": 0}
+
+    def create() -> str:
+        calls["n"] += 1
+        raise _CapacityError("no more resource")
+
+    with pytest.raises(Exception, match="no more resource"):
+        create_with_capacity_retry(
+            create, retries=10, backoff=2, backoff_max=30, total_budget=5
+        )
+    assert slept == [2]  # only the first backoff fit within the budget
+    assert calls["n"] == 2  # first attempt + one retry, then budget stops it
+
+
+def test_total_budget_disabled_when_non_positive(monkeypatch: pytest.MonkeyPatch) -> None:
+    # total_budget<=0 keeps the retries-only behaviour (no wall-time cap).
+    slept = _deterministic_delay(monkeypatch)
+    calls = {"n": 0}
+
+    def create() -> str:
+        calls["n"] += 1
+        raise _CapacityError("no more resource")
+
+    with pytest.raises(Exception, match="no more resource"):
+        create_with_capacity_retry(
+            create, retries=3, backoff=2, backoff_max=30, total_budget=0
+        )
+    assert calls["n"] == 4  # first attempt + 3 retries, budget did not intervene
+    assert slept == [2, 4, 8]

--- a/tests/e2e/sdk_compat/cases/volume/test_bind_unbind.py
+++ b/tests/e2e/sdk_compat/cases/volume/test_bind_unbind.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import pytest
 
-from adapters import create_adapter
+from adapters import create_adapter_with_capacity_retry
 from framework.capabilities import VOLUME_PLUGIN
 from framework.cleanup import safe_kill
 from framework.volume import (
@@ -43,7 +43,7 @@ def test_volume_bind_delete_conflict_then_unbind(sdk_backend, sdk_e2e_config):
     with managed_volume(sdk_e2e_config) as (volume_id, api):
         adapter = None
         try:
-            adapter = create_adapter(
+            adapter = create_adapter_with_capacity_retry(
                 sdk_backend,
                 sdk_e2e_config,
                 metadata={

--- a/tests/e2e/sdk_compat/cases/volume/test_read_only.py
+++ b/tests/e2e/sdk_compat/cases/volume/test_read_only.py
@@ -17,7 +17,8 @@ import sys
 import uuid
 
 import pytest
-from adapters import create_adapter
+
+from adapters import create_adapter_with_capacity_retry
 from framework.capabilities import VOLUME_PLUGIN
 from framework.cleanup import safe_kill
 from framework.volume import managed_volume
@@ -54,7 +55,7 @@ def test_read_only_volume_attachment_rejects_mutations(
         read_write = None
         read_only = None
         try:
-            read_write = create_adapter(
+            read_write = create_adapter_with_capacity_retry(
                 sdk_backend,
                 sdk_e2e_config,
                 metadata={
@@ -69,7 +70,7 @@ def test_read_only_volume_attachment_rejects_mutations(
             read_write.write_file(seed_path, payload)
             assert read_write.read_file(seed_path) == payload
 
-            read_only = create_adapter(
+            read_only = create_adapter_with_capacity_retry(
                 sdk_backend,
                 sdk_e2e_config,
                 metadata={

--- a/tests/e2e/sdk_compat/conftest.py
+++ b/tests/e2e/sdk_compat/conftest.py
@@ -16,13 +16,20 @@ ROOT = Path(__file__).resolve().parents[3]
 SDK_COMPAT_ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(SDK_COMPAT_ROOT))
 
-from adapters import create_adapter  # noqa: E402
+from adapters import create_adapter_with_capacity_retry  # noqa: E402
+from framework.capabilities import (  # noqa: E402
+    CODE_INTERPRETER,
+    capabilities_for_backend,
+)
 from framework.cleanup import safe_kill  # noqa: E402
-from framework.capabilities import CODE_INTERPRETER, capabilities_for_backend  # noqa: E402
 from framework.config import SdkE2EConfig  # noqa: E402
 from framework.preflight import run_preflight  # noqa: E402
 from framework.reporting import JsonlReporter  # noqa: E402
-from framework.trace import TraceCollector, reset_current_trace, set_current_trace  # noqa: E402
+from framework.trace import (  # noqa: E402
+    TraceCollector,
+    reset_current_trace,
+    set_current_trace,
+)
 
 
 def _load_dotenv(path: Path) -> None:
@@ -119,7 +126,11 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     if not config.getoption("--run-e2e"):
         skip = pytest.mark.skip(reason="live SDK E2E disabled; pass --run-e2e to run")
         for item in items:
-            item.add_marker(skip)
+            # Only ``framework`` tests are hermetic pure-logic unit tests that run
+            # on every gate. Everything else (including any test that forgets a
+            # marker) is treated as live and skipped, so the gate stays hermetic.
+            if not item.get_closest_marker("framework"):
+                item.add_marker(skip)
         return
     if volume_skip is None:
         return
@@ -302,11 +313,21 @@ def sdk_sandbox(
                 f"template_id={node_config.cube_template_id} "
                 f"nodeid={request.node.nodeid}"
             )
-            adapter = create_adapter(
+
+            def _log_capacity_retry(attempt: int, delay: float, exc: BaseException) -> None:
+                _setup_log(
+                    f"scheduler out of capacity creating sandbox "
+                    f"backend={sdk_backend} nodeid={request.node.nodeid}; "
+                    f"retry {attempt}/{node_config.create_capacity_retries} "
+                    f"in {delay:.1f}s: {exc}"
+                )
+
+            adapter = create_adapter_with_capacity_retry(
                 sdk_backend,
                 node_config,
                 metadata=metadata,
                 create_options=create_options,
+                on_retry=_log_capacity_retry,
             )
         except ImportError as exc:
             pytest.skip(str(exc))

--- a/tests/e2e/sdk_compat/env.example
+++ b/tests/e2e/sdk_compat/env.example
@@ -37,6 +37,21 @@ CUBE_SANDBOX_DOMAIN=cube.app
 SDK_E2E_DEFAULT_TIMEOUT=120
 SDK_E2E_API_TIMEOUT=5
 SDK_E2E_CREATE_TIMEOUT=120
+# Retry sandbox create when the scheduler is transiently out of capacity
+# ("no more resource", error code 130597). RETRIES is extra attempts after the
+# first (0 disables); BACKOFF is the base seconds, grown exponentially with full
+# jitter and capped at BACKOFF_MAX. Note BACKOFF_MAX<=0 disables the per-delay
+# cap (delays grow up to an internal 3600s ceiling); it does NOT mean "no
+# backoff" — leave it at a positive value unless you intend uncapped growth.
+# BUDGET is the total wall-clock seconds spent *sleeping* across all retries for
+# one create (0 disables). It caps only the cumulative backoff sleep, not the
+# create() calls: each attempt can still run up to CREATE_TIMEOUT, so a
+# slow-to-reject scheduler can take ~ (RETRIES+1) * CREATE_TIMEOUT + BUDGET per
+# test; on the fast HTTP-500 rejection path it bounds per-create retry time.
+SDK_E2E_CREATE_CAPACITY_RETRIES=5
+SDK_E2E_CREATE_CAPACITY_BACKOFF=2
+SDK_E2E_CREATE_CAPACITY_BACKOFF_MAX=30
+SDK_E2E_CREATE_CAPACITY_BUDGET=90
 SDK_E2E_COMMAND_TIMEOUT=30
 SDK_E2E_RUN_CODE_TIMEOUT=60
 SDK_E2E_NETWORK_PROBE_TIMEOUT=5

--- a/tests/e2e/sdk_compat/framework/config.py
+++ b/tests/e2e/sdk_compat/framework/config.py
@@ -45,6 +45,10 @@ class SdkE2EConfig:
     volume_plugin_enabled: bool
     volume_driver: str
     volume_refcount_wait: int
+    create_capacity_retries: int
+    create_capacity_backoff: float
+    create_capacity_backoff_max: float
+    create_capacity_budget: float
 
     @classmethod
     def from_env(
@@ -91,6 +95,18 @@ class SdkE2EConfig:
             volume_plugin_enabled=_bool_env("SDK_E2E_VOLUME_PLUGIN"),
             volume_driver=os.environ.get("SDK_E2E_VOLUME_DRIVER", "cos").strip() or "cos",
             volume_refcount_wait=int(os.environ.get("SDK_E2E_VOLUME_REFCOUNT_WAIT", "60")),
+            create_capacity_retries=int(
+                os.environ.get("SDK_E2E_CREATE_CAPACITY_RETRIES", "5")
+            ),
+            create_capacity_backoff=float(
+                os.environ.get("SDK_E2E_CREATE_CAPACITY_BACKOFF", "2")
+            ),
+            create_capacity_backoff_max=float(
+                os.environ.get("SDK_E2E_CREATE_CAPACITY_BACKOFF_MAX", "30")
+            ),
+            create_capacity_budget=float(
+                os.environ.get("SDK_E2E_CREATE_CAPACITY_BUDGET", "90")
+            ),
         )
 
     def env(self) -> dict[str, str]:

--- a/tests/e2e/sdk_compat/framework/create_retry.py
+++ b/tests/e2e/sdk_compat/framework/create_retry.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Retry sandbox creation when the scheduler is temporarily out of capacity.
+
+A shared CI environment can transiently reject ``create`` calls when every node
+is saturated. The scheduler reports this as ``no more resource`` (see
+``CubeMaster/pkg/scheduler`` ``ErrNoRes`` / ``ErrorCode_SelectNodesNoRes``),
+which the SDK surfaces as an ``ApiError``. That condition clears on its own once
+another sandbox is torn down, so the E2E harness retries with exponential
+backoff instead of failing the whole run.
+
+Only capacity errors are retried; every other failure (bad template, auth,
+``ImportError`` for a missing SDK, …) propagates immediately.
+
+Verified wire shape (why the message markers below are reliable). The full path
+of a saturated create, traced through source rather than assumed:
+
+* CubeMaster scheduler raises ``ErrNoRes`` ("no more resource") with code
+  ``ErrorCode_SelectNodesNoRes`` (130597), returned as
+  ``Status{RetCode: 130597, RetMsg: "no more resource"}``.
+* CubeAPI wraps that as ``CubeMasterError::Api`` whose ``Display`` is
+  ``"CubeMaster returned error code 130597: no more resource"``
+  (``CubeAPI/src/cubemaster/mod.rs``), then serialises it via
+  ``AppError::Internal`` → ``Json(ApiError::new(500, e.to_string()))``
+  (``CubeAPI/src/error/mod.rs``) into a JSON body ``{"code": 500,
+  "message": "CubeMaster returned error code 130597: no more resource"}``.
+* The SDK's ``_check_response`` reads ``body.get("message")``
+  (``sdk/python/cubesandbox/sandbox.py``) and raises
+  ``ApiError(message, status_code=500)``.
+
+So the on-the-wire message carries BOTH the ``130597`` token and the
+``no more resource`` text; detection trips on either. ``test_create_retry``
+pins this exact string so the markers stay verified against the real body.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import re
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+# The scheduler's numeric code for "no schedulable node" (ErrNoRes /
+# ErrorCode_SelectNodesNoRes). Note the CubeSandbox Python SDK's ``ApiError``
+# only carries the HTTP ``status_code``, not this RetCode, so for that backend
+# detection falls back to the message markers below; the code is checked mainly
+# for SDKs/transports that do surface a numeric field, or that echo it in the
+# message text.
+CAPACITY_ERROR_CODE = "130597"
+
+# Absolute finite ceiling (seconds) applied even when ``backoff_max`` is
+# non-positive ("uncapped"). A misconfigured base (e.g. ``backoff=1e308``)
+# overflows the exponential to ``inf``; without this bound the delay would
+# either reach ``time.sleep`` as ``inf`` (raising) or, if forced to ``0.0``,
+# collapse into a tight retry loop. Clamping to a large-but-finite value keeps
+# an uncapped misconfiguration safe without silently disabling backoff.
+_UNCAPPED_BACKOFF_CEILING = 3600.0
+_CAPACITY_CODE_RE = re.compile(rf"\b{CAPACITY_ERROR_CODE}\b")
+
+# Message substrings that identify a transient out-of-capacity failure. Matched
+# case-insensitively; ``no more resource`` is CubeMaster's ``ErrNoRes.Error()``.
+# Kept specific to avoid retrying unrelated errors (e.g. generic gRPC
+# ``resource exhausted`` rate-limit responses).
+_CAPACITY_MARKERS = (
+    "no more resource",
+    "selectnodesnores",
+    "out of capacity",
+    "insufficient capacity",
+)
+
+
+def is_capacity_error(exc: BaseException) -> bool:
+    """Return ``True`` when ``exc`` looks like a transient out-of-capacity error."""
+    code = getattr(exc, "code", None)
+    if code is None:
+        code = getattr(exc, "error_code", None)
+    if code is not None and str(code) == CAPACITY_ERROR_CODE:
+        return True
+    message = str(exc).lower()
+    if _CAPACITY_CODE_RE.search(message):
+        return True
+    return any(marker in message for marker in _CAPACITY_MARKERS)
+
+
+def create_with_capacity_retry(
+    create: Callable[[], T],
+    *,
+    retries: int,
+    backoff: float,
+    backoff_max: float,
+    total_budget: float = 0.0,
+    on_retry: Callable[[int, float, BaseException], None] | None = None,
+) -> T:
+    """Call ``create`` and retry it while the scheduler is out of capacity.
+
+    Args:
+        create: Zero-argument callable that creates and returns the sandbox
+            adapter. Invoked once per attempt.
+        retries: Maximum number of *additional* attempts after the first one.
+            ``0`` disables retrying (a single attempt). Negative values are
+            treated as ``0``.
+        backoff: Base delay, in seconds, for the first retry. Each subsequent
+            retry doubles the ceiling (exponential backoff) and the actual delay
+            is drawn uniformly in ``[0, ceiling]`` (full jitter) so parallel
+            workers do not retry in lockstep.
+        backoff_max: Upper bound, in seconds, for any single backoff delay.
+            ``<= 0`` disables the per-delay cap (delays then grow up to the
+            internal ``_UNCAPPED_BACKOFF_CEILING``), it does NOT mean "zero
+            backoff".
+        total_budget: Optional wall-clock budget, in seconds, for the whole
+            retry loop (sleeps only; the per-attempt ``create`` timeout is
+            owned by the caller). ``<= 0`` disables it. When the accumulated
+            backoff sleep would exceed the budget, the loop stops early and
+            re-raises the last capacity error instead of sleeping again. This
+            bounds worst-case gate duration when many per-test sandboxes each
+            hit a saturated cluster.
+        on_retry: Optional callback invoked before each sleep with
+            ``(attempt, delay, exc)`` where ``attempt`` is 1-based.
+
+    Returns:
+        Whatever ``create`` returns on the first successful attempt.
+
+    Raises:
+        The last capacity error once ``retries`` (or ``total_budget``) is
+        exhausted, or immediately re-raises any non-capacity error.
+    """
+    max_retries = max(0, retries)
+    attempt = 0
+    slept = 0.0
+    while True:
+        try:
+            return create()
+        except Exception as exc:  # noqa: BLE001 - decide per-exception whether to retry
+            if attempt >= max_retries or not is_capacity_error(exc):
+                raise
+            attempt += 1
+            delay = _backoff_delay(attempt, backoff, backoff_max)
+            if total_budget > 0 and slept + delay > total_budget:
+                raise
+            if on_retry is not None:
+                on_retry(attempt, delay, exc)
+            time.sleep(delay)
+            slept += delay
+
+
+def _backoff_delay(attempt: int, backoff: float, backoff_max: float) -> float:
+    """Full-jitter exponential backoff for a 1-based ``attempt``.
+
+    The ceiling grows as ``backoff * 2 ** (attempt - 1)`` (capped at
+    ``backoff_max`` when positive) and the returned delay is a uniform random
+    value in ``[0, ceiling]`` to avoid a thundering herd across parallel workers.
+
+    When ``backoff_max <= 0`` the per-delay cap is disabled, but the ceiling is
+    still clamped to a large finite value (``_UNCAPPED_BACKOFF_CEILING``) so a
+    misconfigured base that overflows to ``inf`` yields a bounded delay rather
+    than crashing ``time.sleep`` or collapsing into a tight ``0.0`` loop.
+    """
+    ceiling = backoff * (2 ** min(attempt - 1, 30))
+    if backoff_max > 0:
+        ceiling = min(ceiling, backoff_max)
+    elif not math.isfinite(ceiling) or ceiling > _UNCAPPED_BACKOFF_CEILING:
+        # Uncapped: a huge/overflowed ceiling is clamped to a finite bound so
+        # the delay stays large-but-safe instead of inf (raises) or 0.0 (tight
+        # loop).
+        ceiling = _UNCAPPED_BACKOFF_CEILING
+    if not math.isfinite(ceiling) or ceiling < 0.0:
+        ceiling = 0.0
+    return random.uniform(0.0, ceiling)
+

--- a/tests/e2e/sdk_compat/framework/host_mount.py
+++ b/tests/e2e/sdk_compat/framework/host_mount.py
@@ -19,7 +19,7 @@ import warnings
 
 import pytest
 
-from adapters import create_adapter
+from adapters import create_adapter, create_adapter_with_capacity_retry
 from framework.capabilities import HOST_MOUNT, capabilities_for_backend
 from framework.cleanup import safe_kill
 
@@ -164,7 +164,7 @@ def provision_host_dirs(backend: str, config, subpaths: list[str]) -> None:
         [mount_option(ALLOWED_PREFIX, _PROVISION_MOUNT, read_only=False)]
     )
     targets = " ".join(f"{_PROVISION_MOUNT}/{r}" for r in rel)
-    adapter = create_adapter(
+    adapter = create_adapter_with_capacity_retry(
         backend, config, metadata={"test_role": "host_mount_provision", **metadata}
     )
     try:

--- a/tests/e2e/sdk_compat/framework/lifecycle.py
+++ b/tests/e2e/sdk_compat/framework/lifecycle.py
@@ -8,7 +8,11 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from typing import Any
 
-from adapters import connect_adapter, create_adapter, list_sandboxes
+from adapters import (
+    connect_adapter,
+    create_adapter_with_capacity_retry,
+    list_sandboxes,
+)
 from adapters.base import SandboxAdapter
 from framework.cleanup import safe_kill
 from framework.config import SdkE2EConfig
@@ -179,7 +183,7 @@ def create_control_sandbox(
     *,
     metadata: dict[str, str] | None = None,
 ) -> SandboxAdapter:
-    return create_adapter(
+    return create_adapter_with_capacity_retry(
         backend,
         config,
         metadata={

--- a/tests/e2e/sdk_compat/pytest.ini
+++ b/tests/e2e/sdk_compat/pytest.ini
@@ -9,6 +9,7 @@ markers =
     p3: P3 tests for release qualification and long-running scenarios
     slow: tests that take longer than the normal PR budget
     e2e: tests that hit a live CubeAPI/CubeProxy environment
+    framework: hermetic pure-logic unit tests that run on every gate without --run-e2e
     sdk_compat: cross-SDK compatibility tests
     lifecycle: sandbox lifecycle compatibility tests
     commands: sandbox command execution compatibility tests


### PR DESCRIPTION
Shared CI transiently rejects create when every node is saturated; the scheduler returns "no more resource" (code 130597), failing otherwise healthy E2E runs. Retry create with jittered exponential backoff so a just-freed node can be reclaimed, and run pure-logic unit tests on every gate without a live environment.

Assisted-by: Claude Code:claude-opus-4.8