### PR TITLE
shim: document rollback as delete-and-restore, not checkpoint

### DIFF
--- a/CubeShim/docs/shimapi/README.md
+++ b/CubeShim/docs/shimapi/README.md
@@ -1,20 +1,20 @@
 # CubeShim Extended API (shimapi)
 
 CubeShim exposes an **extended control plane** on top of the standard containerd Shim v2 API.
-The extension uses containerd's `UpdateContainer` RPC, where the caller passes arbitrary
+The extension uses containerd's Task `Update` RPC, where the caller passes arbitrary
 `annotations` to trigger custom actions inside the shim.
 
 ## How It Works
 
-All shimapi actions are delivered via the **containerd Shim v2 `UpdateContainer` RPC**
-([spec](https://github.com/containerd/containerd/blob/main/core/runtime/v2/README.md)).
-The caller populates the `annotations` map on `UpdateContainerRequest`; CubeShim reads
+All shimapi actions are delivered via the **containerd Shim v2 Task `Update` RPC**
+([spec](https://github.com/containerd/containerd/blob/main/docs/runtime-v2.md)).
+The caller populates the `annotations` map on `UpdateTaskRequest`; CubeShim reads
 `cube.shimapi.update.action` and dispatches to the matching handler.
 
 ```
 caller (CubeAPI / CubeMaster)
     │
-    │  UpdateContainerRequest { id: <sandbox_id>, annotations: { ... } }
+    │  UpdateTaskRequest { id: <sandbox_id>, annotations: { ... } }
     │  (containerd Shim v2 / ttrpc)
     ▼
 CubeShim  →  update_ext::update_route()

--- a/CubeShim/docs/shimapi/rollback-snapshot.md
+++ b/CubeShim/docs/shimapi/rollback-snapshot.md
@@ -4,26 +4,27 @@ Roll back a running sandbox VM to a previously taken snapshot.
 
 ## Overview
 
-The caller pauses the current VM, snapshots it to a temporary path, then resumes from a
-caller-supplied snapshot URL. On success the sandbox continues running from the target
-snapshot state. The temporary pause snapshot is discarded automatically.
+CubeShim marks the sandbox paused (a logical state transition, not a VMM-level pause),
+disconnects the guest agent, deletes the VM with `VmDelete`, then restores the
+caller-supplied snapshot. No temporary safety checkpoint is taken: if restore fails,
+teardown is terminal and the previous VM cannot be restored.
 
 **Precondition:** the sandbox must be in `Normal` (running) state. The operation will
 fail if the sandbox is already paused, pausing, or has pending exec tasks.
 
 ## Trigger
 
-This action is invoked via the **containerd Shim v2 `UpdateContainer` RPC**
-([spec](https://github.com/containerd/containerd/blob/main/core/runtime/v2/README.md)).
-The caller sets custom `annotations` on the `UpdateContainerRequest`; CubeShim's
+This action is invoked via the **containerd Shim v2 Task `Update` RPC**
+([spec](https://github.com/containerd/containerd/blob/main/docs/runtime-v2.md)).
+The caller sets custom `annotations` on the `UpdateTaskRequest`; CubeShim's
 `update_ext::update_route()` dispatches on `cube.shimapi.update.action`.
 
 ```
-caller  ──UpdateContainerRequest { id, annotations }──▶  CubeShim (ttrpc)
+caller  ──UpdateTaskRequest { id, annotations }──▶  CubeShim (ttrpc)
+                                                    │
+                                                    └─▶ update_ext::update_route()
                                                               │
-                                                              └─▶ update_ext::update_route()
-                                                                        │
-                                                                        └─▶ RollbackSnapshot handler
+                                                              └─▶ RollbackSnapshot handler
 ```
 
 | Annotation Key | Required | Value |
@@ -260,4 +261,4 @@ cube-runtime snapshot \
 | `invalid cube.shimapi.update.rollback.restore_config: ...` | The annotation value is not valid JSON or missing required fields |
 | `sandbox not running, cannot rollback` | Sandbox is not in `Normal` state |
 | `sandbox pause forbidding, terminate exec tasks first` | There are active exec tasks blocking the pause |
-| `rollback snapshot failed: ...` | Lower-level hypervisor error during pause/restore |
+| `rollback snapshot failed: ...` | Shim log line for any error returned by `rollback_vm` (VM delete or restore); the caller-visible ttrpc error is `update sandbox failed:<e>` |

--- a/CubeShim/shim/src/service/update_ext.rs
+++ b/CubeShim/shim/src/service/update_ext.rs
@@ -23,7 +23,7 @@ const ANNO_UPDATE_EXT_ACTION: &str = "cube.shimapi.update.action";
 ///   `source_url`  — URL of the snapshot to restore from (e.g. `file:///data/snapshots/foo`)
 ///
 /// Optional fields (replace backend devices after restore):
-///   `disks`, `net`, `fs`, `vsock`, `pmem`, `prefault`, `dirty_log`
+///   `disks`, `net`, `fs`, `vsock`, `pmem`, `prefault`, `dirty_log`, `memory_vol_url`
 const ANNO_ROLLBACK_RESTORE_CONFIG: &str = "cube.shimapi.update.rollback.restore_config";
 
 // ── restore config aligned with hypervisor RestoreConfig ─────────────────────
@@ -92,9 +92,11 @@ impl From<RollbackRestoreConfig> for RestoreConfig {
 /// Roll back the running VM to a previously-taken snapshot.
 ///
 /// Steps:
-/// 1. Pause the current VM and snapshot its state to a temporary path on disk.
-/// 2. Resume the VM from the snapshot specified in `restore_config.source_url`,
-///    optionally replacing backend devices via the other fields.
+/// 1. Mark the sandbox paused (a logical state transition, not a VMM-level pause) and
+///    disconnect the guest agent, then delete the current VM with `VmDelete`.
+/// 2. Restore the target snapshot specified in `restore_config.source_url`, optionally
+///    replacing backend devices via the other fields. Restore failure is terminal; the
+///    previous VM cannot be restored because no temporary checkpoint is taken.
 async fn do_rollback_snapshot(
     sb: &mut SandBox,
     annos: &HashMap<String, String>,


### PR DESCRIPTION
rollback_vm has deleted the current VM with VmDelete before restoring the target snapshot, with no temporary checkpoint, but the docs still described pausing and snapshotting to a temporary path. Align the shimapi docs and the update_ext step comment with the implemented behavior, including that restore failure is terminal.

Changes:
- `rollback-snapshot.md`: rewrite Overview as delete-and-restore (no temporary checkpoint), fix Trigger to the Task `Update` RPC / `UpdateTaskRequest` with the docs/runtime-v2.md spec URL, and clarify the error table (`rollback snapshot failed: ...` is the shim log line; caller sees `update sandbox failed:<e>`).
- `README.md` (shimapi index): apply the same RPC/request-type/spec-URL correction so the sibling doc stays consistent.
- `update_ext.rs`: add `memory_vol_url` to the optional-fields comment and update the `do_rollback_snapshot` step comments to match the implemented order of operations.

Co-developed-by: AlexSun <alexsun@alexsun.top>