### PR TITLE
fix(cubeops): default AgentHub creates to a registered template

### DIFF
--- a/CubeOps/internal/cubemaster/client.go
+++ b/CubeOps/internal/cubemaster/client.go
@@ -43,9 +43,32 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("cubemaster returned %d: %s", e.Status, e.Body)
 }
 
-// IsNotFound reports an HTTP-level not-found.
+// IsNotFound reports a not-found that arrived over the HTTP channel, by status
+// or by ret_code in the error body — CubeMaster picks the two independently.
+// meta's writeErr, for one, derives ret_code 130404 from gorm.ErrRecordNotFound
+// while the status comes from the call site, so the pairing is a convention, not
+// an invariant. Keying on the status alone would let a caller's not-found
+// handling turn on which channel happened to carry it.
 func (e *HTTPError) IsNotFound() bool {
-	return e.Status == http.StatusNotFound
+	if e.Status == http.StatusNotFound {
+		return true
+	}
+	cmErr := CMError{RetCode: retCodeFromBody([]byte(e.Body))}
+	return cmErr.IsNotFound()
+}
+
+// retCodeFromBody extracts CubeMaster's business ret_code from a response body,
+// returning 0 when the body is not one of its envelopes.
+func retCodeFromBody(data []byte) int {
+	var envelope struct {
+		Ret struct {
+			RetCode int `json:"ret_code"`
+		} `json:"ret"`
+	}
+	if json.Unmarshal(data, &envelope) != nil {
+		return 0
+	}
+	return envelope.Ret.RetCode
 }
 
 // IsNotFound returns true for CubeMaster "not found" ret codes.

--- a/CubeOps/internal/cubemaster/client.go
+++ b/CubeOps/internal/cubemaster/client.go
@@ -43,16 +43,20 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("cubemaster returned %d: %s", e.Status, e.Body)
 }
 
-// IsNotFound reports a not-found that arrived over the HTTP channel, by status
-// or by ret_code in the error body — CubeMaster picks the two independently.
-// meta's writeErr, for one, derives ret_code 130404 from gorm.ErrRecordNotFound
-// while the status comes from the call site, so the pairing is a convention, not
-// an invariant. Keying on the status alone would let a caller's not-found
-// handling turn on which channel happened to carry it.
+// IsNotFound reports a not-found that CubeMaster stated in its response
+// envelope, whatever status carried it — the status and the ret_code are chosen
+// independently on that side (meta's writeErr derives 130404 from
+// gorm.ErrRecordNotFound while the status comes from the call site), so keying
+// on one channel alone would make the answer depend on which one was used.
+//
+// A bare 404 with a body that is not one of CubeMaster's envelopes deliberately
+// does NOT count. CubeMaster states resource-not-found in the envelope; it does
+// not answer a missing resource with a bare HTTP 404. So an opaque 404 is
+// evidence about the *route* — a wrong base URL, a proxy in the path, gin's own
+// "404 page not found" — and treating it as a missing resource sends the caller
+// after the wrong fix while the real problem is that we never reached
+// CubeMaster at all.
 func (e *HTTPError) IsNotFound() bool {
-	if e.Status == http.StatusNotFound {
-		return true
-	}
 	cmErr := CMError{RetCode: retCodeFromBody([]byte(e.Body))}
 	return cmErr.IsNotFound()
 }

--- a/CubeOps/internal/cubemaster/client.go
+++ b/CubeOps/internal/cubemaster/client.go
@@ -57,6 +57,13 @@ func (e *HTTPError) Error() string {
 // after the wrong fix while the real problem is that we never reached
 // CubeMaster at all.
 func (e *HTTPError) IsNotFound() bool {
+	// A 5xx is the server saying it failed, not that the thing is missing. Even
+	// when such a body carries a not-found envelope, the caller cannot fix it by
+	// supplying something different, so classifying it as not-found turns a
+	// transient server failure into client-correctable advice.
+	if e.Status >= http.StatusInternalServerError {
+		return false
+	}
 	cmErr := CMError{RetCode: retCodeFromBody([]byte(e.Body))}
 	return cmErr.IsNotFound()
 }

--- a/CubeOps/internal/cubemaster/client.go
+++ b/CubeOps/internal/cubemaster/client.go
@@ -28,6 +28,26 @@ func (e *CMError) Error() string {
 	return fmt.Sprintf("cubemaster error %d: %s", e.RetCode, e.RetMsg)
 }
 
+// HTTPError carries a CubeMaster failure that arrived as an HTTP status rather
+// than as a ret_code in a 200 body. Both shapes occur, and a caller that knows
+// only about CMError mis-handles this one silently: errors.As(&CMError) fails,
+// so the response arrives as an opaque error and collapses into a generic 502
+// regardless of what it said. Keeping it typed lets a caller ask the same
+// question of either shape.
+type HTTPError struct {
+	Status int
+	Body   string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("cubemaster returned %d: %s", e.Status, e.Body)
+}
+
+// IsNotFound reports an HTTP-level not-found.
+func (e *HTTPError) IsNotFound() bool {
+	return e.Status == http.StatusNotFound
+}
+
 // IsNotFound returns true for CubeMaster "not found" ret codes.
 func (e *CMError) IsNotFound() bool {
 	return e.RetCode == 130404 || e.RetCode == 404
@@ -420,7 +440,9 @@ func readResponse(resp *http.Response) (json.RawMessage, error) {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("cubemaster returned %d: %s", resp.StatusCode, string(data))
+		// Typed; the message is byte-identical to the previous fmt.Errorf so
+		// logs and any operator greps keep working.
+		return nil, &HTTPError{Status: resp.StatusCode, Body: string(data)}
 	}
 	// Check CubeMaster business error code. CubeMaster uses ret_code=200 for
 	// success (and sometimes 0). Any other value is a failure, even when HTTP

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -633,7 +633,7 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 			logging.G(ctx).Warnf("agenthub: create failed with an empty template registry, "+
 				"reporting it as a missing registration; cubemaster said: %v", err)
 			return nil, NewBadRequest("no agent template is registered: register one from the template market " +
-				"(POST /agenthub/templates/market), or pass templateId explicitly")
+				"(POST /api/v1/agenthub/templates/market), or pass templateId explicitly")
 		}
 		return nil, NewBadGateway("failed to create sandbox: " + err.Error())
 	}

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -143,6 +143,7 @@ type AgentStore interface {
 	GetAgentSnapshot(ctx context.Context, agentID, snapshotID string) (*store.AgentSnapshot, error)
 	DeleteAgentSnapshot(ctx context.Context, agentID, snapshotID string) error
 	GetAgentTemplate(ctx context.Context, templateID string) (*store.AgentTemplate, error)
+	GetRecommendedAgentTemplate(ctx context.Context) (*store.AgentTemplate, error)
 	ListAgentTemplates(ctx context.Context, limit, offset int) ([]store.AgentTemplate, error)
 	RecordOperation(ctx context.Context, agentID, sandboxID, operationType, status, errMsg string) error
 	LatestHealthySnapshot(ctx context.Context, agentID string) (string, error)
@@ -413,52 +414,38 @@ type CreateInstanceResult struct {
 }
 
 // defaultTemplateID picks the template CreateInstance uses when the caller
-// omits templateId: the recommended registered template if there is one,
-// otherwise the most recently registered one (ListAgentTemplates orders by
-// created_at DESC). The recommended flag is what the Dashboard sets on every
-// template it registers from the market.
+// omits templateId: the template an operator marked recommended if there is
+// one, otherwise the most recently registered one.
 //
-// The preference is exact rather than window-limited: pages are walked until
-// one comes back short, so a recommended template still wins when newer
-// non-recommended ones were registered after it. Any realistic registry fits
-// in the first page, so this is one query in practice.
+// Both are single bounded queries — the recommended preference is exact
+// without reading the registry, which matters because nothing sets the flag
+// automatically (see store.GetRecommendedAgentTemplate), so an install can
+// accumulate any number of newer non-recommended templates after the marked
+// one.
 //
 // none is true only when the registry was read successfully and holds nothing.
 // A failed read returns none=false — the caller must not report "nothing is
-// registered" on the strength of a listing that never happened. Either way the
+// registered" on the strength of a query that never completed. Either way the
 // returned id is then defaultAgentTemplateID, which the caller still passes to
 // CubeMaster so installs carrying that alias keep working.
 func (s *AgentHubService) defaultTemplateID(ctx context.Context) (id string, none bool) {
-	mostRecent := ""
-	for offset := 0; ; offset += store.MaxListLimit {
-		page, err := s.Store.ListAgentTemplates(ctx, store.MaxListLimit, offset)
-		if err != nil {
-			logging.G(ctx).Warnf("failed to list agent templates while choosing a default: %v", err)
-			break
-		}
-		for _, tmpl := range page {
-			if tmpl.Recommended {
-				return tmpl.TemplateID, false
-			}
-		}
-		if mostRecent == "" && len(page) > 0 {
-			mostRecent = page[0].TemplateID
-		}
-		if len(page) < store.MaxListLimit {
-			// Short page: the registry is exhausted and held no recommended
-			// template, so mostRecent (if any) is the answer.
-			if mostRecent != "" {
-				return mostRecent, false
-			}
-			return defaultAgentTemplateID, true
-		}
+	recommended, err := s.Store.GetRecommendedAgentTemplate(ctx)
+	if err != nil {
+		logging.G(ctx).Warnf("failed to read the recommended agent template: %v", err)
+		return defaultAgentTemplateID, false
 	}
-	// Listing failed part-way. Use anything already seen, and do not claim the
-	// registry is empty.
-	if mostRecent != "" {
-		return mostRecent, false
+	if recommended != nil {
+		return recommended.TemplateID, false
 	}
-	return defaultAgentTemplateID, false
+	newest, err := s.Store.ListAgentTemplates(ctx, 1, 0)
+	if err != nil {
+		logging.G(ctx).Warnf("failed to list agent templates while choosing a default: %v", err)
+		return defaultAgentTemplateID, false
+	}
+	if len(newest) > 0 {
+		return newest[0].TemplateID, false
+	}
+	return defaultAgentTemplateID, true
 }
 
 // CreateInstance orchestrates the full agent creation flow:

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -615,6 +615,14 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 		// registration rather than a not-found for an identifier the caller
 		// never supplied.
 		if noTemplateRegistered && isCMNotFound(err) {
+			// The rewrite drops CubeMaster's own words on purpose: they name the
+			// built-in fallback, which the caller never supplied and cannot act
+			// on. An operator can act on it, though, and this is the one place
+			// that still knows it — log before dropping, so a not-found that is
+			// really about something else in the request is diagnosable instead
+			// of being flattened into the registration advice.
+			logging.G(ctx).Warnf("agenthub: create failed with an empty template registry, "+
+				"reporting it as a missing registration; cubemaster said: %v", err)
 			return nil, NewBadRequest("no agent template is registered: register one from the template market " +
 				"(POST /agenthub/templates/market), or pass templateId explicitly")
 		}

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -632,8 +632,9 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 			// of being flattened into the registration advice.
 			logging.G(ctx).Warnf("agenthub: create failed with an empty template registry, "+
 				"reporting it as a missing registration; cubemaster said: %v", err)
-			return nil, NewBadRequest("no agent template is registered: register one from the template market " +
-				"(POST /api/v1/agenthub/templates/market), or pass templateId explicitly")
+			return nil, NewBadRequest("no agent template is registered: register one from the template " +
+				"market (POST /api/v1/agenthub/templates/market) or publish one from a running agent " +
+				"(POST /api/v1/agenthub/instances/{agentID}/publish-template), or pass templateId explicitly")
 		}
 		return nil, NewBadGateway("failed to create sandbox: " + err.Error())
 	}

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -426,7 +426,6 @@ type CreateInstanceResult struct {
 	Instance *store.AgentInstance
 }
 
-// defaultTemplateID picks the template CreateInstance uses when the caller
 // templateOrigin says where a defaulted template identifier came from, which is
 // what decides how to report a CubeMaster not-found for it: whether nothing is
 // registered, whether what was registered vanished under us, or whether we
@@ -445,6 +444,7 @@ const (
 	templateFallbackRegistryUnknown
 )
 
+// defaultTemplateID picks the template CreateInstance uses when the caller
 // omits templateId: the template an operator marked recommended if there is
 // one, otherwise the most recently registered one.
 //
@@ -528,10 +528,6 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 	snapshotID := strings.TrimSpace(req.SnapshotID)
 	rootfsSourceType := "template"
 	rootfsSourceID := ""
-	// Set when the request named no template and the registry was read and
-	// found empty, so the unprovisioned defaultAgentTemplateID was used; lets
-	// the CreateSandbox error below name the real problem. Deliberately not
-	// set when the registry could not be read — see defaultTemplateID.
 	// Set whenever the template was chosen for the caller rather than named by
 	// them — including when a real registered template was picked. Either way
 	// the identifier is not one the caller can be told about usefully, so a
@@ -664,19 +660,23 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 				}
 			}
 			// The registry did hold a template when we read it, and CubeMaster
