### PR TITLE
test(sdk_compat): parallelize live SDK E2E across CPU cores

### DIFF
--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -258,6 +258,24 @@ Optional:
 - `SDK_E2E_SKIP_INTERNET_TESTS`: skip tests marked `requires_internet` when
   the runner or environment has no stable public egress. Defaults to `false`.
 - `SDK_E2E_REPORT_DIR`: JSONL report directory. Defaults to `reports/sdk-dual`.
+- `SDK_E2E_WORKERS`: pytest-xdist worker count for `--run-e2e`. Parallelism is
+  opt-in; unset (or `0`/`1`/`no`/`off`) runs serial to avoid overloading the
+  co-located control plane. Set an integer, `auto`, or `logical` to fan out. An
+  explicit `-n`/`--numprocesses` (or `-p no:xdist`) always wins. Ignored without
+  `--run-e2e`, so the hermetic `framework` gate stays serial.
+- `SDK_E2E_TEMPLATE_BUILD_CONCURRENCY`: max concurrent live template builds
+  across xdist workers. Defaults to `1` (builds fully serialized so results match
+  a serial run); values `< 1` or non-integer fall back to `1`. When the value is
+  at least the worker count the throttle is skipped. POSIX-only (a no-op without
+  `fcntl`). The throttle is namespaced per-UID, not per-run: two concurrent
+  `--run-e2e` jobs of the same user on one host share the slots and serialize
+  their builds against each other. This is intentional -- both jobs contend on
+  the one shared build host -- and the `SDK_E2E_TEMPLATE_BUILD_WAIT` ceiling
+  bounds how long a job waits before degrading to unthrottled.
+- `SDK_E2E_TEMPLATE_BUILD_WAIT`: per-predecessor ceiling (seconds) on waiting for
+  a build slot before a worker gives up and builds unthrottled, so one wedged
+  peer cannot stall the whole suite. The effective wait scales by the worker
+  count. Defaults to `1800`; `<= 0` waits forever.
 - `CUBE_PYTHON_SDK_PATH`: override local CubeSandbox Python SDK path.
 - `SDK_E2E_PLATFORM_LIFECYCLE`: enable platform-managed lifecycle cases
   (`auto-pause`, `auto-resume`, `auto-kill`). Defaults to `false`.
@@ -302,7 +320,10 @@ probes CubeProxy admin health (`heartbeat_last_pushed_ms`) when
 
 ## Reporting
 
-The suite writes JSONL events to `SDK_E2E_REPORT_DIR/events.jsonl`.
+The suite writes JSONL events to `SDK_E2E_REPORT_DIR`. A serial run writes a
+single `events.jsonl`; under pytest-xdist each worker writes its own
+`events-gw0.jsonl`, `events-gw1.jsonl`, ... to avoid interleaved lines, so read
+or aggregate `events*.jsonl` rather than a fixed `events.jsonl`.
 
 To generate a standard HTML report, pass pytest-html options explicitly:
 

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -230,7 +230,20 @@ cp env.example .env
 - `SDK_E2E_SKIP_INTERNET_TESTS`：当 runner 或环境没有稳定公网出站时，
   跳过 `requires_internet` 测试，默认 `false`；
 - `SDK_E2E_REPORT_DIR`：JSONL 报告目录；
-- `CUBE_PYTHON_SDK_PATH`：覆盖本地 CubeSandbox Python SDK 路径；
+- `SDK_E2E_WORKERS`：`--run-e2e` 的 pytest-xdist worker 数量。并行需显式开启，
+  未设置（或 `0`/`1`/`no`/`off`）时串行运行，避免压垮同机的控制面；传整数、
+  `auto` 或 `logical` 才会并行；显式 `-n`/`--numprocesses`（或 `-p no:xdist`）
+  优先。不带 `--run-e2e` 时忽略，因此 hermetic `framework` gate 仍为串行；
+- `SDK_E2E_TEMPLATE_BUILD_CONCURRENCY`：xdist 各 worker 间并发的 live template
+  build 上限，默认 `1`（完全串行，使结果与串行运行一致）；小于 `1` 或非整数回退
+  为 `1`；当取值不小于 worker 数时跳过节流；仅 POSIX（无 `fcntl` 时为 no-op）；
+  节流按 UID 而非按 run 命名：同一用户在同一主机上并发的两个 `--run-e2e` 任务会
+  共享 slot 并相互串行化其构建。这是有意为之——两个任务都在争用同一台共享构建
+  主机——且 `SDK_E2E_TEMPLATE_BUILD_WAIT` 上限会限制任务在降级为不节流前的等待
+  时长；
+- `SDK_E2E_TEMPLATE_BUILD_WAIT`：等待 build slot 的单前驱上限（秒），超时后该
+  worker 放弃节流直接构建，避免某个卡死的 worker 拖垮整个套件；实际等待时间按
+  worker 数缩放；默认 `1800`；`<= 0` 表示无限等待；
 - `SDK_E2E_PLATFORM_LIFECYCLE`：启用平台生命周期测试；
 - `SDK_E2E_PLATFORM_LIFECYCLE_IDLE_TIMEOUT`：平台空闲超时，默认 `30` 秒；
 - `SDK_E2E_PLATFORM_LIFECYCLE_WAIT_MARGIN`：额外等待时间，默认 `20` 秒；
@@ -290,10 +303,13 @@ CubeProxy admin heartbeat。
 
 ## 报告和 Trace
 
-JSONL 报告写入：
+JSONL 报告写入 `SDK_E2E_REPORT_DIR`。串行运行写入单个 `events.jsonl`；启用
+pytest-xdist 后，每个 worker 各自写入 `events-gw0.jsonl`、`events-gw1.jsonl`……
+以避免行交错，因此应读取或聚合 `events*.jsonl` 而非固定的 `events.jsonl`：
 
 ```text
-SDK_E2E_REPORT_DIR/events.jsonl
+SDK_E2E_REPORT_DIR/events.jsonl        # 串行
+SDK_E2E_REPORT_DIR/events-gw0.jsonl    # xdist worker
 ```
 
 主要事件包括：

