### PR TITLE
refactor(one-click): split build-machine env overrides into build.env

### DIFF
--- a/deploy/one-click/.gitignore
+++ b/deploy/one-click/.gitignore
@@ -1,3 +1,4 @@
 .env
+build.env
 .work/
 dist/

--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -17,7 +17,8 @@ This directory is used to build and deliver the single-machine one-click release
 - `install-compute.sh`: Entry point for installing a compute node on the target machine.
 - `down.sh`: Stops the services and dependencies installed by one-click.
 - `smoke.sh`: Runs basic health checks.
-- `env.example`: Shared environment variable template for both the build machine and the target machine.
+- `env.example`: Target-machine environment variable template.
+- `build.env.example`: Build-machine environment variable template for assembling the release bundle.
 - `lib/common.sh`: Common shell utility functions.
 - `scripts/one-click/`: Validation and maintenance helpers used by the systemd-managed deployment after installation.
 - `terraform/tencentcloud/`: Terraform deployer for a **clustered** CubeSandbox on Tencent Cloud (TKE control plane + CVM compute nodes). `create.sh` is the entry point; `destroy.sh` tears everything down. These files are shipped both at the release-bundle top level and inside `sandbox-package` (see "Tencent Cloud Cluster Deployment").
@@ -82,11 +83,11 @@ export ONE_CLICK_GUEST_IMAGE_TAR=/abs/path/to/cube-guest-image-amd64.tar.gz
 
 ## Building the Release Package
 
-It is recommended to copy the environment template first:
+It is recommended to copy the build environment template first:
 
 ```bash
 cd deploy/one-click
-cp env.example .env
+cp build.env.example build.env
 ```
 
 Run the following from the repository root on the host machine (recommended):

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -17,7 +17,8 @@
 - `install-compute.sh`：目标机计算节点安装入口。
 - `down.sh`：停止 one-click 安装的服务与依赖。
 - `smoke.sh`：执行基础健康检查。
-- `env.example`：构建机和目标机共用的环境变量模板。
+- `env.example`：目标机环境变量模板。
+- `build.env.example`：构建机环境变量模板，用于组装发布包。
 - `lib/common.sh`：公共 shell 函数。
 - `scripts/one-click/`：systemd 托管部署安装后使用的校验与维护辅助脚本。
 - `terraform/tencentcloud/`：在腾讯云上部署**集群版** CubeSandbox 的 Terraform 部署器（TKE 控制面 + CVM 计算节点）。`create.sh` 为入口，`destroy.sh` 负责整体销毁。这些文件同时位于发布包顶层和 `sandbox-package` 内（见“腾讯云集群部署”）。
@@ -82,11 +83,11 @@ export ONE_CLICK_GUEST_IMAGE_TAR=/abs/path/to/cube-guest-image-amd64.tar.gz
 
 ## 构建发布包
 
-建议先复制环境模板：
+建议先复制构建环境模板：
 
 ```bash
 cd deploy/one-click
-cp env.example .env
+cp build.env.example build.env
 ```
 
 推荐在宿主机的仓库根目录执行：

--- a/deploy/one-click/build-agent-ext4.sh
+++ b/deploy/one-click/build-agent-ext4.sh
@@ -14,10 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-ENV_FILE="${ONE_CLICK_ENV_FILE:-${SCRIPT_DIR}/.env}"
-if [[ -f "${ENV_FILE}" ]]; then
-  load_env_file "${ENV_FILE}"
-fi
+load_build_env
 
 WORK_ROOT="${ONE_CLICK_WORK_ROOT:-${SCRIPT_DIR}/.work}"
 OUTPUT_DIR="${OUTPUT_DIR:-${ONE_CLICK_AGENT_EXT4_OUTPUT_DIR:-}}"

--- a/deploy/one-click/build-guest-image.sh
+++ b/deploy/one-click/build-guest-image.sh
@@ -19,10 +19,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-ENV_FILE="${ONE_CLICK_ENV_FILE:-${SCRIPT_DIR}/.env}"
-if [[ -f "${ENV_FILE}" ]]; then
-  load_env_file "${ENV_FILE}"
-fi
+load_build_env
 
 WORK_ROOT="${ONE_CLICK_WORK_ROOT:-${SCRIPT_DIR}/.work}"
 OUTPUT_DIR="${OUTPUT_DIR:-${ONE_CLICK_GUEST_IMAGE_OUTPUT_DIR:-}}"