-			// could not find it moments later — a delete that landed in between,
-			// or infra removed underneath it. Retrying re-resolves and may well
-			// pick a different one, so this is a conflict rather than a bad
-			// request, and it is not the 502 naming an identifier the caller
-			// never chose.
-			logging.G(ctx).Warnf("agenthub: the default template resolved from the registry was gone by "+
-				"create time; cubemaster said: %v", err)
+			// could not resolve what we built from it. Which resource it means is
+			// not knowable here — CubeMaster does not say, and by this point the
+			// published-template fast-path above may have swapped the source to
+			// that template's rootfs snapshot — so the message states the
+			// observable fact and lists the causes rather than picking one. It
+			// stays a conflict rather than a bad request because the request was
+			// fine and the state is not, and it is not the 502 naming an
+			// identifier the caller never chose.
+			logging.G(ctx).Warnf("agenthub: cubemaster could not resolve the default template "+
+				"selected from the registry; cubemaster said: %v", err)
 			return nil, &Error{
 				Status: http.StatusConflict,
 				Code:   "conflict",
-				Message: "the agent template selected by default is no longer available — it was registered " +
-					"when the request started and gone by the time the sandbox was created. Retry, or pass " +
-					"templateId explicitly to choose one yourself",
+				Message: "the agent template selected by default could not be resolved: it may have been " +
+					"deleted, its registration may be invalid, or the snapshot it publishes may be gone. " +
+					"Pass templateId explicitly to choose one yourself, or retry to pick up another " +
+					"registered template",
 				Cause: err,
 			}
 		}

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -427,6 +427,24 @@ type CreateInstanceResult struct {
 }
 
 // defaultTemplateID picks the template CreateInstance uses when the caller
+// templateOrigin says where a defaulted template identifier came from, which is
+// what decides how to report a CubeMaster not-found for it: whether nothing is
+// registered, whether what was registered vanished under us, or whether we
+// simply do not know because the read failed.
+type templateOrigin int
+
+const (
+	// templateFromRegistry: a real registered template was picked.
+	templateFromRegistry templateOrigin = iota
+	// templateFallbackEmptyRegistry: the listing completed and held nothing, so
+	// the built-in identifier is in play and nothing is registered.
+	templateFallbackEmptyRegistry
+	// templateFallbackRegistryUnknown: the listing failed, so the built-in
+	// identifier is in play but the registry's contents are unknown — nothing
+	// may be claimed about them.
+	templateFallbackRegistryUnknown
+)
+
 // omits templateId: the template an operator marked recommended if there is
 // one, otherwise the most recently registered one.
 //
