### PR TITLE
fix(cubemaster): add missing cubevs replace so module graph resolves

### DIFF
--- a/CubeMaster/go.mod
+++ b/CubeMaster/go.mod
@@ -187,3 +187,5 @@ replace github.com/tencentcloud/CubeSandbox/cubelog => ../cubelog
 replace github.com/tencentcloud/CubeSandbox/CubeDB => ../CubeDB
 
 replace github.com/tencentcloud/CubeSandbox/Cubelet => ../Cubelet
+
+replace github.com/tencentcloud/CubeSandbox/CubeNet/cubevs => ../CubeNet/cubevs


### PR DESCRIPTION
CubeMaster consumes Cubelet, which requires CubeNet/cubevs. Per the Go module spec, a replace directive does not propagate to consumers — only the main module's go.mod replace applies. CubeMaster's go.mod had a replace for Cubelet but not for its transitive dep cubevs, so resolving the module graph (go list -m all, go mod tidy, IDE sync) tried to fetch cubevs@v0.0.0 from the remote and failed with "unknown revision CubeNet/cubevs/v0.0.0".

Add the replace to point cubevs at the local ../CubeNet/cubevs, mirroring the existing cubelog/CubeDB/Cubelet replace pattern. No require is needed because cubevs already enters the graph transitively via Cubelet.

Verified: go list -m all and go mod tidy now succeed on CubeMaster.