--- a/tests/e2e/sdk_compat/cases/framework/test_parallel.py
+++ b/tests/e2e/sdk_compat/cases/framework/test_parallel.py
@@ -1,0 +1,355 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-logic unit tests for the xdist worker-count resolver.
+
+Marked ``framework`` so they run on every gate without a live environment
+(see ``conftest.pytest_collection_modifyitems``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.build_throttle import _concurrency, template_build_slot
+from framework.parallel import (
+    apply_worker_count,
+    current_worker_count,
+    resolve_worker_count,
+    scale_timeout_for_xdist,
+    wants_parallel,
+)
+
+pytestmark = pytest.mark.framework
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        # Parallelism is opt-in: unset/empty keeps the run serial.
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("0", None),
+        ("1", None),
+        ("no", None),
+        ("off", None),
+        ("OFF", None),
+        (" No ", None),
+        ("auto", "auto"),
+        ("logical", "logical"),
+        ("AUTO", "auto"),
+        ("4", 4),
+        ("16", 16),
+        (" 3 ", 3),
+    ],
+)
+def test_resolve_worker_count(env_value, expected):
+    assert resolve_worker_count(env_value) == expected
+
+
+@pytest.mark.parametrize("env_value", ["four", "2.5", "0x4"])
+def test_resolve_worker_count_rejects_non_integer(env_value):
+    with pytest.raises(ValueError, match="positive integer"):
+        resolve_worker_count(env_value)
+
+
+@pytest.mark.parametrize("env_value", ["-4", "-1"])
+def test_resolve_worker_count_rejects_non_positive(env_value):
+    with pytest.raises(ValueError, match=">= 1"):
+        resolve_worker_count(env_value)
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        # Unset/disabled = serial by choice, not a request for parallelism.
+        (None, False),
+        ("", False),
+        ("0", False),
+        ("1", False),
+        ("off", False),
+        # A real request (count or passthrough token) -- or a malformed value,
+        # which counts as a request so the misconfig is surfaced, not swallowed.
+        ("4", True),
+        ("auto", True),
+        ("four", True),
+    ],
+)
+def test_wants_parallel(env_value, expected):
+    assert wants_parallel(env_value) is expected
+
+
+def _clear_xdist_env(monkeypatch):
+    monkeypatch.delenv("PYTEST_XDIST_WORKER_COUNT", raising=False)
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+
+
+def test_current_worker_count_serial_default(monkeypatch):
+    _clear_xdist_env(monkeypatch)
+    assert current_worker_count() == 1
+
+
+def test_current_worker_count_uses_authoritative_count(monkeypatch):
+    _clear_xdist_env(monkeypatch)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER_COUNT", "8")
+    assert current_worker_count() == 8
+
+
+@pytest.mark.parametrize("bad_count", ["nan", "0"])
+def test_current_worker_count_falls_back_when_count_unusable(monkeypatch, bad_count):
+    # Non-integer or < 1 authoritative value falls through to the host-stable
+    # fallback, which every worker agrees on (no per-worker divergence).
+    _clear_xdist_env(monkeypatch)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER_COUNT", bad_count)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+    monkeypatch.setattr("framework.parallel.os.cpu_count", lambda: 6)
+    assert current_worker_count() == 6
+
+
+@pytest.mark.parametrize("worker_name", ["gw0", "gw1", "gw3"])
+def test_current_worker_count_fallback_is_worker_agnostic(monkeypatch, worker_name):
+    # When the authoritative count is missing, every worker must resolve the SAME
+    # count so timeout/retry scaling and the throttle-skip condition stay in sync.
+    # Deriving ``gwN + 1`` would make gw0 skip the build lock while peers hold it.
+    _clear_xdist_env(monkeypatch)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", worker_name)
+    monkeypatch.setattr("framework.parallel.os.cpu_count", lambda: 6)
+    assert current_worker_count() == 6
+
+
+def test_current_worker_count_fallback_when_cpu_count_unknown(monkeypatch):
+    _clear_xdist_env(monkeypatch)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    monkeypatch.setattr("framework.parallel.os.cpu_count", lambda: None)
+    assert current_worker_count() == 1
+
+
+def test_scale_timeout_serial_is_unchanged(monkeypatch):
+    _clear_xdist_env(monkeypatch)
+    assert scale_timeout_for_xdist(120) == 120
+
+
+def test_scale_timeout_widens_by_worker_count(monkeypatch):
+    _clear_xdist_env(monkeypatch)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER_COUNT", "4")
+    assert scale_timeout_for_xdist(120) == 480
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        (None, 1),
+        ("", 1),
+        ("   ", 1),
+        ("3", 3),
+        (" 2 ", 2),
+        # Non-integer or < 1 falls back to the default of 1.
+        ("nan", 1),
+        ("0", 1),
+        ("-2", 1),
+    ],
+)
+def test_concurrency(monkeypatch, env_value, expected):
+    if env_value is None:
+        monkeypatch.delenv("SDK_E2E_TEMPLATE_BUILD_CONCURRENCY", raising=False)
+    else:
+        monkeypatch.setenv("SDK_E2E_TEMPLATE_BUILD_CONCURRENCY", env_value)
+    assert _concurrency() == expected
+
+
+class _StubOption:
+    def __init__(self, numprocesses=None):
+        self.numprocesses = numprocesses
+
+
+class _StubPluginManager:
+    def __init__(self, has_xdist=True):
+        self._has_xdist = has_xdist
+
+    def hasplugin(self, name):
+        return name == "xdist" and self._has_xdist
+
+
+class _StubConfig:
+    """Minimal stand-in for ``pytest.Config`` for ``apply_worker_count``."""
+
+    def __init__(self, *, run_e2e=True, has_xdist=True, numprocesses=None):
+        self._run_e2e = run_e2e
+        self.option = _StubOption(numprocesses)
+        self.pluginmanager = _StubPluginManager(has_xdist)
+
+    def getoption(self, name):
+        assert name == "--run-e2e"
+        return self._run_e2e
+
+
+@pytest.fixture(autouse=True)
+def _not_in_worker(monkeypatch):
+    # apply_worker_count/the conftest hook short-circuit inside an xdist worker
+    # (PYTEST_XDIST_WORKER set). These tests exercise the controller decision, so
+    # clear it -- otherwise running the suite itself under -n would flip results.
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+
+
+def test_apply_worker_count_sets_numprocesses_from_env(monkeypatch):
+    monkeypatch.setenv("SDK_E2E_WORKERS", "4")
+    config = _StubConfig()
+    assert apply_worker_count(config) == 4
+    assert config.option.numprocesses == 4
+
+
+def test_apply_worker_count_skips_inside_xdist_worker(monkeypatch):
+    # In a worker process numprocesses is None and re-deriving it is useless and
+    # misleading (would trigger a spurious per-worker serial warning). Stay out.
+    monkeypatch.setenv("SDK_E2E_WORKERS", "4")
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    config = _StubConfig()
+    assert apply_worker_count(config) is None
+    assert config.option.numprocesses is None
+
+
+def test_apply_worker_count_passthrough_token(monkeypatch):
+    monkeypatch.setenv("SDK_E2E_WORKERS", "auto")
+    config = _StubConfig()
+    assert apply_worker_count(config) == "auto"
+    assert config.option.numprocesses == "auto"
+
+
+def test_apply_worker_count_serial_when_env_unset(monkeypatch):
+    monkeypatch.delenv("SDK_E2E_WORKERS", raising=False)
+    config = _StubConfig()
+    assert apply_worker_count(config) is None
+    assert config.option.numprocesses is None
+
+
+def test_apply_worker_count_skips_without_run_e2e(monkeypatch):
+    monkeypatch.setenv("SDK_E2E_WORKERS", "4")
+    config = _StubConfig(run_e2e=False)
+    assert apply_worker_count(config) is None
+    assert config.option.numprocesses is None
+
+
+def test_apply_worker_count_skips_when_xdist_absent(monkeypatch):
+    monkeypatch.setenv("SDK_E2E_WORKERS", "4")
+    config = _StubConfig(has_xdist=False)
+    assert apply_worker_count(config) is None
+    assert config.option.numprocesses is None
+
+
+def test_apply_worker_count_respects_explicit_numprocesses(monkeypatch):
+    # An explicit -n (even -n0) must win over SDK_E2E_WORKERS.
+    monkeypatch.setenv("SDK_E2E_WORKERS", "4")
+    config = _StubConfig(numprocesses=0)
+    assert apply_worker_count(config) is None
+    assert config.option.numprocesses == 0
+
+
+def test_apply_worker_count_raises_on_malformed_env(monkeypatch):
+    monkeypatch.setenv("SDK_E2E_WORKERS", "four")
+    config = _StubConfig()
+    with pytest.raises(ValueError, match="positive integer"):
+        apply_worker_count(config)
+
+
+def _force_throttle_active(monkeypatch):
+    # Make template_build_slot take the locking path: >1 worker, concurrency 1.
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    monkeypatch.setenv("PYTEST_XDIST_WORKER_COUNT", "4")
+    monkeypatch.delenv("SDK_E2E_TEMPLATE_BUILD_CONCURRENCY", raising=False)
+
+
+def test_template_build_slot_degrades_when_acquire_fails(monkeypatch):
+    # An OSError from slot acquisition (ELOOP/EACCES/ENOSPC) must degrade to a
+    # yield-through no-op, not crash the build with an unrelated error.
+    _force_throttle_active(monkeypatch)
+
+    def _boom(_slots, _timeout):
+        raise OSError("planted symlink at slot path")
+
+    monkeypatch.setattr("framework.build_throttle._acquire_any_slot", _boom)
+    entered = False
+    with template_build_slot(label="unit"):
+        entered = True
+    assert entered
+
+
+def test_template_build_slot_degrades_on_timeout(monkeypatch):
+    # A wedged peer that never releases its slot must not stall this worker
+    # forever: once the acquisition wait elapses (returns None), degrade to
+    # unthrottled rather than blocking.
+    _force_throttle_active(monkeypatch)
+
+    def _timeout(_slots, _timeout):
+        return None
+
+    monkeypatch.setattr("framework.build_throttle._acquire_any_slot", _timeout)
+    entered = False
+    with template_build_slot(label="unit"):
+        entered = True
+    assert entered
+
+
+def test_template_build_slot_serial_is_noop(monkeypatch):
+    # A serial run (1 worker) never touches the lock dir at all.
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.delenv("PYTEST_XDIST_WORKER_COUNT", raising=False)
+
+    def _should_not_run(_slots, _timeout):
+        raise AssertionError("serial run must not acquire a slot")
+
+    monkeypatch.setattr("framework.build_throttle._acquire_any_slot", _should_not_run)
+    with template_build_slot(label="unit"):
+        pass
+
+
+def test_slot_wait_timeout_scales_with_workers(monkeypatch):
+    monkeypatch.delenv("SDK_E2E_TEMPLATE_BUILD_WAIT", raising=False)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER_COUNT", "4")
+    from framework.build_throttle import _DEFAULT_SLOT_WAIT_BASE, _slot_wait_timeout
+
+    assert _slot_wait_timeout() == _DEFAULT_SLOT_WAIT_BASE * 4
+
+
+def test_slot_wait_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER_COUNT", "2")
+    monkeypatch.setenv("SDK_E2E_TEMPLATE_BUILD_WAIT", "60")
+    from framework.build_throttle import _slot_wait_timeout
+
+    assert _slot_wait_timeout() == 120
+
+
+def test_slot_wait_timeout_disabled_is_infinite(monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER_COUNT", "4")
+    monkeypatch.setenv("SDK_E2E_TEMPLATE_BUILD_WAIT", "0")
+    from framework.build_throttle import _slot_wait_timeout
+
+    assert _slot_wait_timeout() == float("inf")
+
+
+def test_acquire_any_slot_returns_none_on_timeout(monkeypatch, tmp_path):
+    # Drive the real _acquire_any_slot with a slot already held so it must wait,
+    # and a zero timeout so it gives up immediately and returns None.
+    # _acquire_any_slot is POSIX-only (uses fcntl.flock); the module degrades to a
+    # no-op without fcntl, so skip rather than error on a non-POSIX platform.
+    fcntl = pytest.importorskip("fcntl")
+    import framework.build_throttle as bt
+
+    monkeypatch.setattr(bt, "_LOCK_DIR", tmp_path)
+    monkeypatch.setattr(bt, "_POLL_INTERVAL", 0.01)
+    holder, _idx = bt._acquire_any_slot(1)
+    try:
+        assert bt._acquire_any_slot(1, timeout=0.05) is None
+    finally:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()
+
+
+def test_current_worker_count_fallback_is_capped(monkeypatch):
+    # A many-core box must not inflate the fallback multiplier without bound.
+    _clear_xdist_env(monkeypatch)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    monkeypatch.setattr("framework.parallel.os.cpu_count", lambda: 64)
+    from framework.parallel import _MAX_FALLBACK_WORKERS
+
+    assert current_worker_count() == _MAX_FALLBACK_WORKERS

--- a/tests/e2e/sdk_compat/cases/framework/test_reporting.py
+++ b/tests/e2e/sdk_compat/cases/framework/test_reporting.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-logic unit tests for JsonlReporter's report-file naming.
+
+Marked ``framework`` so they run on every gate without a live environment
+(see ``conftest.pytest_collection_modifyitems``). The per-worker filename is the
+contract downstream log aggregation depends on: a regression that collapses all
+xdist workers onto one path is exactly the interleaving corruption this guards.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.reporting import JsonlReporter
+
+pytestmark = pytest.mark.framework
+
+
+def test_serial_run_uses_plain_events_file(tmp_path, monkeypatch):
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    reporter = JsonlReporter(tmp_path)
+    try:
+        assert reporter._path.name == "events.jsonl"
+    finally:
+        reporter.close()
+
+
+def test_xdist_worker_gets_own_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+    reporter = JsonlReporter(tmp_path)
+    try:
+        assert reporter._path.name == "events-gw3.jsonl"
+    finally:
+        reporter.close()

--- a/tests/e2e/sdk_compat/cases/network/test_mask_request_host.py
+++ b/tests/e2e/sdk_compat/cases/network/test_mask_request_host.py
@@ -28,7 +28,9 @@ from adapters import create_adapter
 from framework.assertions import assert_command_ok
 from framework.capabilities import NETWORK_MASK_REQUEST_HOST
 from framework.cleanup import safe_kill
+from framework.build_throttle import template_build_slot
 from framework.config import SdkE2EConfig
+from framework.parallel import scale_timeout_for_xdist
 
 SERVICE_PORT = 8765
 # With ${PORT}: expands to the requested sandbox container port.
@@ -86,9 +88,14 @@ def _template_image() -> str:
     )
 
 