@@ -448,7 +466,7 @@ type CreateInstanceResult struct {
 // registered template to prefer, not whether one exists, so losing it falls
 // through to the newest rather than failing a create the registry can still
 // satisfy.
-func (s *AgentHubService) defaultTemplateID(ctx context.Context) (id string, none bool) {
+func (s *AgentHubService) defaultTemplateID(ctx context.Context) (string, templateOrigin) {
 	recommended, err := s.Store.GetRecommendedAgentTemplate(ctx)
 	switch {
 	case err != nil:
@@ -457,17 +475,17 @@ func (s *AgentHubService) defaultTemplateID(ctx context.Context) (id string, non
 		logging.G(ctx).Warnf("failed to read the recommended agent template, "+
 			"falling back to the newest registered one: %v", err)
 	case recommended != nil:
-		return recommended.TemplateID, false
+		return recommended.TemplateID, templateFromRegistry
 	}
 	newest, err := s.Store.ListAgentTemplates(ctx, 1, 0)
 	if err != nil {
 		logging.G(ctx).Warnf("failed to list agent templates while choosing a default: %v", err)
-		return defaultAgentTemplateID, false
+		return defaultAgentTemplateID, templateFallbackRegistryUnknown
 	}
 	if len(newest) > 0 {
-		return newest[0].TemplateID, false
+		return newest[0].TemplateID, templateFromRegistry
 	}
-	return defaultAgentTemplateID, true
+	return defaultAgentTemplateID, templateFallbackEmptyRegistry
 }
 
 // CreateInstance orchestrates the full agent creation flow:
@@ -514,7 +532,12 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 	// found empty, so the unprovisioned defaultAgentTemplateID was used; lets
 	// the CreateSandbox error below name the real problem. Deliberately not
 	// set when the registry could not be read — see defaultTemplateID.
-	noTemplateRegistered := false
+	// Set whenever the template was chosen for the caller rather than named by
+	// them — including when a real registered template was picked. Either way
+	// the identifier is not one the caller can be told about usefully, so a
+	// not-found for it must not be reported verbatim.
+	templateDefaulted := false
+	origin := templateFromRegistry
 	if snapshotID != "" {
 		rootfsSourceType = "snapshot"
 		rootfsSourceID = snapshotID
@@ -522,7 +545,8 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 		if req.TemplateID != "" {
 			rootfsSourceID = req.TemplateID
 		} else {
-			rootfsSourceID, noTemplateRegistered = s.defaultTemplateID(ctx)
+			rootfsSourceID, origin = s.defaultTemplateID(ctx)
+			templateDefaulted = true
 		}
 	}
 	templateID := rootfsSourceID
@@ -623,18 +647,38 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 		// could not resolve the fallback either. Report the missing
 		// registration rather than a not-found for an identifier the caller
 		// never supplied.
-		if noTemplateRegistered && isCMNotFound(err) {
-			// The rewrite drops CubeMaster's own words on purpose: they name the
-			// built-in fallback, which the caller never supplied and cannot act
-			// on. An operator can act on it, though, and this is the one place
-			// that still knows it — log before dropping, so a not-found that is
-			// really about something else in the request is diagnosable instead
-			// of being flattened into the registration advice.
-			logging.G(ctx).Warnf("agenthub: create failed with an empty template registry, "+
-				"reporting it as a missing registration; cubemaster said: %v", err)
-			return nil, NewBadRequest("no agent template is registered: register one from the template " +
-				"market (POST /api/v1/agenthub/templates/market) or publish one from a running agent " +
-				"(POST /api/v1/agenthub/instances/{agentID}/publish-template), or pass templateId explicitly")
+		// Both branches drop CubeMaster's own words on purpose: they name a
+		// template identifier the caller never supplied and cannot act on. An
+		// operator can act on it, so log it and keep it as Cause (which
+		// writeServiceError does not serialise) rather than discarding it.
+		if templateDefaulted && isCMNotFound(err) && origin != templateFallbackRegistryUnknown {
+			if origin == templateFallbackEmptyRegistry {
+				logging.G(ctx).Warnf("agenthub: create failed with an empty template registry, "+
+					"reporting it as a missing registration; cubemaster said: %v", err)
+				return nil, &Error{
+					Status: http.StatusBadRequest,
+					Message: "no agent template is registered: register one from the template " +
+						"market (POST /api/v1/agenthub/templates/market) or publish one from a running agent " +
+						"(POST /api/v1/agenthub/instances/{agentID}/publish-template), or pass templateId explicitly",
+					Cause: err,
+				}
+			}
+			// The registry did hold a template when we read it, and CubeMaster
+			// could not find it moments later — a delete that landed in between,
+			// or infra removed underneath it. Retrying re-resolves and may well
+			// pick a different one, so this is a conflict rather than a bad
+			// request, and it is not the 502 naming an identifier the caller
+			// never chose.
+			logging.G(ctx).Warnf("agenthub: the default template resolved from the registry was gone by "+
+				"create time; cubemaster said: %v", err)
+			return nil, &Error{
+				Status: http.StatusConflict,
+				Code:   "conflict",
+				Message: "the agent template selected by default is no longer available — it was registered " +
+					"when the request started and gone by the time the sandbox was created. Retry, or pass " +
+					"templateId explicitly to choose one yourself",
+				Cause: err,
+			}
 		}
 		return nil, NewBadGateway("failed to create sandbox: " + err.Error())
 	}

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -459,8 +459,13 @@ const (
 // successful empty listing rules out both — while a failed listing returns
 // none=false, because the caller must not report "nothing is registered" on the
 // strength of a query that never completed. Either way the returned id is then
-// defaultAgentTemplateID, which the caller still passes to CubeMaster so
-// installs carrying that alias keep working.
+// defaultAgentTemplateID, which the caller still passes to CubeMaster — kept as
+// a last resort for the install that has claimed that alias, not as a default.
+// This does change behaviour for one corner install: where the alias is claimed
+// AND templates are registered, the registered one now wins. That is the point
+// of the fix — a template an operator actually registered beats a hand-claimed
+// identifier — but "installs carrying the alias are unaffected" only holds while
+// their registry is empty.
 //
 // A failed recommended-flag read is not fatal: the flag expresses which
 // registered template to prefer, not whether one exists, so losing it falls
@@ -668,6 +673,15 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 			// stays a conflict rather than a bad request because the request was
 			// fine and the state is not, and it is not the 502 naming an
 			// identifier the caller never chose.
+			//
+			// One assumption is worth stating because it is not enforced by
+			// construction: that a 130404 out of CreateSandbox concerns the
+			// template. It holds in this tree — sandbox_create.go raises it only
+			// for ErrTemplateNotFound, and the run phase propagates cubelet ret
+			// codes verbatim (sandbox_run.go, setMasterRsp) from an enum that
+			// contains no 130404 — but it is a property of the codes CubeMaster
+			// happens to use, not a guarantee, which is the other reason the
+			// message stays neutral and the original stays in the log.
 			logging.G(ctx).Warnf("agenthub: cubemaster could not resolve the default template "+
 				"selected from the registry; cubemaster said: %v", err)
 			return nil, &Error{
@@ -675,8 +689,8 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 				Code:   "conflict",
 				Message: "the agent template selected by default could not be resolved: it may have been " +
 					"deleted, its registration may be invalid, or the snapshot it publishes may be gone. " +
-					"Pass templateId explicitly to choose one yourself, or retry to pick up another " +
-					"registered template",
+					"Pass templateId explicitly to choose one yourself — retrying re-runs the same " +
+					"selection and picks the same template until the registry changes",
 				Cause: err,
 			}
 		}

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -42,6 +42,19 @@ type CubeMasterClient interface {
 // SDKInstanceType is the CubeMaster instance_type used for AgentHub sandboxes.
 const SDKInstanceType = "cubebox"
 
+// defaultAgentTemplateID is the last-resort template identifier CreateInstance
+// uses when the caller supplies neither a snapshot nor a templateId and no
+// AgentHub template is registered to default to.
+//
+// Nothing in this repository provisions a template under this identifier: it is
+// not a tpl-/snap- id, so CubeMaster resolves it through GetTemplateByAlias,
+// and it only resolves on installs where an operator happened to claim it as a
+// template alias. Reaching it therefore means "no template is registered",
+// which CreateInstance reports as such instead of surfacing CubeMaster's
+// not-found. Kept as a fallback rather than dropped so that installs which do
+// carry the alias keep working.
+const defaultAgentTemplateID = "wecom-ds-openclaw"
+
 // ── Error ───────────────────────────────────────────────────────────────────
 
 // Error is the service-layer error type. It carries an HTTP status code so
@@ -105,6 +118,13 @@ func wrapCMError(err error) *Error {
 	}
 }
 
+// isCMNotFound reports whether err is a CubeMaster not-found (130404). Callers
+// that need the full status mapping should use wrapCMError instead.
+func isCMNotFound(err error) bool {
+	var cmErr *cubemaster.CMError
+	return errors.As(err, &cmErr) && cmErr.IsNotFound()
+}
+
 // ── AgentStore interface ────────────────────────────────────────────────────
 
 // AgentStore is the subset of *store.Store that AgentHubService depends on.
@@ -123,6 +143,7 @@ type AgentStore interface {
 	GetAgentSnapshot(ctx context.Context, agentID, snapshotID string) (*store.AgentSnapshot, error)
 	DeleteAgentSnapshot(ctx context.Context, agentID, snapshotID string) error
 	GetAgentTemplate(ctx context.Context, templateID string) (*store.AgentTemplate, error)
+	ListAgentTemplates(ctx context.Context, limit, offset int) ([]store.AgentTemplate, error)
 	RecordOperation(ctx context.Context, agentID, sandboxID, operationType, status, errMsg string) error
 	LatestHealthySnapshot(ctx context.Context, agentID string) (string, error)
 	SetBaseSnapshotID(ctx context.Context, agentID, snapshotID string) error
@@ -391,6 +412,34 @@ type CreateInstanceResult struct {
 	Instance *store.AgentInstance
 }
 
+// defaultTemplateID picks the template CreateInstance uses when the caller
+// omits templateId: the recommended registered template if there is one,
+// otherwise the most recently registered one (ListAgentTemplates orders by
+// created_at DESC). The recommended flag is what the Dashboard sets on every
+// template it registers from the market.
+//
+// ok is false when no AgentHub template is registered at all — or when the
+// listing failed, which is indistinguishable from the caller's point of view
+// and is logged. In that case the returned id is defaultAgentTemplateID, which
+// the caller passes to CubeMaster anyway so that installs carrying that alias
+// keep working.
+func (s *AgentHubService) defaultTemplateID(ctx context.Context) (id string, ok bool) {
+	templates, err := s.Store.ListAgentTemplates(ctx, store.DefaultListLimit, 0)
+	if err != nil {
+		logging.G(ctx).Warnf("failed to list agent templates while choosing a default: %v", err)
+		return defaultAgentTemplateID, false
+	}
+	for _, tmpl := range templates {
+		if tmpl.Recommended {
+			return tmpl.TemplateID, true
+		}
+	}
+	if len(templates) > 0 {
+		return templates[0].TemplateID, true
+	}
+	return defaultAgentTemplateID, false
+}
+
 // CreateInstance orchestrates the full agent creation flow:
 //
 //  1. Resolve LLM config + domain + egress network config from settings.
@@ -431,6 +480,10 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 	snapshotID := strings.TrimSpace(req.SnapshotID)
 	rootfsSourceType := "template"
 	rootfsSourceID := ""
+	// Set when the request named no template and none is registered, so the
+	// unprovisioned defaultAgentTemplateID was used; lets the CreateSandbox
+	// error below name the real problem.
+	noTemplateRegistered := false
 	if snapshotID != "" {
 		rootfsSourceType = "snapshot"
 		rootfsSourceID = snapshotID
@@ -438,7 +491,9 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 		if req.TemplateID != "" {
 			rootfsSourceID = req.TemplateID
 		} else {
-			rootfsSourceID = "wecom-ds-openclaw"
+			var resolved bool
+			rootfsSourceID, resolved = s.defaultTemplateID(ctx)
+			noTemplateRegistered = !resolved
 		}
 	}
 	templateID := rootfsSourceID
@@ -535,6 +590,14 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 	// --- Create sandbox ---
 	sandboxResp, err := s.CM.CreateSandbox(ctx, cmReq)
 	if err != nil {
+		// The caller named no template, none is registered, and CubeMaster
+		// could not resolve the fallback either. Report the missing
+		// registration rather than a not-found for an identifier the caller
+		// never supplied.
+		if noTemplateRegistered && isCMNotFound(err) {
+			return nil, NewBadRequest("no agent template is registered: register one from the template market " +
+				"(POST /agenthub/templates/market), or pass templateId explicitly")
+		}
 		return nil, NewBadGateway("failed to create sandbox: " + err.Error())
 	}
 	var sbResult struct {

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -118,11 +118,24 @@ func wrapCMError(err error) *Error {
 	}
 }
 
-// isCMNotFound reports whether err is a CubeMaster not-found (130404). Callers
-// that need the full status mapping should use wrapCMError instead.
+// isCMNotFound reports whether err is a CubeMaster not-found, in either shape
+// CubeMaster uses it: the business code 130404 carried in a 200 body, and an
+// HTTP-level 404. The repro in #1327 is the first shape, but keying only on it
+// would make this silently stop working the day CubeMaster answers with an HTTP
+// status instead — and the caller's whole purpose is to avoid leaking an
+// identifier the requester never supplied.
+//
+// Callers that need the full status mapping should use wrapCMError instead. Note
+// that wrapCMError deliberately still maps HTTPError to 502: widening the
+// service-wide status mapping is a larger behavioural change than this fix and
+// belongs in its own patch.
 func isCMNotFound(err error) bool {
 	var cmErr *cubemaster.CMError
-	return errors.As(err, &cmErr) && cmErr.IsNotFound()
+	if errors.As(err, &cmErr) && cmErr.IsNotFound() {
+		return true
+	}
+	var httpErr *cubemaster.HTTPError
+	return errors.As(err, &httpErr) && httpErr.IsNotFound()
 }
 
 // ── AgentStore interface ────────────────────────────────────────────────────

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -436,18 +436,27 @@ type CreateInstanceResult struct {
 // accumulate any number of newer non-recommended templates after the marked
 // one.
 //
-// none is true only when the registry was read successfully and holds nothing.
-// A failed read returns none=false — the caller must not report "nothing is
-// registered" on the strength of a query that never completed. Either way the
-// returned id is then defaultAgentTemplateID, which the caller still passes to
-// CubeMaster so installs carrying that alias keep working.
+// none is true only when the listing completed and came back empty. The listing
+// is what settles emptiness — a marked template is also a listed one, so a
+// successful empty listing rules out both — while a failed listing returns
+// none=false, because the caller must not report "nothing is registered" on the
+// strength of a query that never completed. Either way the returned id is then
+// defaultAgentTemplateID, which the caller still passes to CubeMaster so
+// installs carrying that alias keep working.
+//
+// A failed recommended-flag read is not fatal: the flag expresses which
+// registered template to prefer, not whether one exists, so losing it falls
+// through to the newest rather than failing a create the registry can still
+// satisfy.
 func (s *AgentHubService) defaultTemplateID(ctx context.Context) (id string, none bool) {
 	recommended, err := s.Store.GetRecommendedAgentTemplate(ctx)
-	if err != nil {
-		logging.G(ctx).Warnf("failed to read the recommended agent template: %v", err)
-		return defaultAgentTemplateID, false
-	}
-	if recommended != nil {
+	switch {
+	case err != nil:
+		// Log rather than return: an operator's marked choice is about to be
+		// passed over, and this is the only place that knows it happened.
+		logging.G(ctx).Warnf("failed to read the recommended agent template, "+
+			"falling back to the newest registered one: %v", err)
+	case recommended != nil:
 		return recommended.TemplateID, false
 	}
 	newest, err := s.Store.ListAgentTemplates(ctx, 1, 0)

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -644,12 +644,8 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 	// --- Create sandbox ---
 	sandboxResp, err := s.CM.CreateSandbox(ctx, cmReq)
 	if err != nil {
-		// The caller named no template, none is registered, and CubeMaster
-		// could not resolve the fallback either. Report the missing
-		// registration rather than a not-found for an identifier the caller
-		// never supplied.
-		// Both branches drop CubeMaster's own words on purpose: they name a
-		// template identifier the caller never supplied and cannot act on. An
+		// Both branches below drop CubeMaster's own words on purpose: they name
+		// a template identifier the caller never supplied and cannot act on. An
 		// operator can act on it, so log it and keep it as Cause (which
 		// writeServiceError does not serialise) rather than discarding it.
 		if templateDefaulted && isCMNotFound(err) && origin != templateFallbackRegistryUnknown {
@@ -664,24 +660,36 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 					Cause: err,
 				}
 			}
-			// The registry did hold a template when we read it, and CubeMaster
-			// could not resolve what we built from it. Which resource it means is
-			// not knowable here — CubeMaster does not say, and by this point the
-			// published-template fast-path above may have swapped the source to
-			// that template's rootfs snapshot — so the message states the
-			// observable fact and lists the causes rather than picking one. It
-			// stays a conflict rather than a bad request because the request was
-			// fine and the state is not, and it is not the 502 naming an
-			// identifier the caller never chose.
+			// The registry did hold a template when we read it. Before blaming
+			// it, require CubeMaster's own error to name the identifier we sent
+			// — rootfsSourceID, which the published-template fast-path above may
+			// already have swapped to that template's rootfs snapshot. Without
+			// that corroboration the not-found could be about anything else in
+			// the request, and a confident "the default template could not be
+			// resolved" would be worse than the 502 it replaces, which at least
+			// carries CubeMaster's raw message.
 			//
-			// One assumption is worth stating because it is not enforced by
-			// construction: that a 130404 out of CreateSandbox concerns the
-			// template. It holds in this tree — sandbox_create.go raises it only
-			// for ErrTemplateNotFound, and the run phase propagates cubelet ret
-			// codes verbatim (sandbox_run.go, setMasterRsp) from an enum that
-			// contains no 130404 — but it is a property of the codes CubeMaster
-			// happens to use, not a guarantee, which is the other reason the
-			// message stays neutral and the original stays in the log.
+			// This is a substring match on an error string, which is exactly the
+			// dependency the empty-registry branch above refuses to take. The
+			// difference is what a wording change costs: there it would silently
+			// withhold the actionable 400 and reinstate the bug this PR fixes,
+			// while here it degrades to CubeMaster's own error — which is the
+			// right answer whenever we cannot attribute the failure.
+			//
+			// It also stops leaning on an invariant that lives in another tree:
+			// 130404 out of CreateSandbox means a template only because
+			// sandbox_create.go raises it solely for ErrTemplateNotFound and the
+			// run phase forwards cubelet ret codes verbatim from an enum with no
+			// 130404 in it. True today, not enforced here.
+			if rootfsSourceID == "" || !strings.Contains(err.Error(), rootfsSourceID) {
+				logging.G(ctx).Warnf("agenthub: cubemaster reported a not-found that does not name the "+
+					"default template %q; passing its error through unchanged: %v", rootfsSourceID, err)
+				return nil, NewBadGateway("failed to create sandbox: " + err.Error())
+			}
+			// Reported as a conflict rather than a bad request: the request was
+			// fine and the state is not. The message still states the observable
+			// fact and lists the causes rather than picking one, since knowing
+			// the identifier is ours does not tell us why it stopped resolving.
 			logging.G(ctx).Warnf("agenthub: cubemaster could not resolve the default template "+
 				"selected from the registry; cubemaster said: %v", err)
 			return nil, &Error{

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -418,24 +418,45 @@ type CreateInstanceResult struct {
 // created_at DESC). The recommended flag is what the Dashboard sets on every
 // template it registers from the market.
 //
-// ok is false when no AgentHub template is registered at all — or when the
-// listing failed, which is indistinguishable from the caller's point of view
-// and is logged. In that case the returned id is defaultAgentTemplateID, which
-// the caller passes to CubeMaster anyway so that installs carrying that alias
-// keep working.
-func (s *AgentHubService) defaultTemplateID(ctx context.Context) (id string, ok bool) {
-	templates, err := s.Store.ListAgentTemplates(ctx, store.DefaultListLimit, 0)
-	if err != nil {
-		logging.G(ctx).Warnf("failed to list agent templates while choosing a default: %v", err)
-		return defaultAgentTemplateID, false
-	}
-	for _, tmpl := range templates {
-		if tmpl.Recommended {
-			return tmpl.TemplateID, true
+// The preference is exact rather than window-limited: pages are walked until
+// one comes back short, so a recommended template still wins when newer
+// non-recommended ones were registered after it. Any realistic registry fits
+// in the first page, so this is one query in practice.
+//
+// none is true only when the registry was read successfully and holds nothing.
+// A failed read returns none=false — the caller must not report "nothing is
+// registered" on the strength of a listing that never happened. Either way the
+// returned id is then defaultAgentTemplateID, which the caller still passes to
+// CubeMaster so installs carrying that alias keep working.
+func (s *AgentHubService) defaultTemplateID(ctx context.Context) (id string, none bool) {
+	mostRecent := ""
+	for offset := 0; ; offset += store.MaxListLimit {
+		page, err := s.Store.ListAgentTemplates(ctx, store.MaxListLimit, offset)
+		if err != nil {
+			logging.G(ctx).Warnf("failed to list agent templates while choosing a default: %v", err)
+			break
+		}
+		for _, tmpl := range page {
+			if tmpl.Recommended {
+				return tmpl.TemplateID, false
+			}
+		}
+		if mostRecent == "" && len(page) > 0 {
+			mostRecent = page[0].TemplateID
+		}
+		if len(page) < store.MaxListLimit {
+			// Short page: the registry is exhausted and held no recommended
+			// template, so mostRecent (if any) is the answer.
+			if mostRecent != "" {
+				return mostRecent, false
+			}
+			return defaultAgentTemplateID, true
 		}
 	}
-	if len(templates) > 0 {
-		return templates[0].TemplateID, true
+	// Listing failed part-way. Use anything already seen, and do not claim the
+	// registry is empty.
+	if mostRecent != "" {
+		return mostRecent, false
 	}
 	return defaultAgentTemplateID, false
 }
@@ -480,9 +501,10 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 	snapshotID := strings.TrimSpace(req.SnapshotID)
 	rootfsSourceType := "template"
 	rootfsSourceID := ""
-	// Set when the request named no template and none is registered, so the
-	// unprovisioned defaultAgentTemplateID was used; lets the CreateSandbox
-	// error below name the real problem.
+	// Set when the request named no template and the registry was read and
+	// found empty, so the unprovisioned defaultAgentTemplateID was used; lets
+	// the CreateSandbox error below name the real problem. Deliberately not
+	// set when the registry could not be read — see defaultTemplateID.
 	noTemplateRegistered := false
 	if snapshotID != "" {
 		rootfsSourceType = "snapshot"
@@ -491,9 +513,7 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 		if req.TemplateID != "" {
 			rootfsSourceID = req.TemplateID
 		} else {
-			var resolved bool
-			rootfsSourceID, resolved = s.defaultTemplateID(ctx)
-			noTemplateRegistered = !resolved
+			rootfsSourceID, noTemplateRegistered = s.defaultTemplateID(ctx)
 		}
 	}
 	templateID := rootfsSourceID

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -434,6 +434,67 @@ func TestCreateInstance_DefaultTemplateSelection(t *testing.T) {
 	}
 }
 
+// TestCreateInstance_RecommendedBeyondFirstPage verifies that the recommended
+// preference is exact rather than window-limited: a recommended template that
+// only appears on a later page still wins over the newest one.
+func TestCreateInstance_RecommendedBeyondFirstPage(t *testing.T) {
+	full := make([]store.AgentTemplate, store.MaxListLimit)
+	for i := range full {
+		full[i] = store.AgentTemplate{TemplateID: "tpl-filler", Recommended: false}
+	}
+	full[0].TemplateID = "tpl-newest"
+
+	cm := &fakeServiceCM{}
+	st := llmKeyStore()
+	st.listAgentTemplates = func(_ context.Context, limit, offset int) ([]store.AgentTemplate, error) {
+		if offset == 0 {
+			return full, nil // exactly one full page, so a second is fetched
+		}
+		return []store.AgentTemplate{{TemplateID: "tpl-recommended", Recommended: true}}, nil
+	}
+	svc := newTestService(st, cm)
+
+	if _, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:   "my-agent",
+		Engine: "openclaw",
+	}); err != nil {
+		t.Fatalf("CreateInstance returned error: %v", err)
+	}
+	if got := rootfsSourceID(t, cm); got != "tpl-recommended" {
+		t.Errorf("rootfs_source_id = %q, want tpl-recommended", got)
+	}
+}
+
+// TestCreateInstance_TemplateListingFailureIsNotReportedAsUnregistered
+// verifies that a failed registry read is not turned into "no agent template
+// is registered": the listing never happened, so CubeMaster's own error is
+// what the caller gets.
+func TestCreateInstance_TemplateListingFailureIsNotReportedAsUnregistered(t *testing.T) {
+	cm := &fakeServiceCM{
+		createSandboxErr: &cubemaster.CMError{RetCode: 130404, RetMsg: "template not found"},
+	}
+	st := llmKeyStore()
+	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+		return nil, errors.New("dial tcp: connection refused")
+	}
+	svc := newTestService(st, cm)
+
+	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:   "my-agent",
+		Engine: "openclaw",
+	})
+	var svcErr *Error
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("error is not *service.Error: %v", err)
+	}
+	if svcErr.Status != 502 {
+		t.Errorf("status = %d, want 502", svcErr.Status)
+	}
+	if strings.Contains(svcErr.Message, "no agent template is registered") {
+		t.Errorf("message = %q, should not claim an empty registry when the listing failed", svcErr.Message)
+	}
+}
+
 // TestCreateInstance_ExplicitTemplateIDWins verifies that an explicit
 // templateId is used as-is and the registered-template lookup is skipped.
 func TestCreateInstance_ExplicitTemplateIDWins(t *testing.T) {

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -927,9 +927,9 @@ func TestWrapCMError(t *testing.T) {
 	}
 }
 
-// TestIsCMNotFoundCoversBothShapes pins that a not-found is recognised however
-// CubeMaster reports it: as a business ret_code in a 200 body, as an HTTP 404,
-// or as a ret_code envelope under some other >=400 status.
+// TestIsCMNotFoundCoversBothShapes pins that a not-found is recognised whenever
+// CubeMaster states one in its envelope — under a 200 body or under any >=400
+// status — and is NOT inferred from a bare 404 whose body says nothing.
 // Only the first shape appears in the #1327 repro; keying on it alone would let
 // the actionable 400 silently regress into a 502 leaking an identifier the
 // requester never supplied, which is what this path exists to prevent.
@@ -941,8 +941,22 @@ func TestIsCMNotFoundCoversBothShapes(t *testing.T) {
 	}{
 		{"business 130404", &cubemaster.CMError{RetCode: 130404, RetMsg: "template not found"}, true},
 		{"business 404", &cubemaster.CMError{RetCode: 404, RetMsg: "template not found"}, true},
-		{"http 404", &cubemaster.HTTPError{Status: 404, Body: "template not found"}, true},
-		{"http 404 wrapped", fmt.Errorf("create sandbox: %w", &cubemaster.HTTPError{Status: 404}), true},
+		{
+			"http 404 stating it in the envelope",
+			&cubemaster.HTTPError{Status: 404, Body: `{"ret":{"ret_code":130404,"ret_msg":"template not found"}}`},
+			true,
+		},
+		{
+			"http 404 wrapped",
+			fmt.Errorf("create sandbox: %w", &cubemaster.HTTPError{Status: 404, Body: `{"ret":{"ret_code":130404}}`}),
+			true,
+		},
+		// A bare 404 is evidence about the route, not the resource: CubeMaster
+		// states resource-not-found in the envelope, so an opaque one came from a
+		// proxy or a misconfigured base URL. Classifying it as a missing template
+		// would answer "register a template" to an operator whose real problem is
+		// that CubeOps never reached CubeMaster.
+		{"http 404 from something in the path", &cubemaster.HTTPError{Status: 404, Body: "404 page not found"}, false},
 		{"http 500", &cubemaster.HTTPError{Status: 500, Body: "boom"}, false},
 		// The status line and the ret_code are chosen independently on the
 		// CubeMaster side, so a not-found can arrive under some other >=400

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -473,58 +473,98 @@ func TestCreateInstance_RecommendedIsNotWindowLimited(t *testing.T) {
 	}
 }
 
-// TestCreateInstance_TemplateReadFailureIsNotReportedAsUnregistered verifies
-// that a failed registry read is not turned into "no agent template is
-// registered": the query never completed, so CubeMaster's own error is what
-// the caller gets. Both reads are covered — either one failing is enough to
-// leave the registry's contents unknown.
-func TestCreateInstance_TemplateReadFailureIsNotReportedAsUnregistered(t *testing.T) {
-	dbDown := errors.New("dial tcp: connection refused")
-	tests := []struct {
-		name  string
-		store func(*fakeAgentStore)
-	}{
-		{
-			name: "recommended query fails",
-			store: func(st *fakeAgentStore) {
-				st.getRecommendedTemplate = func(_ context.Context) (*store.AgentTemplate, error) {
-					return nil, dbDown
-				}
-			},
-		},
-		{
-			name: "listing fails",
-			store: func(st *fakeAgentStore) {
-				st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
-					return nil, dbDown
-				}
-			},
-		},
+// TestCreateInstance_TemplateListingFailureIsNotReportedAsUnregistered verifies
+// that a failed *listing* is not turned into "no agent template is registered":
+// that query never completed, so the registry's contents are unknown and
+// CubeMaster's own error is what the caller gets.
+//
+// The recommended-flag query is deliberately not covered here — losing it does
+// not leave the registry unknown, since a marked template is also a listed one.
+// The two tests below pin what a failure there does instead.
+func TestCreateInstance_TemplateListingFailureIsNotReportedAsUnregistered(t *testing.T) {
+	cm := &fakeServiceCM{
+		createSandboxErr: &cubemaster.CMError{RetCode: 130404, RetMsg: "template not found"},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cm := &fakeServiceCM{
-				createSandboxErr: &cubemaster.CMError{RetCode: 130404, RetMsg: "template not found"},
-			}
-			st := llmKeyStore()
-			tt.store(st)
-			svc := newTestService(st, cm)
+	st := llmKeyStore()
+	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+		return nil, errors.New("dial tcp: connection refused")
+	}
+	svc := newTestService(st, cm)
 
-			_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
-				Name:   "my-agent",
-				Engine: "openclaw",
-			})
-			var svcErr *Error
-			if !errors.As(err, &svcErr) {
-				t.Fatalf("error is not *service.Error: %v", err)
-			}
-			if svcErr.Status != 502 {
-				t.Errorf("status = %d, want 502", svcErr.Status)
-			}
-			if strings.Contains(svcErr.Message, "no agent template is registered") {
-				t.Errorf("message = %q, should not claim an empty registry when the read failed", svcErr.Message)
-			}
-		})
+	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:   "my-agent",
+		Engine: "openclaw",
+	})
+	var svcErr *Error
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("error is not *service.Error: %v", err)
+	}
+	if svcErr.Status != 502 {
+		t.Errorf("status = %d, want 502", svcErr.Status)
+	}
+	if strings.Contains(svcErr.Message, "no agent template is registered") {
+		t.Errorf("message = %q, should not claim an empty registry when the read failed", svcErr.Message)
+	}
+}
+
+// TestCreateInstance_RecommendedReadFailureFallsBackToNewest verifies that
+// losing the recommended-flag query does not fail a create the registry can
+// still satisfy. The flag says which registered template to prefer, not whether
+// one exists, so a transient failure there falls through to the newest instead
+// of handing CubeMaster an identifier no install has to carry.
+func TestCreateInstance_RecommendedReadFailureFallsBackToNewest(t *testing.T) {
+	cm := &fakeServiceCM{}
+	st := llmKeyStore()
+	st.getRecommendedTemplate = func(_ context.Context) (*store.AgentTemplate, error) {
+		return nil, errors.New("dial tcp: connection refused")
+	}
+	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+		return []store.AgentTemplate{{TemplateID: "tpl-newest"}}, nil
+	}
+	svc := newTestService(st, cm)
+
+	if _, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:   "my-agent",
+		Engine: "openclaw",
+	}); err != nil {
+		t.Fatalf("CreateInstance returned error: %v", err)
+	}
+	if got := rootfsSourceID(t, cm); got != "tpl-newest" {
+		t.Errorf("rootfs_source_id = %q, want tpl-newest", got)
+	}
+}
+
+// TestCreateInstance_EmptyListingSettlesEmptinessDespiteRecommendedFailure
+// verifies the other half: when the recommended query fails but the listing
+// completes and comes back empty, the registry really is empty — a marked
+// template would have been listed too — so the caller still gets the actionable
+// registration hint rather than a 502 naming the built-in identifier.
+func TestCreateInstance_EmptyListingSettlesEmptinessDespiteRecommendedFailure(t *testing.T) {
+	cm := &fakeServiceCM{
+		createSandboxErr: &cubemaster.CMError{RetCode: 130404, RetMsg: "template not found"},
+	}
+	st := llmKeyStore()
+	st.getRecommendedTemplate = func(_ context.Context) (*store.AgentTemplate, error) {
+		return nil, errors.New("dial tcp: connection refused")
+	}
+	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+		return nil, nil
+	}
+	svc := newTestService(st, cm)
+
+	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:   "my-agent",
+		Engine: "openclaw",
+	})
+	var svcErr *Error
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("error is not *service.Error: %v", err)
+	}
+	if svcErr.Status != 400 {
+		t.Errorf("status = %d, want 400", svcErr.Status)
+	}
+	if !strings.Contains(svcErr.Message, "no agent template is registered") {
+		t.Errorf("message = %q, want it to name the missing registration", svcErr.Message)
 	}
 }
 

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -36,6 +36,7 @@ type fakeAgentStore struct {
 	getAgentSnapshot           func(ctx context.Context, agentID, snapshotID string) (*store.AgentSnapshot, error)
 	deleteAgentSnapshot        func(ctx context.Context, agentID, snapshotID string) error
 	getAgentTemplate           func(ctx context.Context, templateID string) (*store.AgentTemplate, error)
+	getRecommendedTemplate     func(ctx context.Context) (*store.AgentTemplate, error)
 	listAgentTemplates         func(ctx context.Context, limit, offset int) ([]store.AgentTemplate, error)
 	recordOperation            func(ctx context.Context, agentID, sandboxID, operationType, status, errMsg string) error
 	latestHealthySnapshot      func(ctx context.Context, agentID string) (string, error)
@@ -109,6 +110,12 @@ func (f *fakeAgentStore) GetAgentTemplate(ctx context.Context, templateID string
 		return nil, nil
 	}
 	return f.getAgentTemplate(ctx, templateID)
+}
+func (f *fakeAgentStore) GetRecommendedAgentTemplate(ctx context.Context) (*store.AgentTemplate, error) {
+	if f.getRecommendedTemplate == nil {
+		return nil, nil // default: none marked recommended
+	}
+	return f.getRecommendedTemplate(ctx)
 }
 func (f *fakeAgentStore) ListAgentTemplates(ctx context.Context, limit, offset int) ([]store.AgentTemplate, error) {
 	if f.listAgentTemplates == nil {
@@ -380,44 +387,44 @@ func rootfsSourceID(t *testing.T, cm *fakeServiceCM) string {
 
 // TestCreateInstance_DefaultTemplateSelection verifies which template
 // CreateInstance uses when the request names neither a snapshot nor a
-// templateId: the recommended registered template if there is one, else the
-// most recently registered one (ListAgentTemplates orders created_at DESC).
-// Before this, the request always went out with the hardcoded
-// defaultAgentTemplateID, which nothing provisions.
+// templateId: the operator-marked recommended template if there is one, else
+// the most recently registered one. Before this, the request always went out
+// with the hardcoded defaultAgentTemplateID, which nothing provisions.
 func TestCreateInstance_DefaultTemplateSelection(t *testing.T) {
 	tests := []struct {
-		name      string
-		templates []store.AgentTemplate
-		want      string
+		name        string
+		recommended *store.AgentTemplate
+		newest      []store.AgentTemplate
+		want        string
 	}{
 		{
-			name: "prefers the recommended template over a newer one",
-			templates: []store.AgentTemplate{
-				{TemplateID: "tpl-newest", Recommended: false},
-				{TemplateID: "tpl-recommended", Recommended: true},
-			},
-			want: "tpl-recommended",
+			name:        "prefers the recommended template over a newer one",
+			recommended: &store.AgentTemplate{TemplateID: "tpl-recommended", Recommended: true},
+			newest:      []store.AgentTemplate{{TemplateID: "tpl-newest"}},
+			want:        "tpl-recommended",
 		},
 		{
-			name: "falls back to the most recent when none is recommended",
-			templates: []store.AgentTemplate{
-				{TemplateID: "tpl-newest", Recommended: false},
-				{TemplateID: "tpl-older", Recommended: false},
-			},
-			want: "tpl-newest",
+			name:   "falls back to the most recent when none is recommended",
+			newest: []store.AgentTemplate{{TemplateID: "tpl-newest"}},
+			want:   "tpl-newest",
 		},
 		{
-			name:      "uses the built-in identifier when nothing is registered",
-			templates: nil,
-			want:      defaultAgentTemplateID,
+			name: "uses the built-in identifier when nothing is registered",
+			want: defaultAgentTemplateID,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cm := &fakeServiceCM{}
 			st := llmKeyStore()
-			st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
-				return tt.templates, nil
+			st.getRecommendedTemplate = func(_ context.Context) (*store.AgentTemplate, error) {
+				return tt.recommended, nil
+			}
+			st.listAgentTemplates = func(_ context.Context, limit, _ int) ([]store.AgentTemplate, error) {
+				if limit != 1 {
+					t.Errorf("ListAgentTemplates limit = %d, want 1 — only the newest is needed", limit)
+				}
+				return tt.newest, nil
 			}
 			svc := newTestService(st, cm)
 
@@ -434,23 +441,20 @@ func TestCreateInstance_DefaultTemplateSelection(t *testing.T) {
 	}
 }
 
-// TestCreateInstance_RecommendedBeyondFirstPage verifies that the recommended
-// preference is exact rather than window-limited: a recommended template that
-// only appears on a later page still wins over the newest one.
-func TestCreateInstance_RecommendedBeyondFirstPage(t *testing.T) {
-	full := make([]store.AgentTemplate, store.MaxListLimit)
-	for i := range full {
-		full[i] = store.AgentTemplate{TemplateID: "tpl-filler", Recommended: false}
-	}
-	full[0].TemplateID = "tpl-newest"
-
+// TestCreateInstance_RecommendedIsNotWindowLimited verifies that the
+// recommended preference does not depend on how many newer templates were
+// registered after it: the flag is resolved by its own query, so any number of
+// non-recommended registrations cannot bury it.
+func TestCreateInstance_RecommendedIsNotWindowLimited(t *testing.T) {
 	cm := &fakeServiceCM{}
 	st := llmKeyStore()
-	st.listAgentTemplates = func(_ context.Context, limit, offset int) ([]store.AgentTemplate, error) {
-		if offset == 0 {
-			return full, nil // exactly one full page, so a second is fetched
-		}
-		return []store.AgentTemplate{{TemplateID: "tpl-recommended", Recommended: true}}, nil
+	st.getRecommendedTemplate = func(_ context.Context) (*store.AgentTemplate, error) {
+		return &store.AgentTemplate{TemplateID: "tpl-recommended", Recommended: true}, nil
+	}
+	listed := false
+	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+		listed = true
+		return []store.AgentTemplate{{TemplateID: "tpl-newest"}}, nil
 	}
 	svc := newTestService(st, cm)
 
@@ -463,35 +467,63 @@ func TestCreateInstance_RecommendedBeyondFirstPage(t *testing.T) {
 	if got := rootfsSourceID(t, cm); got != "tpl-recommended" {
 		t.Errorf("rootfs_source_id = %q, want tpl-recommended", got)
 	}
+	if listed {
+		t.Error("the registry should not be listed once a recommended template is found")
+	}
 }
 
-// TestCreateInstance_TemplateListingFailureIsNotReportedAsUnregistered
-// verifies that a failed registry read is not turned into "no agent template
-// is registered": the listing never happened, so CubeMaster's own error is
-// what the caller gets.
-func TestCreateInstance_TemplateListingFailureIsNotReportedAsUnregistered(t *testing.T) {
-	cm := &fakeServiceCM{
-		createSandboxErr: &cubemaster.CMError{RetCode: 130404, RetMsg: "template not found"},
+// TestCreateInstance_TemplateReadFailureIsNotReportedAsUnregistered verifies
+// that a failed registry read is not turned into "no agent template is
+// registered": the query never completed, so CubeMaster's own error is what
+// the caller gets. Both reads are covered — either one failing is enough to
+// leave the registry's contents unknown.
+func TestCreateInstance_TemplateReadFailureIsNotReportedAsUnregistered(t *testing.T) {
+	dbDown := errors.New("dial tcp: connection refused")
+	tests := []struct {
+		name  string
+		store func(*fakeAgentStore)
+	}{
+		{
+			name: "recommended query fails",
+			store: func(st *fakeAgentStore) {
+				st.getRecommendedTemplate = func(_ context.Context) (*store.AgentTemplate, error) {
+					return nil, dbDown
+				}
+			},
+		},
+		{
+			name: "listing fails",
+			store: func(st *fakeAgentStore) {
+				st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+					return nil, dbDown
+				}
+			},
+		},
 	}
-	st := llmKeyStore()
-	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
-		return nil, errors.New("dial tcp: connection refused")
-	}
-	svc := newTestService(st, cm)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := &fakeServiceCM{
+				createSandboxErr: &cubemaster.CMError{RetCode: 130404, RetMsg: "template not found"},
+			}
+			st := llmKeyStore()
+			tt.store(st)
+			svc := newTestService(st, cm)
 
-	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
-		Name:   "my-agent",
-		Engine: "openclaw",
-	})
-	var svcErr *Error
-	if !errors.As(err, &svcErr) {
-		t.Fatalf("error is not *service.Error: %v", err)
-	}
-	if svcErr.Status != 502 {
-		t.Errorf("status = %d, want 502", svcErr.Status)
-	}
-	if strings.Contains(svcErr.Message, "no agent template is registered") {
-		t.Errorf("message = %q, should not claim an empty registry when the listing failed", svcErr.Message)
+			_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+				Name:   "my-agent",
+				Engine: "openclaw",
+			})
+			var svcErr *Error
+			if !errors.As(err, &svcErr) {
+				t.Fatalf("error is not *service.Error: %v", err)
+			}
+			if svcErr.Status != 502 {
+				t.Errorf("status = %d, want 502", svcErr.Status)
+			}
+			if strings.Contains(svcErr.Message, "no agent template is registered") {
+				t.Errorf("message = %q, should not claim an empty registry when the read failed", svcErr.Message)
+			}
+		})
 	}
 }
 
@@ -500,10 +532,14 @@ func TestCreateInstance_TemplateListingFailureIsNotReportedAsUnregistered(t *tes
 func TestCreateInstance_ExplicitTemplateIDWins(t *testing.T) {
 	cm := &fakeServiceCM{}
 	st := llmKeyStore()
-	listed := false
+	consulted := false
+	st.getRecommendedTemplate = func(_ context.Context) (*store.AgentTemplate, error) {
+		consulted = true
+		return &store.AgentTemplate{TemplateID: "tpl-recommended", Recommended: true}, nil
+	}
 	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
-		listed = true
-		return []store.AgentTemplate{{TemplateID: "tpl-recommended", Recommended: true}}, nil
+		consulted = true
+		return []store.AgentTemplate{{TemplateID: "tpl-newest"}}, nil
 	}
 	svc := newTestService(st, cm)
 
@@ -517,8 +553,8 @@ func TestCreateInstance_ExplicitTemplateIDWins(t *testing.T) {
 	if got := rootfsSourceID(t, cm); got != "tpl-explicit" {
 		t.Errorf("rootfs_source_id = %q, want tpl-explicit", got)
 	}
-	if listed {
-		t.Error("ListAgentTemplates should not be consulted when templateId is explicit")
+	if consulted {
+		t.Error("the template registry should not be consulted when templateId is explicit")
 	}
 }
 

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -998,6 +998,19 @@ func TestIsCMNotFoundCoversBothShapes(t *testing.T) {
 		// that CubeOps never reached CubeMaster.
 		{"http 404 from something in the path", &cubemaster.HTTPError{Status: 404, Body: "404 page not found"}, false},
 		{"http 500", &cubemaster.HTTPError{Status: 500, Body: "boom"}, false},
+		// A server-side failure is not the caller's to fix, whatever its body
+		// says — otherwise a transient 5xx is rewritten into "register a
+		// template", advice the operator cannot act on and that hides an outage.
+		{
+			"http 500 carrying 130404",
+			&cubemaster.HTTPError{Status: 500, Body: `{"ret":{"ret_code":130404,"ret_msg":"template not found"}}`},
+			false,
+		},
+		{
+			"http 503 carrying 130404",
+			&cubemaster.HTTPError{Status: 503, Body: `{"ret":{"ret_code":130404,"ret_msg":"template not found"}}`},
+			false,
+		},
 		// The status line and the ret_code are chosen independently on the
 		// CubeMaster side, so a not-found can arrive under some other >=400
 		// status. Recognise it by content, not by which channel carried it.

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -921,6 +922,35 @@ func TestWrapCMError(t *testing.T) {
 			}
 			if tt.wantCode != "" && got.Code != tt.wantCode {
 				t.Errorf("code = %q, want %q", got.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+// TestIsCMNotFoundCoversBothShapes pins that a not-found is recognised whether
+// CubeMaster reports it as a business ret_code in a 200 body or as an HTTP 404.
+// Only the first shape appears in the #1327 repro; keying on it alone would let
+// the actionable 400 silently regress into a 502 leaking an identifier the
+// requester never supplied, which is what this path exists to prevent.
+func TestIsCMNotFoundCoversBothShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"business 130404", &cubemaster.CMError{RetCode: 130404, RetMsg: "template not found"}, true},
+		{"business 404", &cubemaster.CMError{RetCode: 404, RetMsg: "template not found"}, true},
+		{"http 404", &cubemaster.HTTPError{Status: 404, Body: "template not found"}, true},
+		{"http 404 wrapped", fmt.Errorf("create sandbox: %w", &cubemaster.HTTPError{Status: 404}), true},
+		{"http 500", &cubemaster.HTTPError{Status: 500, Body: "boom"}, false},
+		{"business conflict", &cubemaster.CMError{RetCode: 130409, RetMsg: "exists"}, false},
+		{"unrelated", errors.New("network timeout"), false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCMNotFound(tt.err); got != tt.want {
+				t.Errorf("isCMNotFound(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -629,6 +629,51 @@ func TestCreateInstance_NoTemplateRegisteredReportsMissingRegistration(t *testin
 	if strings.Contains(svcErr.Message, defaultAgentTemplateID) {
 		t.Errorf("message = %q, should not surface the built-in identifier to the caller", svcErr.Message)
 	}
+	if svcErr.Cause == nil {
+		t.Error("Cause is nil; the CubeMaster error must stay attached for diagnosis")
+	}
+}
+
+// TestCreateInstance_DefaultedTemplateVanishingIsAConflict covers the race the
+// registry read cannot close: a template that was registered when the request
+// started and gone by the time CubeMaster resolved it. The caller named no
+// template, so reporting a not-found for the one we picked would name an
+// identifier they never chose — the failure class this path exists to remove —
+// and it is not a missing registration either, because one was registered.
+// Retrying re-resolves and may pick another, so it is a conflict.
+func TestCreateInstance_DefaultedTemplateVanishingIsAConflict(t *testing.T) {
+	cm := &fakeServiceCM{
+		createSandboxErr: &cubemaster.CMError{
+			RetCode: 130404,
+			RetMsg:  `failed to resolve template identifier "tpl-vanished": template not found`,
+		},
+	}
+	st := llmKeyStore()
+	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+		return []store.AgentTemplate{{TemplateID: "tpl-vanished"}}, nil
+	}
+	svc := newTestService(st, cm)
+
+	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:   "my-agent",
+		Engine: "openclaw",
+	})
+	var svcErr *Error
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("error is not *service.Error: %v", err)
+	}
+	if svcErr.Status != 409 {
+		t.Errorf("status = %d, want 409", svcErr.Status)
+	}
+	if strings.Contains(svcErr.Message, "tpl-vanished") {
+		t.Errorf("message = %q, should not surface an identifier the caller never chose", svcErr.Message)
+	}
+	if strings.Contains(svcErr.Message, "no agent template is registered") {
+		t.Errorf("message = %q, should not claim an empty registry when one was registered", svcErr.Message)
+	}
+	if svcErr.Cause == nil {
+		t.Error("Cause is nil; the CubeMaster error must stay attached for diagnosis")
+	}
 }
 
 // TestCreateInstance_ExplicitTemplateNotFoundStaysBadGateway guards the

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -927,8 +927,9 @@ func TestWrapCMError(t *testing.T) {
 	}
 }
 
-// TestIsCMNotFoundCoversBothShapes pins that a not-found is recognised whether
-// CubeMaster reports it as a business ret_code in a 200 body or as an HTTP 404.
+// TestIsCMNotFoundCoversBothShapes pins that a not-found is recognised however
+// CubeMaster reports it: as a business ret_code in a 200 body, as an HTTP 404,
+// or as a ret_code envelope under some other >=400 status.
 // Only the first shape appears in the #1327 repro; keying on it alone would let
 // the actionable 400 silently regress into a 502 leaking an identifier the
 // requester never supplied, which is what this path exists to prevent.
@@ -943,6 +944,20 @@ func TestIsCMNotFoundCoversBothShapes(t *testing.T) {
 		{"http 404", &cubemaster.HTTPError{Status: 404, Body: "template not found"}, true},
 		{"http 404 wrapped", fmt.Errorf("create sandbox: %w", &cubemaster.HTTPError{Status: 404}), true},
 		{"http 500", &cubemaster.HTTPError{Status: 500, Body: "boom"}, false},
+		// The status line and the ret_code are chosen independently on the
+		// CubeMaster side, so a not-found can arrive under some other >=400
+		// status. Recognise it by content, not by which channel carried it.
+		{
+			"http 400 carrying 130404",
+			&cubemaster.HTTPError{Status: 400, Body: `{"ret":{"ret_code":130404,"ret_msg":"template not found"}}`},
+			true,
+		},
+		{
+			"http 400 carrying a non-not-found code",
+			&cubemaster.HTTPError{Status: 400, Body: `{"ret":{"ret_code":130400,"ret_msg":"bad instance_type"}}`},
+			false,
+		},
+		{"http 500 with a non-envelope body", &cubemaster.HTTPError{Status: 500, Body: "130404"}, false},
 		{"business conflict", &cubemaster.CMError{RetCode: 130409, RetMsg: "exists"}, false},
 		{"unrelated", errors.New("network timeout"), false},
 		{"nil", nil, false},

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -36,6 +36,7 @@ type fakeAgentStore struct {
 	getAgentSnapshot           func(ctx context.Context, agentID, snapshotID string) (*store.AgentSnapshot, error)
 	deleteAgentSnapshot        func(ctx context.Context, agentID, snapshotID string) error
 	getAgentTemplate           func(ctx context.Context, templateID string) (*store.AgentTemplate, error)
+	listAgentTemplates         func(ctx context.Context, limit, offset int) ([]store.AgentTemplate, error)
 	recordOperation            func(ctx context.Context, agentID, sandboxID, operationType, status, errMsg string) error
 	latestHealthySnapshot      func(ctx context.Context, agentID string) (string, error)
 	setBaseSnapshotID          func(ctx context.Context, agentID, snapshotID string) error
@@ -108,6 +109,12 @@ func (f *fakeAgentStore) GetAgentTemplate(ctx context.Context, templateID string
 		return nil, nil
 	}
 	return f.getAgentTemplate(ctx, templateID)
+}
+func (f *fakeAgentStore) ListAgentTemplates(ctx context.Context, limit, offset int) ([]store.AgentTemplate, error) {
+	if f.listAgentTemplates == nil {
+		return nil, nil // default: no template registered
+	}
+	return f.listAgentTemplates(ctx, limit, offset)
 }
 func (f *fakeAgentStore) RecordOperation(ctx context.Context, agentID, sandboxID, operationType, status, errMsg string) error {
 	if f.recordOperation == nil {
@@ -343,6 +350,172 @@ func TestCreateInstance_ValidationErrors(t *testing.T) {
 				t.Error("CreateSandbox should not have been called for a validation error")
 			}
 		})
+	}
+}
+
+// llmKeyStore returns a fakeAgentStore whose only wired method resolves the
+// LLM API key, which CreateInstance requires before it reaches CubeMaster.
+func llmKeyStore() *fakeAgentStore {
+	return &fakeAgentStore{
+		getSetting: func(_ context.Context, key string) (string, error) {
+			if key == "llm_api_key" {
+				return "test-key", nil
+			}
+			return "", nil
+		},
+	}
+}
+
+// rootfsSourceID returns the resolved rootfs source id CreateInstance sent to
+// CubeMaster, which BuildCreateSandboxRequest carries as a label.
+func rootfsSourceID(t *testing.T, cm *fakeServiceCM) string {
+	t.Helper()
+	if cm.createSandboxBody == nil {
+		t.Fatal("CreateSandbox was not called")
+	}
+	labels, _ := cm.createSandboxBody["labels"].(map[string]interface{})
+	id, _ := labels["agenthub.rootfs_source_id"].(string)
+	return id
+}
+
+// TestCreateInstance_DefaultTemplateSelection verifies which template
+// CreateInstance uses when the request names neither a snapshot nor a
+// templateId: the recommended registered template if there is one, else the
+// most recently registered one (ListAgentTemplates orders created_at DESC).
+// Before this, the request always went out with the hardcoded
+// defaultAgentTemplateID, which nothing provisions.
+func TestCreateInstance_DefaultTemplateSelection(t *testing.T) {
+	tests := []struct {
+		name      string
+		templates []store.AgentTemplate
+		want      string
+	}{
+		{
+			name: "prefers the recommended template over a newer one",
+			templates: []store.AgentTemplate{
+				{TemplateID: "tpl-newest", Recommended: false},
+				{TemplateID: "tpl-recommended", Recommended: true},
+			},
+			want: "tpl-recommended",
+		},
+		{
+			name: "falls back to the most recent when none is recommended",
+			templates: []store.AgentTemplate{
+				{TemplateID: "tpl-newest", Recommended: false},
+				{TemplateID: "tpl-older", Recommended: false},
+			},
+			want: "tpl-newest",
+		},
+		{
+			name:      "uses the built-in identifier when nothing is registered",
+			templates: nil,
+			want:      defaultAgentTemplateID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := &fakeServiceCM{}
+			st := llmKeyStore()
+			st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+				return tt.templates, nil
+			}
+			svc := newTestService(st, cm)
+
+			if _, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+				Name:   "my-agent",
+				Engine: "openclaw",
+			}); err != nil {
+				t.Fatalf("CreateInstance returned error: %v", err)
+			}
+			if got := rootfsSourceID(t, cm); got != tt.want {
+				t.Errorf("rootfs_source_id = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCreateInstance_ExplicitTemplateIDWins verifies that an explicit
+// templateId is used as-is and the registered-template lookup is skipped.
+func TestCreateInstance_ExplicitTemplateIDWins(t *testing.T) {
+	cm := &fakeServiceCM{}
+	st := llmKeyStore()
+	listed := false
+	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+		listed = true
+		return []store.AgentTemplate{{TemplateID: "tpl-recommended", Recommended: true}}, nil
+	}
+	svc := newTestService(st, cm)
+
+	if _, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:       "my-agent",
+		Engine:     "openclaw",
+		TemplateID: "tpl-explicit",
+	}); err != nil {
+		t.Fatalf("CreateInstance returned error: %v", err)
+	}
+	if got := rootfsSourceID(t, cm); got != "tpl-explicit" {
+		t.Errorf("rootfs_source_id = %q, want tpl-explicit", got)
+	}
+	if listed {
+		t.Error("ListAgentTemplates should not be consulted when templateId is explicit")
+	}
+}
+
+// TestCreateInstance_NoTemplateRegisteredReportsMissingRegistration verifies
+// that when no template is registered and CubeMaster cannot resolve the
+// built-in identifier either, the caller gets an actionable 400 instead of a
+// 502 naming an identifier they never supplied.
+func TestCreateInstance_NoTemplateRegisteredReportsMissingRegistration(t *testing.T) {
+	cm := &fakeServiceCM{
+		createSandboxErr: &cubemaster.CMError{
+			RetCode: 130404,
+			RetMsg:  `failed to resolve template identifier "` + defaultAgentTemplateID + `": template not found`,
+		},
+	}
+	svc := newTestService(llmKeyStore(), cm)
+
+	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:   "my-agent",
+		Engine: "openclaw",
+	})
+	var svcErr *Error
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("error is not *service.Error: %v", err)
+	}
+	if svcErr.Status != 400 {
+		t.Errorf("status = %d, want 400", svcErr.Status)
+	}
+	if !strings.Contains(svcErr.Message, "no agent template is registered") {
+		t.Errorf("message = %q, want it to name the missing registration", svcErr.Message)
+	}
+	if strings.Contains(svcErr.Message, defaultAgentTemplateID) {
+		t.Errorf("message = %q, should not surface the built-in identifier to the caller", svcErr.Message)
+	}
+}
+
+// TestCreateInstance_ExplicitTemplateNotFoundStaysBadGateway guards the
+// narrowness of the case above: a not-found for a template the caller did name
+// is still reported as-is, not rewritten into the registration hint.
+func TestCreateInstance_ExplicitTemplateNotFoundStaysBadGateway(t *testing.T) {
+	cm := &fakeServiceCM{
+		createSandboxErr: &cubemaster.CMError{RetCode: 130404, RetMsg: "template not found"},
+	}
+	svc := newTestService(llmKeyStore(), cm)
+
+	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:       "my-agent",
+		Engine:     "openclaw",
+		TemplateID: "tpl-typo",
+	})
+	var svcErr *Error
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("error is not *service.Error: %v", err)
+	}
+	if svcErr.Status != 502 {
+		t.Errorf("status = %d, want 502", svcErr.Status)
+	}
+	if strings.Contains(svcErr.Message, "no agent template is registered") {
+		t.Errorf("message = %q, should not claim a missing registration", svcErr.Message)
 	}
 }
 

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -676,6 +676,43 @@ func TestCreateInstance_DefaultedTemplateVanishingIsAConflict(t *testing.T) {
 	}
 }
 