--- a/deploy/one-click/build-release-bundle-builder.sh
+++ b/deploy/one-click/build-release-bundle-builder.sh
@@ -6,10 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-ENV_FILE="${ONE_CLICK_ENV_FILE:-${SCRIPT_DIR}/.env}"
-if [[ -f "${ENV_FILE}" ]]; then
-  load_env_file "${ENV_FILE}"
-fi
+load_build_env
 
 PREBUILT_DIR="${SCRIPT_DIR}/.work/prebuilt"
 HELPER_SCRIPT="${SCRIPT_DIR}/.work/build-prebuilt-in-builder.sh"

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -8,10 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-ENV_FILE="${ONE_CLICK_ENV_FILE:-${SCRIPT_DIR}/.env}"
-if [[ -f "${ENV_FILE}" ]]; then
-  load_env_file "${ENV_FILE}"
-fi
+load_build_env
 
 # tar_czf: create a gzip-compressed tarball, using pigz (parallel gzip) when it
 # is installed and falling back to tar's built-in single-threaded gzip

--- a/deploy/one-click/build-vm-assets.sh
+++ b/deploy/one-click/build-vm-assets.sh
@@ -6,10 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-ENV_FILE="${ONE_CLICK_ENV_FILE:-${SCRIPT_DIR}/.env}"
-if [[ -f "${ENV_FILE}" ]]; then
-  load_env_file "${ENV_FILE}"
-fi
+load_build_env
 
 WORK_ROOT="${ONE_CLICK_WORK_ROOT:-${SCRIPT_DIR}/.work}"
 RUNTIME_LAYOUT_DIR="${ONE_CLICK_RUNTIME_LAYOUT_DIR:-${WORK_ROOT}/runtime-layout}"