-def _wait_for_template_ready(template_id: str, config, timeout: int = TEMPLATE_READY_TIMEOUT):
+def _wait_for_template_ready(template_id: str, config, timeout: int | None = None):
     from cubesandbox import Template
 
+    # Widen the serial-run budget for parallel (xdist) runs: same-image builds
+    # serialize on CubeMaster's per-artifactID lock, so the last worker's build
+    # can queue well past TEMPLATE_READY_TIMEOUT on a loaded-but-healthy node.
+    if timeout is None:
+        timeout = scale_timeout_for_xdist(TEMPLATE_READY_TIMEOUT)
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
@@ -136,22 +143,26 @@ def mask_request_host_template_id(pytestconfig: pytest.Config):
     sdk_config = Config(api_url=base.cube_api_url)
     created_id: str | None = None
     try:
-        job = Template.build(
-            image=_template_image(),
-            writable_layer_size=os.environ.get(
-                "CUBE_TEMPLATE_E2E_WRITABLE_LAYER_SIZE",
-                DEFAULT_WRITABLE_LAYER_SIZE,
-            ),
-            exposed_ports=TEMPLATE_EXPOSED_PORTS,
-            probe_port=49999,
-            config=sdk_config,
-        )
-        assert job.template_id.startswith("tpl-"), job.template_id
-        created_id = job.template_id
-        info = _wait_for_template_ready(created_id, sdk_config)
-        assert info.status == "READY", (
-            f"template {created_id} finished with status={info.status!r}"
-        )
+        # Hold a build slot across build + READY wait so concurrent in-flight
+        # template builds stay bounded regardless of the xdist worker count;
+        # this keeps the outcome identical to a serial ``-n1`` run.
+        with template_build_slot(label="mask_request_host"):
+            job = Template.build(
+                image=_template_image(),
+                writable_layer_size=os.environ.get(
+                    "CUBE_TEMPLATE_E2E_WRITABLE_LAYER_SIZE",
+                    DEFAULT_WRITABLE_LAYER_SIZE,
+                ),
+                exposed_ports=TEMPLATE_EXPOSED_PORTS,
+                probe_port=49999,
+                config=sdk_config,
+            )
+            assert job.template_id.startswith("tpl-"), job.template_id
+            created_id = job.template_id
+            info = _wait_for_template_ready(created_id, sdk_config)
+            assert info.status == "READY", (
+                f"template {created_id} finished with status={info.status!r}"
+            )
         yield created_id
     finally:
         if created_id is not None:

--- a/tests/e2e/sdk_compat/cases/network/test_template_network_merge.py
+++ b/tests/e2e/sdk_compat/cases/network/test_template_network_merge.py
@@ -11,9 +11,11 @@ import time
 import pytest
 
 from adapters import create_adapter
+from framework.build_throttle import template_build_slot
 from framework.capabilities import NETWORK_TEMPLATE_MERGE, capabilities_for_backend
 from framework.cleanup import safe_kill
 from framework.config import SdkE2EConfig
+from framework.parallel import scale_timeout_for_xdist
 from framework.network_probe import (
     assert_tcp_blocked,
     assert_tcp_reachable,
@@ -76,9 +78,12 @@ def _template_image() -> str:
     )
 
 
