### PR TITLE
fix(test): disable inlining for gomonkey-based unit tests

### DIFF
--- a/CubeMaster/Makefile
+++ b/CubeMaster/Makefile
@@ -127,8 +127,13 @@ test:
 	$(call msg,Run unit tests)
 	$(Q)go clean -testcache
 	$(Q)mkdir -p coverage
+	@# -gcflags=all=-l disables inlining, which is REQUIRED by the gomonkey-based
+	@# tests (e.g. ./pkg/templatecenter): gomonkey redirects a function by
+	@# rewriting its machine code, but an inlined call site bypasses the patch, so
+	@# a stub intermittently fails to take effect and the real function runs. The
+	@# integration targets (testlocal/testtt) already pass this flag.
 	@( for pkg in ${COVERAGE_PACKAGES}; do \
-		CI=true go test -short -v -timeout=20m ${TEST_FLAGS} \
+		CI=true go test -short -v -gcflags=all=-l -timeout=20m ${TEST_FLAGS} \
 			-coverprofile=coverage/unit-test-`echo $$pkg | tr "/" "_"`.cov \
 			$$pkg || exit 1 ;\
 	done )

--- a/tests/unittest/run.sh
+++ b/tests/unittest/run.sh
@@ -82,7 +82,13 @@ cd "$REPO_ROOT"
 # same package set (`-short` skips the Redis/KVM-dependent cases).
 WITH_TESTS=(
 	"cubeops|Go|0|make cubeops-test"
-	"cubemaster|Go|0|make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go mod download && make proto && if [ -f test/conf.yaml ]; then export CUBE_MASTER_CONFIG_PATH=/workspace/CubeMaster/test/conf.yaml; fi && CI=true go test -short -timeout=20m ./api/... ./pkg/...'"
+	# -gcflags=all=-l disables inlining, which is REQUIRED by the gomonkey-based
+	# tests in ./pkg/templatecenter: gomonkey rewrites a function's machine code
+	# to redirect it, but an inlined call site bypasses that patch, so a stub
+	# intermittently fails to take effect and the real function runs (e.g. the
+	# flaky "template store is not initialized" failures). The repo already uses
+	# this flag for the integration tests (CubeMaster/Makefile testlocal/testtt).
+	"cubemaster|Go|0|make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go mod download && make proto && if [ -f test/conf.yaml ]; then export CUBE_MASTER_CONFIG_PATH=/workspace/CubeMaster/test/conf.yaml; fi && CI=true go test -short -gcflags=all=-l -timeout=20m ./api/... ./pkg/...'"
 	# cubelet-network: the standalone network-agent module was removed in #1285 and
 	# folded into Cubelet/network/runtime (NetworkController). Its tests moved there
 	# and need the generated CubeNet/cubevs code but no cubecow/CGO, so build cubevs


### PR DESCRIPTION
fix(test): disable inlining for gomonkey-based unit tests

The unit-test targets ran without -gcflags=all=-l, so ./pkg/templatecenter
intermittently failed (e.g. "template store is not initialized"). gomonkey
patches a function by rewriting the machine code at its entry point,
installing a jump to the stub. When the compiler inlines the target
function, its body is expanded directly into the caller and the patched
entry point is never executed, so the stub silently has no effect and the
real function runs.

Why it passed on x86 but failed on aarch64: inlining is a cost-budget
heuristic, and the same Go source compiles to different instruction
sequences per architecture, so a function's estimated cost can land on
opposite sides of the inlining threshold. The target function happened to
be left un-inlined on x86 (patch worked by luck) but was inlined on
aarch64 (patch defeated). x86 passing was accidental, not correct -- it
relied on the compiler happening not to inline, which can drift with the
architecture, Go version, or unrelated code changes.

Add -gcflags=all=-l to the unit-test commands to remove that dependency on
incidental inlining behavior, matching the flag the integration targets
(testlocal/testtt) already use. This is also what the gomonkey docs require
when running tests.

Assisted-by: Claude Code:claude-opus-4.7
Signed-off-by: Like Xu <likexu@tencent.com>