### PR TITLE
 fix(cubemaster): prevent unbounded context chain growth in metric loop

### DIFF
--- a/CubeMaster/pkg/localcache/redis_cache.go
+++ b/CubeMaster/pkg/localcache/redis_cache.go
@@ -278,10 +278,13 @@ func (l *local) loopUpdateMetric(ctx context.Context) {
 				defer func() {
 					checkDeadline = time.Now().Add(config.GetConfig().Common.SyncMetricDataInterval)
 				}()
-				ctx = context.WithValue(ctx, CubeLog.KeyRequestID, uuid.New().String())
+				// Keep the loop's base context immutable. Reassigning ctx here would
+				// create an unbounded valueCtx chain (one layer per metric tick),
+				// making every later ctx.Value/Done lookup increasingly expensive.
+				metricCtx := context.WithValue(ctx, CubeLog.KeyRequestID, uuid.New().String())
 				elems := l.cache.Items()
 				for k := range elems {
-					if tmpNode, found, err := l.getNodeMetricWithFallback(ctx, k); found && err == nil {
+					if tmpNode, found, err := l.getNodeMetricWithFallback(metricCtx, k); found && err == nil {
 						if err := l.updateNodeMetric(tmpNode); err != nil {
 
 							CubeLog.WithContext(context.Background()).Fatalf("updateMetric fail:%v", err)


### PR DESCRIPTION
 ## Problem

  After running CubeMaster continuously for approximately nine days, the
  `cube-sandbox-cubemaster.service` process began consuming more than 100% CPU
  (about 103–105% in `pidstat` on a 20-vCPU host).

  The metric-related intervals were configured to run approximately once per
  second. Backend load was low: Redis traffic, MySQL queries, and network traffic
  did not indicate a request or data-volume spike.

  ## Investigation

  We first confirmed the CPU usage and process uptime with `pidstat` and service
  status checks. We then used `perf` to profile the running process.

  Approximately 69% of the sampled CPU time was spent in Go context-related
  functions. After symbolizing the samples, the hot paths included:

  - `context.valueCtx.Done`
  - `context.(*valueCtx).Done`
  - `context.value`

  The metric update loop contained the following code:

  ```go
  ctx = context.WithValue(ctx, CubeLog.KeyRequestID, uuid.New().String())
  ```

  This line was executed on every metric update iteration.

  ## Root Cause

  context.WithValue returns a new derived context whose parent is the previous
  context. Reassigning the long-lived loop context on every iteration therefore
  created an ever-growing valueCtx chain.

  With a one-second interval, the process had accumulated hundreds of thousands
  of context layers after several days of uptime. Subsequent Value and Done
  operations had to traverse this increasingly long chain, which caused the
  progressive CPU increase.

  This was not caused by increased request volume or backend load. It was a
  source-level bug in the handling of a long-lived context.

  ## Solution

  The base loop context is now kept immutable. A short-lived context is created
  for each metric update iteration:

  metricCtx := context.WithValue(ctx, CubeLog.KeyRequestID, uuid.New().String())

  The metric lookup operations use metricCtx, while the original ctx remains
  the base context for cancellation and loop termination.

  This prevents the context chain from growing across iterations while preserving
  the existing cancellation behavior.

  ## Validation

  - go test ./pkg/localcache passes.
  - After deploying the rebuilt binary and restarting CubeMaster, CPU usage
    dropped from over 100% to approximately 4–5%.

  - After several additional hours of continuous operation, CPU usage remained
    stable at approximately 4.8%.

  - The service health check continued to return successfully.