+// TestCreateInstance_UnattributableNotFoundIsPassedThrough guards the other side
+// of the conflict branch: a not-found that does not name the identifier we sent
+// is not attributed to the default template. Blaming it there would be worse
+// than the 502 it replaces, which at least carries CubeMaster's own words about
+// whatever the missing resource actually was.
+func TestCreateInstance_UnattributableNotFoundIsPassedThrough(t *testing.T) {
+	cm := &fakeServiceCM{
+		createSandboxErr: &cubemaster.CMError{
+			RetCode: 130404,
+			RetMsg:  `egress network resource "net-7f2" not found`,
+		},
+	}
+	st := llmKeyStore()
+	st.listAgentTemplates = func(_ context.Context, _, _ int) ([]store.AgentTemplate, error) {
+		return []store.AgentTemplate{{TemplateID: "tpl-registered"}}, nil
+	}
+	svc := newTestService(st, cm)
+
+	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+		Name:   "my-agent",
+		Engine: "openclaw",
+	})
+	var svcErr *Error
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("error is not *service.Error: %v", err)
+	}
+	if svcErr.Status != 502 {
+		t.Errorf("status = %d, want 502 — the not-found names another resource", svcErr.Status)
+	}
+	if strings.Contains(svcErr.Message, "selected by default") {
+		t.Errorf("message = %q, should not blame the default template", svcErr.Message)
+	}
+	if !strings.Contains(svcErr.Message, "net-7f2") {
+		t.Errorf("message = %q, want CubeMaster's own words about the missing resource", svcErr.Message)
+	}
+}
+
 // TestCreateInstance_ExplicitTemplateNotFoundStaysBadGateway guards the
 // narrowness of the case above: a not-found for a template the caller did name
 // is still reported as-is, not rewritten into the registration hint.

