### PR TITLE
fix(cubelet): clone run templates so concurrent flows stop mutating the cache

### DIFF
--- a/Cubelet/pkg/controller/runtemplate/template_manager.go
+++ b/Cubelet/pkg/controller/runtemplate/template_manager.go
@@ -93,7 +93,10 @@ func (h *localCubeRunTemplateManager) ListLocalTemplates(ctx context.Context) (m
 	}
 	templateMap := make(map[string]*templatetypes.LocalRunTemplate)
 	for _, template := range templates {
-		templateMap[template.TemplateID] = template
+		if template == nil {
+			continue
+		}
+		templateMap[template.TemplateID] = template.Clone()
 	}
 	return templateMap, nil
 }
@@ -162,7 +165,6 @@ func (h *localCubeRunTemplateManager) removeMissingLocalTemplates(ctx context.Co
 }
 
 func (h *localCubeRunTemplateManager) EnsureCubeRunTemplate(ctx context.Context, templateID string) (*templatetypes.LocalRunTemplate, error) {
-
 	h.lock.Lock()
 	delete(h.unusedTemplateMap, templateID)
 	h.lock.Unlock()
@@ -170,15 +172,12 @@ func (h *localCubeRunTemplateManager) EnsureCubeRunTemplate(ctx context.Context,
 	if !h.IsReady() {
 		return nil, fmt.Errorf("local template manager is not ready")
 	}
-	templates, err := h.store.ByIndexGeneric(templateIDIndexerKey, templateID)
+	cloned, err := h.cloneAndHydrate(templateID)
 	if err != nil {
 		return nil, err
 	}
-	for _, template := range templates {
-		if template != nil {
-			hydrateLocalTemplateComponentVersions(template)
-			return template, nil
-		}
+	if cloned != nil {
+		return cloned, nil
 	}
 	if err := h.recoverLocalTemplatesFromSnapshotRoot(ctx, constants.DefaultSnapshotDir, templateID); err != nil {
 		log.G(ctx).WithFields(CubeLog.Fields{
@@ -186,15 +185,12 @@ func (h *localCubeRunTemplateManager) EnsureCubeRunTemplate(ctx context.Context,
 			"err":         err.Error(),
 		}).Warn("failed to recover template from snapshot root")
 	}
-	templates, err = h.store.ByIndexGeneric(templateIDIndexerKey, templateID)
+	cloned, err = h.cloneAndHydrate(templateID)
 	if err != nil {
 		return nil, err
 	}
-	for _, template := range templates {
-		if template != nil {
-			hydrateLocalTemplateComponentVersions(template)
-			return template, nil
-		}
+	if cloned != nil {
+		return cloned, nil
 	}
 	log.G(ctx).WithFields(CubeLog.Fields{
 		"template_id": templateID,
@@ -281,6 +277,22 @@ func isTemporarySnapshotPath(snapshotPath string) bool {
 	return strings.HasSuffix(base, ".tmp")
 }
 
+func (h *localCubeRunTemplateManager) cloneAndHydrate(templateID string) (*templatetypes.LocalRunTemplate, error) {
+	templates, err := h.store.ByIndexGeneric(templateIDIndexerKey, templateID)
+	if err != nil {
+		return nil, err
+	}
+	for _, template := range templates {
+		if template == nil {
+			continue
+		}
+		cloned := template.Clone()
+		hydrateLocalTemplateComponentVersions(cloned)
+		return cloned, nil
+	}
+	return nil, nil
+}
+
 func hydrateLocalTemplateComponentVersions(local *templatetypes.LocalRunTemplate) {
 	if local == nil {
 		return
@@ -288,10 +300,7 @@ func hydrateLocalTemplateComponentVersions(local *templatetypes.LocalRunTemplate
 	if len(templatetypes.VersionMapFromComponts(local)) > 0 {
 		return
 	}
-	snapshotPath := ""
-	if local.Snapshot.Snapshot.Path != "" {
-		snapshotPath = local.Snapshot.Snapshot.Path
-	}
+	snapshotPath := local.Snapshot.Snapshot.Path
 	if snapshotPath == "" {
 		return
 	}

--- a/Cubelet/pkg/controller/runtemplate/template_manager_test.go
+++ b/Cubelet/pkg/controller/runtemplate/template_manager_test.go
@@ -6,11 +6,14 @@ package runtemplate
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/templatetypes"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
 )
 
 func TestRecoveredLocalTemplateFromSnapshotPath(t *testing.T) {
@@ -121,6 +124,168 @@ func TestRemoveMissingLocalTemplatesKeepsTemporarySnapshot(t *testing.T) {
 	}
 	if _, err := manager.store.GetGeneric(template.DistributionTaskID); err != nil {
 		t.Fatalf("template metadata was removed while temporary snapshot exists: %v", err)
+	}
+}
+
+func TestEnsureCubeRunTemplateReturnsClone(t *testing.T) {
+	manager := newReadyTemplateManager(t)
+	cached := seedLocalTemplate(t, manager, "tpl-clone", "task-clone", map[string]templatetypes.LocalComponent{
+		templatetypes.CubeComponentCubeShim: {Component: templatetypes.MachineComponent{Version: "v1"}},
+	})
+
+	got, err := manager.EnsureCubeRunTemplate(context.Background(), "tpl-clone")
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if got == cached {
+		t.Fatal("EnsureCubeRunTemplate returned the cached pointer")
+	}
+	got.Componts[templatetypes.CubeComponentCubeShim] = templatetypes.LocalComponent{
+		Component: templatetypes.MachineComponent{Version: "mutated"},
+	}
+	stored, err := manager.store.GetGeneric("task-clone")
+	if err != nil {
+		t.Fatalf("get cached: %v", err)
+	}
+	if stored.Componts[templatetypes.CubeComponentCubeShim].Component.Version != "v1" {
+		t.Fatalf("cache Componts mutated: %q", stored.Componts[templatetypes.CubeComponentCubeShim].Component.Version)
+	}
+}
+
+func TestEnsureCubeRunTemplateHydratesCloneNotCache(t *testing.T) {
+	manager := newReadyTemplateManager(t)
+	snapshotPath := t.TempDir()
+	writeSnapshotCatalog(t, snapshotPath, map[string]string{
+		templatetypes.CubeComponentCubeShim: "v-from-catalog",
+	})
+	cached := newLocalRunTemplateForPath("tpl-hydrate", snapshotPath)
+	if err := manager.store.Update(cached); err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+
+	got, err := manager.EnsureCubeRunTemplate(context.Background(), "tpl-hydrate")
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if got.Componts[templatetypes.CubeComponentCubeShim].Component.Version != "v-from-catalog" {
+		t.Fatalf("clone was not hydrated: %+v", got.Componts)
+	}
+	stored, err := manager.store.GetGeneric(cached.DistributionTaskID)
+	if err != nil {
+		t.Fatalf("get cached: %v", err)
+	}
+	if _, ok := stored.Componts[templatetypes.CubeComponentCubeShim]; ok {
+		t.Fatalf("hydrate wrote through to cache: %+v", stored.Componts)
+	}
+}
+
+func TestListLocalTemplatesReturnsClone(t *testing.T) {
+	manager := newReadyTemplateManager(t)
+	seedLocalTemplate(t, manager, "tpl-list", "task-list", map[string]templatetypes.LocalComponent{
+		templatetypes.CubeComponentCubeAgent: {Component: templatetypes.MachineComponent{Version: "a1"}},
+	})
+
+	listed, err := manager.ListLocalTemplates(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	got := listed["tpl-list"]
+	if got == nil {
+		t.Fatal("missing listed template")
+	}
+	stored, err := manager.store.GetGeneric("task-list")
+	if err != nil {
+		t.Fatalf("get cached: %v", err)
+	}
+	if got == stored {
+		t.Fatal("ListLocalTemplates returned the cached pointer")
+	}
+	got.Componts[templatetypes.CubeComponentCubeAgent] = templatetypes.LocalComponent{
+		Component: templatetypes.MachineComponent{Version: "mutated"},
+	}
+	if stored.Componts[templatetypes.CubeComponentCubeAgent].Component.Version != "a1" {
+		t.Fatal("list clone mutated cache Componts")
+	}
+}
+
+func TestConcurrentEnsureMutatesClonesOnly(t *testing.T) {
+	manager := newReadyTemplateManager(t)
+	seedLocalTemplate(t, manager, "tpl-race", "task-race", map[string]templatetypes.LocalComponent{
+		templatetypes.CubeComponentCubeShim: {Component: templatetypes.MachineComponent{Version: "v1"}},
+	})
+
+	const n = 32
+	var start, done sync.WaitGroup
+	start.Add(n)
+	done.Add(n)
+	for range n {
+		go func() {
+			defer done.Done()
+			start.Done()
+			start.Wait()
+			got, err := manager.EnsureCubeRunTemplate(context.Background(), "tpl-race")
+			if err != nil {
+				t.Errorf("ensure: %v", err)
+				return
+			}
+			got.Componts[templatetypes.CubeComponentCubeShim] = templatetypes.LocalComponent{
+				Component: templatetypes.MachineComponent{Version: "g"},
+			}
+			listed, err := manager.ListLocalTemplates(context.Background())
+			if err != nil {
+				t.Errorf("list: %v", err)
+				return
+			}
+			for _, lt := range listed {
+				_ = lt.Componts[templatetypes.CubeComponentCubeShim]
+			}
+		}()
+	}
+	done.Wait()
+
+	stored, err := manager.store.GetGeneric("task-race")
+	if err != nil {
+		t.Fatalf("get cached: %v", err)
+	}
+	if stored.Componts[templatetypes.CubeComponentCubeShim].Component.Version != "v1" {
+		t.Fatalf("cache mutated under concurrency: %q", stored.Componts[templatetypes.CubeComponentCubeShim].Component.Version)
+	}
+}
+
+func newReadyTemplateManager(t *testing.T) *localCubeRunTemplateManager {
+	t.Helper()
+	db := &mockMetadataDB{data: make(map[string][]byte)}
+	manager, err := NewCubeRunTemplateManager(db, nil)
+	if err != nil {
+		t.Fatalf("create local template manager: %v", err)
+	}
+	manager.SetInstanceType("SA5")
+	return manager
+}
+
+func seedLocalTemplate(t *testing.T, manager *localCubeRunTemplateManager, templateID, taskID string, componts map[string]templatetypes.LocalComponent) *templatetypes.LocalRunTemplate {
+	t.Helper()
+	cached := &templatetypes.LocalRunTemplate{
+		DistributionReference: templatetypes.DistributionReference{
+			TemplateID:         templateID,
+			DistributionTaskID: taskID,
+		},
+		Componts: componts,
+	}
+	if err := manager.store.Update(cached); err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+	return cached
+}
+
+func writeSnapshotCatalog(t *testing.T, snapshotPath string, versions map[string]string) {
+	t.Helper()
+	raw, err := json.Marshal(storage.SnapshotCatalogEntry{ComponentVersions: versions})
+	if err != nil {
+		t.Fatalf("marshal catalog: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snapshotPath, "catalog.json"), raw, 0o644); err != nil {
+		t.Fatalf("write catalog: %v", err)
 	}
 }
 

--- a/Cubelet/pkg/controller/runtemplate/templatetypes/clone.go
+++ b/Cubelet/pkg/controller/runtemplate/templatetypes/clone.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatetypes
+
+import (
+	"maps"
+	"slices"
+)
+
+// Clone returns a caller-owned copy. Maps and slices are independent of the
+// original so Create/List can mutate Componts without racing the template cache.
+func (t *LocalRunTemplate) Clone() *LocalRunTemplate {
+	if t == nil {
+		return nil
+	}
+	out := *t
+	out.Componts = maps.Clone(t.Componts)
+	out.Volumes = cloneVolumes(t.Volumes)
+	out.Images = cloneImages(t.Images)
+	return &out
+}
+
+func cloneVolumes(in map[string]LocalBaseVolume) map[string]LocalBaseVolume {
+	out := maps.Clone(in)
+	for k, v := range out {
+		if v.Volume.BaseBlockSource.RemoteCos == nil {
+			continue
+		}
+		cos := *v.Volume.BaseBlockSource.RemoteCos
+		cos.Annotations = maps.Clone(cos.Annotations)
+		v.Volume.BaseBlockSource.RemoteCos = &cos
+		out[k] = v
+	}
+	return out
+}
+
+func cloneImages(in []LocalDistributionImage) []LocalDistributionImage {
+	out := slices.Clone(in)
+	for i := range out {
+		img := &out[i].Image
+		img.References = slices.Clone(img.References)
+		img.Snapshots = slices.Clone(img.Snapshots)
+		img.HostLayers = slices.Clone(img.HostLayers)
+		img.Annotation = maps.Clone(img.Annotation)
+	}
+	return out
+}

--- a/Cubelet/pkg/controller/runtemplate/templatetypes/clone_test.go
+++ b/Cubelet/pkg/controller/runtemplate/templatetypes/clone_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatetypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	imagestore "github.com/tencentcloud/CubeSandbox/Cubelet/internal/cube/store/image"
+)
+
+func TestLocalRunTemplateCloneNil(t *testing.T) {
+	var local *LocalRunTemplate
+	assert.Nil(t, local.Clone())
+}
+
+func TestLocalRunTemplateCloneCompontsIndependent(t *testing.T) {
+	src := &LocalRunTemplate{
+		DistributionReference: DistributionReference{TemplateID: "tpl-1"},
+		Componts: map[string]LocalComponent{
+			CubeComponentCubeShim: {Component: MachineComponent{Name: CubeComponentCubeShim, Version: "v1"}},
+		},
+		Volumes: map[string]LocalBaseVolume{
+			"root": {
+				VolumeID: "vol-1",
+				Volume: VolumeSource{BaseBlockSource: BaseBlockVolumeSource{
+					RemoteCos: &CosFileInfo{URL: "cos://x", Annotations: map[string]string{"a": "b"}},
+				}},
+			},
+		},
+		Images: []LocalDistributionImage{{
+			Image: imagestore.Image{
+				ID:         "img-1",
+				References: []string{"ref"},
+				Annotation: map[string]string{"k": "v"},
+			},
+		}},
+	}
+
+	got := src.Clone()
+	require.NotNil(t, got)
+	assert.Equal(t, "tpl-1", got.TemplateID)
+	assert.NotSame(t, src, got)
+
+	got.Componts[CubeComponentCubeShim] = LocalComponent{Component: MachineComponent{Version: "mutated"}}
+	assert.Equal(t, "v1", src.Componts[CubeComponentCubeShim].Component.Version)
+
+	vol := got.Volumes["root"]
+	vol.VolumeID = "mutated"
+	got.Volumes["root"] = vol
+	assert.Equal(t, "vol-1", src.Volumes["root"].VolumeID)
+	got.Volumes["root"].Volume.BaseBlockSource.RemoteCos.URL = "mutated"
+	assert.Equal(t, "cos://x", src.Volumes["root"].Volume.BaseBlockSource.RemoteCos.URL)
+
+	got.Images[0].Image.Annotation["k"] = "mutated"
+	assert.Equal(t, "v", src.Images[0].Image.Annotation["k"])
+	got.Images[0].Image.References[0] = "mutated"
+	assert.Equal(t, "ref", src.Images[0].Image.References[0])
+}

--- a/Cubelet/pkg/store/cubebox/deepcopy.go
+++ b/Cubelet/pkg/store/cubebox/deepcopy.go
@@ -117,10 +117,7 @@ func (cb *CubeBox) DeepCopy() *CubeBox {
 		copied.Status = cb.Status.DeepCopy()
 	}
 
-	if cb.LocalRunTemplate != nil {
-		templateCopy := *cb.LocalRunTemplate
-		copied.LocalRunTemplate = &templateCopy
-	}
+	copied.LocalRunTemplate = cb.LocalRunTemplate.Clone()
 
 	if cb.ComponentVersions != nil {
 		copied.ComponentVersions = make(map[string]string, len(cb.ComponentVersions))

--- a/Cubelet/pkg/store/cubebox/deepcopy_test.go
+++ b/Cubelet/pkg/store/cubebox/deepcopy_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/templatetypes"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -135,6 +136,33 @@ func TestCubeBoxDeepCopy(t *testing.T) {
 	}
 	if !copied.DeletedTime.Equal(*original.DeletedTime) {
 		t.Errorf("DeletedTime value should be equal")
+	}
+}
+
+func TestCubeBoxDeepCopyCompontsIndependent(t *testing.T) {
+	original := &CubeBox{
+		LocalRunTemplate: &templatetypes.LocalRunTemplate{
+			Componts: map[string]templatetypes.LocalComponent{
+				templatetypes.CubeComponentCubeShim: {Component: templatetypes.MachineComponent{Version: "v1"}},
+			},
+			Volumes: map[string]templatetypes.LocalBaseVolume{
+				"root": {VolumeID: "vol-1"},
+			},
+		},
+	}
+	copied := original.DeepCopy()
+	if copied.LocalRunTemplate == original.LocalRunTemplate {
+		t.Fatal("DeepCopy shared LocalRunTemplate pointer")
+	}
+	copied.LocalRunTemplate.Componts[templatetypes.CubeComponentCubeShim] = templatetypes.LocalComponent{
+		Component: templatetypes.MachineComponent{Version: "mutated"},
+	}
+	copied.LocalRunTemplate.Volumes["root"] = templatetypes.LocalBaseVolume{VolumeID: "mutated"}
+	if original.LocalRunTemplate.Componts[templatetypes.CubeComponentCubeShim].Component.Version != "v1" {
+		t.Fatal("DeepCopy shared Componts map")
+	}
+	if original.LocalRunTemplate.Volumes["root"].VolumeID != "vol-1" {
+		t.Fatal("DeepCopy shared Volumes map")
 	}
 }
 

--- a/Cubelet/services/cubebox/component_ensure_test.go
+++ b/Cubelet/services/cubebox/component_ensure_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,4 +68,35 @@ func TestEnsureTemplateComponentsSkipsEmptyVersions(t *testing.T) {
 		templatetypes.CubeComponentCubeShim: "",
 	}))
 	require.Empty(t, local.Componts)
+}
+
+func TestEnsureTemplateComponentsOnClonesConcurrent(t *testing.T) {
+	base := t.TempDir()
+	ver := "1.0.0"
+	shimFile := filepath.Join(base, templatetypes.CubeComponentCubeShim, ver, templatetypes.RelativePathCubeShim)
+	require.NoError(t, os.MkdirAll(filepath.Dir(shimFile), 0o755))
+	require.NoError(t, os.WriteFile(shimFile, []byte("shim"), 0o755))
+	SetComponentManagerForTest(components.NewComponentManager(&components.ComponentManagerConfig{
+		VersionedBaseDir: base,
+	}))
+
+	src := &templatetypes.LocalRunTemplate{Componts: map[string]templatetypes.LocalComponent{}}
+	versions := map[string]string{templatetypes.CubeComponentCubeShim: ver}
+	const n = 16
+	var start, done sync.WaitGroup
+	start.Add(n)
+	done.Add(n)
+	for range n {
+		go func() {
+			defer done.Done()
+			start.Done()
+			start.Wait()
+			local := src.Clone()
+			if err := EnsureTemplateComponents(context.Background(), local, versions); err != nil {
+				t.Errorf("ensure: %v", err)
+			}
+		}()
+	}
+	done.Wait()
+	require.Empty(t, src.Componts)
 }


### PR DESCRIPTION
## Background

`ListLocalTemplates` and `EnsureCubeRunTemplate` returned pointers straight into the store's template cache. Concurrent create/list flows then mutated `Componts` in place, racing the cache and the underlying store — under parallel sandbox creates the same cached template object was modified from multiple goroutines.

## Change

Both paths now hand out caller-owned copies instead of the cached object:

- `templatetypes`: new `LocalRunTemplate.Clone()` deep-copies the `Componts`, `Volumes`, and `Images` maps/slices so a returned template can be freely mutated.
- `template_manager`: `ListLocalTemplates` skips nil entries and returns clones; `EnsureCubeRunTemplate` re-reads after snapshot recovery via `cloneAndHydrate`, so component-version hydration applies to the copy and never writes through to the cached object.
- `store/cubebox`: `CubeBox.DeepCopy()` no longer shares the `LocalRunTemplate` pointer with the source.

## Tests

- Pointer independence of `Clone()`, `ListLocalTemplates`, and `EnsureCubeRunTemplate`.
- Hydration applies to the clone and does not leak into the cache.
- Concurrent ensure/list regression test (32 goroutines) proving the cache stays untouched.
- Concurrent `EnsureTemplateComponents` on clones.
- Concurrent creating with `cube-bench`  tool.

## Checklist

- [x] Unit tests pass for the touched packages
- [x] Tested on a real cluster.