### PR TITLE
fix(helm): align bundled CubeMaster config with current schema

### DIFF
--- a/deploy/kubernetes/chart/files/cube-master/conf.yaml
+++ b/deploy/kubernetes/chart/files/cube-master/conf.yaml
@@ -40,7 +40,7 @@ req_template_conf:
     Poststop: true
     Prestop: true
   cube_box_req_template: >-
-    {"volumes":[{"name":"tmp","volume_source":{"empty_dir":{"medium":0}}}],"containers":[{"name":"cubebox-default","envs":[{"key":"TZ","value":"Asia/Shanghai"},{"key":"TERM","value":"xterm"}],"volume_mounts":[{"name":"tmp","container_path":"/"}],"security_context":{"privileged":true,"readonly_rootfs":false,"no_new_privs":false}}],"network_type":"tap","cubevs_context":{"allowInternetAccess":true,"denyOut":["10.0.0.0/8","100.64.0.0/10","172.16.0.0/12","192.168.0.0/18"]}}
+    {"volumes":[{"name":"tmp","volume_source":{"empty_dir":{"medium":0}}}],"containers":[{"name":"cubebox-default","envs":[{"key":"TZ","value":"Asia/Shanghai"},{"key":"TERM","value":"xterm"}],"volume_mounts":[{"name":"tmp","container_path":"/"}],"security_context":{"privileged":true,"readonly_rootfs":false,"no_new_privs":false}}],"network_type":"tap","cube_network_config":{"allowInternetAccess":true,"denyOut":["10.0.0.0/8","100.64.0.0/10","172.16.0.0/12","192.168.0.0/18"]}}
 
 instance_db_config:
   driver: {{ include "cube.dbDriver" . | quote }}
@@ -56,30 +56,6 @@ instance_db_config:
   max_conn_life_time_seconds: 300
 
 redis:
-  nodes: {{ include "cube.redisNodes" . | quote }}
-  master_name: {{ .Values.redis.masterName | default "" | quote }}
-  sentinel_nodes: {{ .Values.redis.sentinelNodes | default "" | quote }}
-  sentinel_password: {{ .Values.redis.sentinelPassword | default "" | quote }}
-  password: {{ .Values.redis.password | quote }}
-  db_no: 0
-  max_idle: 8
-  max_active: 32
-  idle_timeout: 30
-  max_retry: 2
-
-redis_read:
-  nodes: {{ include "cube.redisNodes" . | quote }}
-  master_name: {{ .Values.redis.masterName | default "" | quote }}
-  sentinel_nodes: {{ .Values.redis.sentinelNodes | default "" | quote }}
-  sentinel_password: {{ .Values.redis.sentinelPassword | default "" | quote }}
-  password: {{ .Values.redis.password | quote }}
-  db_no: 0
-  max_idle: 8
-  max_active: 32
-  idle_timeout: 30
-  max_retry: 2
-
-redis_write:
   nodes: {{ include "cube.redisNodes" . | quote }}
   master_name: {{ .Values.redis.masterName | default "" | quote }}
   sentinel_nodes: {{ .Values.redis.sentinelNodes | default "" | quote }}


### PR DESCRIPTION
## Motivation

The Kubernetes Chart's bundled CubeMaster config still uses the legacy `cubevs_context` key in `cube_box_req_template`.

Current CubeMaster only reads `cube_network_config`, so the rendered Chart appears to configure a default sandbox egress policy, but CubeMaster silently ignores it.

The same config also includes unused `redis_read` and `redis_write` sections, while current CubeMaster uses the supported `redis` section.

## What Changed

- Replace `cubevs_context` with `cube_network_config`.
- Remove unused `redis_read` and `redis_write`.
- Preserve the supported `redis` section and existing Chart-managed values.

## Validation

- `helm lint deploy/kubernetes/chart --set-string mysql.password=test --set-string mysql.rootPassword=test --set-string redis.password=test`
- `helm template chart-check deploy/kubernetes/chart` with the same test credentials
- `deploy/kubernetes/chart/scripts/test-*.sh`
- Verified that the rendered CubeMaster config loads through the current `config.Init()` path and populates `CubeNetworkConfig`.

## Scope

This PR only updates the bundled Kubernetes Chart CubeMaster config.

It does not change CubeMaster runtime code, Helm values, or config mounting.