### PR TITLE
cubelet: fix exec IO drain race and DeleteWithTx error propagation

### DIFF
--- a/Cubelet/cmd/cubecli/commands/container/exec.go
+++ b/Cubelet/cmd/cubecli/commands/container/exec.go
@@ -181,7 +181,7 @@ var ExecCommand = &cli.Command{
 		if flagD {
 			return nil
 		}
-		status := <-statusC
+		status := waitForProcessIO(statusC, process.IO().Wait)
 		code, _, err := status.Result()
 		if err != nil {
 			return fmt.Errorf("failed to get exit code: %w", err)
@@ -191,6 +191,14 @@ var ExecCommand = &cli.Command{
 		}
 		return nil
 	},
+}
+
+// waitForProcessIO prevents process deletion from racing the final stdout and
+// stderr copy loops after the process has exited.
+func waitForProcessIO(statusC <-chan containerd.ExitStatus, wait func()) containerd.ExitStatus {
+	status := <-statusC
+	wait()
+	return status
 }
 
 func findContainer(ctx gocontext.Context, id string, cntdClient *containerd.Client) ([]containerd.Container, error) {

--- a/Cubelet/cmd/cubecli/commands/container/exec_test.go
+++ b/Cubelet/cmd/cubecli/commands/container/exec_test.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,4 +39,78 @@ func TestStdinCloserClosesOnceOnEOF(t *testing.T) {
 	assert.Equal(t, 0, n)
 	assert.ErrorIs(t, err, io.EOF)
 	assert.Equal(t, int32(1), closeCount.Load())
+}
+
+func TestWaitForProcessIOWaitsAfterExit(t *testing.T) {
+	statusC := make(chan containerd.ExitStatus, 1)
+	statusC <- *containerd.NewExitStatus(1, time.Now(), nil)
+	outputDrained := false
+
+	status := waitForProcessIO(statusC, func() { outputDrained = true })
+
+	assert.True(t, outputDrained)
+	code, _, err := status.Result()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), code)
+}
+
+// TestWaitForProcessIOReturnsOnlyAfterDrain guards the ordering invariant that
+// caused the original race: the exit status must not be returned to the caller
+// (which triggers process.Delete) until the IO drain has completed. A drain that
+// is still running when waitForProcessIO returns would let deletion truncate the
+// final stdout/stderr copy loops.
+func TestWaitForProcessIOReturnsOnlyAfterDrain(t *testing.T) {
+	statusC := make(chan containerd.ExitStatus, 1)
+	statusC <- *containerd.NewExitStatus(0, time.Now(), nil)
+
+	drainStarted := make(chan struct{})
+	releaseDrain := make(chan struct{})
+	var drainReturned atomic.Bool
+
+	returned := make(chan struct{})
+	go func() {
+		waitForProcessIO(statusC, func() {
+			close(drainStarted)
+			<-releaseDrain
+			drainReturned.Store(true)
+		})
+		close(returned)
+	}()
+
+	<-drainStarted
+	// The drain is in flight; waitForProcessIO must still be blocked.
+	select {
+	case <-returned:
+		t.Fatal("waitForProcessIO returned before IO drain completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseDrain)
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("waitForProcessIO did not return after IO drain completed")
+	}
+	assert.True(t, drainReturned.Load(), "drain must have finished before return")
+}
+
+// TestWaitForProcessIODrainsAfterStatus asserts the drain observes the exit
+// status first (status is consumed from the channel before wait runs), matching
+// the "<-statusC then wait()" order in the implementation. The status is loaded
+// synchronously before the call so that a reordered "wait(); <-statusC" would
+// still see it buffered and fail the assertion.
+func TestWaitForProcessIODrainsAfterStatus(t *testing.T) {
+	statusC := make(chan containerd.ExitStatus, 1)
+	statusC <- *containerd.NewExitStatus(3, time.Now(), nil)
+	var statusReadyAtDrain atomic.Bool
+
+	status := waitForProcessIO(statusC, func() {
+		// The status must already be drained from the channel before wait runs.
+		statusReadyAtDrain.Store(len(statusC) == 0)
+	})
+
+	assert.True(t, statusReadyAtDrain.Load())
+	code, _, err := status.Result()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(3), code)
 }

--- a/Cubelet/pkg/utils/localstorage.go
+++ b/Cubelet/pkg/utils/localstorage.go
@@ -174,7 +174,7 @@ func (cs *CubeStore) DeleteWithTx(bucket, key string, callback func() error) (er
 		if callback != nil {
 			err = callback()
 		}
-		return nil
+		return err
 	})
 	return
 }

--- a/Cubelet/pkg/utils/localstorage_test.go
+++ b/Cubelet/pkg/utils/localstorage_test.go
@@ -5,6 +5,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -17,6 +18,96 @@ import (
 	"github.com/stretchr/testify/assert"
 	bolt "go.etcd.io/bbolt"
 )
