### PR TITLE
test(sdk_compat): add network egress e2e coverage for DNS, L7, and template merge

### DIFF
--- a/tests/e2e/sdk_compat/cases/network/test_dns_allow.py
+++ b/tests/e2e/sdk_compat/cases/network/test_dns_allow.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Domain allow_out + DNS A learning (exact and leading ``*.`` wildcard)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import NETWORK_DNS_ALLOW
+
+ALLOWED_DOMAIN = os.environ.get("SDK_E2E_DNS_ALLOW_DOMAIN", "example.com")
+ALLOWED_WILDCARD = os.environ.get("SDK_E2E_DNS_ALLOW_WILDCARD", "*.example.com")
+WILDCARD_SUBDOMAIN = os.environ.get(
+    "SDK_E2E_DNS_ALLOW_WILDCARD_SUBDOMAIN",
+    "www.example.com",
+)
+BLOCKED_DOMAIN = os.environ.get("SDK_E2E_DNS_ALLOW_BLOCKED_DOMAIN", "one.one.one.one")
+DOMAIN_TCP_PORT = int(os.environ.get("SDK_E2E_DNS_ALLOW_TCP_PORT", "443"))
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.network,
+    pytest.mark.p1,
+    pytest.mark.requires_internet,
+    pytest.mark.requires_capability(NETWORK_DNS_ALLOW),
+]
+
+
+def _resolve_and_probe_command(host: str, port: int, timeout: int) -> str:
+    """Resolve *host*, print addrs, then TCP-probe the first IPv4 address."""
+    return (
+        "python3 - <<'PY'\n"
+        "import socket\n"
+        f"host = {host!r}\n"
+        f"port = {port!r}\n"
+        f"timeout = {timeout!r}\n"
+        "try:\n"
+        "    infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)\n"
+        "except Exception as exc:\n"
+        "    print(f'RESOLVE:ERROR:{type(exc).__name__}:{exc}')\n"
+        "    raise SystemExit(0)\n"
+        "addrs = []\n"
+        "for family, _, _, _, sockaddr in infos:\n"
+        "    if family not in (socket.AF_INET,):\n"
+        "        continue\n"
+        "    addrs.append(sockaddr[0])\n"
+        "print('RESOLVED:' + ','.join(dict.fromkeys(addrs)))\n"
+        "if not addrs:\n"
+        "    print('PROBE:ERROR:no_ipv4')\n"
+        "    raise SystemExit(0)\n"
+        "target = addrs[0]\n"
+        "s = socket.socket()\n"
+        "try:\n"
+        "    s.settimeout(timeout)\n"
+        "    rc = s.connect_ex((target, port))\n"
+        "    print('PROBE:OK' if rc == 0 else f'PROBE:FAIL:{rc}')\n"
+        "except Exception as exc:\n"
+        "    print(f'PROBE:ERROR:{type(exc).__name__}:{exc}')\n"
+        "finally:\n"
+        "    s.close()\n"
+        "PY"
+    )
+
+
+def _assert_domain_reachable(result, host: str) -> None:
+    assert_command_ok(result)
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    resolve_err = next((line for line in lines if line.startswith("RESOLVE:ERROR:")), "")
+    assert not resolve_err, (
+        f"{host} DNS resolve failed inside sandbox (not a policy verdict); "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    resolved = next((line for line in lines if line.startswith("RESOLVED:")), "")
+    probe = next((line for line in lines if line.startswith("PROBE:")), "")
+    assert resolved.startswith("RESOLVED:") and resolved != "RESOLVED:", (
+        f"{host} should resolve via DNS learning path; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert probe == "PROBE:OK", (
+        f"{host}:{DOMAIN_TCP_PORT} should be reachable after DNS A learning; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def _assert_domain_blocked_after_resolve(result, host: str) -> None:
+    """DNS must succeed so we can judge TCP deny; then connect to that IP fails.
+
+    Domain allow-list mode still forwards DNS for unmatched QNAMEs; only the
+    later TCP connect is denied. A resolve failure is an environment/DNS issue,
+    not a TCP-policy verdict.
+    """
+    assert_command_ok(result)
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    resolve_err = next((line for line in lines if line.startswith("RESOLVE:ERROR:")), "")
+    assert not resolve_err, (
+        f"{host} DNS resolve failed inside sandbox (cannot judge TCP policy); "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    probe = next((line for line in lines if line.startswith("PROBE:")), "")
+    blocked = probe.startswith("PROBE:FAIL:") or (
+        probe.startswith("PROBE:ERROR:")
+        and ("Timeout" in probe or "timed out" in probe.lower())
+    )
+    assert blocked, (
+        f"{host}:{DOMAIN_TCP_PORT} should be blocked (no learned allow); "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+@pytest.mark.sandbox_create_options(
+    allow_internet_access=False,
+    network={
+        "allow_out": [ALLOWED_DOMAIN],
+        "deny_out": ["0.0.0.0/0"],
+    },
+)
+def test_domain_allow_out_learns_dns_and_blocks_others(sdk_sandbox, sdk_e2e_config):
+    """Exact domain allow_out + DNS learning; other destinations blocked."""
+    allowed = sdk_sandbox.run_command(
+        _resolve_and_probe_command(
+            ALLOWED_DOMAIN,
+            DOMAIN_TCP_PORT,
+            sdk_e2e_config.network_probe_timeout,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    _assert_domain_reachable(allowed, ALLOWED_DOMAIN)
+
+    blocked = sdk_sandbox.run_command(
+        _resolve_and_probe_command(
+            BLOCKED_DOMAIN,
+            DOMAIN_TCP_PORT,
+            sdk_e2e_config.network_probe_timeout,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    _assert_domain_blocked_after_resolve(blocked, BLOCKED_DOMAIN)
+
+
+@pytest.mark.sandbox_create_options(
+    allow_internet_access=False,
+    network={
+        "allow_out": [ALLOWED_WILDCARD],
+        "deny_out": ["0.0.0.0/0"],
+    },
+)
+def test_wildcard_domain_allow_matches_subdomain_not_apex(sdk_sandbox, sdk_e2e_config):
+    """``*.example.com`` matches subdomain; apex does not (probe apex first).
+
+    Apex is probed before the subdomain so a shared A-record cannot be learned
+    via the subdomain and then make a later apex TCP probe succeed by IP.
+    """
+    # Apex resolve + TCP to the learned-or-resolved IP must fail: ``*.`` does
+    # not match the apex QNAME, so no allow entry is installed for that IP.
+    apex = sdk_sandbox.run_command(
+        _resolve_and_probe_command(
+            ALLOWED_DOMAIN,
+            DOMAIN_TCP_PORT,
+            sdk_e2e_config.network_probe_timeout,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    _assert_domain_blocked_after_resolve(apex, ALLOWED_DOMAIN)
+
+    subdomain = sdk_sandbox.run_command(
+        _resolve_and_probe_command(
+            WILDCARD_SUBDOMAIN,
+            DOMAIN_TCP_PORT,
+            sdk_e2e_config.network_probe_timeout,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    _assert_domain_reachable(subdomain, WILDCARD_SUBDOMAIN)
+
+    other = sdk_sandbox.run_command(
+        _resolve_and_probe_command(
+            BLOCKED_DOMAIN,
+            DOMAIN_TCP_PORT,
+            sdk_e2e_config.network_probe_timeout,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    _assert_domain_blocked_after_resolve(other, BLOCKED_DOMAIN)

--- a/tests/e2e/sdk_compat/cases/network/test_l7_egress.py
+++ b/tests/e2e/sdk_compat/cases/network/test_l7_egress.py
@@ -1,0 +1,410 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CubeEgress L7 rules: inject, first-match, deny, TLS MITM CA, SNI/host."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import NETWORK_L7_EGRESS
+
+HTTPBUN_HOST = os.environ.get("SDK_E2E_L7_ECHO_HOST", "httpbun.com")
+OTHER_HOST = os.environ.get("SDK_E2E_L7_OTHER_HOST", "example.com")
+INJECT_HEADER = os.environ.get("SDK_E2E_L7_INJECT_HEADER", "X-Cube-E2E-Inject")
+INJECT_SECRET = os.environ.get("SDK_E2E_L7_INJECT_SECRET", "e2e-inject-secret-not-a-real-key")
+# CubeEgress MITM CA CN varies by install path (one-click prepare vs chart bake).
+# Match a stable substring; override with SDK_E2E_L7_MITM_CA_CN when needed.
+MITM_CA_CN = os.environ.get("SDK_E2E_L7_MITM_CA_CN", "Cube Sandbox Egress CA")
+# Cold MITM path (DNS learn + TLS + upstream) needs more headroom than the
+# shared TCP network_probe_timeout default (5s).
+L7_HTTP_TIMEOUT = int(os.environ.get("SDK_E2E_L7_HTTP_TIMEOUT", "15"))
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.network,
+    pytest.mark.p1,
+    pytest.mark.requires_internet,
+    pytest.mark.requires_capability(NETWORK_L7_EGRESS),
+]
+
+
+def _https_rule(
+    name: str,
+    *,
+    host: str,
+    allow: bool,
+    path: str | None = None,
+    method: list[str] | None = None,
+    inject: list[dict] | None = None,
+) -> dict:
+    match: dict = {"scheme": "https", "sni": host, "host": host}
+    if path is not None:
+        match["path"] = path
+    if method is not None:
+        match["method"] = method
+    action: dict = {"allow": allow}
+    if inject is not None:
+        action["inject"] = inject
+    return {"name": name, "match": match, "action": action}
+
+
+def _http_json_command(url: str, *, method: str = "GET", timeout: int = 15) -> str:
+    """Fetch URL without TLS verify; print STATUS + body (or error)."""
+    return (
+        "python3 - <<'PY'\n"
+        "import json, ssl, urllib.error, urllib.request\n"
+        f"url = {url!r}\n"
+        f"method = {method!r}\n"
+        f"timeout = {timeout!r}\n"
+        "ctx = ssl._create_unverified_context()\n"
+        "req = urllib.request.Request(url, method=method)\n"
+        "try:\n"
+        "    with urllib.request.urlopen(req, context=ctx, timeout=timeout) as resp:\n"
+        "        body = resp.read().decode('utf-8', errors='replace')\n"
+        "        print(f'STATUS:{resp.status}')\n"
+        "        print(body)\n"
+        "except urllib.error.HTTPError as exc:\n"
+        "    body = exc.read().decode('utf-8', errors='replace')\n"
+        "    print(f'STATUS:{exc.code}')\n"
+        "    print(body)\n"
+        "except Exception as exc:\n"
+        "    print(f'ERROR:{type(exc).__name__}:{exc}')\n"
+        "PY"
+    )
+
+
+def _parse_status_and_body(result) -> tuple[int | None, str]:
+    assert_command_ok(result)
+    text = result.stdout
+    assert not text.startswith("ERROR:"), (
+        f"HTTPS request failed inside sandbox; stdout={text!r} stderr={result.stderr!r}"
+    )
+    lines = text.splitlines()
+    assert lines and lines[0].startswith("STATUS:"), (
+        f"expected STATUS: line; stdout={text!r} stderr={result.stderr!r}"
+    )
+    status = int(lines[0].split(":", 1)[1])
+    return status, "\n".join(lines[1:])
+
+
+def _headers_from_httpbun(body: str, *, status: int | None = None) -> dict[str, str]:
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"httpbun response was not JSON; status={status} "
+            f"body={body[:200]!r}: {exc}"
+        ) from exc
+    raw = data.get("headers") or data
+    if not isinstance(raw, dict):
+        raise AssertionError(
+            f"unexpected httpbun body; status={status} body={body[:200]!r}"
+        )
+    return {str(k): str(v) for k, v in raw.items()}
+
+
+def _header_ci(headers: dict[str, str], name: str) -> str | None:
+    want = name.lower()
+    for key, value in headers.items():
+        if key.lower() == want:
+            return value
+    return None
+
+
+def _tls_issuer_command(host: str, timeout: int = 15) -> str:
+    return (
+        "python3 - <<'PY'\n"
+        "import shutil, socket, ssl, subprocess, tempfile\n"
+        f"host = {host!r}\n"
+        f"timeout = {timeout!r}\n"
+        "if shutil.which('openssl') is None:\n"
+        "    print('ISSUER:ERROR:openssl_not_found')\n"
+        "    raise SystemExit(0)\n"
+        "ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)\n"
+        "ctx.check_hostname = False\n"
+        "ctx.verify_mode = ssl.CERT_NONE\n"
+        "with socket.create_connection((host, 443), timeout=timeout) as sock:\n"
+        "    with ctx.wrap_socket(sock, server_hostname=host) as ssock:\n"
+        "        der = ssock.getpeercert(binary_form=True)\n"
+        "if not der:\n"
+        "    print('ISSUER:ERROR:empty_peer_cert')\n"
+        "    raise SystemExit(0)\n"
+        "try:\n"
+        "    with tempfile.NamedTemporaryFile() as tmp:\n"
+        "        tmp.write(der)\n"
+        "        tmp.flush()\n"
+        "        out = subprocess.check_output(\n"
+        "            ['openssl', 'x509', '-inform', 'DER', '-in', tmp.name, '-noout', '-issuer'],\n"
+        "            text=True,\n"
+        "        )\n"
+        "except Exception as exc:\n"
+        "    print(f'ISSUER:ERROR:openssl_failed:{type(exc).__name__}:{exc}')\n"
+        "    raise SystemExit(0)\n"
+        "print('ISSUER:' + out.strip())\n"
+        "PY"
+    )
+
+
+@pytest.mark.sandbox_create_options(
+    allow_internet_access=False,
+    network={
+        "rules": [
+            _https_rule(
+                "inject_httpbun_headers",
+                host=HTTPBUN_HOST,
+                allow=True,
+                path="/headers",
+                method=["GET"],
+                inject=[
+                    {
+                        "header": INJECT_HEADER,
+                        "secret": INJECT_SECRET,
+                    }
+                ],
+            ),
+        ],
+    },
+)
+def test_l7_credential_inject_visible_on_httpbun(sdk_sandbox, sdk_e2e_config):
+    """CubeEgress injects header; httpbun echoes it (secret never in VM env)."""
+    env_dump = sdk_sandbox.run_command(
+        "env",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(env_dump)
+    assert INJECT_SECRET not in env_dump.stdout, (
+        "inject secret must not appear in the sandbox environment"
+    )
+
+    result = sdk_sandbox.run_command(
+        _http_json_command(
+            f"https://{HTTPBUN_HOST}/headers",
+            timeout=L7_HTTP_TIMEOUT,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    status, body = _parse_status_and_body(result)
+    assert status == 200, f"expected 200 from httpbun; status={status} body={body[:200]!r}"
+    headers = _headers_from_httpbun(body, status=status)
+    assert _header_ci(headers, INJECT_HEADER) == INJECT_SECRET, (
+        f"injected header {INJECT_HEADER!r} missing or wrong; headers={headers!r}"
+    )
+
+
+@pytest.mark.sandbox_create_options(
+    allow_internet_access=False,
+    network={
+        "rules": [
+            # First match wins: allow /headers despite a later deny for the same path.
+            _https_rule(
+                "allow_headers_first",
+                host=HTTPBUN_HOST,
+                allow=True,
+                path="/headers",
+                method=["GET"],
+            ),
+            _https_rule(
+                "deny_headers_second",
+                host=HTTPBUN_HOST,
+                allow=False,
+                path="/headers",
+                method=["GET"],
+            ),
+            # First match wins: deny /get despite a later allow.
+            _https_rule(
+                "deny_get_first",
+                host=HTTPBUN_HOST,
+                allow=False,
+                path="/get",
+                method=["GET"],
+            ),
+            _https_rule(
+                "allow_get_second",
+                host=HTTPBUN_HOST,
+                allow=True,
+                path="/get",
+                method=["GET"],
+            ),
+        ],
+    },
+)
+def test_l7_first_match_wins(sdk_sandbox, sdk_e2e_config):
+    """CubeEgress walks rules in order; first match decides allow/deny."""
+    allowed = sdk_sandbox.run_command(
+        _http_json_command(
+            f"https://{HTTPBUN_HOST}/headers",
+            timeout=L7_HTTP_TIMEOUT,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    status, body = _parse_status_and_body(allowed)
+    assert status == 200, (
+        f"/headers should hit the first allow rule; status={status} body={body[:200]!r}"
+    )
+
+    denied = sdk_sandbox.run_command(
+        _http_json_command(
+            f"https://{HTTPBUN_HOST}/get",
+            timeout=L7_HTTP_TIMEOUT,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    status, body = _parse_status_and_body(denied)
+    assert status == 403, (
+        f"/get should hit the first deny rule; status={status} body={body[:200]!r}"
+    )
+
+
+@pytest.mark.sandbox_create_options(
+    allow_internet_access=False,
+    network={
+        "rules": [
+            _https_rule(
+                "allow_headers_only",
+                host=HTTPBUN_HOST,
+                allow=True,
+                path="/headers",
+                method=["GET"],
+            ),
+            _https_rule(
+                "deny_anything_explicit",
+                host=HTTPBUN_HOST,
+                allow=False,
+                path="/anything",
+                method=["GET"],
+            ),
+        ],
+    },
+)
+def test_l7_deny_and_unmatched_are_blocked(sdk_sandbox, sdk_e2e_config):
+    """Explicit deny and no-rule-match both return HTTP 403."""
+    ok = sdk_sandbox.run_command(
+        _http_json_command(
+            f"https://{HTTPBUN_HOST}/headers",
+            timeout=L7_HTTP_TIMEOUT,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    status, _ = _parse_status_and_body(ok)
+    assert status == 200
+
+    explicit_deny = sdk_sandbox.run_command(
+        _http_json_command(
+            f"https://{HTTPBUN_HOST}/anything",
+            timeout=L7_HTTP_TIMEOUT,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    status, body = _parse_status_and_body(explicit_deny)
+    assert status == 403, (
+        f"explicit deny should return 403; status={status} body={body[:200]!r}"
+    )
+
+    unmatched = sdk_sandbox.run_command(
+        _http_json_command(
+            f"https://{HTTPBUN_HOST}/get",
+            timeout=L7_HTTP_TIMEOUT,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    status, body = _parse_status_and_body(unmatched)
+    assert status == 403, (
+        f"unmatched path should return 403 under L7 default-deny; "
+        f"status={status} body={body[:200]!r}"
+    )
+
+
+@pytest.mark.sandbox_create_options(
+    allow_internet_access=False,
+    network={
+        "rules": [
+            # No path/method: this probe only does a TLS handshake with SNI
+            # (no HTTP request). CubeEgress MITMs at SNI/TLS before L7 HTTP
+            # match fields apply. Requires ``openssl`` in the guest image.
+            _https_rule(
+                "mitm_httpbun",
+                host=HTTPBUN_HOST,
+                allow=True,
+            ),
+        ],
+    },
+)
+def test_l7_tls_mitm_issuer_is_cube_egress_ca(sdk_sandbox, sdk_e2e_config):
+    """Peer cert issuer is CubeEgress CA after SNI-layer MITM (needs openssl)."""
+    result = sdk_sandbox.run_command(
+        _tls_issuer_command(HTTPBUN_HOST, timeout=L7_HTTP_TIMEOUT),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    line = result.stdout.strip()
+    assert line.startswith("ISSUER:"), (
+        f"expected ISSUER: line; stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    issuer = line[len("ISSUER:") :]
+    assert not issuer.startswith("ERROR:"), (
+        f"could not read peer certificate issuer inside sandbox "
+        f"(openssl missing or failed?): {issuer!r}; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    # Accept the configured CN, or any CubeEgress-style CA subject.
+    mitm_ok = MITM_CA_CN in issuer or bool(
+        re.search(r"Cube\s*Sandbox\s+Egress", issuer, re.I)
+    )
+    assert mitm_ok, (
+        f"peer certificate issuer should be CubeEgress MITM CA "
+        f"(want substring {MITM_CA_CN!r}); got {issuer!r}"
+    )
+
+
+@pytest.mark.sandbox_create_options(
+    allow_internet_access=False,
+    network={
+        "rules": [
+            _https_rule(
+                "allow_httpbun_sni_host",
+                host=HTTPBUN_HOST,
+                allow=True,
+                path="/headers",
+                method=["GET"],
+            ),
+            _https_rule(
+                "deny_other_host",
+                host=OTHER_HOST,
+                allow=False,
+                method=["GET"],
+            ),
+        ],
+    },
+)
+def test_l7_sni_host_match_allow_and_deny(sdk_sandbox, sdk_e2e_config):
+    """match.sni/host allow one destination and deny another."""
+    allowed = sdk_sandbox.run_command(
+        _http_json_command(
+            f"https://{HTTPBUN_HOST}/headers",
+            timeout=L7_HTTP_TIMEOUT,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    status, body = _parse_status_and_body(allowed)
+    assert status == 200, (
+        f"{HTTPBUN_HOST} should match allow rule; status={status} body={body[:200]!r}"
+    )
+
+    denied = sdk_sandbox.run_command(
+        _http_json_command(
+            f"https://{OTHER_HOST}/",
+            timeout=L7_HTTP_TIMEOUT,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    status, body = _parse_status_and_body(denied)
+    assert status == 403, (
+        f"{OTHER_HOST} should match deny rule; status={status} body={body[:200]!r}"
+    )

--- a/tests/e2e/sdk_compat/cases/network/test_policy.py
+++ b/tests/e2e/sdk_compat/cases/network/test_policy.py
@@ -3,10 +3,16 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from framework.assertions import assert_command_ok
-from framework.capabilities import NETWORK_ALLOW_DENY, NETWORK_PUBLIC_ACCESS
+from framework.capabilities import (
+    NETWORK_ALLOW_DENY,
+    NETWORK_ALWAYS_DENIED,
+    NETWORK_PUBLIC_ACCESS,
+)
 from framework.network_probe import (
     ALTERNATE_TCP_TARGET_IP,
     TCP_TARGET_IP,
@@ -171,3 +177,47 @@ def test_restricted_public_access_requires_traffic_token(
             headers={header_name: token},
         )
         assert_public_response(response)
+
+
+# Representative addresses from CubeVS built-in deny CIDRs when public egress
+# is enabled (link-local + RFC1918; see docs/guide/network-policy.md).
+ALWAYS_DENIED_TARGETS = (
+    os.environ.get("SDK_E2E_ALWAYS_DENIED_LINK_LOCAL_IP", "169.254.1.1"),
+    os.environ.get("SDK_E2E_ALWAYS_DENIED_PRIVATE_IP", "10.255.255.1"),
+)
+ALWAYS_DENIED_PORT = int(os.environ.get("SDK_E2E_ALWAYS_DENIED_PORT", "80"))
+
+
+@pytest.mark.requires_capability(NETWORK_ALWAYS_DENIED)
+@pytest.mark.sandbox_create_options(allow_internet_access=True)
+def test_always_denied_blocks_link_local_and_private_by_default(
+    sdk_sandbox,
+    sdk_e2e_config,
+):
+    """Smoke: with public egress on, representative private/link-local targets fail.
+
+    This is not a strong proof that CubeVS always-deny is installed: generic
+    addresses like 169.254.1.1 / 10.255.255.1 are usually unreachable even
+    without policy. A discriminating check needs a lab-routable private IP
+    that would succeed if always-deny were absent (not wired here).
+    """
+    public_ok = sdk_sandbox.run_command(
+        tcp_probe_command(
+            TCP_TARGET_IP,
+            TCP_TARGET_PORT,
+            timeout=sdk_e2e_config.network_probe_timeout,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_tcp_reachable(public_ok, TCP_TARGET_IP)
+
+    for target in ALWAYS_DENIED_TARGETS:
+        blocked = sdk_sandbox.run_command(
+            tcp_probe_command(
+                target,
+                ALWAYS_DENIED_PORT,
+                timeout=sdk_e2e_config.network_probe_timeout,
+            ),
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_tcp_blocked(blocked, target, ALWAYS_DENIED_PORT)

--- a/tests/e2e/sdk_compat/cases/network/test_template_network_merge.py
+++ b/tests/e2e/sdk_compat/cases/network/test_template_network_merge.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Template CubeNetworkConfig merged with per-create network options."""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from adapters import create_adapter
+from framework.capabilities import NETWORK_TEMPLATE_MERGE, capabilities_for_backend
+from framework.cleanup import safe_kill
+from framework.config import SdkE2EConfig
+from framework.network_probe import (
+    assert_tcp_blocked,
+    assert_tcp_reachable,
+    tcp_probe_command,
+)
+
+
+def _env_true(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+TEMPLATE_ALLOW_IP = os.environ.get("SDK_E2E_TEMPLATE_MERGE_ALLOW_IP", "8.8.8.8")
+CREATE_ALLOW_IP = os.environ.get("SDK_E2E_TEMPLATE_MERGE_CREATE_ALLOW_IP", "1.1.1.1")
+BLOCKED_IP = os.environ.get("SDK_E2E_TEMPLATE_MERGE_BLOCKED_IP", "9.9.9.9")
+TCP_PORT = int(os.environ.get("SDK_E2E_TEMPLATE_MERGE_TCP_PORT", "53"))
+
+DEFAULT_TEMPLATE_IMAGE = (
+    "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest"
+)
+DEFAULT_WRITABLE_LAYER_SIZE = "1G"
+TEMPLATE_READY_TIMEOUT = 300
+# Optional guest nameserver(s). Some lab networks cannot reach the image default
+# resolver (e.g. 119.29.29.29); pin a reachable one via SDK_E2E_GUEST_DNS.
+def _guest_dns() -> list[str] | None:
+    raw = os.environ.get("SDK_E2E_GUEST_DNS", "").strip()
+    if not raw:
+        return None
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.network,
+    pytest.mark.p1,
+    # Documented intent; real gates are the autouse fixture + module fixture
+    # below because this module uses create_adapter, not sdk_sandbox.
+    pytest.mark.requires_internet,
+    pytest.mark.requires_capability(NETWORK_TEMPLATE_MERGE),
+]
+
+
+# Mirrors cases/volume/conftest.py: markers alone only gate sdk_sandbox.
+@pytest.fixture(autouse=True)
+def _gate_template_merge_case(sdk_backend: str) -> None:
+    if NETWORK_TEMPLATE_MERGE not in capabilities_for_backend(sdk_backend):
+        pytest.skip(
+            f"backend {sdk_backend!r} does not support capability "
+            f"{NETWORK_TEMPLATE_MERGE!r}"
+        )
+    if _env_true("SDK_E2E_SKIP_INTERNET_TESTS"):
+        pytest.skip(
+            "internet-dependent SDK E2E tests disabled by SDK_E2E_SKIP_INTERNET_TESTS"
+        )
+
+
+def _template_image() -> str:
+    return (
+        os.environ.get("SDK_E2E_TEMPLATE_MERGE_IMAGE")
+        or os.environ.get("CUBE_TEMPLATE_E2E_IMAGE")
+        or DEFAULT_TEMPLATE_IMAGE
+    )
+
+
+def _wait_for_template_ready(template_id: str, config, timeout: int = TEMPLATE_READY_TIMEOUT):
+    from cubesandbox import Template
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            info = Template.get(template_id, config=config)
+            if info.status in ("READY", "FAILED"):
+                return info
+        except Exception:
+            pass
+        time.sleep(2)
+    # Raise Exception (not pytest.fail / BaseException) so the module fixture
+    # can stash the error and let non-cubesandbox params skip cleanly.
+    raise TimeoutError(
+        f"template {template_id} did not reach READY within {timeout}s"
+    )
+
+
+def _delete_template(template_id: str, config) -> None:
+    from cubesandbox import Template
+    from cubesandbox._exceptions import ApiError, TemplateNotFoundError
+
+    deadline = time.time() + 180
+    while time.time() < deadline:
+        try:
+            Template.delete(template_id, config=config)
+            return
+        except TemplateNotFoundError:
+            return
+        except ApiError as exc:
+            if "attempt is already in progress" in str(exc):
+                time.sleep(5)
+                continue
+            raise
+
+
+# Stashed when module fixture build fails so e2b params can still skip instead
+# of erroring during fixture setup (module fixtures run before autouse gates).
+_TEMPLATE_BUILD_ERROR: Exception | None = None
+
+
+@pytest.fixture(scope="module")
+def network_merge_template_id(pytestconfig: pytest.Config):
+    """Build a template with deny-all + a single allow_out CIDR to merge at create."""
+    global _TEMPLATE_BUILD_ERROR
+    from cubesandbox import Config, Template
+
+    # Module-scoped setup runs before the function autouse gate; skip here so
+    # we do not build a template when internet cases are disabled.
+    if _env_true("SDK_E2E_SKIP_INTERNET_TESTS"):
+        pytest.skip(
+            "internet-dependent SDK E2E tests disabled by SDK_E2E_SKIP_INTERNET_TESTS"
+        )
+
+    base = SdkE2EConfig.from_env(
+        backends=pytestconfig.getoption("--sdk-e2e-backends"),
+        cube_api_url=pytestconfig.getoption("--cube-api-url"),
+        cube_template_id=pytestconfig.getoption("--cube-template-id"),
+    )
+    if "cubesandbox" not in base.backends:
+        yield None
+        return
+    if NETWORK_TEMPLATE_MERGE not in capabilities_for_backend("cubesandbox"):
+        yield None
+        return
+
+    sdk_config = Config(api_url=base.cube_api_url)
+    created_id: str | None = None
+    try:
+        try:
+            build_kwargs: dict = {
+                "image": _template_image(),
+                "writable_layer_size": os.environ.get(
+                    "CUBE_TEMPLATE_E2E_WRITABLE_LAYER_SIZE",
+                    DEFAULT_WRITABLE_LAYER_SIZE,
+                ),
+                "exposed_ports": [49999, 49983],
+                "probe_port": 49999,
+                "allow_internet_access": False,
+                "allow_out": [TEMPLATE_ALLOW_IP],
+                "deny_out": ["0.0.0.0/0"],
+                "config": sdk_config,
+            }
+            guest_dns = _guest_dns()
+            if guest_dns is not None:
+                build_kwargs["dns"] = guest_dns
+            job = Template.build(**build_kwargs)
+            assert job.template_id.startswith("tpl-"), job.template_id
+            created_id = job.template_id
+            info = _wait_for_template_ready(created_id, sdk_config)
+            assert info.status == "READY", (
+                f"template {created_id} finished with status={info.status!r}"
+            )
+            yield created_id
+        except Exception as exc:  # noqa: BLE001 - defer to cubesandbox test body
+            _TEMPLATE_BUILD_ERROR = exc
+            if created_id is not None:
+                try:
+                    _delete_template(created_id, sdk_config)
+                except Exception:
+                    pass
+                created_id = None
+            yield None
+    finally:
+        if created_id is not None:
+            try:
+                _delete_template(created_id, sdk_config)
+            except Exception:
+                pass
+
+
+def test_template_and_create_allow_out_merge(
+    sdk_backend,
+    sdk_e2e_config,
+    network_merge_template_id,
+):
+    """Create-time allow_out is appended to template allow_out under deny-all."""
+    if sdk_backend != "cubesandbox":
+        pytest.skip("template network merge is CubeSandbox-specific")
+    if not network_merge_template_id:
+        if _TEMPLATE_BUILD_ERROR is not None:
+            pytest.fail(
+                f"failed to provision merge template: {_TEMPLATE_BUILD_ERROR!r}"
+            )
+        pytest.skip("failed to provision a template with network policy")
+
+    adapter = None
+    try:
+        adapter = create_adapter(
+            sdk_backend,
+            sdk_e2e_config,
+            metadata={
+                "test_suite": "sdk_compat",
+                "test_backend": sdk_backend,
+                "test_case": "template_network_merge",
+            },
+            create_options={
+                "template": network_merge_template_id,
+                "network": {"allow_out": [CREATE_ALLOW_IP]},
+            },
+        )
+
+        from_template = adapter.run_command(
+            tcp_probe_command(
+                TEMPLATE_ALLOW_IP,
+                TCP_PORT,
+                timeout=sdk_e2e_config.network_probe_timeout,
+            ),
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_tcp_reachable(from_template, TEMPLATE_ALLOW_IP, TCP_PORT)
+
+        from_create = adapter.run_command(
+            tcp_probe_command(
+                CREATE_ALLOW_IP,
+                TCP_PORT,
+                timeout=sdk_e2e_config.network_probe_timeout,
+            ),
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_tcp_reachable(from_create, CREATE_ALLOW_IP, TCP_PORT)
+
+        blocked = adapter.run_command(
+            tcp_probe_command(
+                BLOCKED_IP,
+                TCP_PORT,
+                timeout=sdk_e2e_config.network_probe_timeout,
+            ),
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_tcp_blocked(blocked, BLOCKED_IP, TCP_PORT)
+    finally:
+        if adapter is not None:
+            safe_kill(adapter, sdk_e2e_config)

--- a/tests/e2e/sdk_compat/docs/case-authoring.md
+++ b/tests/e2e/sdk_compat/docs/case-authoring.md
@@ -105,6 +105,28 @@ For a strict domain allowlist, combine `allow_out` with
 `allow_internet_access=False` or `deny_out=["0.0.0.0/0"]`. A successful TCP
 connection alone does not prove an HTTP or L7 policy.
 
+Capabilities (Cube-only unless noted):
+
+| Capability | Coverage |
+| --- | --- |
+| `network_allow_deny` / `network_public_access` | IP allow/deny, `allow_internet_access`, restrict public traffic (also on E2B where applicable) |
+| `network_dns_allow` | Domain `allow_out` + DNS learning, `*.` wildcards |
+| `network_always_denied` | Built-in deny of link-local / private CIDRs |
+| `network_l7_egress` | CubeEgress inject / first-match / deny / TLS MITM / SNI·host |
+| `network_mask_request_host` | `mask_request_host` rewrite |
+| `network_template_merge` | Template `allow_out`/`deny_out` merged with create-time network |
+
+L7 echo / header observation uses the public service **httpbun.com**
+(`SDK_E2E_L7_ECHO_HOST` to override). Mark those cases `requires_internet`.
+Pass L7 `rules` as wire-shaped dicts in `sandbox_create_options` (no SDK
+import in shared cases). Inject secrets must be test-only placeholders —
+never commit real credentials.
+
+Domain / L7 cases need a working guest nameserver. If the template image
+default resolver is unreachable in your lab, rebuild the template with
+`dns=[...]` or set `SDK_E2E_GUEST_DNS` for module-provisioned templates
+(for example `test_template_network_merge.py`).
+
 ## Lifecycle and cleanup
 
 Platform lifecycle cases normally use `slow` and `requires_cubeproxy`:

--- a/tests/e2e/sdk_compat/docs/zh/case-authoring.md
+++ b/tests/e2e/sdk_compat/docs/zh/case-authoring.md
@@ -305,6 +305,25 @@ finally:
 `allow_internet_access=False` 或 `deny_out=["0.0.0.0/0"]`。公网 target 必须
 来自 `SDK_E2E_TCP_TARGET_*` 等配置，不得在用例中硬编码为唯一环境假设。
 
+能力位（除注明外为 Cube 专用）：
+
+| Capability | 覆盖 |
+| --- | --- |
+| `network_allow_deny` / `network_public_access` | IP allow/deny、`allow_internet_access`、restrict public traffic |
+| `network_dns_allow` | 域名 `allow_out` + DNS 学习、`*.` 通配 |
+| `network_always_denied` | 默认拒绝 link-local / 私网 CIDR |
+| `network_l7_egress` | CubeEgress inject / first-match / deny / TLS MITM / SNI·host |
+| `network_mask_request_host` | `mask_request_host` 改写 |
+| `network_template_merge` | 模板网络配置与 create-time network 合并 |
+
+L7 echo 使用公共服务 **httpbun.com**（可用 `SDK_E2E_L7_ECHO_HOST` 覆盖），
+用例需标 `requires_internet`。`rules` 用 wire 形态 dict 放进
+`sandbox_create_options`；inject secret 只用测试占位值。
+
+域名 / L7 用例依赖 guest 内可用的 DNS。若镜像默认 nameserver 在实验环境
+不可达，请用 `dns=[...]` 重建模板，或对模块内建模板设置
+`SDK_E2E_GUEST_DNS`（如 `test_template_network_merge.py`）。
+
 ### 6.6 Concurrency 与多实例
 
 需要第二个实例时，使用 `managed_control_sandbox`，使 peer 的清理语义与主

--- a/tests/e2e/sdk_compat/framework/capabilities.py
+++ b/tests/e2e/sdk_compat/framework/capabilities.py
@@ -12,6 +12,14 @@ PAUSE_RESUME = "pause_resume"
 NETWORK_ALLOW_DENY = "network_allow_deny"
 NETWORK_PUBLIC_ACCESS = "network_public_access"
 NETWORK_MASK_REQUEST_HOST = "network_mask_request_host"
+# CubeVS domain allow_out + DNS A learning (exact / leading "*.").
+NETWORK_DNS_ALLOW = "network_dns_allow"
+# Built-in deny of sandbox-private / link-local CIDRs when public egress is on.
+NETWORK_ALWAYS_DENIED = "network_always_denied"
+# CubeEgress L7 rules: inject, first-match, deny, TLS MITM, SNI/host.
+NETWORK_L7_EGRESS = "network_l7_egress"
+# Template CubeNetworkConfig merged with per-create network options.
+NETWORK_TEMPLATE_MERGE = "network_template_merge"
 PLATFORM_LIFECYCLE = "platform_lifecycle"
 HOST_MOUNT = "host_mount"
 VOLUME_PLUGIN = "volume_plugin"
@@ -38,6 +46,10 @@ CUBESANDBOX_CAPABILITIES = frozenset(
         NETWORK_ALLOW_DENY,
         NETWORK_PUBLIC_ACCESS,
         NETWORK_MASK_REQUEST_HOST,
+        NETWORK_DNS_ALLOW,
+        NETWORK_ALWAYS_DENIED,
+        NETWORK_L7_EGRESS,
+        NETWORK_TEMPLATE_MERGE,
         PLATFORM_LIFECYCLE,
         HOST_MOUNT,
         VOLUME_PLUGIN,

--- a/tests/e2e/sdk_compat/framework/network_probe.py
+++ b/tests/e2e/sdk_compat/framework/network_probe.py
@@ -56,20 +56,33 @@ def tcp_probe_command(
     )
 
 
-def assert_tcp_reachable(result, target: str) -> None:
+def assert_tcp_reachable(result, target: str, port: int | None = None) -> None:
+    if port is None:
+        port = TCP_TARGET_PORT
     assert_command_ok(result)
     assert result.stdout.strip() == "OK", (
-        f"TCP target {target}:{TCP_TARGET_PORT} should be reachable; "
+        f"TCP target {target}:{port} should be reachable; "
         f"stdout={result.stdout!r} stderr={result.stderr!r}"
     )
 
 
-def assert_tcp_blocked(result, target: str) -> None:
+def assert_tcp_blocked(result, target: str, port: int | None = None) -> None:
+    """Accept REJECT (FAIL:<errno>) or DROP (timeout / TimeoutError) as blocked."""
+    if port is None:
+        port = TCP_TARGET_PORT
     assert_command_ok(result)
     output = result.stdout.strip()
-    assert output.startswith("FAIL:"), (
-        f"TCP target {target}:{TCP_TARGET_PORT} should be blocked; "
+    blocked = output.startswith("FAIL:") or _is_timeout_block(output)
+    assert blocked, (
+        f"TCP target {target}:{port} should be blocked; "
         f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def _is_timeout_block(output: str) -> bool:
+    # Silent drop often surfaces as socket.timeout from settimeout, not errno.
+    return output.startswith("ERROR:") and (
+        "Timeout" in output or "timed out" in output.lower()
     )
 
 


### PR DESCRIPTION
Expand sdk_compat network cases beyond IP allow/deny and inbound restrict:

- Domain allow_out with DNS A learning, plus leading "*.\" wildcard matching
- Built-in always-denied link-local / private CIDRs under default public egress
- CubeEgress L7: credential inject (httpbun), first-match-wins, deny/unmatched 403, TLS MITM issuer check, and sni/host allow vs deny
- Template CubeNetworkConfig allow_out merged with create-time network

Wire Cube-only capabilities, shared TCP probe helpers, and case-authoring notes for httpbun and optional SDK_E2E_GUEST_DNS on module-built templates.