-def _wait_for_template_ready(template_id: str, config, timeout: int = TEMPLATE_READY_TIMEOUT):
+def _wait_for_template_ready(template_id: str, config, timeout: int | None = None):
     from cubesandbox import Template
 
+    # Widen the serial-run budget under xdist (same-node build contention).
+    if timeout is None:
+        timeout = scale_timeout_for_xdist(TEMPLATE_READY_TIMEOUT)
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
@@ -163,13 +168,14 @@ def network_merge_template_id(pytestconfig: pytest.Config):
             guest_dns = _guest_dns()
             if guest_dns is not None:
                 build_kwargs["dns"] = guest_dns
-            job = Template.build(**build_kwargs)
-            assert job.template_id.startswith("tpl-"), job.template_id
-            created_id = job.template_id
-            info = _wait_for_template_ready(created_id, sdk_config)
-            assert info.status == "READY", (
-                f"template {created_id} finished with status={info.status!r}"
-            )
+            with template_build_slot(label="template_network_merge"):
+                job = Template.build(**build_kwargs)
+                assert job.template_id.startswith("tpl-"), job.template_id
+                created_id = job.template_id
+                info = _wait_for_template_ready(created_id, sdk_config)
+                assert info.status == "READY", (
+                    f"template {created_id} finished with status={info.status!r}"
+                )
             yield created_id
         except Exception as exc:  # noqa: BLE001 - defer to cubesandbox test body
             _TEMPLATE_BUILD_ERROR = exc

--- a/tests/e2e/sdk_compat/cases/templates/test_alias.py
+++ b/tests/e2e/sdk_compat/cases/templates/test_alias.py
@@ -24,6 +24,8 @@ from cubesandbox import Config, Template
 from cubesandbox._exceptions import ApiError, TemplateNotFoundError
 
 from framework.auth import auth_headers
