### PR TITLE
feat(cubelog): configurable roll policy via config.toml

### DIFF
--- a/Cubelet/cmd/cubelet/config.go
+++ b/Cubelet/cmd/cubelet/config.go
@@ -164,6 +164,11 @@ func platformAgnosticDefaultConfig() *srvconfig.Config {
 		},
 		PidFile:           "/run/cube-let.pid",
 		DynamicConfigPath: "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.yaml",
+		CubeLog: srvconfig.CubeLogConfig{
+			Path:     srvconfig.DefaultCubeLogPath,
+			FileNum:  srvconfig.DefaultCubeLogFileNum,
+			FileSize: srvconfig.DefaultCubeLogFileSize,
+		},
 	}
 	return baseConfig
 }

--- a/Cubelet/cmd/cubelet/cubelog.go
+++ b/Cubelet/cmd/cubelet/cubelog.go
@@ -7,15 +7,13 @@ package main
 import (
 	"fmt"
 
-	"github.com/urfave/cli/v2"
-
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/version"
+	srvconfig "github.com/tencentcloud/CubeSandbox/Cubelet/services/server/config"
 	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
-func initCubeLog(context *cli.Context, module, logPath string) {
-
+func initCubeLog(module string, logCfg srvconfig.CubeLogConfig) {
 	cubelog.SetModuleName(module)
 
 	cubelog.EnableFileLog()
@@ -27,14 +25,15 @@ func initCubeLog(context *cli.Context, module, logPath string) {
 
 	cubelog.EnableLogMetric()
 
+	logPath := logCfg.Path
 	if logPath == "" {
 		logPath = fmt.Sprintf("/data/log/%s", module)
 	}
 	cubelog.Create(logPath)
 	traceLogName := fmt.Sprintf("%s-stat", module)
 
-	num := context.Int("log-roll-num")
-	size := context.Int("log-roll-size")
+	num := logCfg.FileNum
+	size := logCfg.FileSizeMB()
 
 	cubelog.SetTraceOutput(cubelog.NewRollFileWriter(logPath, traceLogName, num, size))
 

--- a/Cubelet/cmd/cubelet/main.go
+++ b/Cubelet/cmd/cubelet/main.go
@@ -262,18 +262,18 @@ func App() *cli.App {
 		},
 		&cli.StringFlag{
 			Name:  "logpath",
-			Value: "/data/log/Cubelet",
+			Value: srvconfig.DefaultCubeLogPath,
 			Usage: "cubelog log directory",
 		},
 		&cli.IntFlag{
 			Name:  "log-roll-num",
-			Value: 10,
+			Value: srvconfig.DefaultCubeLogFileNum,
 			Usage: "cubelog files roll number",
 		},
-		&cli.IntFlag{
+		&cli.StringFlag{
 			Name:  "log-roll-size",
-			Value: 500,
-			Usage: "cubelog files roll size(MB)",
+			Value: string(srvconfig.DefaultCubeLogFileSize),
+			Usage: "cubelog files roll size (500m, 1g; unitless integer is MiB)",
 		},
 		&cli.IntFlag{
 			Name:  "state-tmpfs-size",
@@ -324,6 +324,9 @@ func App() *cli.App {
 		if err := applyFlags(context, config); err != nil {
 			return err
 		}
+		if err := config.CubeLog.ApplyDefaults(); err != nil {
+			return err
+		}
 		ensureRequiredPlugins(config)
 
 		_, err = dynamConf.Init(config.DynamicConfigPath, context.Bool("no-dynamic-path"))
@@ -331,7 +334,7 @@ func App() *cli.App {
 			return err
 		}
 
-		initCubeLog(context, "Cubelet", context.String("logpath"))
+		initCubeLog("Cubelet", config.CubeLog)
 
 		if err := server.CreateTopLevelDirectories(config); err != nil {
 			return err
@@ -578,6 +581,16 @@ func applyFlags(context *cli.Context, config *srvconfig.Config) error {
 		if s := context.String(v.name); s != "" {
 			*v.d = s
 		}
+	}
+
+	if context.IsSet("logpath") {
+		config.CubeLog.Path = context.String("logpath")
+	}
+	if context.IsSet("log-roll-num") {
+		config.CubeLog.FileNum = context.Int("log-roll-num")
+	}
+	if context.IsSet("log-roll-size") {
+		config.CubeLog.FileSize = srvconfig.CubeLogFileSize(context.String("log-roll-size"))
 	}
 	return nil
 }

--- a/Cubelet/cmd/cubelet/main_test.go
+++ b/Cubelet/cmd/cubelet/main_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	srvconfig "github.com/tencentcloud/CubeSandbox/Cubelet/services/server/config"
+	"github.com/urfave/cli/v2"
 )
 
 func TestEnsureRequiredPluginsAddsCriticalCubeletPlugins(t *testing.T) {
@@ -21,4 +24,78 @@ func TestEnsureRequiredPluginsAddsCriticalCubeletPlugins(t *testing.T) {
 	assert.Contains(t, cfg.RequiredPlugins, string(constants.InternalPlugin)+"."+constants.CubeboxID.ID())
 	assert.Contains(t, cfg.RequiredPlugins, string(constants.WorkflowPlugin)+"."+constants.WorkflowID.ID())
 	assert.Contains(t, cfg.RequiredPlugins, string(constants.CubeboxServicePlugin)+"."+constants.CubeboxServiceID.ID())
+}
+
+func TestApplyFlagsCubeLogCLIOverridesTomlWhenSet(t *testing.T) {
+	cfg := platformAgnosticDefaultConfig()
+	cfg.CubeLog = srvconfig.CubeLogConfig{
+		Path:     "/from/toml",
+		FileNum:  3,
+		FileSize: "100m",
+	}
+
+	require.NoError(t, runApplyFlags(cfg,
+		"--logpath", "/from/cli",
+		"--log-roll-num", "7",
+		"--log-roll-size", "1g",
+	))
+	require.NoError(t, cfg.CubeLog.ApplyDefaults())
+
+	assert.Equal(t, "/from/cli", cfg.CubeLog.Path)
+	assert.Equal(t, 7, cfg.CubeLog.FileNum)
+	assert.Equal(t, srvconfig.CubeLogFileSize("1g"), cfg.CubeLog.FileSize)
+	assert.Equal(t, 1024, cfg.CubeLog.FileSizeMB())
+}
+
+func TestApplyFlagsCubeLogKeepsTomlWhenCLIUnset(t *testing.T) {
+	cfg := platformAgnosticDefaultConfig()
+	cfg.CubeLog = srvconfig.CubeLogConfig{
+		Path:     "/from/toml",
+		FileNum:  3,
+		FileSize: "100m",
+	}
+
+	require.NoError(t, runApplyFlags(cfg))
+	require.NoError(t, cfg.CubeLog.ApplyDefaults())
+
+	assert.Equal(t, "/from/toml", cfg.CubeLog.Path)
+	assert.Equal(t, 3, cfg.CubeLog.FileNum)
+	assert.Equal(t, srvconfig.CubeLogFileSize("100m"), cfg.CubeLog.FileSize)
+	assert.Equal(t, 100, cfg.CubeLog.FileSizeMB())
+}
+
+func TestApplyFlagsCubeLogZeroCLIClampedByDefaults(t *testing.T) {
+	cfg := platformAgnosticDefaultConfig()
+	cfg.CubeLog = srvconfig.CubeLogConfig{
+		Path:     "/from/toml",
+		FileNum:  3,
+		FileSize: "100m",
+	}
+
+	require.NoError(t, runApplyFlags(cfg, "--log-roll-num", "0", "--log-roll-size", "0"))
+	require.NoError(t, cfg.CubeLog.ApplyDefaults())
+
+	assert.Equal(t, "/from/toml", cfg.CubeLog.Path)
+	assert.Equal(t, srvconfig.DefaultCubeLogFileNum, cfg.CubeLog.FileNum)
+	assert.Equal(t, srvconfig.DefaultCubeLogFileSize, cfg.CubeLog.FileSize)
+	assert.Equal(t, srvconfig.DefaultCubeLogFileSizeMB, cfg.CubeLog.FileSizeMB())
+}
+
+func runApplyFlags(cfg *srvconfig.Config, args ...string) error {
+	app := &cli.App{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "log-level", Value: "warn"},
+			&cli.StringFlag{Name: "root"},
+			&cli.StringFlag{Name: "state"},
+			&cli.StringFlag{Name: "address"},
+			&cli.StringFlag{Name: "dynamic-conf-path"},
+			&cli.StringFlag{Name: "logpath", Value: srvconfig.DefaultCubeLogPath},
+			&cli.IntFlag{Name: "log-roll-num", Value: srvconfig.DefaultCubeLogFileNum},
+			&cli.StringFlag{Name: "log-roll-size", Value: string(srvconfig.DefaultCubeLogFileSize)},
+		},
+		Action: func(c *cli.Context) error {
+			return applyFlags(c, cfg)
+		},
+	}
+	return app.Run(append([]string{"cubelet"}, args...))
 }

--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -34,6 +34,10 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
   disable = true
 [debug]
   address = ":9966"
+[cubelog]
+  path = "/data/log/Cubelet"
+  file_num = 10      # retained files (current + numbered backups)
+  file_size = "500m" # per-file roll size: 500m, 1g, 2g (binary MiB/GiB); unitless integer is MiB
 [plugins]
   [plugins."io.cubelet.controller.config.v1.cubelet"]
     # Static-only cadence for node status and resource reporting.

--- a/Cubelet/services/server/config/config.go
+++ b/Cubelet/services/server/config/config.go
@@ -28,10 +28,12 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/log"
+	"github.com/docker/go-units"
 	"github.com/imdario/mergo"
 	"github.com/pelletier/go-toml/v2"
 
@@ -50,7 +52,16 @@ type Config struct {
 	OperationServer OperationServerConfig `toml:"operation_server"`
 
 	DynamicConfigPath string `toml:"dynamic_config_path"`
+
+	CubeLog CubeLogConfig `toml:"cubelog"`
 }
+
+const (
+	DefaultCubeLogPath       = "/data/log/Cubelet"
+	DefaultCubeLogFileNum    = 10
+	DefaultCubeLogFileSize   = CubeLogFileSize("500m")
+	DefaultCubeLogFileSizeMB = 500
+)
 
 type StreamProcessor struct {
 	Accepts []string `toml:"accepts"`
@@ -79,6 +90,94 @@ type CubeTapConfig struct {
 
 type HttpConfig struct {
 	Address string `toml:"address"`
+}
+
+// CubeLogFileSize is a human-readable roll size such as "500m" or "1g".
+// A unitless integer (toml 500 or CLI --log-roll-size 500) means MiB.
+type CubeLogFileSize string
+
+func (s *CubeLogFileSize) UnmarshalText(text []byte) error {
+	*s = CubeLogFileSize(strings.TrimSpace(string(text)))
+	return nil
+}
+
+// CubeLogConfig is the process-lifetime cubelog roll policy. Changing these
+// values requires a cubelet restart; they are not hot-reloaded from dynamicconf.
+type CubeLogConfig struct {
+	Path     string          `toml:"path"`
+	FileNum  int             `toml:"file_num"`
+	FileSize CubeLogFileSize `toml:"file_size"`
+
+	fileSizeMB int
+}
+
+// ApplyDefaults fills empty path and non-positive roll limits with the
+// historical CLI defaults. file_size that resolves to <= 0 MiB would otherwise
+// rotate on every write. Invalid size strings return an error so a typo does
+// not silently fall back.
+func (c *CubeLogConfig) ApplyDefaults() error {
+	if c == nil {
+		return nil
+	}
+	if c.Path == "" {
+		c.Path = DefaultCubeLogPath
+	}
+	if c.FileNum <= 0 {
+		c.FileNum = DefaultCubeLogFileNum
+	}
+	if cubeLogFileSizeIsNonPositive(string(c.FileSize)) {
+		c.FileSize = DefaultCubeLogFileSize
+	}
+	mb, err := ParseCubeLogFileSize(c.FileSize)
+	if err != nil {
+		return fmt.Errorf("cubelog.file_size: %w", err)
+	}
+	c.fileSizeMB = mb
+	return nil
+}
+
+// FileSizeMB returns the resolved roll size in MiB. ApplyDefaults must run first.
+func (c *CubeLogConfig) FileSizeMB() int {
+	if c == nil || c.fileSizeMB <= 0 {
+		return DefaultCubeLogFileSizeMB
+	}
+	return c.fileSizeMB
+}
+
+// ParseCubeLogFileSize converts a toml/CLI size to MiB.
+// "500m", "1g", "2Gi" use binary units (1024). A unitless integer is MiB.
+// Empty or non-positive values return the default 500MiB.
+func ParseCubeLogFileSize(size CubeLogFileSize) (int, error) {
+	s := strings.TrimSpace(string(size))
+	if cubeLogFileSizeIsNonPositive(s) {
+		return DefaultCubeLogFileSizeMB, nil
+	}
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return int(n), nil
+	}
+	bytes, err := units.RAMInBytes(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q: %w", s, err)
+	}
+	mb := bytes / units.MiB
+	if mb <= 0 {
+		return 0, fmt.Errorf("size %q is smaller than 1MiB", s)
+	}
+	return int(mb), nil
+}
+
+// cubeLogFileSizeIsNonPositive reports clamp-to-default cases:
+// empty, unitless n <= 0, or a unit string that parses to <= 0 bytes.
+func cubeLogFileSizeIsNonPositive(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return true
+	}
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n <= 0
+	}
+	bytes, err := units.RAMInBytes(s)
+	return err == nil && bytes <= 0
 }
 
 func (c *Config) Decode(ctx context.Context, id string, config interface{}) (interface{}, error) {

--- a/Cubelet/services/server/config/config_test.go
+++ b/Cubelet/services/server/config/config_test.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	containerdconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
+)
+
+func TestParseCubeLogFileSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in      CubeLogFileSize
+		wantMB  int
+		wantErr bool
+	}{
+		{in: "", wantMB: DefaultCubeLogFileSizeMB},
+		{in: "0", wantMB: DefaultCubeLogFileSizeMB},
+		{in: "-1", wantMB: DefaultCubeLogFileSizeMB},
+		{in: "500", wantMB: 500},
+		{in: "500m", wantMB: 500},
+		{in: "500M", wantMB: 500},
+		{in: "1g", wantMB: 1024},
+		{in: "2g", wantMB: 2048},
+		{in: "1gib", wantMB: 1024},
+		{in: "512k", wantErr: true},
+		{in: "bogus", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.in), func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseCubeLogFileSize(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseCubeLogFileSize(%q) = %d, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseCubeLogFileSize(%q): %v", tc.in, err)
+			}
+			if got != tc.wantMB {
+				t.Fatalf("ParseCubeLogFileSize(%q) = %d, want %d", tc.in, got, tc.wantMB)
+			}
+		})
+	}
+}
+
+func TestCubeLogApplyDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		in         CubeLogConfig
+		wantPath   string
+		wantNum    int
+		wantSize   CubeLogFileSize
+		wantSizeMB int
+		wantErr    bool
+	}{
+		{
+			name:       "empty",
+			in:         CubeLogConfig{},
+			wantPath:   DefaultCubeLogPath,
+			wantNum:    DefaultCubeLogFileNum,
+			wantSize:   DefaultCubeLogFileSize,
+			wantSizeMB: DefaultCubeLogFileSizeMB,
+		},
+		{
+			name: "zero_size_and_num",
+			in: CubeLogConfig{
+				Path:     "/custom",
+				FileNum:  0,
+				FileSize: "0",
+			},
+			wantPath:   "/custom",
+			wantNum:    DefaultCubeLogFileNum,
+			wantSize:   DefaultCubeLogFileSize,
+			wantSizeMB: DefaultCubeLogFileSizeMB,
+		},
+		{
+			name: "zero_unit_size_normalized",
+			in: CubeLogConfig{
+				Path:     "/custom",
+				FileNum:  4,
+				FileSize: "0m",
+			},
+			wantPath:   "/custom",
+			wantNum:    4,
+			wantSize:   DefaultCubeLogFileSize,
+			wantSizeMB: DefaultCubeLogFileSizeMB,
+		},
+		{
+			name: "explicit_unitless_500_kept",
+			in: CubeLogConfig{
+				Path:     "/keep",
+				FileNum:  3,
+				FileSize: "500",
+			},
+			wantPath:   "/keep",
+			wantNum:    3,
+			wantSize:   "500",
+			wantSizeMB: DefaultCubeLogFileSizeMB,
+		},
+		{
+			name: "explicit_500m_kept",
+			in: CubeLogConfig{
+				Path:     "/keep",
+				FileNum:  3,
+				FileSize: "500m",
+			},
+			wantPath:   "/keep",
+			wantNum:    3,
+			wantSize:   "500m",
+			wantSizeMB: DefaultCubeLogFileSizeMB,
+		},
+		{
+			name: "human_size_1g",
+			in: CubeLogConfig{
+				Path:     "/keep",
+				FileNum:  3,
+				FileSize: "1g",
+			},
+			wantPath:   "/keep",
+			wantNum:    3,
+			wantSize:   "1g",
+			wantSizeMB: 1024,
+		},
+		{
+			name: "invalid_size",
+			in: CubeLogConfig{
+				FileSize: "nope",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.in
+			err := got.ApplyDefaults()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("ApplyDefaults() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ApplyDefaults(): %v", err)
+			}
+			if got.Path != tc.wantPath || got.FileNum != tc.wantNum || got.FileSize != tc.wantSize || got.FileSizeMB() != tc.wantSizeMB {
+				t.Fatalf("ApplyDefaults() = path=%q num=%d size=%q mb=%d, want path=%q num=%d size=%q mb=%d",
+					got.Path, got.FileNum, got.FileSize, got.FileSizeMB(),
+					tc.wantPath, tc.wantNum, tc.wantSize, tc.wantSizeMB)
+			}
+		})
+	}
+}
+
+func TestLoadConfigParsesCubeLogHumanSize(t *testing.T) {
+	t.Parallel()
+
+	path := writeCubeletTOML(t, `
+version = 3
+[cubelog]
+  path = "/tmp/cubelet-log"
+  file_num = 4
+  file_size = "1g"
+`)
+	out := newLoadTarget()
+	if err := LoadConfig(context.Background(), path, out); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := out.CubeLog.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	if out.CubeLog.Path != "/tmp/cubelet-log" {
+		t.Fatalf("path = %q, want /tmp/cubelet-log", out.CubeLog.Path)
+	}
+	if out.CubeLog.FileNum != 4 {
+		t.Fatalf("file_num = %d, want 4", out.CubeLog.FileNum)
+	}
+	if out.CubeLog.FileSize != "1g" {
+		t.Fatalf("file_size = %q, want 1g", out.CubeLog.FileSize)
+	}
+	if out.CubeLog.FileSizeMB() != 1024 {
+		t.Fatalf("file_size MiB = %d, want 1024", out.CubeLog.FileSizeMB())
+	}
+}
+
+func TestLoadConfigParsesCubeLogUnitlessInteger(t *testing.T) {
+	t.Parallel()
+
+	path := writeCubeletTOML(t, `
+version = 3
+[cubelog]
+  path = "/tmp/cubelet-log"
+  file_num = 4
+  file_size = 80
+`)
+	out := newLoadTarget()
+	if err := LoadConfig(context.Background(), path, out); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := out.CubeLog.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	if out.CubeLog.FileSizeMB() != 80 {
+		t.Fatalf("file_size MiB = %d, want 80", out.CubeLog.FileSizeMB())
+	}
+}
+
+func TestLoadConfigMissingCubeLogKeepsDefaults(t *testing.T) {
+	t.Parallel()
+
+	path := writeCubeletTOML(t, `
+version = 3
+[http]
+  address = ":9998"
+`)
+	out := newLoadTarget()
+	if err := LoadConfig(context.Background(), path, out); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := out.CubeLog.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	if out.CubeLog.Path != DefaultCubeLogPath {
+		t.Fatalf("path = %q, want %q", out.CubeLog.Path, DefaultCubeLogPath)
+	}
+	if out.CubeLog.FileNum != DefaultCubeLogFileNum {
+		t.Fatalf("file_num = %d, want %d", out.CubeLog.FileNum, DefaultCubeLogFileNum)
+	}
+	if out.CubeLog.FileSizeMB() != DefaultCubeLogFileSizeMB {
+		t.Fatalf("file_size MiB = %d, want %d", out.CubeLog.FileSizeMB(), DefaultCubeLogFileSizeMB)
+	}
+}
+
+func TestLoadConfigZeroCubeLogFileSizeApplyDefaults(t *testing.T) {
+	t.Parallel()
+
+	path := writeCubeletTOML(t, `
+version = 3
+[cubelog]
+  path = ""
+  file_num = -2
+  file_size = 0
+`)
+	out := newLoadTarget()
+	if err := LoadConfig(context.Background(), path, out); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := out.CubeLog.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	if out.CubeLog.Path != DefaultCubeLogPath {
+		t.Fatalf("path = %q, want %q", out.CubeLog.Path, DefaultCubeLogPath)
+	}
+	if out.CubeLog.FileNum != DefaultCubeLogFileNum {
+		t.Fatalf("file_num = %d, want %d", out.CubeLog.FileNum, DefaultCubeLogFileNum)
+	}
+	if out.CubeLog.FileSize != DefaultCubeLogFileSize {
+		t.Fatalf("file_size = %q, want %q", out.CubeLog.FileSize, DefaultCubeLogFileSize)
+	}
+	if out.CubeLog.FileSizeMB() != DefaultCubeLogFileSizeMB {
+		t.Fatalf("file_size MiB = %d, want %d", out.CubeLog.FileSizeMB(), DefaultCubeLogFileSizeMB)
+	}
+}
+
+func TestLoadShippedConfigParsesCubeLog(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", "..", "config", "config.toml")
+	out := newLoadTarget()
+	if err := LoadConfig(context.Background(), path, out); err != nil {
+		t.Fatalf("LoadConfig shipped config.toml: %v", err)
+	}
+	if err := out.CubeLog.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	if out.CubeLog.Path != DefaultCubeLogPath {
+		t.Fatalf("path = %q, want %q", out.CubeLog.Path, DefaultCubeLogPath)
+	}
+	if out.CubeLog.FileNum != DefaultCubeLogFileNum {
+		t.Fatalf("file_num = %d, want %d", out.CubeLog.FileNum, DefaultCubeLogFileNum)
+	}
+	if out.CubeLog.FileSizeMB() != DefaultCubeLogFileSizeMB {
+		t.Fatalf("file_size MiB = %d, want %d", out.CubeLog.FileSizeMB(), DefaultCubeLogFileSizeMB)
+	}
+}
+
+func newLoadTarget() *Config {
+	return &Config{
+		Config: &containerdconfig.Config{Version: 3},
+		CubeLog: CubeLogConfig{
+			Path:     DefaultCubeLogPath,
+			FileNum:  DefaultCubeLogFileNum,
+			FileSize: DefaultCubeLogFileSize,
+		},
+	}
+}
+
+func writeCubeletTOML(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write toml: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

Moves the cubelog roll policy (`path`, `file_num`, `file_size`) from CLI-only flags into the cubelet config file via a new `[cubelog]` section, backed by a typed `CubeLogConfig` in `Cubelet/services/server/config`.

## What changed

- **Config**: add `CubeLogConfig` with `Path`, `FileNum`, and human-readable `FileSize` (e.g. `"500m"`, `"1g"`); a unitless integer is treated as MiB.
- **Defaults**: `ApplyDefaults()` fills empty or non-positive values with the historical CLI defaults; an invalid size string now errors instead of silently falling back.
- **CLI**: `--log-roll-size` becomes a string flag (`"500m"`) and still overrides config when set; `--logpath` / `--log-roll-num` overrides are preserved.
- **Config file**: add a `[cubelog]` section to the shipped `config.toml`.
- **Tests**: cover size parsing, defaults, TOML loading, and CLI-over-config precedence.

## Change statistics

Most of this PR is test code.

| Category | Files | Insertions | Deletions |
|---|---:|---:|---:|
| Test code (`*_test.go`) | 2 | 356 | 0 |
| Non-test code | 5 | 122 | 10 |
| **Total** | **7** | **478** | **10** |

- Test code accounts for **~74.5%** of all added lines (356 / 478).
- Test files:
  - `Cubelet/services/server/config/config_test.go`: +280
  - `Cubelet/cmd/cubelet/main_test.go`: +76
- Non-test files:
  - `Cubelet/services/server/config/config.go`: +91 / −0
  - `Cubelet/cmd/cubelet/main.go`: +17 / −4
  - `Cubelet/cmd/cubelet/cubelog.go`: +5 / −6
  - `Cubelet/cmd/cubelet/config.go`: +5 / −0
  - `Cubelet/config/config.toml`: +4 / −0

## Why

Roll behavior was previously only expressible via runtime flags, which made the policy invisible in the deployed config and easy to lose across restarts. Moving it into the config file and supporting human-readable sizes makes the roll policy declarative and self-documenting.


