### PR TITLE
fix(cubelet): remove old local template metadata

### DIFF
--- a/Cubelet/pkg/controller/runtemplate/template_manager.go
+++ b/Cubelet/pkg/controller/runtemplate/template_manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/templatetypes"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/membolt"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/multimeta"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
@@ -78,6 +79,11 @@ func (h *localCubeRunTemplateManager) ListLocalTemplates(ctx context.Context) (m
 			"err": err.Error(),
 		}).Warn("failed to recover local templates from snapshot root")
 	}
+	if err := h.removeMissingLocalTemplates(ctx); err != nil {
+		log.G(ctx).WithFields(CubeLog.Fields{
+			"err": err.Error(),
+		}).Warn("failed to remove missing local templates")
+	}
 	templates, err := h.store.ListGeneric()
 	if err != nil {
 		log.G(ctx).WithFields(CubeLog.Fields{
@@ -90,6 +96,69 @@ func (h *localCubeRunTemplateManager) ListLocalTemplates(ctx context.Context) (m
 		templateMap[template.TemplateID] = template
 	}
 	return templateMap, nil
+}
+
+// removeMissingLocalTemplates reconciles the persisted local-template store
+// with snapshot data on disk. CleanupTemplate removes snapshot directories,
+// but historical records may remain in this store and otherwise continue to
+// be reported in every node heartbeat.
+func (h *localCubeRunTemplateManager) removeMissingLocalTemplates(ctx context.Context) error {
+	templates, err := h.store.ListGeneric()
+	if err != nil {
+		return err
+	}
+	for _, template := range templates {
+		if template == nil {
+			continue
+		}
+		snapshotPath := strings.TrimSpace(template.Snapshot.Snapshot.Path)
+		if snapshotPath == "" {
+			continue
+		}
+		exists, err := utils.DenExist(snapshotPath)
+		if err != nil {
+			log.G(ctx).WithFields(CubeLog.Fields{
+				"template_id": template.TemplateID,
+				"path":        snapshotPath,
+				"err":         err.Error(),
+			}).Warn("failed to inspect local template path")
+			continue
+		}
+		if exists {
+			continue
+		}
+
+		// Snapshot writers build the replacement under <snapshotPath>.tmp,
+		// then remove the old final directory and rename the temporary one.
+		// During that publish window the final path is briefly absent. Check
+		// the temporary path, then the final path again in case the rename
+		// completed between the two checks, before treating metadata as stale.
+		for _, path := range []string{snapshotPath + ".tmp", snapshotPath} {
+			exists, err = utils.DenExist(path)
+			if err != nil {
+				log.G(ctx).WithFields(CubeLog.Fields{
+					"template_id": template.TemplateID,
+					"path":        path,
+					"err":         err.Error(),
+				}).Warn("failed to inspect local template path")
+				break
+			}
+			if exists {
+				break
+			}
+		}
+		if err != nil || exists {
+			continue
+		}
+		if err := h.store.Delete(template); err != nil {
+			return fmt.Errorf("delete missing local template %s: %w", template.TemplateID, err)
+		}
+		log.G(ctx).WithFields(CubeLog.Fields{
+			"template_id": template.TemplateID,
+			"path":        snapshotPath,
+		}).Info("removed missing local template metadata")
+	}
+	return nil
 }
 
 func (h *localCubeRunTemplateManager) EnsureCubeRunTemplate(ctx context.Context, templateID string) (*templatetypes.LocalRunTemplate, error) {

--- a/Cubelet/pkg/controller/runtemplate/template_manager_test.go
+++ b/Cubelet/pkg/controller/runtemplate/template_manager_test.go
@@ -5,9 +5,12 @@
 package runtemplate
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/templatetypes"
 )
 
 func TestRecoveredLocalTemplateFromSnapshotPath(t *testing.T) {
@@ -49,5 +52,86 @@ func TestRecoveredLocalTemplateFromSnapshotPathRejectsTemporaryDir(t *testing.T)
 
 	if template := recoveredLocalTemplateFromSnapshotPath(snapshotPath); template != nil {
 		t.Fatalf("expected nil for temporary snapshot path, got %+v", template)
+	}
+}
+
+func TestRemoveMissingLocalTemplates(t *testing.T) {
+	existingPath := t.TempDir()
+	missingPath := filepath.Join(t.TempDir(), "missing")
+	db := &mockMetadataDB{data: make(map[string][]byte)}
+	manager, err := NewCubeRunTemplateManager(db, nil)
+	if err != nil {
+		t.Fatalf("create local template manager: %v", err)
+	}
+
+	templates := []*templatetypes.LocalRunTemplate{
+		newLocalRunTemplateForPath("tpl-existing", existingPath),
+		newLocalRunTemplateForPath("snap-missing", missingPath),
+		newLocalRunTemplateForPath("tpl-missing", missingPath),
+		newLocalRunTemplateForPath("tpl-no-path", ""),
+	}
+	for _, template := range templates {
+		if err := manager.store.Update(template); err != nil {
+			t.Fatalf("seed template %s: %v", template.TemplateID, err)
+		}
+	}
+
+	if err := manager.removeMissingLocalTemplates(context.Background()); err != nil {
+		t.Fatalf("remove missing local templates: %v", err)
+	}
+	got, err := manager.store.ListGeneric()
+	if err != nil {
+		t.Fatalf("list local templates: %v", err)
+	}
+	gotIDs := make(map[string]bool, len(got))
+	for _, template := range got {
+		gotIDs[template.TemplateID] = true
+	}
+	if gotIDs["snap-missing"] {
+		t.Fatal("missing snapshot metadata was not removed")
+	}
+	if gotIDs["tpl-missing"] {
+		t.Fatal("missing template metadata was not removed")
+	}
+	if !gotIDs["tpl-existing"] {
+		t.Fatal("existing template metadata was removed")
+	}
+	if !gotIDs["tpl-no-path"] {
+		t.Fatal("template metadata without a local path was removed")
+	}
+}
+
+func TestRemoveMissingLocalTemplatesKeepsTemporarySnapshot(t *testing.T) {
+	snapshotPath := filepath.Join(t.TempDir(), "snapshot")
+	if err := os.MkdirAll(snapshotPath+".tmp", 0o755); err != nil {
+		t.Fatalf("create temporary snapshot directory: %v", err)
+	}
+	db := &mockMetadataDB{data: make(map[string][]byte)}
+	manager, err := NewCubeRunTemplateManager(db, nil)
+	if err != nil {
+		t.Fatalf("create local template manager: %v", err)
+	}
+	template := newLocalRunTemplateForPath("tpl-publishing", snapshotPath)
+	if err := manager.store.Update(template); err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+
+	if err := manager.removeMissingLocalTemplates(context.Background()); err != nil {
+		t.Fatalf("remove missing local templates: %v", err)
+	}
+	if _, err := manager.store.GetGeneric(template.DistributionTaskID); err != nil {
+		t.Fatalf("template metadata was removed while temporary snapshot exists: %v", err)
+	}
+}
+
+func newLocalRunTemplateForPath(templateID, snapshotPath string) *templatetypes.LocalRunTemplate {
+	return &templatetypes.LocalRunTemplate{
+		DistributionReference: templatetypes.DistributionReference{
+			TemplateID:         templateID,
+			DistributionTaskID: "recovered-" + templateID,
+		},
+		Snapshot: templatetypes.LocalSnapshot{
+			Snapshot: templatetypes.Snapshot{Path: snapshotPath},
+		},
 	}
 }


### PR DESCRIPTION

## Background

Cubelet persists locally discovered templates and snapshots in the `generic_LocalRunTemplate` metadata store. During every node-status update, `ListLocalTemplates` scans the snapshot directory and restores missing store entries before reporting the complete list to CubeMaster.

The reconciliation was one-way: it added records found on disk but never removed records whose snapshot paths had already been deleted. Template, snapshot, and pause/resume cleanup could therefore remove the local artifacts while leaving their `LocalRunTemplate` records behind.

## Impact

run the following command to see the old record

```bash
cubecli meta view generic_LocalRunTemplate |
  jq -s '
    [.[].value | fromjson] |
    {
      total: length,
      snapshots: (
        [.[] | select(
          .distributionReference.templateID | startswith("snap-")
        )] | length
      ),
      templates: (
        [.[] | select(
          .distributionReference.templateID | startswith("tpl-")
        )] | length
      ),
      other: (
        [.[] | select(
          (
            .distributionReference.templateID |
            startswith("snap-") or startswith("tpl-")
          ) | not
        )] | length
      )
    }
  '
```
```bash
{
  "total": 110,
  "snapshots": 456,
  "templates": 110,
  "other": 0
}
```

Stale `tpl-*` and `snap-*` records accumulated over time and were included in every Cubelet heartbeat even though the corresponding local artifacts no longer existed. On nodes with frequent pause/resume or snapshot operations, this could substantially increase the `local_templates` payload persisted by CubeMaster, causing unnecessary metadata growth and database write pressure. It also made the node appear to have local templates or snapshots that were no longer usable.

## Result

After the next node-status reconciliation, orphaned local-template metadata is
removed and no longer reported to CubeMaster. Valid local artifacts continue
to be discovered and reported normally.