--- a/CubeOps/internal/store/agenthub.go
+++ b/CubeOps/internal/store/agenthub.go
@@ -507,6 +507,42 @@ func (s *Store) GetAgentTemplate(ctx context.Context, templateID string) (*Agent
 	return &tmpl, nil
 }
 
+// GetRecommendedAgentTemplate returns the most recently registered template
+// flagged recommended, or nil when none is flagged.
+//
+// The flag is set only through PATCH /agenthub/templates/{templateID}
+// (AgentHubHandler.UpdateTemplate, which the Dashboard's per-template toggle
+// calls). Neither registration path writes it — RegisterMarketTemplate omits
+// the column and UpsertTemplateSQL hardcodes it false — so an install has no
+// recommended template until an operator marks one.
+func (s *Store) GetRecommendedAgentTemplate(ctx context.Context) (*AgentTemplate, error) {
+	row := s.db.WithContext(ctx).Raw(
+		`SELECT template_id, name, source_agent_id, source_snapshot_id,
+		        source_sandbox_id, model, version, persistence_mode,
+		        recommended, created_at
+		 FROM t_agenthub_template
+		 WHERE recommended = ? AND deleted_at IS NULL
+		 ORDER BY created_at DESC, id DESC
+		 LIMIT 1`,
+		true,
+	).Row()
+	var tmpl AgentTemplate
+	var persistenceMode, created sql.NullString
+	if err := row.Scan(
+		&tmpl.TemplateID, &tmpl.Name, &tmpl.SourceAgentID, &tmpl.SourceSnapshotID,
+		&tmpl.SourceSandboxID, &tmpl.Model, &tmpl.Version, &persistenceMode,
+		&tmpl.Recommended, &created,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get recommended template: %w", err)
+	}
+	tmpl.PersistenceMode = nullStringPtr(persistenceMode)
+	tmpl.CreatedAt = nullStringPtr(created)
+	return &tmpl, nil
+}
+
 // DeleteAgentTemplate soft-deletes a template.
 //
 // This is the explicit AgentHub delete (DELETE /agenthub/templates/{id}).

