### PR TITLE
cubeproxy: fix nil global unpack in redis_iresty on Lua 5.2+

### DIFF
--- a/CubeProxy/lua/redis_iresty.lua
+++ b/CubeProxy/lua/redis_iresty.lua
@@ -1,6 +1,8 @@
 -- file name: redis_iresty.lua
 local redis_c = require "resty.redis"
 
+local unpack = unpack or table.unpack
+
 local ok, new_tab = pcall(require, "table.new")
 if not ok or type(new_tab) ~= "function" then
     new_tab = function(narr, nrec)


### PR DESCRIPTION
The sentinel unit test runs under standard Lua and aborts:

  attempt to call a nil value (global 'unpack')

unpack is global in LuaJIT/Lua 5.1 but moved to table.unpack in Lua 5.2+, so it is nil off OpenResty. Bridge both so tests pass on any interpreter; LuaJIT behavior is unchanged.

Test: bash tests/unittest/run.sh cube-proxy
Assisted-by: Claude Code:claude-opus-4.8