--- a/deploy/one-click/build.env.example
+++ b/deploy/one-click/build.env.example
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+
+# Build-machine environment template for the one-click release bundle.
+# Copy this file and edit overrides before building:
+#   cp build.env.example build.env
+#   ./deploy/one-click/build-release-bundle-builder.sh
+#
+# This file is NOT shipped in the release tarball. Target-machine install
+# options live in env.example.
+
+# Recommended entrypoint:
+#   ./deploy/one-click/build-release-bundle-builder.sh
+# This wrapper compiles one-click component binaries inside the builder image,
+# writes them into deploy/one-click/.work/prebuilt, then invokes
+# build-release-bundle.sh on the host with ONE_CLICK_*_BIN overrides.
+# Optional builder image override:
+# BUILDER_IMAGE=cube-sandbox-builder:latest
+#
+# Builder-side options
+ONE_CLICK_CUBEMASTER_BUILD_MODE=local
+ONE_CLICK_CUBELET_BUILD_MODE=local
+ONE_CLICK_CUBE_API_BUILD_MODE=local
+ONE_CLICK_CUBE_OPS_BUILD_MODE=local
+ONE_CLICK_CUBE_AGENT_BUILD_MODE=local
+ONE_CLICK_CUBE_SHIM_BUILD_MODE=local
+
+# Build-performance knobs (all optional).
+# Max concurrent build tracks. Default: auto (min of CPU count and
+# available-memory/3GiB, where available memory respects a cgroup limit when the
+# build runs in a container). Set 1 for a fully serial build, or a large number
+# to uncap.
+# ONE_CLICK_BUILD_JOBS=1
+# Force portable single-threaded gzip for tarballs instead of pigz (parallel
+# gzip); use when a consistent single-tool compressor is preferred.
+# ONE_CLICK_DISABLE_PIGZ=1
+# Build the WebUI synchronously instead of overlapping the guest-image build.
+# ONE_CLICK_SEQUENTIAL_WEB_BUILD=1
+# CUBE_BUILD_TIME defaults to the HEAD commit date (UTC) so repeated builds on
+# the same commit reuse incremental caches; override for a literal timestamp.
+# CUBE_BUILD_TIME=2026-01-01T00:00:00Z
+
+# Optional overrides for prebuilt binaries or fixed artifacts.
+# ONE_CLICK_CUBEMASTER_BIN=/abs/path/to/cubemaster
+# ONE_CLICK_CUBEMASTERCLI_BIN=/abs/path/to/cubemastercli
+# Optional: embed a default envd binary into cubemastercli when using
+# build-release-bundle-builder.sh. Prepare/download envd before building;
+# the path is read on the build host and copied into the builder workspace.
+# ENVD_LOCAL_PATH=/abs/path/to/envd
+# ONE_CLICK_CUBELET_BIN=/abs/path/to/cubelet
+# ONE_CLICK_CUBECLI_BIN=/abs/path/to/cubecli
+# ONE_CLICK_CUBE_API_BIN=/abs/path/to/cube-api
+# ONE_CLICK_CUBE_OPS_BIN=/abs/path/to/cubeops
+# ONE_CLICK_CUBE_AGENT_BIN=/abs/path/to/cube-agent  # packaged into cube-agent.ext4
+# ONE_CLICK_CUBE_INIT_BIN=/abs/path/to/cube-init    # injected into guest image as /sbin/init
+# ONE_CLICK_CUBE_INIT_BUILD_MODE=local
+
+# ONE_CLICK_CUBESHIM_BIN=/abs/path/to/containerd-shim-cube-rs
+# ONE_CLICK_CUBE_RUNTIME_BIN=/abs/path/to/cube-runtime
+# ONE_CLICK_GUEST_IMAGE_DOCKERFILE=/abs/path/to/cube-sandbox/deploy/guest-image/Dockerfile
+# ONE_CLICK_GUEST_IMAGE_CONTEXT_DIR=/abs/path/to/cube-sandbox/deploy/guest-image
+# ONE_CLICK_GUEST_IMAGE_REF=cube-sandbox-guest-image:one-click
+# ONE_CLICK_GUEST_IMAGE_VERSION=custom-guest-image-version
+# Optional: reuse a prebuilt guest image archive (same layout as the Release /
+# docker asset cube-guest-image-*.tar.gz). When set, build-guest-image.sh
+# extracts it into the output directory and skips the local docker/mkfs rebuild.
+# ONE_CLICK_GUEST_IMAGE_TAR=/abs/path/to/cube-guest-image-amd64.tar.gz
+# ONE_CLICK_AGENT_EXT4_OUTPUT_DIR=/abs/path/to/cube-agent
+# ONE_CLICK_CUBE_KERNEL_VMLINUX=/abs/path/to/vmlinux
+# Optional PVM guest kernel. When present, it is packaged as cube-kernel-scf/vmlinux-pvm.
+# ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX=/abs/path/to/vmlinux-pvm
+# ONE_CLICK_RUNTIME_CFG_SRC=/abs/path/to/config-cube.toml
+# Headroom in bytes left in the guest ext4 image after shrink (default 32MB).
+# ONE_CLICK_GUEST_IMAGE_RESERVED_BYTES=33554432
+
+# mkcert is bundled in the release package (support/bin/mkcert).
+# Override with a custom binary path at build time if needed:
+# ONE_CLICK_MKCERT_BIN=/abs/path/to/mkcert
+
+# Optional: reuse a prebuilt Vite dist directory when building the one-click bundle.
+# ONE_CLICK_WEB_DIST_DIR=/abs/path/to/web/dist

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -1,69 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026 Tencent. All rights reserved.
 
-# Recommended entrypoint:
-#   ./deploy/one-click/build-release-bundle-builder.sh
-# This wrapper compiles one-click component binaries inside the builder image,
-# writes them into deploy/one-click/.work/prebuilt, then invokes
-# build-release-bundle.sh on the host with ONE_CLICK_*_BIN overrides.
-# Optional builder image override:
-# BUILDER_IMAGE=cube-sandbox-builder:latest
+# Target-machine environment template for one-click install.
+# Copy this file and edit overrides before installing:
+#   cp env.example .env
+#   sudo ./install.sh
 #