--- a/CubeOps/internal/store/agenthub.go
+++ b/CubeOps/internal/store/agenthub.go
@@ -519,7 +519,7 @@ func (s *Store) GetRecommendedAgentTemplate(ctx context.Context) (*AgentTemplate
 	row := s.db.WithContext(ctx).Raw(
 		`SELECT template_id, name, source_agent_id, source_snapshot_id,
 		        source_sandbox_id, model, version, persistence_mode,
-		        recommended, created_at
+		        recommended, `+formatTimestamp("created_at")+` AS created_at
 		 FROM t_agenthub_template
 		 WHERE recommended = ? AND deleted_at IS NULL
 		 ORDER BY created_at DESC, id DESC

--- a/CubeOps/internal/store/agenthub_test.go
+++ b/CubeOps/internal/store/agenthub_test.go
@@ -259,7 +259,8 @@ func TestStore_AgentTemplate(t *testing.T) {
 // TestStore_GetRecommendedAgentTemplate covers the query AgentHub uses to pick
 // a default template: nothing recommended by default (registration never sets
 // the flag), the marked row once PATCH sets it — even when a newer unmarked
-// one exists — and no resurrection after a soft delete.
+// one exists — the newest one when several are marked, and no resurrection
+// after a soft delete.
 func TestStore_GetRecommendedAgentTemplate(t *testing.T) {
 	env := newTestStore(t)
 	defer env.teardown()
@@ -304,6 +305,28 @@ func TestStore_GetRecommendedAgentTemplate(t *testing.T) {
 	}
 	if !got.Recommended {
 		t.Error("Recommended = false on the row returned by the recommended query")
+	}
+
+	// Nothing stops an operator marking several, since the toggle is per
+	// template and clears nothing else. With more than one marked, the ORDER BY
+	// decides — the newest wins, and with both rows written in the same second
+	// it is the id tiebreaker that settles it.
+	if err := s.DB().WithContext(ctx).Exec(
+		`UPDATE t_agenthub_template SET recommended = ? WHERE template_id = ?`, true, "tpl-rec-new",
+	).Error; err != nil {
+		t.Fatalf("mark second recommended: %v", err)
+	}
+	got, err = s.GetRecommendedAgentTemplate(ctx)
+	if err != nil {
+		t.Fatalf("GetRecommendedAgentTemplate: %v", err)
+	}
+	if got == nil || got.TemplateID != "tpl-rec-new" {
+		t.Fatalf("got %v, want tpl-rec-new — the newest of several marked rows must win", got)
+	}
+	if err := s.DB().WithContext(ctx).Exec(
+		`UPDATE t_agenthub_template SET recommended = ? WHERE template_id = ?`, false, "tpl-rec-new",
+	).Error; err != nil {
+		t.Fatalf("unmark second recommended: %v", err)
 	}
 
 	// A soft-deleted recommendation must not come back.

--- a/CubeOps/internal/store/agenthub_test.go
+++ b/CubeOps/internal/store/agenthub_test.go
@@ -255,3 +255,66 @@ func TestStore_AgentTemplate(t *testing.T) {
 		t.Error("GetAgentTemplate after delete should return nil")
 	}
 }
+
+// TestStore_GetRecommendedAgentTemplate covers the query AgentHub uses to pick
+// a default template: nothing recommended by default (registration never sets
+// the flag), the marked row once PATCH sets it — even when a newer unmarked
+// one exists — and no resurrection after a soft delete.
+func TestStore_GetRecommendedAgentTemplate(t *testing.T) {
+	env := newTestStore(t)
+	defer env.teardown()
+	s := env.store
+	ctx := context.Background()
+
+	insert := func(id string) {
+		t.Helper()
+		if err := s.DB().WithContext(ctx).Exec(
+			`INSERT INTO t_agenthub_template (template_id, name, source_agent_id, source_snapshot_id, source_sandbox_id, model, version)
+			 VALUES (?, ?, 'market', '', '', 'deepseek-v4', '1.0')`,
+			id, id,
+		).Error; err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+	insert("tpl-rec-old")
+	insert("tpl-rec-new")
+
+	// Registration does not set the flag, so nothing is recommended yet.
+	got, err := s.GetRecommendedAgentTemplate(ctx)
+	if err != nil {
+		t.Fatalf("GetRecommendedAgentTemplate: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("got %q, want nil — registration must not mark a template recommended", got.TemplateID)
+	}
+
+	// Mark the older row, the way PATCH /agenthub/templates/{id} does. It must
+	// win over the newer, unmarked one.
+	if err := s.DB().WithContext(ctx).Exec(
+		`UPDATE t_agenthub_template SET recommended = ? WHERE template_id = ?`, true, "tpl-rec-old",
+	).Error; err != nil {
+		t.Fatalf("mark recommended: %v", err)
+	}
+	got, err = s.GetRecommendedAgentTemplate(ctx)
+	if err != nil {
+		t.Fatalf("GetRecommendedAgentTemplate: %v", err)
+	}
+	if got == nil || got.TemplateID != "tpl-rec-old" {
+		t.Fatalf("got %v, want tpl-rec-old", got)
+	}
+	if !got.Recommended {
+		t.Error("Recommended = false on the row returned by the recommended query")
+	}
+
+	// A soft-deleted recommendation must not come back.
+	if err := s.DeleteAgentTemplate(ctx, "tpl-rec-old"); err != nil {
+		t.Fatalf("DeleteAgentTemplate: %v", err)
+	}
+	got, err = s.GetRecommendedAgentTemplate(ctx)
+	if err != nil {
+		t.Fatalf("GetRecommendedAgentTemplate: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %q after soft delete, want nil", got.TemplateID)
+	}
+}


### PR DESCRIPTION
## Summary

`AgentHubService.CreateInstance` fell back to the hardcoded template identifier `"wecom-ds-openclaw"` whenever the request carried neither a snapshot nor a `templateId`. Nothing in this repository provisions a template under that identifier — it is not a `tpl-`/`snap-` id, so CubeMaster resolves it through `GetTemplateByAlias`, and it only resolves on installs where an operator claimed that alias by hand. On a self-hosted install every such create fails with

```
failed to create sandbox: cubemaster error 130404: failed to resolve template identifier "wecom-ds-openclaw": template not found
```

naming an identifier the caller never supplied. The Dashboard sends exactly this request whenever its template selector has nothing to select.

Fixes #1327 — full analysis, repro and environment there.

## What changed

- `CreateInstance` resolves its default from the registered AgentHub templates: the one an operator marked recommended if there is one, otherwise the most recently registered. Both are single bounded queries — `store.GetRecommendedAgentTemplate` (new) and `ListAgentTemplates(1, 0)`.
- The literal moves into a documented `defaultAgentTemplateID` constant and stays as a **last resort**, reached only when the registry listing completed and came back empty. One corner install does change: where the alias is claimed **and** templates are registered, the registered template now wins. That is intended — a template an operator actually registered should beat a hand-claimed identifier — but "installs carrying the alias are unaffected" only holds while their registry is empty, so it is stated rather than implied.
- When that last resort is the identifier CubeMaster failed to resolve, the caller gets a `400` naming the missing registration instead of the `502` not-found. The rewrite fires on a CubeMaster not-found in a request whose only template identifier is that fallback, and only when the registry listing completed and came back empty — it does not inspect *which* resource the not-found was about, because CubeMaster does not say. In this tree that is the same thing: `sandbox_create.go` raises `130404` only for `ErrTemplateNotFound`, while `instance_type`, `distribution_scope` and the rest exit as `MasterParamsError`. Neighbouring cases are unaffected: a not-found for a template the caller did name surfaces as before, so does one after a listing that failed rather than came back empty, and an opaque route 404 or any 5xx is not treated as a not-found at all. CubeMaster's own message is logged before the rewrite, so nothing is lost to an operator if a not-found ever does arrive for something else.
- `GetRecommendedAgentTemplate` / `ListAgentTemplates` added to the `AgentStore` interface — `*store.Store` already implemented the latter.

## Behaviour

| request | before | after |
|---|---|---|
| `templateId` given | used as-is | unchanged |
| `snapshotId` given | used as-is | unchanged |
| neither, template(s) registered | `wecom-ds-openclaw` → 130404 | recommended if one is marked, else most recently registered |
| neither, none registered, alias exists on the install | resolves | unchanged — still resolves |
| neither, **some registered**, alias exists on the install | resolves via the alias | resolves via the registered template (recommended, else newest) — **intended change** |
| neither, some registered, that template unresolvable at create time | 502 naming an identifier the caller never chose | 409 `the agent template selected by default could not be resolved … Pass templateId explicitly` |
| neither, none registered, no alias | 502 `cubemaster error 130404: … "wecom-ds-openclaw" …` | 400 `no agent template is registered: register one from the template market (POST /agenthub/templates/market), or pass templateId explicitly` |
| neither, registry read failed | 502 from CubeMaster | unchanged — 502, never the 400 |

## Where `recommended` comes from

**Correction to an earlier revision of this description**, which claimed the Dashboard marks every market-registered template recommended. It does send `recommended: true`, but the server does not persist it: `RegisterMarketTemplate` (`internal/handler/agenthub.go:522-560`) parses the field and its INSERT omits the column, and `UpsertTemplateSQL` (`internal/store/dialect.go:139-157`) hardcodes it false on the publish path — so registration always lands `recommended = 0`.

The flag is set only by `PATCH /agenthub/templates/{templateID}`, which the Dashboard's per-template toggle calls (`web/src/pages/AgentHub.tsx:482`). That makes the preference an explicit operator choice rather than a side effect of registration, and it is why this PR resolves it with its own query: a marked template can sit behind any number of newer registrations.

Whether registration *should* persist the flag the Dashboard sends looks like a separate question — persisting it as-is would mark every market template recommended — so this PR leaves that path alone. Happy to file it separately if you would like it changed.

## Testing

`go test ./...` passes in `CubeOps/`, including the dockertest store suite against MySQL 8.0.

- `TestStore_GetRecommendedAgentTemplate` (real MySQL) — nothing recommended after registration; a marked older row wins over a newer unmarked one; a soft-deleted recommendation does not come back
- `TestCreateInstance_DefaultTemplateSelection` — recommended wins; most-recent when none is marked; the built-in identifier when nothing is registered
- `TestCreateInstance_RecommendedIsNotWindowLimited` — the registry is not listed at all once a recommended template is found
- `TestCreateInstance_ExplicitTemplateIDWins` — an explicit id is used as-is and the registry is never consulted
- `TestCreateInstance_NoTemplateRegisteredReportsMissingRegistration` — the actionable 400, and that the built-in identifier is not leaked to the caller
- `TestCreateInstance_TemplateReadFailureIsNotReportedAsUnregistered` — either read failing keeps the 502, so a transient DB failure is never reported as an empty registry
- `TestCreateInstance_ExplicitTemplateNotFoundStaysBadGateway` — guards the narrowness of the rewrite

The `130404` in the issue was hit on a v0.6.0 single-node install; this branch is covered by the tests above and has not been deployed to that install.

## Left alone deliberately

`docs/guide/digital-assistant.md:17` (and the `zh` mirror) and `CubeAPI/scripts/test-cube-api.sh:26` also reference `wecom-ds-openclaw` as though it exists. Those look like the same leak but they are documentation/tooling wording rather than behaviour, so they are not touched here — happy to follow up in a separate PR if you want them reworded.

Assisted-by: Claude Code:claude-opus-5


