### PR TITLE
fix(sdk/node): handle case-insensitive Authorization header in controlFetch

### DIFF
--- a/sdk/node/src/transport.ts
+++ b/sdk/node/src/transport.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Tencent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Agent, buildConnector, fetch, type Dispatcher } from "undici";
+import { Agent, buildConnector, fetch, Headers, type Dispatcher } from "undici";
 
 import type { Config } from "./config.js";
 
@@ -71,9 +71,9 @@ export function controlFetch(
   init: Parameters<typeof fetch>[1] = {},
 ): ReturnType<typeof fetch> {
   const signal = init?.signal ?? AbortSignal.timeout(config.requestTimeoutMs);
-  const headers: Record<string, string> = { ...(init?.headers as Record<string, string>) };
-  if (config.apiKey && headers.Authorization === undefined) {
-    headers.Authorization = `Bearer ${config.apiKey}`;
+  const headers = new Headers(init?.headers);
+  if (config.apiKey && !headers.has("authorization")) {
+    headers.set("authorization", `Bearer ${config.apiKey}`);
   }
   return fetch(url, { ...init, headers, signal });
 }

--- a/sdk/node/test/transport.test.ts
+++ b/sdk/node/test/transport.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { TLSSocket } from "node:tls";
 
-import { fetch } from "undici";
+import { fetch, Headers } from "undici";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { Config } from "../src/config.js";
@@ -54,6 +54,17 @@ describe("controlFetch auth", () => {
     await controlFetch(cfg, `http://127.0.0.1:${port}/health`, {
       headers: { Authorization: "Bearer caller" },
     });
+    expect(seenAuth).toBe("Bearer caller");
+  });
+
+  it.each([
+    ["lowercase record", { authorization: "Bearer caller" }],
+    ["Headers instance", new Headers({ Authorization: "Bearer caller" })],
+    ["tuple list", [["Authorization", "Bearer caller"]] as [string, string][]],
+  ])("preserves caller Authorization from a %s", async (_name, headers) => {
+    seenAuth = undefined;
+    const cfg = new Config({ apiKey: "secret-key" });
+    await controlFetch(cfg, `http://127.0.0.1:${port}/health`, { headers });
     expect(seenAuth).toBe("Bearer caller");
   });
 });


### PR DESCRIPTION
## What
`controlFetch` merged caller headers into a plain `Record<string, string>` and decided whether to inject the API key with `headers.Authorization === undefined`. HTTP header names are case-insensitive, so a caller passing `{ authorization: "Bearer ..." }` (lowercase) was not detected and the configured `apiKey` would override the caller's explicit Authorization header.

This PR switches the merge/check to undici's `Headers`, which normalizes header names, so:
- caller's Authorization is preserved regardless of the case used (plain record, `Headers` instance, or tuple list);
- `Bearer <apiKey>` is still injected only when the caller did not set an Authorization header.

## How verified
- Added tests covering lowercase record, `Headers` instance, and tuple-list inputs (`sdk/node/test/transport.test.ts`).
- `npx vitest run test/transport.test.ts -t controlFetch`: 6 passed, 3 skipped (skips are TLS/environment-dependent, unrelated to this change).
- The one other failing test in the file (`buildDataDispatcher` https SNI preservation) also fails on `master` in this environment because it shells out to `openssl`, which is unavailable; it is unrelated to this change.