### PR TITLE
docs(examples): fix broken relative links in cos volume plugin guides

### DIFF
--- a/examples/volume/cos/README.md
+++ b/examples/volume/cos/README.md
@@ -3,7 +3,7 @@
 This guide is for **first-time Volume Plugin users**: follow the steps in order to use COS as persistent storage (create Volume → mount in sandbox → read/write → unmount → delete).
 
 > **Version requirement:** Cube platform **≥ 0.6.0**, Python SDK **`cubesandbox` ≥ 0.6.0**.  
-> Protocol and Hook details: [Volume Plugin framework](../../docs/guide/volume-plugin.md).
+> Protocol and Hook details: [Volume Plugin framework](../../../docs/guide/volume-plugin.md).
 
 **Default path: binary plugin** (`driver=cos`, Shell + coscmd + cosfs — easiest to run). For the Go rpc plugin (`driver=cos-rpc`), see [rpc path](#rpc-path-optional) at the end.
 
@@ -356,7 +356,7 @@ The script prints a grouped report (PASS / FAIL / SKIP). Exit code is non-zero i
 | SDK write fails | `CUBE_PROXY_NODE_IP`; CubeAPI / template READY |
 | `Volume.create` without driver not using cos | **First** entry in `volume_plugins` is the default driver |
 
-More: [Framework §8 Troubleshooting](../../docs/guide/volume-plugin.md#8-debugging-and-troubleshooting).
+More: [Framework §8 Troubleshooting](../../../docs/guide/volume-plugin.md#debugging-and-troubleshooting).
 
 ---
 
@@ -420,4 +420,4 @@ examples/volume/cos/
 | [binary/README.md](binary/README.md) | Script implementation, manual attach/detach |
 | [rpc/README.md](rpc/README.md) | rpc build, systemd, running both plugins |
 | [verify_volume.py](verify_volume.py) | Automated Python SDK verification |
-| [Volume Plugin framework](../../docs/guide/volume-plugin.md) | Protocol, RefCount, Hook semantics |
+| [Volume Plugin framework](../../../docs/guide/volume-plugin.md) | Protocol, RefCount, Hook semantics |

--- a/examples/volume/cos/README.zh.md
+++ b/examples/volume/cos/README.zh.md
@@ -3,7 +3,7 @@
 本文面向**第一次使用 Volume 插件**的用户：按顺序完成下面步骤，即可用 COS 做持久化存储（创建 Volume → 挂载到沙箱 → 读写 → 解绑 → 删除）。
 
 > **版本要求**：Cube 平台 **≥ 0.6.0**、Python SDK **`cubesandbox` ≥ 0.6.0**。  
-> 协议与 Hook 细节见 [Volume 插件框架](../../docs/zh/guide/volume-plugin.md)。
+> 协议与 Hook 细节见 [Volume 插件框架](../../../docs/zh/guide/volume-plugin.md)。
 
 **默认走 binary 插件**（`driver=cos`，Shell + coscmd + cosfs，最容易跑通）。若要用 Go rpc 插件（`driver=cos-rpc`），见文末 [rpc 路径](#rpc-路径可选)。
 
@@ -355,7 +355,7 @@ python3 verify_volume.py
 | SDK 写文件失败 | 是否设置 `CUBE_PROXY_NODE_IP`；CubeAPI / 模板是否 READY |
 | `Volume.create` 无 driver 但不是 cos | `volume_plugins` **列表顺序**：第一项才是默认 driver |
 
-更多见 [框架指南 §8 故障排查](../../docs/zh/guide/volume-plugin.md#八调试与排障)。
+更多见 [框架指南 §8 故障排查](../../../docs/zh/guide/volume-plugin.md#调试与排障)。
 
 ---
 
@@ -419,4 +419,4 @@ examples/volume/cos/
 | [binary/README.zh.md](binary/README.zh.md) | 插件脚本实现细节、手动 attach/detach |
 | [rpc/README.zh.md](rpc/README.zh.md) | rpc 构建、systemd、双插件并存 |
 | [verify_volume.py](verify_volume.py) | Python SDK 自动化验证 |
-| [Volume 插件框架](../../docs/zh/guide/volume-plugin.md) | 协议、RefCount、Hook 语义 |
+| [Volume 插件框架](../../../docs/zh/guide/volume-plugin.md) | 协议、RefCount、Hook 语义 |

--- a/examples/volume/cos/binary/README.md
+++ b/examples/volume/cos/binary/README.md
@@ -165,7 +165,7 @@ grep -aF '[plugin_volume] initialized' /data/log/Cubelet/Cubelet-req.log | tail 
 
 ## Usage
 
-Examples use **Python SDK `cubesandbox` ≥ 0.6.0**. See [Framework §2.1](../../../docs/guide/volume-plugin.md).
+Examples use **Python SDK `cubesandbox` ≥ 0.6.0**. See [Framework §2.1](../../../../docs/guide/volume-plugin.md).
 
 ### Create Volume
 
@@ -415,4 +415,4 @@ Volume still exists. `Volume.destroy("<id>")` first, then recreate.
 - [COS Go SDK](https://cloud.tencent.com/document/product/436/31215) (rpc example)
 - rpc example: [../rpc/](../rpc/)
 - Binary driver: [Cubelet/plugins/volume/binary/driver.go](../../../../Cubelet/plugins/volume/binary/driver.go)
-- Framework: [docs/guide/volume-plugin.md](../../../docs/guide/volume-plugin.md)
+- Framework: [docs/guide/volume-plugin.md](../../../../docs/guide/volume-plugin.md)

--- a/examples/volume/cos/binary/README.zh.md
+++ b/examples/volume/cos/binary/README.zh.md
@@ -165,7 +165,7 @@ grep -aF '[plugin_volume] initialized' /data/log/Cubelet/Cubelet-req.log | tail 
 
 ## 使用
 
-以下示例使用 **Python SDK `cubesandbox` ≥ 0.6.0**。请先安装 SDK 并配置环境变量（见 [框架指南 §2.1](../../../docs/zh/guide/volume-plugin.md)）。
+以下示例使用 **Python SDK `cubesandbox` ≥ 0.6.0**。请先安装 SDK 并配置环境变量（见 [框架指南 §2.1](../../../../docs/zh/guide/volume-plugin.md)）。
 
 ### 创建 Volume
 
@@ -435,4 +435,4 @@ ln -sf /opt/coscmd-venv/bin/coscmd /usr/local/bin/coscmd
 - COS Go SDK（rpc 示例用）：[Go SDK 快速入门](https://cloud.tencent.com/document/product/436/31215)
 - rpc 类型示例：[../rpc/](../rpc/)
 - Binary plugin 驱动：[Cubelet/plugins/volume/binary/driver.go](../../../../Cubelet/plugins/volume/binary/driver.go)
-- VolumePlugin 框架：[docs/zh/guide/volume-plugin.md](../../../docs/zh/guide/volume-plugin.md)
+- VolumePlugin 框架：[docs/zh/guide/volume-plugin.md](../../../../docs/zh/guide/volume-plugin.md)


### PR DESCRIPTION
## What
Fixes broken relative links in the COS volume plugin example guides:
- `examples/volume/cos/README.md` / `README.zh.md`: `../../docs/...` -> `../../../docs/...` (4 links)
- `examples/volume/cos/binary/README.md` / `README.zh.md`: `../../../docs/...` -> `../../../../docs/...` (4 links)

Also updates two anchors to match the current target headings (`#debugging-and-troubleshooting`, `#调试与排障`).

## Why
These READMEs live three/four levels deep under `examples/volume/cos(/binary)`, so the previous link depths resolved to non-existent paths (404 on GitHub).

## How verified
- Confirmed `docs/guide/volume-plugin.md` and `docs/zh/guide/volume-plugin.md` exist at the corrected paths.
- Confirmed the target headings exist: `## Debugging and Troubleshooting`, `## 调试与排障`.
- Docs-only change, no code affected.