-# Builder-side options
-ONE_CLICK_CUBEMASTER_BUILD_MODE=local
-ONE_CLICK_CUBELET_BUILD_MODE=local
-ONE_CLICK_CUBE_API_BUILD_MODE=local
-ONE_CLICK_CUBE_OPS_BUILD_MODE=local
-ONE_CLICK_CUBE_AGENT_BUILD_MODE=local
-ONE_CLICK_CUBE_SHIM_BUILD_MODE=local
-
-# Build-performance knobs (all optional).
-# Max concurrent build tracks. Default: auto (min of CPU count and
-# available-memory/3GiB, where available memory respects a cgroup limit when the
-# build runs in a container). Set 1 for a fully serial build, or a large number
-# to uncap.
-# ONE_CLICK_BUILD_JOBS=1
-# Force portable single-threaded gzip for tarballs instead of pigz (parallel
-# gzip); use when a consistent single-tool compressor is preferred.
-# ONE_CLICK_DISABLE_PIGZ=1
-# Build the WebUI synchronously instead of overlapping the guest-image build.
-# ONE_CLICK_SEQUENTIAL_WEB_BUILD=1
-# CUBE_BUILD_TIME defaults to the HEAD commit date (UTC) so repeated builds on
-# the same commit reuse incremental caches; override for a literal timestamp.
-# CUBE_BUILD_TIME=2026-01-01T00:00:00Z
-
-# Optional overrides for prebuilt binaries or fixed artifacts.
-# ONE_CLICK_CUBEMASTER_BIN=/abs/path/to/cubemaster
-# ONE_CLICK_CUBEMASTERCLI_BIN=/abs/path/to/cubemastercli
-# Optional: embed a default envd binary into cubemastercli when using
-# build-release-bundle-builder.sh. Prepare/download envd before building;
-# the path is read on the build host and copied into the builder workspace.
-# ENVD_LOCAL_PATH=/abs/path/to/envd
-# ONE_CLICK_CUBELET_BIN=/abs/path/to/cubelet
-# ONE_CLICK_CUBECLI_BIN=/abs/path/to/cubecli
-# ONE_CLICK_CUBE_API_BIN=/abs/path/to/cube-api
-# ONE_CLICK_CUBE_OPS_BIN=/abs/path/to/cubeops
-# ONE_CLICK_CUBE_AGENT_BIN=/abs/path/to/cube-agent  # packaged into cube-agent.ext4
-# ONE_CLICK_CUBE_INIT_BIN=/abs/path/to/cube-init    # injected into guest image as /sbin/init
-# ONE_CLICK_CUBE_INIT_BUILD_MODE=local
-
-# ONE_CLICK_CUBESHIM_BIN=/abs/path/to/containerd-shim-cube-rs
-# ONE_CLICK_CUBE_RUNTIME_BIN=/abs/path/to/cube-runtime
-# ONE_CLICK_GUEST_IMAGE_DOCKERFILE=/abs/path/to/cube-sandbox/deploy/guest-image/Dockerfile
-# ONE_CLICK_GUEST_IMAGE_CONTEXT_DIR=/abs/path/to/cube-sandbox/deploy/guest-image
-# ONE_CLICK_GUEST_IMAGE_REF=cube-sandbox-guest-image:one-click
-# ONE_CLICK_GUEST_IMAGE_VERSION=custom-guest-image-version
-# Optional: reuse a prebuilt guest image archive (same layout as the Release /
-# docker asset cube-guest-image-*.tar.gz). When set, build-guest-image.sh
-# extracts it into the output directory and skips the local docker/mkfs rebuild.
-# ONE_CLICK_GUEST_IMAGE_TAR=/abs/path/to/cube-guest-image-amd64.tar.gz
-# ONE_CLICK_AGENT_EXT4_OUTPUT_DIR=/abs/path/to/cube-agent
-# ONE_CLICK_CUBE_KERNEL_VMLINUX=/abs/path/to/vmlinux
-# Optional PVM guest kernel. When present, it is packaged as cube-kernel-scf/vmlinux-pvm.
-# ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX=/abs/path/to/vmlinux-pvm
-# ONE_CLICK_RUNTIME_CFG_SRC=/abs/path/to/config-cube.toml
-# Headroom in bytes left in the guest ext4 image after shrink (default 32MB).
-# ONE_CLICK_GUEST_IMAGE_RESERVED_BYTES=33554432
+# Build-machine options (component compile, guest image, prebuilt binaries)
+# live in build.env.example and are not used at install time.
 
 # Target-machine install options.
 ONE_CLICK_RUN_QUICKCHECK=1