+from framework.build_throttle import template_build_slot
+from framework.parallel import scale_timeout_for_xdist
 
 pytestmark = [
     pytest.mark.e2e,
@@ -50,7 +52,13 @@ def _cfg(sdk_e2e_config):
     return Config(api_url=sdk_e2e_config.cube_api_url)
 
 
-def _wait_for_ready(template_id, config, timeout=120):
+def _wait_for_ready(template_id, config, timeout=None):
+    # Widen the serial-run budget for parallel (xdist) runs: every alias case
+    # builds a fresh template from the same image, so under xdist all workers
+    # submit near-identical builds that serialize on CubeMaster's per-artifactID
+    # lock. The last worker's build can then take well past the serial budget.
+    if timeout is None:
+        timeout = scale_timeout_for_xdist(120)
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
@@ -96,10 +104,11 @@ def test_template_create_from_image_and_cleanup(sdk_backend, sdk_e2e_config):
     cfg = _cfg(sdk_e2e_config)
     created_id = None
     try:
-        job = Template.build(image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
-        assert job.template_id.startswith("tpl-")
-        created_id = job.template_id
-        _wait_for_ready(created_id, cfg)
+        with template_build_slot(label="alias_create_from_image"):
+            job = Template.build(image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            assert job.template_id.startswith("tpl-")
+            created_id = job.template_id
+            _wait_for_ready(created_id, cfg)
         assert Template.get(created_id, config=cfg).status == "READY"
     finally:
         if created_id:
@@ -127,9 +136,10 @@ def test_template_alias_create_get_and_delete(sdk_backend, sdk_e2e_config):
     alias = f"e2e-alias-{uuid.uuid4().hex[:8]}"
     created_id = None
     try:
-        job = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
-        created_id = job.template_id
-        _wait_for_ready(created_id, cfg)
+        with template_build_slot(label="alias_create_get_delete"):
+            job = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            created_id = job.template_id
+            _wait_for_ready(created_id, cfg)
         assert Template.get(alias, config=cfg).template_id == created_id
         assert any(t.template_id == created_id for t in Template.list(config=cfg))
         _delete_with_retry(alias, cfg)
@@ -152,9 +162,10 @@ def test_template_alias_dedicated_lookup_endpoint(sdk_backend, sdk_e2e_config):
     alias = f"e2e-alias-ep-{uuid.uuid4().hex[:8]}"
     created_id = None
     try:
-        job = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
-        created_id = job.template_id
-        _wait_for_ready(created_id, cfg)
+        with template_build_slot(label="alias_dedicated_lookup"):
+            job = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            created_id = job.template_id
+            _wait_for_ready(created_id, cfg)
         resp = requests.get(
             f"{sdk_e2e_config.cube_api_url}/templates/aliases/{alias}",
             headers=auth_headers(),
@@ -177,14 +188,16 @@ def test_template_alias_rebuild_reassignment(sdk_backend, sdk_e2e_config):
     alias = f"e2e-alias-rebuild-{uuid.uuid4().hex[:8]}"
     template_ids = []
     try:
-        job_a = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
-        template_ids.append(job_a.template_id)
-        _wait_for_ready(job_a.template_id, cfg)
+        with template_build_slot(label="alias_rebuild_a"):
+            job_a = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            template_ids.append(job_a.template_id)
+            _wait_for_ready(job_a.template_id, cfg)
         assert Template.get(alias, config=cfg).template_id == job_a.template_id
 
-        job_b = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
-        template_ids.append(job_b.template_id)
-        _wait_for_ready(job_b.template_id, cfg)
+        with template_build_slot(label="alias_rebuild_b"):
+            job_b = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            template_ids.append(job_b.template_id)
+            _wait_for_ready(job_b.template_id, cfg)
         assert Template.get(alias, config=cfg).template_id == job_b.template_id
         assert Template.get(job_a.template_id, config=cfg).template_id == job_a.template_id
     finally:

--- a/tests/e2e/sdk_compat/conftest.py
+++ b/tests/e2e/sdk_compat/conftest.py
@@ -23,6 +23,11 @@ from framework.capabilities import (  # noqa: E402
 )
 from framework.cleanup import safe_kill  # noqa: E402
 from framework.config import SdkE2EConfig  # noqa: E402
+from framework.parallel import (  # noqa: E402
+    apply_worker_count,
+    current_worker_count,
+    wants_parallel,
+)
 from framework.preflight import run_preflight  # noqa: E402
 from framework.reporting import JsonlReporter  # noqa: E402
 from framework.trace import (  # noqa: E402
@@ -88,7 +93,62 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_configure(config: pytest.Config) -> None:
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_cmdline_main(config: pytest.Config):
+    # Live SDK E2E is I/O-bound: every test provisions its own per-UUID sandbox
+    # and the create path already jitters capacity retries so parallel workers
+    # do not retry in lockstep. Parallelism is opt-in via ``SDK_E2E_WORKERS`` (or
+    # ``-n``): the default stays serial so ``pytest --run-e2e`` does not overload
+    # the local CubeAPI/scheduler sharing the box. Runs without --run-e2e only
+    # collect hermetic ``framework`` unit tests, which stay serial.
+    #
+    # This ``tryfirst`` cmdline_main hookwrapper must run before xdist reads
+    # ``numprocesses`` to decide whether to activate. That ordering is a pluggy
+    # convention (conftest plugins sort before the ``xdist`` plugin), not a
+    # documented contract, and the failure mode would be silent -- a fallback to
+    # serial with no speedup -- so log the resolved plan below to make an ignored
+    # ``SDK_E2E_WORKERS`` visible instead of invisible.
+    try:
+        workers = apply_worker_count(config)
+    except ValueError as exc:
+        raise pytest.UsageError(str(exc)) from None
+    # xdist re-runs this hook in every worker (with ``numprocesses=None``); only
+    # the controller decides and reports the plan. Logging from workers would spam
+    # a "serial" line per worker for a run that is in fact parallel, so guard it.
+    if config.getoption("--run-e2e") and not os.environ.get("PYTEST_XDIST_WORKER"):
+        if workers is not None:
+            # We set numprocesses ourselves from SDK_E2E_WORKERS.
+            _setup_log(f"SDK E2E parallelism: xdist numprocesses={workers} (from SDK_E2E_WORKERS)")
+            config._sdk_e2e_expected_parallel = workers
+        else:
+            # apply_worker_count returned None either because we stayed serial or
+            # because an explicit -n/--numprocesses already won. Read the option
+            # back so the log reflects the plan xdist will actually run, rather
+            # than mislabeling ``-n 2`` as "serial".
+            explicit = getattr(config.option, "numprocesses", None)
+            if explicit:
+                _setup_log(f"SDK E2E parallelism: xdist numprocesses={explicit} (explicit -n)")
+                config._sdk_e2e_expected_parallel = explicit
+            elif not config.pluginmanager.hasplugin("xdist") and wants_parallel(os.environ.get("SDK_E2E_WORKERS")):
+                # SDK_E2E_WORKERS asked for parallelism but xdist is unavailable
+                # (not installed or ``-p no:xdist``): apply_worker_count returned
+                # None for that reason, not because the env var was unset. Say so
+                # rather than implying the env var was silently ignored.
+                _setup_log(
+                    "WARNING: SDK_E2E_WORKERS is set but pytest-xdist is unavailable "
+                    "(not installed or disabled via -p no:xdist); running SERIALLY."
+                )
+            else:
+                _setup_log("SDK E2E parallelism: serial (SDK_E2E_WORKERS unset/disabled, no -n)")
+    yield
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_configure(config: pytest.Config):
+    # ``pytest_configure`` is a historic hook and cannot be a hookwrapper, so use
+    # ``trylast`` to run after xdist's own ``pytest_configure`` (which registers
+    # the ``dsession`` controller when distribution mode activates). That lets
+    # ``_verify_xdist_activated`` observe the real activation state below.
     for marker in (
         "sdk_compat: SDK compatibility E2E tests",
         "requires_capability(name): current SDK backend must support this capability",
@@ -100,6 +160,32 @@ def pytest_configure(config: pytest.Config) -> None:
         "auth: CUBE_API_KEY simple-key authentication control-plane tests",
     ):
         config.addinivalue_line("markers", marker)
+    _verify_xdist_activated(config)
+
+
+def _verify_xdist_activated(config: pytest.Config) -> None:
+    # Runs after xdist's own ``pytest_configure`` (this hook is ``trylast``). When ``-n``/
+    # ``SDK_E2E_WORKERS`` asks for parallelism, ``pytest_cmdline_main`` above sets
+    # ``numprocesses`` and logs the plan, but that only *requests* xdist -- actual
+    # activation depends on xdist's ``pytest_cmdline_main`` running before its
+    # ``pytest_configure`` reads the plan, an ordering that is a pluggy convention,
+    # not a contract. If it ever breaks, ``numprocesses`` is set but no workers
+    # start and the run silently falls back to serial. xdist registers its
+    # ``dsession`` controller plugin only when distribution mode truly activated,
+    # so treat its presence as the authoritative signal and warn loudly on a
+    # mismatch rather than letting the earlier "numprocesses=N" log lie.
+    expected = getattr(config, "_sdk_e2e_expected_parallel", None)
+    if not expected:
+        return
+    if config.getoption("collectonly", False):
+        return
+    if not config.pluginmanager.hasplugin("dsession"):
+        _setup_log(
+            "WARNING: requested SDK E2E parallelism "
+            f"(numprocesses={expected}) but xdist did not activate "
+            "(no 'dsession' controller registered); the run will execute SERIALLY. "
+            "Check pytest-xdist is installed and not disabled (-p no:xdist)."
+        )
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
@@ -194,15 +280,19 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         reporter.close()
 
 
-@pytest.fixture(scope="session")
-def sdk_e2e_config(pytestconfig: pytest.Config) -> SdkE2EConfig:
-    cfg = _config_from_pytest(pytestconfig)
+def _prepare_runtime_env(cfg: SdkE2EConfig) -> None:
     if cfg.cube_python_sdk_path:
         sys.path.insert(0, cfg.cube_python_sdk_path)
     else:
         sys.path.insert(0, str(ROOT / "sdk" / "python"))
     for key, value in cfg.env().items():
         os.environ.setdefault(key, value)
+
+
+@pytest.fixture(scope="session")
+def sdk_e2e_config(pytestconfig: pytest.Config) -> SdkE2EConfig:
+    cfg = _config_from_pytest(pytestconfig)
+    _prepare_runtime_env(cfg)
     if pytestconfig.getoption("--run-e2e"):
         _log_effective_environment(cfg)
     return cfg
@@ -236,6 +326,10 @@ def sdk_e2e_trace(request: pytest.FixtureRequest, pytestconfig: pytest.Config) -
 
 @pytest.fixture(scope="session", autouse=True)
 def sdk_e2e_preflight(pytestconfig: pytest.Config, sdk_e2e_config: SdkE2EConfig, sdk_e2e_reporter: JsonlReporter):
+    # Under pytest-xdist "session" scope is per worker process, so preflight runs
+    # once per worker (a health check + template sweep). That is intentional: each
+    # worker must fail fast on its own before provisioning sandboxes, and the read
+    # traffic is negligible next to the sandbox creates the workers go on to issue.
     if not pytestconfig.getoption("--run-e2e"):
         return
     try:
@@ -250,6 +344,15 @@ def sdk_e2e_preflight(pytestconfig: pytest.Config, sdk_e2e_config: SdkE2EConfig,
             ),
         )
     except RuntimeError as exc:
+        # ``pytest.exit`` from inside an xdist worker does not stop the session
+        # cleanly: it terminates the worker process mid-test, which the
+        # controller surfaces as an opaque "worker 'gwN' crashed while running
+        # ..." instead of the real preflight diagnostic. Under xdist raise the
+        # error so this session-scoped autouse fixture fails every test at setup
+        # with the actual message; keep the clean early ``pytest.exit`` for the
+        # serial run where it stops the whole session as intended.
+        if os.environ.get("PYTEST_XDIST_WORKER"):
+            raise
         pytest.exit(str(exc), returncode=2)
 
 
@@ -358,10 +461,34 @@ def sdk_sandbox(
 
 
 def _config_from_pytest(config: pytest.Config) -> SdkE2EConfig:
-    return SdkE2EConfig.from_env(
+    cfg = SdkE2EConfig.from_env(
         backends=config.getoption("--sdk-e2e-backends"),
         cube_api_url=config.getoption("--cube-api-url"),
         cube_template_id=config.getoption("--cube-template-id"),
+    )
+    return _scale_capacity_retries_for_xdist(cfg)
+
+
+def _scale_capacity_retries_for_xdist(cfg: SdkE2EConfig) -> SdkE2EConfig:
+    """Widen the sandbox-create capacity-retry patience by the xdist worker count.
+
+    The single co-located node has a finite concurrent-sandbox ceiling. Serially
+    (``-n1``) a create never sees ``130597: no more resource``; with N workers all
+    creating at once, some creates transiently bounce off the ceiling and only
+    succeed once a peer's sandbox is torn down. The retry budget is what absorbs
+    that, so a run at high ``-n`` reaches the SAME per-test outcome as ``-n1`` —
+    just after a few retries. Fixed defaults sized for serial runs can be
+    exhausted under load and turn a would-pass test into a spurious ERROR, so
+    scale both the attempt count and the sleep budget with the worker count.
+    Serial runs (factor 1) keep the configured values unchanged.
+    """
+    workers = current_worker_count()
+    if workers <= 1:
+        return cfg
+    return replace(
+        cfg,
+        create_capacity_retries=cfg.create_capacity_retries * workers,
+        create_capacity_budget=cfg.create_capacity_budget * workers,
     )
 
 

--- a/tests/e2e/sdk_compat/docs/framework-design.md
+++ b/tests/e2e/sdk_compat/docs/framework-design.md
@@ -67,8 +67,9 @@ preflight can also probe the CubeProxy admin heartbeat.
 
 `TraceCollector` records timestamp, operation, sanitized input/output,
 duration, and success. Secrets are redacted, large values are truncated, and
-file contents are represented by length only. JSONL events are written
-to `SDK_E2E_REPORT_DIR/events.jsonl`.
+file contents are represented by length only. JSONL events are written to
+`SDK_E2E_REPORT_DIR/events.jsonl` for serial runs, or per-worker
+`events-gw*.jsonl` files under pytest-xdist.
 
 Use `--sdk-e2e-trace` for live operation output:
 

--- a/tests/e2e/sdk_compat/docs/zh/case-authoring.md
+++ b/tests/e2e/sdk_compat/docs/zh/case-authoring.md
@@ -370,7 +370,8 @@ pytest --run-e2e --sdk-e2e-trace -vv \
 
 1. pytest 的 setup/call/teardown phase；
 2. terminal trace 的最后一次失败操作；
-3. `SDK_E2E_REPORT_DIR/events.jsonl` 中同一 node ID 的事件；
+3. `SDK_E2E_REPORT_DIR` 下同一 node ID 的事件（串行为 `events.jsonl`，
+   xdist 并行时在 `events-gw*.jsonl` 之一）；
 4. sandbox `info().raw` 中的 state、endAt、metadata；
 5. 平台生命周期场景下的 CubeProxy heartbeat 与 lifecycle-manager 日志。
 

--- a/tests/e2e/sdk_compat/docs/zh/framework-design.md
+++ b/tests/e2e/sdk_compat/docs/zh/framework-design.md
@@ -219,7 +219,8 @@ sandbox 仍必须由 `managed_control_sandbox` 或 `finally` 清理。保留实�
 
 ## 9. 报告与诊断
 
-`JsonlReporter` 以 session 为边界持有 `events.jsonl` 文件句柄，并写入：
+`JsonlReporter` 以 session 为边界持有 JSONL 文件句柄（串行为 `events.jsonl`，
+pytest-xdist 下每个 worker 各自写 `events-gw*.jsonl`），并写入：
 
 - `preflight_passed` / `preflight_failed`；
 - `sandbox_created`；

--- a/tests/e2e/sdk_compat/env.example
+++ b/tests/e2e/sdk_compat/env.example
@@ -85,8 +85,20 @@ SDK_E2E_KEEP_SANDBOX_ON_FAILURE=false
 # SDK_E2E_TRACE=true
 # Skip requires_internet tests when the runner has no stable public egress.
 # SDK_E2E_SKIP_INTERNET_TESTS=false
-# Directory for JSONL events.jsonl and related reports.
+# Directory for JSONL event reports. Serial runs write events.jsonl; pytest-xdist
+# workers each write events-gw0.jsonl, events-gw1.jsonl, ...
 SDK_E2E_REPORT_DIR=reports/sdk-dual
+# pytest-xdist worker count for --run-e2e. Parallelism is opt-in: unset (or
+# 0/1/no/off) runs serial. Set an integer / auto / logical to fan out; -n wins.
+# SDK_E2E_WORKERS=auto
+# Max concurrent live template builds across xdist workers. Default 1 (fully
+# serialized so results match a serial run); <1 or non-integer falls back to 1.
+# POSIX-only (no-op without fcntl).
+# SDK_E2E_TEMPLATE_BUILD_CONCURRENCY=1
+# Per-predecessor ceiling (seconds) on waiting for a build slot before a worker
+# gives up and builds unthrottled, so a wedged peer cannot stall the suite. The
+# effective wait scales by the worker count. Default 1800; <=0 waits forever.
+# SDK_E2E_TEMPLATE_BUILD_WAIT=1800
 
 # Platform-managed lifecycle (auto-pause / auto-resume / auto-kill) requires
 # cube-proxy plus cube-lifecycle-manager coordination. Keep disabled for PR

--- a/tests/e2e/sdk_compat/framework/build_throttle.py
+++ b/tests/e2e/sdk_compat/framework/build_throttle.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-process throttle for live template builds.
+
+Building a template from an image is the single most control-plane-intensive
+operation in the suite: CubeMaster pulls the image, builds an ext4 rootfs
+artifact, and distributes it. On a single co-located node these builds do NOT
+fan out cleanly — concurrent builds of distinct fingerprints contend on the
+shared image pull / build host, and under enough of them a build goroutine can
+starve long past any per-test READY budget.
+
+That makes template-building cases *load-sensitive*: at ``-n1`` a build always
+completes, but at high ``-n`` several fire at once and some time out — so the
+same test yields a different outcome purely because of the worker count. To keep
+results identical to ``pytest -n1 --run-e2e`` at any concurrency, serialize the
+builds across worker processes with a filesystem lock. The lock is held across
+build *and* the wait for READY, so the number of in-flight builds never exceeds
+``SDK_E2E_TEMPLATE_BUILD_CONCURRENCY`` (default 1) regardless of ``-n``.
+
+The lock is a POSIX ``fcntl`` advisory lock over a small set of slot files in a
+per-UID temp dir. It degrades to a no-op if ``fcntl`` is unavailable (non-POSIX),
+the configured concurrency already covers every worker, or the lock dir cannot be
+created/trusted, so it never blocks a run it cannot coordinate.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import tempfile
+import time
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+
+from framework.parallel import current_worker_count
+
+try:  # POSIX only; the throttle degrades to a no-op without it.
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX fallback
+    fcntl = None  # type: ignore[assignment]
+
+# Shared across the workers of a single user's run. Kept out of the report dir so
+# it is never collected as an artifact, and namespaced per-UID so a concurrent
+# run by another user on a shared host coordinates through its own slot files
+# rather than cross-coupling (and cannot squat this user's predictable path).
+# ``getuid`` is POSIX-only, matching ``fcntl``; the throttle is a no-op without it.
+#
+# The namespace is deliberately per-UID and NOT per-run: two concurrent
+# ``--run-e2e`` jobs of the *same* user on one host (e.g. parallel self-hosted CI
+# jobs) share these slot files and serialize their template builds against each
+# other. That is intended -- both jobs contend on the one shared CubeMaster build
+# host, so throttling across them is exactly the coordination this lock exists to
+# provide; a per-run identifier would let them build in lockstep and reintroduce
+# the contention the throttle prevents. The bounded ``_slot_wait_timeout`` still
+# caps how long such cross-run waiting can last before degrading to unthrottled.
+_UID = getattr(os, "getuid", lambda: "shared")()
+_LOCK_DIR = (
+    Path(tempfile.gettempdir()) / f"cube-sdk-e2e-template-build.locks-{_UID}"
+)
+
+_DEFAULT_CONCURRENCY = 1
+_POLL_INTERVAL = 0.5
+# Bound the wait for a slot so one worker whose build never reaches READY cannot
+# stall every other template-building worker forever. The holder keeps the slot
+# across ``Template.build`` *and* the worker-count-scaled READY wait, so size the
+# ceiling generously (per-worker, since up to N-1 peers may build ahead of us),
+# but keep it finite. Overridable via env for slow control planes.
+_DEFAULT_SLOT_WAIT_BASE = 1800  # 30 min per potential predecessor build
+
+
+def _log(message: str) -> None:
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "-")
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+    print(f"[sdk-e2e][{timestamp}][{worker}] build-throttle {message}", file=sys.stderr, flush=True)
+
+
+def _slot_wait_timeout() -> float:
+    """Ceiling (seconds) on how long to wait for a build slot before degrading.
+
+    Scales with the worker count: with N workers up to N-1 peers may be building
+    ahead of us, each holding the slot across its own scaled READY wait. Env
+    ``SDK_E2E_TEMPLATE_BUILD_WAIT`` overrides the per-predecessor base for slow
+    control planes; a non-positive value disables the ceiling (wait forever).
+    """
+    raw = os.environ.get("SDK_E2E_TEMPLATE_BUILD_WAIT", "").strip()
+    base = _DEFAULT_SLOT_WAIT_BASE
+    if raw:
+        try:
+            base = int(raw)
+        except ValueError:
+            base = _DEFAULT_SLOT_WAIT_BASE
+    if base <= 0:
+        return float("inf")
+    return base * max(current_worker_count(), 1)
+
+
+def _concurrency() -> int:
+    raw = os.environ.get("SDK_E2E_TEMPLATE_BUILD_CONCURRENCY", "").strip()
+    if not raw:
+        return _DEFAULT_CONCURRENCY
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_CONCURRENCY
+    return value if value >= 1 else _DEFAULT_CONCURRENCY
+
+
+@contextlib.contextmanager
+def template_build_slot(label: str = "") -> Iterator[None]:
+    """Hold one of the limited template-build slots for the duration of a build.
+
+    Acquire before ``Template.build`` and keep the context open until the
+    template has reached READY (or failed), so concurrent in-flight builds stay
+    bounded. A no-op when the lock cannot help or is unnecessary: ``fcntl`` is
+    unavailable (non-POSIX), the allowed build concurrency already covers every
+    worker (so the lock could never block), or the lock dir cannot be created.
+
+    ``label`` names the build site (e.g. ``alias_rebuild_a``) and is logged on
+    slot wait/acquire/release so throttle contention is diagnosable when a
+    parallel run stalls on the shared build host.
+    """
+    slots = _concurrency()
+    # If the operator allows at least as many concurrent builds as there are
+    # workers, the lock would never block, so skip it. A serial run has one
+    # worker, so the default concurrency of 1 already covers it.
+    if fcntl is None or slots >= current_worker_count():
+        yield
+        return
+    try:
+        _LOCK_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+        st = _LOCK_DIR.stat()
+        if st.st_uid != os.getuid() or (st.st_mode & 0o077):
+            # Foreign-owned or group/other-accessible (possibly squatted on a
+            # shared host): do not trust it to coordinate, and do not block.
+            yield
+            return
+    except OSError:
+        # Cannot coordinate; do not block the run.
+        yield
+        return
+
+    timeout = _slot_wait_timeout()
+    _log(f"waiting for a build slot ({slots} slot(s), timeout={timeout}s) label={label!r}")
+    try:
+        acquired = _acquire_any_slot(slots, timeout)
+    except OSError as exc:
+        # A slot path could not be opened/locked -- e.g. ELOOP from a symlink
+        # planted at a predictable slot path (O_NOFOLLOW), EACCES, or ENOSPC.
+        # The throttle promises never to block a run it cannot coordinate, so
+        # degrade to serial (yield through) rather than failing the build with
+        # an error unrelated to what the test is exercising.
+        _log(f"could not acquire a slot ({exc}); proceeding unthrottled label={label!r}")
+        yield
+        return
+
+    if acquired is None:
+        # Waited the full ceiling without winning a slot -- a peer's build is
+        # wedged. Proceed unthrottled rather than stalling this worker forever;
+        # the OS releases the peer's flock on process death, so this is a
+        # last-resort escape, not a silent disable of the throttle.
+        _log(f"timed out after {timeout}s waiting for a slot; proceeding unthrottled label={label!r}")
+        yield
+        return
+
+    handle, slot_index = acquired
+    _log(f"acquired slot {slot_index} label={label!r}")
+    try:
+        yield
+    finally:
+        with contextlib.suppress(Exception):
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        with contextlib.suppress(Exception):
+            handle.close()
+        _log(f"released slot {slot_index} label={label!r}")
+
+
+def _acquire_any_slot(slots: int, timeout: float = float("inf")):
+    """Wait until one of ``slots`` lock files can be exclusively locked.
+
+    Returns ``(handle, index)`` on success, or ``None`` if ``timeout`` seconds
+    elapse first (an infinite ``timeout`` never gives up). Raises ``OSError`` if
+    a slot path cannot be opened/locked at all.
+    """
+    deadline = time.monotonic() + timeout
+    handles = []
+    try:
+        for index in range(slots):
+            path = _LOCK_DIR / f"slot-{index}.lock"
+            # O_NOFOLLOW + owner-only perms: never follow a symlink someone may
+            # have planted at a predictable slot path on a shared host.
+            fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+            handles.append((index, os.fdopen(fd, "w")))  # noqa: SIM115 - closed by caller
+        while True:
+            for index, handle in handles:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except OSError:
+                    continue
+                # Won this slot: keep its handle, close the rest.
+                for other_index, other in handles:
+                    if other_index != index:
+                        with contextlib.suppress(Exception):
+                            other.close()
+                return handle, index
+            if time.monotonic() >= deadline:
+                for _index, handle in handles:
+                    with contextlib.suppress(Exception):
+                        handle.close()
+                return None
+            time.sleep(_POLL_INTERVAL)
+    except BaseException:
+        for _index, handle in handles:
+            with contextlib.suppress(Exception):
+                handle.close()
+        raise

--- a/tests/e2e/sdk_compat/framework/parallel.py
+++ b/tests/e2e/sdk_compat/framework/parallel.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve the pytest-xdist worker count for the live SDK E2E suite.
+
+Kept as a pure helper so the branching (opt-in serial fallback, disable tokens,
+``auto``/``logical`` passthrough, numeric parsing) can be unit-tested without
+pytest-xdist or a live environment.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Upper bound for the *fallback* worker count when the authoritative
+# ``PYTEST_XDIST_WORKER_COUNT`` is missing. The fallback multiplies timeout and
+# capacity-retry budgets, so an uncapped ``os.cpu_count()`` on a many-core box
+# would inflate a 300s READY budget into hours. Cap it to a sane ceiling: still
+# large enough to keep the throttle engaged and the budgets generous, but not
+# absurd. The authoritative count (when present) is trusted as-is because the
+# operator chose it explicitly via ``-n``/``SDK_E2E_WORKERS``.
+_MAX_FALLBACK_WORKERS = 8
+
+# Tokens that force a serial run (leave ``numprocesses`` unset).
+_DISABLE_TOKENS = {"0", "1", "no", "off"}
+# Values xdist expects as strings; a fixed count must be an int because xdist
+# builds ``["popen"] * numprocesses`` from it.
+_PASSTHROUGH_TOKENS = {"auto", "logical"}
+
+
+def resolve_worker_count(env_value: str | None) -> int | str | None:
+    """Return the xdist ``numprocesses`` value, or ``None`` to stay serial.
+
+    ``env_value`` is the raw ``SDK_E2E_WORKERS`` string (or ``None``); matching
+    is case-insensitive. Raises ``ValueError`` on a malformed or non-positive
+    count so the caller can surface a clean message.
+
+    Parallelism is strictly opt-in: an unset value keeps the run serial so the
+    default ``pytest --run-e2e`` does not overload the co-located control plane.
+    Pass ``auto``/``logical`` (resolved by xdist) or an explicit count to fan out.
+    """
+    value = (env_value or "").strip().lower()
+    if not value or value in _DISABLE_TOKENS:
+        return None
+    if value in _PASSTHROUGH_TOKENS:
+        return value
+    try:
+        count = int(value)
+    except ValueError:
+        raise ValueError(
+            "SDK_E2E_WORKERS must be a positive integer, 'auto', 'logical', "
+            f"or a disable token (0/1/no/off); got {env_value!r}"
+        ) from None
+    if count < 1:
+        raise ValueError(f"SDK_E2E_WORKERS must be >= 1; got {env_value!r}")
+    return count
+
+
+def current_worker_count() -> int:
+    """Best-effort number of xdist workers in the running session (``1`` serial).
+
+    Reads the environment xdist injects into each worker process:
+    ``PYTEST_XDIST_WORKER_COUNT`` is authoritative and set by ``pytest-xdist``
+    (present since well before the pinned ``>=3.0``). It reflects the operator's
+    chosen ``-n``, so it is trusted as-is with no cap. If it is somehow absent we
+    cannot know the true count -- deriving ``gwN + 1`` from ``PYTEST_XDIST_WORKER``
+    would return a *different* value on every worker (``gw0``->1, ``gw1``->2, ...),
+    which would desync ``scale_timeout_for_xdist``/``_scale_capacity_retries_for_xdist``
+    across workers and, worse, let ``gw0`` evaluate ``slots >= 1`` and skip the
+    build throttle entirely while its peers serialize. So when the authoritative
+    count is missing, fall back to a value every worker agrees on: ``os.cpu_count()``
+    (a host constant) capped at ``_MAX_FALLBACK_WORKERS`` -- biased high enough to
+    keep the throttle engaged, but bounded so timeout/retry budgets are not
+    inflated into hours on a many-core box. If we are not under xdist at all, the
+    run is serial, so return ``1``.
+    """
+    count = os.environ.get("PYTEST_XDIST_WORKER_COUNT")
+    if count:
+        try:
+            parsed = int(count)
+            if parsed >= 1:
+                return parsed
+        except ValueError:
+            pass
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        return min(os.cpu_count() or 1, _MAX_FALLBACK_WORKERS)
+    return 1
+
+
+def wants_parallel(env_value: str | None) -> bool:
+    """True when ``SDK_E2E_WORKERS`` asks for parallelism (not unset/disabled).
+
+    Lets the conftest distinguish "env var unset/disabled" (serial by choice)
+    from "env var asked for workers but xdist is unavailable" (a misconfig worth
+    warning about), without duplicating the token/parsing rules. Malformed values
+    count as a request so the mismatch is still surfaced rather than swallowed.
+    """
+    try:
+        return resolve_worker_count(env_value) is not None
+    except ValueError:
+        return True
+
+
+def apply_worker_count(config) -> int | str | None:
+    """Resolve ``SDK_E2E_WORKERS`` into xdist's ``numprocesses`` on ``config``.
+
+    Returns the value written (an int, or ``auto``/``logical``) or ``None`` when
+    the run stays serial. Kept here (rather than inline in the conftest hook) so
+    it can be unit-tested against a stub config/plugin-manager: it only reads
+    ``config.getoption('--run-e2e')``, ``config.pluginmanager.hasplugin('xdist')``
+    and ``config.option.numprocesses``, and on opt-in writes ``numprocesses``.
+    Raises ``ValueError`` (from ``resolve_worker_count``) on a malformed value so
+    the caller can surface a clean usage error.
+    """
+    # xdist re-runs the ``pytest_cmdline_main`` hook inside every worker process,
+    # where ``numprocesses`` is always ``None`` (the worker argv carries no
+    # ``-n``). Only the controller spawns workers, so re-deriving the count and
+    # writing ``numprocesses`` back into a worker's own config is both useless and
+    # actively misleading (it would set ``_sdk_e2e_expected_parallel`` and make
+    # ``_verify_xdist_activated`` emit a spurious serial warning from each worker).
+    # A worker inherits its parallelism from the controller; stay out of its way.
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        return None
+    if not config.getoption("--run-e2e"):
+        return None
+    # ``-p no:xdist`` unregisters the plugin, so honoring it falls out here.
+    if not config.pluginmanager.hasplugin("xdist"):
+        return None
+    # Respect an explicit ``-n``/``--numprocesses`` (including ``-n0``, which
+    # xdist stores as int 0 to force serial); ``None`` means the flag was unset.
+    if getattr(config.option, "numprocesses", None) is not None:
+        return None
+    workers = resolve_worker_count(os.environ.get("SDK_E2E_WORKERS"))
+    if workers is not None:
+        config.option.numprocesses = workers
+    return workers
+
+
+def scale_timeout_for_xdist(base: int) -> int:
+    """Widen a per-item wait ``base`` by the xdist worker count.
+
+    Live template builds serialize on CubeMaster's per-artifactID build lock and
+    contend with every worker's sandbox creates, so a wait sized for a serial run
+    can expire on a healthy-but-loaded control plane once N workers submit at
+    once. Multiply by the worker count (``1`` serial → unchanged).
+    """
+    return base * max(current_worker_count(), 1)

--- a/tests/e2e/sdk_compat/framework/preflight.py
+++ b/tests/e2e/sdk_compat/framework/preflight.py
@@ -5,13 +5,46 @@ from __future__ import annotations
 
 import importlib
 import os
-from typing import Any
+import time
+from typing import Any, Callable, TypeVar
 
 from adapters.api_adapter import ApiClient
 from framework.config import SdkE2EConfig
 from framework.models import first_present
 from framework.platform_lifecycle import probe_platform_lifecycle
 from framework.reporting import JsonlReporter
+
+T = TypeVar("T")
+
+# Under pytest-xdist every worker runs this preflight once, so N workers issue
+# their health/template reads against the co-located control plane at nearly the
+# same instant. A single transient blip there (a warmup 401, a 503, a dropped
+# connection) would otherwise fail one worker's preflight and — because preflight
+# is a session-scoped autouse fixture — error every test that worker owns. Retry
+# the read a few times with a short backoff so a momentary hiccup does not sink a
+# whole worker; a genuinely down/misconfigured server still fails after the
+# retries and reports the real error.
+_PREFLIGHT_READ_ATTEMPTS = 3
+_PREFLIGHT_READ_BACKOFF = 2.0
+
+
+def _retry_transient(fn: Callable[[], T], *, attempts: int = _PREFLIGHT_READ_ATTEMPTS,
+                     backoff: float = _PREFLIGHT_READ_BACKOFF) -> T:
+    """Call ``fn`` and retry it on any exception up to ``attempts`` times.
+
+    Preflight reads are pure GETs (health, template metadata), so retrying is
+    safe. The last exception propagates once the attempts are exhausted.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001 - preflight aggregates diagnostics
+            last_exc = exc
+            if attempt < attempts:
+                time.sleep(backoff * attempt)
+    assert last_exc is not None
+    raise last_exc
 
 
 def run_preflight(
@@ -37,7 +70,7 @@ def run_preflight(
     api = ApiClient(config)
     try:
         try:
-            health = api.health()
+            health = _retry_transient(api.health)
             details["health"] = health
             if health.get("status") not in ("ok", "healthy"):
                 errors.append(f"CubeAPI health returned unexpected status: {health!r}")
@@ -48,7 +81,7 @@ def run_preflight(
             template_summaries = []
             try:
                 for template_id in sorted(effective_template_ids):
-                    template = api.get_template(template_id)
+                    template = _retry_transient(lambda tid=template_id: api.get_template(tid))
                     template_summaries.append(_template_summary(template_id, template))
                     if not template:
                         errors.append(f"template {template_id!r} was not found")

--- a/tests/e2e/sdk_compat/framework/reporting.py
+++ b/tests/e2e/sdk_compat/framework/reporting.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -14,7 +15,12 @@ from framework.trace import sanitize
 class JsonlReporter:
     def __init__(self, report_dir: Path) -> None:
         self._report_dir = report_dir
-        self._path = report_dir / "events.jsonl"
+        # Under pytest-xdist each worker is a separate process; a shared append
+        # log would interleave and corrupt lines. Give every worker its own file
+        # (events-gw0.jsonl, ...) and keep the serial run on plain events.jsonl.
+        worker = os.environ.get("PYTEST_XDIST_WORKER")
+        filename = f"events-{worker}.jsonl" if worker else "events.jsonl"
+        self._path = report_dir / filename
         self._report_dir.mkdir(parents=True, exist_ok=True)
         self._file = self._path.open("a", encoding="utf-8")
 

--- a/tests/e2e/sdk_compat/requirements.txt
+++ b/tests/e2e/sdk_compat/requirements.txt
@@ -1,4 +1,5 @@
 pytest>=7.0
+pytest-xdist>=3.0
 httpx>=0.27
 requests>=2
 


### PR DESCRIPTION
The live SDK E2E suite is I/O-bound: each test provisions its own per-UUID sandbox, so it fans out cleanly across processes. Wire up pytest-xdist for --run-e2e as an opt-in via SDK_E2E_WORKERS (or -n):

	pytest -n 2 --run-e2e -vv

the default stays serial to avoid overloading the co-located control plane, and setting an integer/auto/logical fans out. Each worker writes its own report file to avoid interleaved output.

Assisted-by: Claude Code:claude-opus-4.7