+
+func TestDeleteWithTxCallbackErrorRollsBack(t *testing.T) {
+	db, err := NewCubeStore(filepath.Join(t.TempDir(), "meta.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Set("bucket", "key", []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	want := errors.New("callback failed")
+	if err := db.DeleteWithTx("bucket", "key", func() error { return want }); !errors.Is(err, want) {
+		t.Fatalf("DeleteWithTx error = %v, want %v", err, want)
+	}
+	if got, err := db.Get("bucket", "key"); err != nil || string(got) != "value" {
+		t.Fatalf("deleted value after callback failure: %q, %v", got, err)
+	}
+}
+
+// TestDeleteWithTxCallbackSuccessCommits is the positive counterpart: when the
+// callback succeeds the delete must commit and DeleteWithTx must return nil.
+// This guards against a regression where propagating the callback error would
+// also surface a spurious error on the happy path.
+func TestDeleteWithTxCallbackSuccessCommits(t *testing.T) {
+	db, err := NewCubeStore(filepath.Join(t.TempDir(), "meta.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Set("bucket", "key", []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	if err := db.DeleteWithTx("bucket", "key", func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("DeleteWithTx returned error on success: %v", err)
+	}
+	if !called {
+		t.Fatal("callback was not invoked")
+	}
+	if _, err := db.Get("bucket", "key"); !errors.Is(err, ErrorKeyNotFound) {
+		t.Fatalf("key still present after successful delete: err=%v", err)
+	}
+}
+
+// TestDeleteWithTxNilCallbackDeletes covers the plain-delete path (nil callback,
+// used by Delete): the key is removed and no error is returned.
+func TestDeleteWithTxNilCallbackDeletes(t *testing.T) {
+	db, err := NewCubeStore(filepath.Join(t.TempDir(), "meta.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Set("bucket", "key", []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.DeleteWithTx("bucket", "key", nil); err != nil {
+		t.Fatalf("DeleteWithTx(nil) returned error: %v", err)
+	}
+	if _, err := db.Get("bucket", "key"); !errors.Is(err, ErrorKeyNotFound) {
+		t.Fatalf("key still present after nil-callback delete: err=%v", err)
+	}
+}
+
+// TestDeleteWithTxBucketNotFoundSkipsCallback covers the early-return path: when
+// the bucket does not exist the transaction aborts with ErrorBucketNotFound
+// before the callback runs, so cascading-cleanup callbacks must not fire.
+func TestDeleteWithTxBucketNotFoundSkipsCallback(t *testing.T) {
+	db, err := NewCubeStore(filepath.Join(t.TempDir(), "meta.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	called := false
+	err = db.DeleteWithTx("missing", "key", func() error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, ErrorBucketNotFound) {
+		t.Fatalf("DeleteWithTx error = %v, want %v", err, ErrorBucketNotFound)
+	}
+	if called {
+		t.Fatal("callback ran despite missing bucket")
+	}
+}
 
 func TestSet_SingleDb(t *testing.T) {
 	basePath := t.TempDir()


### PR DESCRIPTION
## Summary

Two related Cubelet bug fixes in the CLI exec path and the local metadata store.

- **Drain exec IO before reading exit status** (`cmd/cubecli/commands/container/exec.go`):
`ExecCommand` waited only on the exit status channel and then returned, letting
the deferred `process.Delete` race the final stdout/stderr copy loops — the tail
of a command's output could be truncated. It now waits for `process.IO().Wait()`
to finish before returning the status, so deletion only happens after the IO
drain completes.

- **Propagate DeleteWithTx callback errors** (`pkg/utils/localstorage.go`):
`DeleteWithTx` returned `nil` even when the transaction callback failed, so the
on-disk delete committed while the callback's side effect (e.g. in-memory indexer
cleanup) had failed — leaving the store inconsistent. It now returns the callback
error, which aborts and rolls back the bbolt transaction, matching `SetWithTx`'s
semantics.

  Scope of the guarantee: only the bbolt delete is transactional. When the
  callback fails, the on-disk delete is rolled back, but any in-memory side
  effect the callback already performed (e.g. `indexer.Delete`) is not undone.
  This is strictly better than the previous behavior — which silently committed
  the on-disk delete regardless of callback failure — but it is not full
  cross-store atomicity between the bbolt delete and the in-memory index.

## Callers reviewed

Both real callers of `DeleteWithTx` (`pkg/store/cubebox/store.go`,
`pkg/store/membolt/bolt_cache_store.go`) already check the returned error; the new
rollback semantics only improve consistency. No caller relied on the old
always-nil behavior.

## Test plan

- [x] `go test -short ./pkg/utils/...` — DeleteWithTx tests pass (error rollback,
      success commit, nil callback, bucket-not-found)
- [x] New unit tests for the `waitForProcessIO` helper cover the ordering invariant
      (status drained → IO wait → return)
- [ ] `tests/unittest/run.sh cubelet` in the builder (runs `make gen` first, needed
      for the `CubeNet/cubevs` BPF-generated code)

Assisted-by: Claude Code:claude-opus-4-7