@@ -220,9 +164,6 @@ CUBE_PROXY_COREDNS_CONTAINER=cube-proxy-coredns
 # later crashes nothing restarts it; recover with "systemctl restart
 # cube-sandbox-dns".
 CUBE_PROXY_DNSMASQ_MODE=networkmanager
-# mkcert is bundled in the release package (support/bin/mkcert).
-# Override with a custom binary path at build time if needed:
-# ONE_CLICK_MKCERT_BIN=/abs/path/to/mkcert
 
 # WebUI options.
 WEB_UI_ENABLE=1
@@ -230,8 +171,6 @@ WEB_UI_ENABLE=1
 WEB_UI_CONTAINER_NAME=cube-webui
 WEB_UI_HOST_PORT=12088
 WEB_UI_UPSTREAM=http://host.docker.internal:3010
-# Optional: reuse a prebuilt Vite dist directory when building the one-click bundle.
-# ONE_CLICK_WEB_DIST_DIR=/abs/path/to/web/dist
 
 # Process listen overrides.
 CUBEMASTER_ADDR=127.0.0.1:8089

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -315,6 +315,27 @@ load_env_file() {
   fi
 }
 
+# Load build-machine overrides for release-bundle scripts.
+# Precedence: ONE_CLICK_BUILD_ENV_FILE > ${ONE_CLICK_DIR}/build.env >
+# legacy ONE_CLICK_ENV_FILE / .env (with a migration hint).
+load_build_env() {
+  local build_env_file legacy_env_file
+  if [[ -n "${ONE_CLICK_BUILD_ENV_FILE:-}" ]]; then
+    load_env_file "${ONE_CLICK_BUILD_ENV_FILE}"
+    return
+  fi
+  build_env_file="${ONE_CLICK_DIR}/build.env"
+  if [[ -f "${build_env_file}" ]]; then
+    load_env_file "${build_env_file}"
+    return
+  fi
+  legacy_env_file="${ONE_CLICK_ENV_FILE:-${ONE_CLICK_DIR}/.env}"
+  if [[ -f "${legacy_env_file}" ]]; then
+    log "build.env not found; falling back to ${legacy_env_file} (copy build.env.example to build.env for build-only overrides)"
+    load_env_file "${legacy_env_file}"
+  fi
+}
+
 ensure_file() {
   local path="$1"
   [[ -f "${path}" ]] || die "required file not found: ${path}"
@@ -1085,6 +1106,44 @@ DEPRECATED_KEYS = {
     # the old local-build knobs must not linger as kept-extra after upgrade.
     "CUBE_PROXY_IMAGE_TAG",
     "CUBE_PROXY_BASE_IMAGE",
+    # Build-machine knobs used to live in env.example and could leak into
+    # .one-click.env. They now live in build.env.example and are unused at
+    # install/runtime, so drop them on upgrade instead of keeping them extra.
+    "BUILDER_IMAGE",
+    "ONE_CLICK_CUBEMASTER_BUILD_MODE",
+    "ONE_CLICK_CUBELET_BUILD_MODE",
+    "ONE_CLICK_CUBE_API_BUILD_MODE",
+    "ONE_CLICK_CUBE_OPS_BUILD_MODE",
+    "ONE_CLICK_CUBE_AGENT_BUILD_MODE",
+    "ONE_CLICK_CUBE_SHIM_BUILD_MODE",
+    "ONE_CLICK_CUBE_INIT_BUILD_MODE",
+    "ONE_CLICK_BUILD_JOBS",
+    "ONE_CLICK_DISABLE_PIGZ",
+    "ONE_CLICK_SEQUENTIAL_WEB_BUILD",
+    "CUBE_BUILD_TIME",
+    "ONE_CLICK_CUBEMASTER_BIN",
+    "ONE_CLICK_CUBEMASTERCLI_BIN",
+    "ENVD_LOCAL_PATH",
+    "ONE_CLICK_CUBELET_BIN",
+    "ONE_CLICK_CUBECLI_BIN",
+    "ONE_CLICK_CUBE_API_BIN",
+    "ONE_CLICK_CUBE_OPS_BIN",
+    "ONE_CLICK_CUBE_AGENT_BIN",
+    "ONE_CLICK_CUBE_INIT_BIN",
+    "ONE_CLICK_CUBESHIM_BIN",
+    "ONE_CLICK_CUBE_RUNTIME_BIN",
+    "ONE_CLICK_GUEST_IMAGE_DOCKERFILE",
+    "ONE_CLICK_GUEST_IMAGE_CONTEXT_DIR",
+    "ONE_CLICK_GUEST_IMAGE_REF",
+    "ONE_CLICK_GUEST_IMAGE_VERSION",
+    "ONE_CLICK_GUEST_IMAGE_TAR",
+    "ONE_CLICK_AGENT_EXT4_OUTPUT_DIR",
+    "ONE_CLICK_CUBE_KERNEL_VMLINUX",
+    "ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX",
+    "ONE_CLICK_RUNTIME_CFG_SRC",
+    "ONE_CLICK_GUEST_IMAGE_RESERVED_BYTES",
+    "ONE_CLICK_MKCERT_BIN",
+    "ONE_CLICK_WEB_DIST_DIR",
 }
 
 LEGACY_CUBE_PROXY_CERT_DIR_DEFAULTS = {

--- a/deploy/one-click/tests/test_env_merge.sh
+++ b/deploy/one-click/tests/test_env_merge.sh
@@ -457,6 +457,40 @@ EOF
   assert_value "${out}" MY_CUSTOM_KEEP stays
 }
 
+test_drops_legacy_build_keys() {
+  local new="${TMP_DIR}/new_build.example" old="${TMP_DIR}/old_build.env"
+  local out="${TMP_DIR}/out_build.env" diff="${TMP_DIR}/diff_build.txt"
+  write_new_example "${new}"
+  # Old runtime env leaked build-machine knobs from the previously shared
+  # env.example. They must be dropped rather than kept as extra custom keys.
+  cat > "${old}" <<'EOF'
+CUBE_SANDBOX_MYSQL_PORT=3306
+ONE_CLICK_CUBEMASTER_BUILD_MODE=local
+ONE_CLICK_CUBELET_BUILD_MODE=local
+ONE_CLICK_CUBE_API_BUILD_MODE=local
+ONE_CLICK_CUBEMASTER_BIN=/tmp/cubemaster
+ENVD_LOCAL_PATH=/tmp/envd
+ONE_CLICK_WEB_DIST_DIR=/tmp/web/dist
+ONE_CLICK_MKCERT_BIN=/tmp/mkcert
+CUBE_BUILD_TIME=2026-01-01T00:00:00Z
+MY_CUSTOM_KEEP=stays
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  for k in \
+    ONE_CLICK_CUBEMASTER_BUILD_MODE ONE_CLICK_CUBELET_BUILD_MODE \
+    ONE_CLICK_CUBE_API_BUILD_MODE ONE_CLICK_CUBEMASTER_BIN \
+    ENVD_LOCAL_PATH ONE_CLICK_WEB_DIST_DIR ONE_CLICK_MKCERT_BIN \
+    CUBE_BUILD_TIME; do
+    if grep -q "^${k}=" "${out}"; then
+      fail "build-only key ${k} should have been dropped from ${out}"
+    fi
+  done
+  assert_contains "${diff}" "[dropped] obsolete keys removed on upgrade:"
+  assert_value "${out}" MY_CUSTOM_KEEP stays
+}
+
 test_migrates_custom_cube_proxy_image_tag() {
   local new="${TMP_DIR}/new_proxy_img.example" old="${TMP_DIR}/old_proxy_img.env"
   local out="${TMP_DIR}/out_proxy_img.env" diff="${TMP_DIR}/diff_proxy_img.txt"
@@ -625,6 +659,7 @@ test_new_dotenv_overrides_take_priority
 test_version_lt
 test_diff_report_redacts_secrets
 test_drops_obsolete_agenthub_keys
+test_drops_legacy_build_keys
 test_migrates_custom_cube_proxy_image_tag
 test_drops_default_cube_proxy_image_tag_without_migration
 test_keeps_existing_cube_sandbox_cube_proxy_image_over_legacy_tag

--- a/deploy/one-click/tests/test_package_layout.sh
+++ b/deploy/one-click/tests/test_package_layout.sh
@@ -255,6 +255,38 @@ test_reinstall_cleanup_tracks_packaged_components() {
   fi
 }
 
+# 3g) Build-machine knobs live in build.env.example; the shipped env.example is
+#     deploy-only. The release bundle must copy env.example and must not ship
+#     build.env.example.
+test_env_templates_are_split() {
+  local env_example="${ONE_CLICK_DIR}/env.example"
+  local build_example="${ONE_CLICK_DIR}/build.env.example"
+  require_file "${env_example}" "deploy env.example"
+  require_file "${build_example}" "build.env.example"
+
+  if grep -E '^[[:space:]]*(#[[:space:]]*)?ONE_CLICK_[A-Z0-9_]+_BUILD_MODE=' "${env_example}" >/dev/null; then
+    fail "env.example must not contain ONE_CLICK_*_BUILD_MODE keys"
+  fi
+  if grep -E '^[[:space:]]*(#[[:space:]]*)?ONE_CLICK_[A-Z0-9_]+_BIN=' "${env_example}" >/dev/null; then
+    fail "env.example must not contain ONE_CLICK_*_BIN keys"
+  fi
+
+  grep -q '^ONE_CLICK_CUBEMASTER_BUILD_MODE=' "${build_example}" \
+    || fail "build.env.example missing ONE_CLICK_CUBEMASTER_BUILD_MODE"
+  grep -q 'ONE_CLICK_CUBEMASTER_BIN=' "${build_example}" \
+    || fail "build.env.example missing ONE_CLICK_CUBEMASTER_BIN"
+  grep -q 'ONE_CLICK_MKCERT_BIN=' "${build_example}" \
+    || fail "build.env.example missing ONE_CLICK_MKCERT_BIN"
+  grep -q 'ONE_CLICK_WEB_DIST_DIR=' "${build_example}" \
+    || fail "build.env.example missing ONE_CLICK_WEB_DIST_DIR"
+
+  grep -q 'copy_file "${SCRIPT_DIR}/env.example"' "${BUNDLE_SH}" \
+    || fail "build-release-bundle.sh must copy env.example into DIST_ROOT"
+  if grep -q 'build.env.example' "${BUNDLE_SH}"; then
+    fail "build-release-bundle.sh must not ship build.env.example"
+  fi
+}
+
 # 4) The build entrypoints AND every shipped Terraform deployer script must at
 #    least be syntactically valid — a cheap, cloud-free guard so a broken script
 #    fails here instead of only when a user runs it from the bundle.
@@ -275,6 +307,7 @@ test_cubeproxy_host_log_wiring
 test_tke_addons_network_config_key
 test_reinstall_cleanup_tracks_packaged_components
 test_terraform_deployer_files_present
+test_env_templates_are_split
 test_build_scripts_parse
 
 if [[ "${failures}" -gt 0 ]]; then

--- a/docs/guide/self-build-deploy.md
+++ b/docs/guide/self-build-deploy.md
@@ -66,10 +66,11 @@ The default expected filename is `vmlinux`. You can override the path via the `O
 
 ### 1.2 Run the Build
 
-From the repository root:
+Copy the build environment template if you need overrides, then run from the repository root:
 
 ```bash
 cd cube-sandbox
+cp deploy/one-click/build.env.example deploy/one-click/build.env
 ./deploy/one-click/build-release-bundle-builder.sh
 ```
 
@@ -252,9 +253,11 @@ To reinstall over an existing deployment, simply run `install.sh` again. The scr
 
 ## Configuration Reference
 
-All configuration is managed through the `.env` file. Below is the full parameter reference.
+Install-time configuration is managed through the `.env` file copied from `env.example`. Build-time options live in `build.env` (copied from `build.env.example`) on the build machine.
 
 ### Build-time Options
+
+Copy `deploy/one-click/build.env.example` to `deploy/one-click/build.env` and set overrides there (or export them in the shell).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -281,6 +284,7 @@ You can also point to prebuilt binaries to skip compilation:
 
 | `ONE_CLICK_CUBESHIM_BIN` | Path to prebuilt containerd-shim-cube-rs binary |
 | `ONE_CLICK_CUBE_RUNTIME_BIN` | Path to prebuilt cube-runtime binary |
+| `ONE_CLICK_MKCERT_BIN` | Override path to mkcert binary at build time (default: bundled `assets/bin/mkcert`) |
 
 Build-performance knobs (all optional):
 
@@ -331,7 +335,6 @@ Build-performance knobs (all optional):
 | `CUBE_PROXY_DNS_ENABLE` | `1` | Enable CoreDNS (must be `1` for one-click) |
 | `CUBE_PROXY_DNS_ANSWER_IP` | `${CUBE_SANDBOX_NODE_IP}` | IP returned by CoreDNS for `cube.app` |
 | `CUBE_PROXY_COREDNS_BIND_ADDR` | `127.0.0.54` | CoreDNS bind address |
-| `ONE_CLICK_MKCERT_BIN` | `assets/bin/mkcert` (bundled) | Override path to mkcert binary at build time |
 
 ### Process Addresses
 

--- a/docs/zh/guide/self-build-deploy.md
+++ b/docs/zh/guide/self-build-deploy.md
@@ -66,10 +66,11 @@ cp /path/to/vmlinux deploy/one-click/assets/kernel-artifacts/
 
 ### 1.2 执行构建
 
-在仓库根目录执行：
+如需覆盖构建选项，先复制构建环境模板，然后在仓库根目录执行：
 
 ```bash
 cd cube-sandbox
+cp deploy/one-click/build.env.example deploy/one-click/build.env
 ./deploy/one-click/build-release-bundle-builder.sh
 ```
 
@@ -252,9 +253,11 @@ sudo ./down.sh
 
 ## 配置参考
 
-所有配置通过 `.env` 文件管理。以下为完整参数说明。
+安装时配置通过从 `env.example` 复制的 `.env` 文件管理。构建时选项位于构建机上的 `build.env`（从 `build.env.example` 复制）。
 
 ### 构建时选项
+
+将 `deploy/one-click/build.env.example` 复制为 `deploy/one-click/build.env`，在其中设置覆盖项（也可在 shell 中 export）。
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
@@ -281,6 +284,7 @@ sudo ./down.sh
 
 | `ONE_CLICK_CUBESHIM_BIN` | 预编译 containerd-shim-cube-rs 路径 |
 | `ONE_CLICK_CUBE_RUNTIME_BIN` | 预编译 cube-runtime 路径 |
+| `ONE_CLICK_MKCERT_BIN` | 构建时自定义 mkcert 二进制路径（默认：内置 `assets/bin/mkcert`） |
 
 构建性能选项（均为可选）：
 
@@ -331,7 +335,6 @@ sudo ./down.sh
 | `CUBE_PROXY_DNS_ENABLE` | `1` | 启用 CoreDNS（一键部署必须为 `1`） |
 | `CUBE_PROXY_DNS_ANSWER_IP` | `${CUBE_SANDBOX_NODE_IP}` | CoreDNS 对 `cube.app` 返回的 IP |
 | `CUBE_PROXY_COREDNS_BIND_ADDR` | `127.0.0.54` | CoreDNS 绑定地址 |
-| `ONE_CLICK_MKCERT_BIN` | `assets/bin/mkcert`（内置） | 构建时自定义 mkcert 二进制路径 |
 
 ### 进程监听地址
 


### PR DESCRIPTION
## Summary

Separate the one-click release-bundle build machine options out of the shared `env.example` template into a dedicated `build.env.example`, and load them via a new `load_build_env()` helper. `env.example` now only covers target-machine install/runtime settings.

## What changed

- Add `deploy/one-click/build.env.example` with the full build-side option reference (build modes, binary overrides, guest-image knobs).
- Add `load_build_env()` in `lib/common.sh`: precedence is `ONE_CLICK_BUILD_ENV_FILE` > `${ONE_CLICK_DIR}/build.env` > legacy `ONE_CLICK_ENV_FILE` / `.env` (with a migration hint).
- Remove the build-only keys from `env.example` and list them as deprecated in the upgrade merge logic so they are dropped instead of lingering as kept-extra keys.
- Update the build scripts and READMEs / self-build-deploy docs to copy `build.env.example` to `build.env`.
- Extend `test_env_merge.sh` and `test_package_layout.sh` for the new env file.