### PR TITLE
cubeops: reject an empty JWT signing secret

### DIFF
--- a/CubeOps/e2e/doc.go
+++ b/CubeOps/e2e/doc.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package e2e holds end-to-end tests that drive the real cubeops binary against
+// a real database over HTTP.
+//
+// Every test file in this package carries the e2e build tag, so the default
+// unit gate (go test ./...) compiles this file and reports "no test files"
+// instead of failing on a package with no buildable sources. Run the suite with:
+//
+//	go test -tags e2e ./e2e/...
+package e2e

--- a/CubeOps/e2e/empty_jwt_secret_test.go
+++ b/CubeOps/e2e/empty_jwt_secret_test.go
@@ -1,0 +1,131 @@
+//go:build e2e
+
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// forgeAccessToken mints the token an attacker would build once they guess the
+// signing secret is empty: sub=admin, aud=cubeops:access, typ=access, signed
+// with a zero-length HMAC key. It deliberately does not go through JWTManager,
+// which now refuses to sign with an empty key.
+func forgeAccessToken(secret string) string {
+	seg := func(v any) string {
+		raw, _ := json.Marshal(v)
+		return base64.RawURLEncoding.EncodeToString(raw)
+	}
+	now := time.Now().Unix()
+	header := seg(map[string]any{"alg": "HS256", "typ": "JWT"})
+	claims := seg(map[string]any{
+		"sub": "admin", "username": "admin", "role": "admin", "scopes": []string{},
+		"typ": "access", "aud": []string{"cubeops:access"},
+		"iat": now, "exp": now + 900,
+	})
+	signingInput := header + "." + claims
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signingInput))
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func readJWTSecret(t *testing.T, e *env) string {
+	t.Helper()
+	db := e.db(t)
+	defer db.Close()
+	var v *string
+	err := db.QueryRow(
+		"SELECT setting_value FROM t_system_setting WHERE setting_key = 'jwt_secret'").Scan(&v)
+	if err != nil {
+		t.Fatalf("read jwt_secret: %v", err)
+	}
+	if v == nil {
+		return "<null>"
+	}
+	return *v
+}
+
+func setJWTSecret(t *testing.T, e *env, value any) {
+	t.Helper()
+	db := e.db(t)
+	defer db.Close()
+	if _, err := db.Exec(
+		"REPLACE INTO t_system_setting (setting_key, setting_value) VALUES ('jwt_secret', ?)",
+		value); err != nil {
+		t.Fatalf("seed jwt_secret: %v", err)
+	}
+}
+
+// TestEmptyJWTSecretEndToEnd is the wire-level guard for #1373. It runs the real
+// binary against a real database and presents a forged admin token to a real
+// authenticated route.
+func TestEmptyJWTSecretEndToEnd(t *testing.T) {
+	e := newEnv(t)
+	defer e.teardown()
+
+	// First boot runs migrations and seeds admin/admin.
+	first := e.start(t)
+	first.stop()
+
+	for _, stored := range []any{"", " ", "\t", nil} {
+		label := fmt.Sprintf("%#v", stored)
+		t.Run("degenerate stored secret "+label, func(t *testing.T) {
+			setJWTSecret(t, e, stored)
+
+			inst := e.start(t)
+			defer inst.stop()
+
+			repaired := readJWTSecret(t, e)
+			if strings.TrimSpace(repaired) == "" || repaired == "<null>" {
+				t.Fatalf("jwt_secret is still degenerate after startup: %q", repaired)
+			}
+
+			forged := forgeAccessToken("")
+			code, body := do(t, http.MethodGet, inst.baseURL+"/api/v1/auth/session", forged, "")
+			if code == http.StatusOK {
+				t.Fatalf("a token signed with the empty HMAC key was accepted: %s", body)
+			}
+
+			token := login(t, inst.baseURL, "admin", "admin")
+			code, body = do(t, http.MethodGet, inst.baseURL+"/api/v1/auth/session", token, "")
+			if code != http.StatusOK {
+				t.Fatalf("a genuine token was rejected: %d %s", code, body)
+			}
+		})
+	}
+}
+
+// TestBlankEnvJWTSecretIsNotUsedEndToEnd proves a whitespace-only JWT_SECRET no
+// longer produces a server that boots but rejects every token it issues.
+func TestBlankEnvJWTSecretIsNotUsedEndToEnd(t *testing.T) {
+	e := newEnv(t)
+	defer e.teardown()
+
+	first := e.start(t)
+	first.stop()
+
+	inst := e.start(t, "JWT_SECRET=   ")
+	defer inst.stop()
+
+	token := login(t, inst.baseURL, "admin", "admin")
+	code, body := do(t, http.MethodGet, inst.baseURL+"/api/v1/auth/session", token, "")
+	if code != http.StatusOK {
+		t.Fatalf("a blank JWT_SECRET left the server unable to honour its own tokens: %d %s", code, body)
+	}
+
+	forged := forgeAccessToken(" ")
+	code, body = do(t, http.MethodGet, inst.baseURL+"/api/v1/auth/session", forged, "")
+	if code == http.StatusOK {
+		t.Fatalf("a token signed with the whitespace key was accepted: %s", body)
+	}
+}

--- a/CubeOps/e2e/harness_test.go
+++ b/CubeOps/e2e/harness_test.go
@@ -1,0 +1,283 @@
+//go:build e2e
+
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package e2e drives the real cubeops binary against a real MySQL instance over
+// HTTP. It is excluded from the default unit gate by the e2e build tag; run it
+// with:
+//
+//	cd CubeOps && go test -tags e2e ./e2e/...
+package e2e
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+)
+
+const (
+	requireDockerEnv = "CUBEOPS_REQUIRE_DOCKER_TESTS"
+	mysqlTag         = "8.0"
+	dbName           = "cubeops_e2e"
+)
+
+type env struct {
+	t        *testing.T
+	binary   string
+	dsn      string
+	mysqlURL struct{ host, port string }
+	logDir   string
+	teardown func()
+}
+
+func requireDocker() bool {
+	v := os.Getenv(requireDockerEnv)
+	if v == "1" || strings.EqualFold(v, "true") {
+		return true
+	}
+	ci := os.Getenv("CI")
+	return ci == "true" || ci == "1"
+}
+
+func abortOrSkip(t *testing.T, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if requireDocker() {
+		t.Fatalf("%s (set %s or fix Docker — CI forbids skip)", msg, requireDockerEnv)
+	}
+	t.Skipf("%s", msg)
+}
+
+// newEnv builds the cubeops binary and starts a throwaway MySQL container.
+func newEnv(t *testing.T) *env {
+	t.Helper()
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		abortOrSkip(t, "dockertest not available (%v)", err)
+	}
+	if err := pool.Client.Ping(); err != nil {
+		abortOrSkip(t, "docker daemon not reachable (%v)", err)
+	}
+
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "mysql",
+		Tag:        mysqlTag,
+		Env: []string{
+			"MYSQL_ROOT_PASSWORD=root",
+			"MYSQL_DATABASE=" + dbName,
+		},
+	}, func(hc *docker.HostConfig) {
+		hc.AutoRemove = true
+		hc.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	if err != nil {
+		abortOrSkip(t, "could not start mysql container (%v)", err)
+	}
+
+	port := resource.GetPort("3306/tcp")
+	dsn := fmt.Sprintf("root:root@tcp(127.0.0.1:%s)/%s?charset=utf8&parseTime=true", port, dbName)
+
+	// MySQL's entrypoint runs a temporary server during initialisation and then
+	// restarts, so the first successful connection can still be to the throwaway
+	// instance. Require a working query, then a short settle, before proceeding.
+	pool.MaxWait = 3 * time.Minute
+	if err := pool.Retry(func() error {
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		var one int
+		return db.QueryRow("SELECT 1").Scan(&one)
+	}); err != nil {
+		_ = pool.Purge(resource)
+		t.Fatalf("mysql never became reachable: %v", err)
+	}
+	time.Sleep(2 * time.Second)
+
+	binary := filepath.Join(t.TempDir(), "cubeops")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/cubeops")
+	build.Dir = ".."
+	if out, err := build.CombinedOutput(); err != nil {
+		_ = pool.Purge(resource)
+		t.Fatalf("building cubeops failed: %v\n%s", err, out)
+	}
+
+	e := &env{t: t, binary: binary, dsn: dsn, logDir: t.TempDir()}
+	e.mysqlURL.host, e.mysqlURL.port = "127.0.0.1", port
+	e.teardown = func() { _ = pool.Purge(resource) }
+	return e
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+type instance struct {
+	baseURL string
+	cmd     *exec.Cmd
+	logPath string
+}
+
+// start launches cubeops and waits for /health. extraEnv entries are KEY=VALUE.
+func (e *env) start(t *testing.T, extraEnv ...string) *instance {
+	t.Helper()
+	port := freePort(t)
+	logPath := filepath.Join(e.logDir, fmt.Sprintf("cubeops-%d.out", port))
+	out, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("create log: %v", err)
+	}
+
+	cmd := exec.Command(e.binary)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("CUBE_OPS_BIND=127.0.0.1:%d", port),
+		"CUBE_SANDBOX_MYSQL_HOST="+e.mysqlURL.host,
+		"CUBE_SANDBOX_MYSQL_PORT="+e.mysqlURL.port,
+		"CUBE_SANDBOX_MYSQL_USER=root",
+		"CUBE_SANDBOX_MYSQL_PASSWORD=root",
+		"CUBE_SANDBOX_MYSQL_DB="+dbName,
+		"CUBE_OPS_LOG_DIR="+filepath.Join(e.logDir, fmt.Sprintf("log-%d", port)),
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd.Stdout, cmd.Stderr = out, out
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start cubeops: %v", err)
+	}
+
+	inst := &instance{baseURL: fmt.Sprintf("http://127.0.0.1:%d", port), cmd: cmd, logPath: logPath}
+	deadline := time.Now().Add(4 * time.Minute)
+	for time.Now().Before(deadline) {
+		if resp, err := http.Get(inst.baseURL + "/health"); err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return inst
+			}
+		}
+		if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	body, _ := os.ReadFile(logPath)
+	inst.stop()
+	t.Fatalf("cubeops never became healthy on %s\n--- output ---\n%s", inst.baseURL, tailLines(string(body), 25))
+	return nil
+}
+
+// startExpectingExit launches cubeops and waits for it to terminate, returning
+// its combined output. It fails the test if the process stays up.
+func (e *env) startExpectingExit(t *testing.T, extraEnv ...string) string {
+	t.Helper()
+	port := freePort(t)
+	cmd := exec.Command(e.binary)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("CUBE_OPS_BIND=127.0.0.1:%d", port),
+		"CUBE_SANDBOX_MYSQL_HOST="+e.mysqlURL.host,
+		"CUBE_SANDBOX_MYSQL_PORT="+e.mysqlURL.port,
+		"CUBE_SANDBOX_MYSQL_USER=root",
+		"CUBE_SANDBOX_MYSQL_PASSWORD=root",
+		"CUBE_SANDBOX_MYSQL_DB="+dbName,
+		"CUBE_OPS_LOG_DIR="+filepath.Join(e.logDir, fmt.Sprintf("exitlog-%d", port)),
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("cubeops kept running; expected it to abort\n%s", tailLines(string(out), 20))
+	}
+	return string(out)
+}
+
+func (i *instance) stop() {
+	if i == nil || i.cmd == nil || i.cmd.Process == nil {
+		return
+	}
+	_ = i.cmd.Process.Kill()
+	_, _ = i.cmd.Process.Wait()
+}
+
+func tailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (e *env) db(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("mysql", e.dsn)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	return db
+}
+
+// do issues a request and returns the status and body.
+func do(t *testing.T, method, url, bearer, body string) (int, string) {
+	t.Helper()
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, url, rdr)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(raw)
+}
+
+// login performs a real login and returns the access token.
+func login(t *testing.T, baseURL, user, pass string) string {
+	t.Helper()
+	code, body := do(t, http.MethodPost, baseURL+"/api/v1/auth/login", "",
+		fmt.Sprintf(`{"username":%q,"password":%q}`, user, pass))
+	if code != http.StatusOK {
+		t.Fatalf("login returned %d: %s", code, body)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("login response is not JSON: %s", body)
+	}
+	for _, key := range []string{"accessToken", "access_token"} {
+		if v, ok := parsed[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	t.Fatalf("no access token in login response: %s", body)
+	return ""
+}

--- a/CubeOps/internal/auth/jwt.go
+++ b/CubeOps/internal/auth/jwt.go
@@ -59,6 +59,15 @@ func NewJWTManager(secret string, accessTTL, refreshTTL time.Duration) *JWTManag
 	}
 }
 
+var errEmptyJWTSecret = errors.New("jwt: signing secret is empty")
+
+func (m *JWTManager) checkSecret() error {
+	if len(m.secret) == 0 {
+		return errEmptyJWTSecret
+	}
+	return nil
+}
+
 // AccessTTL returns the configured access-token TTL.
 func (m *JWTManager) AccessTTL() time.Duration { return m.accessTTL }
 
@@ -67,6 +76,9 @@ func (m *JWTManager) RefreshTTL() time.Duration { return m.refreshTTL }
 
 // GenerateAccessToken creates a signed JWT access token.
 func (m *JWTManager) GenerateAccessToken(username string) (string, error) {
+	if err := m.checkSecret(); err != nil {
+		return "", err
+	}
 	now := time.Now()
 	claims := AccessClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -86,6 +98,9 @@ func (m *JWTManager) GenerateAccessToken(username string) (string, error) {
 
 // GenerateRefreshToken creates a signed JWT refresh token.
 func (m *JWTManager) GenerateRefreshToken(username string) (string, string, error) {
+	if err := m.checkSecret(); err != nil {
+		return "", "", err
+	}
 	now := time.Now()
 	tokenID := uuid.New().String()
 	claims := RefreshClaims{
@@ -111,6 +126,9 @@ func (m *JWTManager) GenerateRefreshToken(username string) (string, string, erro
 // tokens by checking the "typ" claim and the audience, so a long-lived
 // refresh token cannot be used as an access token.
 func (m *JWTManager) VerifyAccessToken(tokenStr string) (*AccessClaims, error) {
+	if err := m.checkSecret(); err != nil {
+		return nil, err
+	}
 	token, err := jwt.ParseWithClaims(tokenStr, &AccessClaims{}, func(t *jwt.Token) (interface{}, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
@@ -136,6 +154,9 @@ func (m *JWTManager) VerifyAccessToken(tokenStr string) (*AccessClaims, error) {
 // than on this package's internals. It rejects access tokens via the "typ"
 // claim and the audience.
 func (m *JWTManager) VerifyRefreshToken(tokenStr string) (*service.RefreshClaims, error) {
+	if err := m.checkSecret(); err != nil {
+		return nil, err
+	}
 	token, err := jwt.ParseWithClaims(tokenStr, &RefreshClaims{}, func(t *jwt.Token) (interface{}, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])

--- a/CubeOps/internal/auth/jwt.go
+++ b/CubeOps/internal/auth/jwt.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -62,7 +63,7 @@ func NewJWTManager(secret string, accessTTL, refreshTTL time.Duration) *JWTManag
 var errEmptyJWTSecret = errors.New("jwt: signing secret is empty")
 
 func (m *JWTManager) checkSecret() error {
-	if len(m.secret) == 0 {
+	if strings.TrimSpace(string(m.secret)) == "" {
 		return errEmptyJWTSecret
 	}
 	return nil

--- a/CubeOps/internal/auth/jwt_empty_secret_test.go
+++ b/CubeOps/internal/auth/jwt_empty_secret_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/auth"
+)
+
+func TestEmptySecretRejectedOnGenerate(t *testing.T) {
+	jm := auth.NewJWTManager("", 15*time.Minute, 168*time.Hour)
+
+	if _, err := jm.GenerateAccessToken("admin"); err == nil {
+		t.Fatal("GenerateAccessToken accepted an empty signing secret")
+	}
+	if _, _, err := jm.GenerateRefreshToken("admin"); err == nil {
+		t.Fatal("GenerateRefreshToken accepted an empty signing secret")
+	}
+}
+
+func TestEmptySecretRejectedOnVerify(t *testing.T) {
+	signer := auth.NewJWTManager("forged-secret-32-bytes-long-ok!!", 15*time.Minute, 168*time.Hour)
+	minted, err := signer.GenerateAccessToken("admin")
+	if err != nil {
+		t.Fatalf("failed to mint a token for the test: %v", err)
+	}
+
+	empty := auth.NewJWTManager("", 15*time.Minute, 168*time.Hour)
+	if _, err := empty.VerifyAccessToken(minted); err == nil {
+		t.Fatal("VerifyAccessToken accepted a token while configured with an empty secret")
+	}
+	if _, err := empty.VerifyRefreshToken(minted); err == nil {
+		t.Fatal("VerifyRefreshToken accepted a token while configured with an empty secret")
+	}
+}
+
+func TestNonEmptySecretStillWorks(t *testing.T) {
+	jm := auth.NewJWTManager("good-secret-32-bytes-long-enough!", 15*time.Minute, 168*time.Hour)
+
+	access, err := jm.GenerateAccessToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateAccessToken: %v", err)
+	}
+	claims, err := jm.VerifyAccessToken(access)
+	if err != nil {
+		t.Fatalf("VerifyAccessToken: %v", err)
+	}
+	if claims.Username != "admin" {
+		t.Fatalf("Username = %q, want admin", claims.Username)
+	}
+}

--- a/CubeOps/internal/auth/jwt_empty_secret_test.go
+++ b/CubeOps/internal/auth/jwt_empty_secret_test.go
@@ -75,16 +75,16 @@ func TestForgedTokenSignedWithEmptySecretIsRejected(t *testing.T) {
 	}
 }
 
-func TestTokenSignedWithADifferentSecretIsRejected(t *testing.T) {
-	signer := auth.NewJWTManager("other-secret-32-bytes-long-ok!!!", 15*time.Minute, 168*time.Hour)
-	minted, err := signer.GenerateAccessToken("admin")
-	if err != nil {
-		t.Fatalf("failed to mint a token for the test: %v", err)
-	}
+func TestWhitespaceOnlySecretIsTreatedAsEmpty(t *testing.T) {
+	for _, secret := range []string{" ", "\t", "\n", "   \t\n "} {
+		jm := auth.NewJWTManager(secret, 15*time.Minute, 168*time.Hour)
 
-	empty := auth.NewJWTManager("", 15*time.Minute, 168*time.Hour)
-	if _, err := empty.VerifyAccessToken(minted); err == nil {
-		t.Fatal("VerifyAccessToken accepted a token signed with a different secret")
+		if _, err := jm.GenerateAccessToken("admin"); err == nil {
+			t.Errorf("GenerateAccessToken accepted a whitespace-only secret %q", secret)
+		}
+		if _, err := jm.VerifyAccessToken(forgedAccessToken(t)); err == nil {
+			t.Errorf("VerifyAccessToken accepted a forged token with a whitespace-only secret %q", secret)
+		}
 	}
 }
 

--- a/CubeOps/internal/auth/jwt_empty_secret_test.go
+++ b/CubeOps/internal/auth/jwt_empty_secret_test.go
@@ -7,8 +7,51 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/auth"
 )
+
+func mintWithEmptySecret(t *testing.T, claims jwt.Claims) string {
+	t.Helper()
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(""))
+	if err != nil {
+		t.Fatalf("failed to mint a token with an empty key: %v", err)
+	}
+	return signed
+}
+
+func forgedAccessToken(t *testing.T) string {
+	t.Helper()
+	now := time.Now()
+	return mintWithEmptySecret(t, auth.AccessClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(15 * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			Subject:   "admin",
+			Audience:  jwt.ClaimStrings{"cubeops:access"},
+		},
+		Username: "admin",
+		Role:     "admin",
+		Scopes:   []string{},
+		Typ:      "access",
+	})
+}
+
+func forgedRefreshToken(t *testing.T) string {
+	t.Helper()
+	now := time.Now()
+	return mintWithEmptySecret(t, auth.RefreshClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(168 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			Subject:   "admin",
+			Audience:  jwt.ClaimStrings{"cubeops:refresh"},
+		},
+		Username: "admin",
+		TokenID:  "forged-token-id",
+		Typ:      "refresh",
+	})
+}
 
 func TestEmptySecretRejectedOnGenerate(t *testing.T) {
 	jm := auth.NewJWTManager("", 15*time.Minute, 168*time.Hour)
@@ -21,8 +64,19 @@ func TestEmptySecretRejectedOnGenerate(t *testing.T) {
 	}
 }
 
-func TestEmptySecretRejectedOnVerify(t *testing.T) {
-	signer := auth.NewJWTManager("forged-secret-32-bytes-long-ok!!", 15*time.Minute, 168*time.Hour)
+func TestForgedTokenSignedWithEmptySecretIsRejected(t *testing.T) {
+	empty := auth.NewJWTManager("", 15*time.Minute, 168*time.Hour)
+
+	if _, err := empty.VerifyAccessToken(forgedAccessToken(t)); err == nil {
+		t.Fatal("VerifyAccessToken accepted an admin token forged with the empty signing key")
+	}
+	if _, err := empty.VerifyRefreshToken(forgedRefreshToken(t)); err == nil {
+		t.Fatal("VerifyRefreshToken accepted a token forged with the empty signing key")
+	}
+}
+
+func TestTokenSignedWithADifferentSecretIsRejected(t *testing.T) {
+	signer := auth.NewJWTManager("other-secret-32-bytes-long-ok!!!", 15*time.Minute, 168*time.Hour)
 	minted, err := signer.GenerateAccessToken("admin")
 	if err != nil {
 		t.Fatalf("failed to mint a token for the test: %v", err)
@@ -30,10 +84,7 @@ func TestEmptySecretRejectedOnVerify(t *testing.T) {
 
 	empty := auth.NewJWTManager("", 15*time.Minute, 168*time.Hour)
 	if _, err := empty.VerifyAccessToken(minted); err == nil {
-		t.Fatal("VerifyAccessToken accepted a token while configured with an empty secret")
-	}
-	if _, err := empty.VerifyRefreshToken(minted); err == nil {
-		t.Fatal("VerifyRefreshToken accepted a token while configured with an empty secret")
+		t.Fatal("VerifyAccessToken accepted a token signed with a different secret")
 	}
 }
 

--- a/CubeOps/internal/store/db.go
+++ b/CubeOps/internal/store/db.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao"
@@ -139,6 +140,9 @@ func (s *Store) BootstrapJWTSecret(ctx context.Context, envSecret string) (strin
 	winner, err := s.GetOrCreateSystemSetting(ctx, "jwt_secret", generated)
 	if err != nil {
 		return "", fmt.Errorf("persist JWT secret: %w", err)
+	}
+	if winner == "" {
+		return "", errors.New("JWT secret resolved to an empty value in t_system_setting")
 	}
 	if winner == generated {
 		logging.G(ctx).Info("JWT secret auto-generated and persisted to database (t_system_setting)")

--- a/CubeOps/internal/store/db.go
+++ b/CubeOps/internal/store/db.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao"
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao/driver/mysql"
@@ -141,8 +142,19 @@ func (s *Store) BootstrapJWTSecret(ctx context.Context, envSecret string) (strin
 	if err != nil {
 		return "", fmt.Errorf("persist JWT secret: %w", err)
 	}
-	if winner == "" {
-		return "", errors.New("JWT secret resolved to an empty value in t_system_setting")
+	if strings.TrimSpace(winner) == "" {
+		if err := s.repairEmptySystemSetting(ctx, "jwt_secret", generated); err != nil {
+			return "", fmt.Errorf("repair empty JWT secret: %w", err)
+		}
+		winner, err = s.GetSystemSetting(ctx, "jwt_secret")
+		if err != nil {
+			return "", fmt.Errorf("re-read JWT secret after repair: %w", err)
+		}
+		if strings.TrimSpace(winner) == "" {
+			return "", errors.New("could not resolve a usable JWT secret from t_system_setting: the stored value is empty and the repair did not take, or the read failed; set JWT_SECRET or delete the jwt_secret row")
+		}
+		logging.G(ctx).Info("JWT secret in database (t_system_setting) was empty; repaired with a freshly generated value")
+		return winner, nil
 	}
 	if winner == generated {
 		logging.G(ctx).Info("JWT secret auto-generated and persisted to database (t_system_setting)")

--- a/CubeOps/internal/store/db.go
+++ b/CubeOps/internal/store/db.go
@@ -128,7 +128,7 @@ func (s *Store) bootstrapMasterKey(ctx context.Context) error {
 // settings table, and returned.  This allows zero-config deployment — the
 // secret is auto-generated on first run and reused on subsequent runs.
 func (s *Store) BootstrapJWTSecret(ctx context.Context, envSecret string) (string, error) {
-	if envSecret != "" {
+	if strings.TrimSpace(envSecret) != "" {
 		return envSecret, nil
 	}
 	// Use GetOrCreateSystemSetting (INSERT IGNORE + read-back) so that
@@ -143,7 +143,7 @@ func (s *Store) BootstrapJWTSecret(ctx context.Context, envSecret string) (strin
 		return "", fmt.Errorf("persist JWT secret: %w", err)
 	}
 	if strings.TrimSpace(winner) == "" {
-		if err := s.repairEmptySystemSetting(ctx, "jwt_secret", generated); err != nil {
+		if err := s.repairSystemSettingIfStill(ctx, "jwt_secret", winner, generated); err != nil {
 			return "", fmt.Errorf("repair empty JWT secret: %w", err)
 		}
 		winner, err = s.GetSystemSetting(ctx, "jwt_secret")

--- a/CubeOps/internal/store/jwt_secret_bootstrap_test.go
+++ b/CubeOps/internal/store/jwt_secret_bootstrap_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestBootstrapJWTSecretRejectsAnEmptyStoredValue(t *testing.T) {
+func TestBootstrapJWTSecretRepairsAnEmptyStoredValue(t *testing.T) {
 	env := newTestStore(t)
 	defer env.teardown()
 	s := env.store
@@ -20,14 +20,46 @@ func TestBootstrapJWTSecretRejectsAnEmptyStoredValue(t *testing.T) {
 	}
 
 	secret, err := s.BootstrapJWTSecret(ctx, "")
-	if err == nil {
-		t.Fatalf("BootstrapJWTSecret returned %q with no error for an empty stored secret", secret)
+	if err != nil {
+		t.Fatalf("BootstrapJWTSecret did not repair an empty stored secret: %v", err)
 	}
-	if secret != "" {
-		t.Fatalf("BootstrapJWTSecret returned %q alongside an error, want empty", secret)
+	if strings.TrimSpace(secret) == "" {
+		t.Fatal("BootstrapJWTSecret returned an empty secret after repair")
 	}
-	if !strings.Contains(err.Error(), "empty") {
-		t.Fatalf("BootstrapJWTSecret error = %v, want it to mention the empty value", err)
+
+	persisted, err := s.GetSystemSetting(ctx, "jwt_secret")
+	if err != nil {
+		t.Fatalf("GetSystemSetting: %v", err)
+	}
+	if persisted != secret {
+		t.Fatalf("repaired secret was not persisted: row=%q returned=%q", persisted, secret)
+	}
+
+	again, err := s.BootstrapJWTSecret(ctx, "")
+	if err != nil {
+		t.Fatalf("BootstrapJWTSecret after repair: %v", err)
+	}
+	if again != secret {
+		t.Fatalf("a later start got a different secret: %q != %q", again, secret)
+	}
+}
+
+func TestBootstrapJWTSecretDoesNotOverwriteAHealthyValue(t *testing.T) {
+	env := newTestStore(t)
+	defer env.teardown()
+	s := env.store
+	ctx := context.Background()
+
+	if err := s.SetSystemSetting(ctx, "jwt_secret", "already-good-32-bytes-long-ok!!!"); err != nil {
+		t.Fatalf("SetSystemSetting: %v", err)
+	}
+
+	secret, err := s.BootstrapJWTSecret(ctx, "")
+	if err != nil {
+		t.Fatalf("BootstrapJWTSecret: %v", err)
+	}
+	if secret != "already-good-32-bytes-long-ok!!!" {
+		t.Fatalf("BootstrapJWTSecret = %q, want the stored value untouched", secret)
 	}
 }
 

--- a/CubeOps/internal/store/jwt_secret_bootstrap_test.go
+++ b/CubeOps/internal/store/jwt_secret_bootstrap_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestBootstrapJWTSecretRejectsAnEmptyStoredValue(t *testing.T) {
+	env := newTestStore(t)
+	defer env.teardown()
+	s := env.store
+	ctx := context.Background()
+
+	if err := s.SetSystemSetting(ctx, "jwt_secret", ""); err != nil {
+		t.Fatalf("SetSystemSetting: %v", err)
+	}
+
+	secret, err := s.BootstrapJWTSecret(ctx, "")
+	if err == nil {
+		t.Fatalf("BootstrapJWTSecret returned %q with no error for an empty stored secret", secret)
+	}
+	if secret != "" {
+		t.Fatalf("BootstrapJWTSecret returned %q alongside an error, want empty", secret)
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("BootstrapJWTSecret error = %v, want it to mention the empty value", err)
+	}
+}
+
+func TestBootstrapJWTSecretGeneratesAndReusesANonEmptySecret(t *testing.T) {
+	env := newTestStore(t)
+	defer env.teardown()
+	s := env.store
+	ctx := context.Background()
+
+	first, err := s.BootstrapJWTSecret(ctx, "")
+	if err != nil {
+		t.Fatalf("BootstrapJWTSecret: %v", err)
+	}
+	if first == "" {
+		t.Fatal("BootstrapJWTSecret returned an empty secret on first run")
+	}
+
+	second, err := s.BootstrapJWTSecret(ctx, "")
+	if err != nil {
+		t.Fatalf("BootstrapJWTSecret (second run): %v", err)
+	}
+	if second != first {
+		t.Fatalf("second run returned a different secret: %q != %q", second, first)
+	}
+}
+
+func TestBootstrapJWTSecretPrefersTheEnvironmentSecret(t *testing.T) {
+	env := newTestStore(t)
+	defer env.teardown()
+	ctx := context.Background()
+
+	got, err := env.store.BootstrapJWTSecret(ctx, "env-secret-32-bytes-long-enough!")
+	if err != nil {
+		t.Fatalf("BootstrapJWTSecret: %v", err)
+	}
+	if got != "env-secret-32-bytes-long-enough!" {
+		t.Fatalf("BootstrapJWTSecret = %q, want the env secret", got)
+	}
+}

--- a/CubeOps/internal/store/jwt_secret_bootstrap_test.go
+++ b/CubeOps/internal/store/jwt_secret_bootstrap_test.go
@@ -5,97 +5,120 @@ package store_test
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"testing"
 )
 
-func TestBootstrapJWTSecretRepairsAnEmptyStoredValue(t *testing.T) {
+func TestBootstrapJWTSecret(t *testing.T) {
 	env := newTestStore(t)
 	defer env.teardown()
 	s := env.store
 	ctx := context.Background()
 
-	if err := s.SetSystemSetting(ctx, "jwt_secret", ""); err != nil {
-		t.Fatalf("SetSystemSetting: %v", err)
-	}
-
-	secret, err := s.BootstrapJWTSecret(ctx, "")
+	raw, err := sql.Open("mysql", env.dsn)
 	if err != nil {
-		t.Fatalf("BootstrapJWTSecret did not repair an empty stored secret: %v", err)
+		t.Fatalf("open raw connection: %v", err)
 	}
-	if strings.TrimSpace(secret) == "" {
-		t.Fatal("BootstrapJWTSecret returned an empty secret after repair")
+	defer raw.Close()
+
+	setRow := func(t *testing.T, value any) {
+		t.Helper()
+		if _, err := raw.ExecContext(ctx,
+			"REPLACE INTO t_system_setting (setting_key, setting_value) VALUES (?, ?)",
+			"jwt_secret", value); err != nil {
+			t.Fatalf("seed jwt_secret=%v: %v", value, err)
+		}
+	}
+	clearRow := func(t *testing.T) {
+		t.Helper()
+		if _, err := raw.ExecContext(ctx,
+			"DELETE FROM t_system_setting WHERE setting_key = ?", "jwt_secret"); err != nil {
+			t.Fatalf("delete jwt_secret: %v", err)
+		}
+	}
+	readRow := func(t *testing.T) string {
+		t.Helper()
+		var v sql.NullString
+		if err := raw.QueryRowContext(ctx,
+			"SELECT setting_value FROM t_system_setting WHERE setting_key = ?", "jwt_secret").Scan(&v); err != nil {
+			t.Fatalf("read jwt_secret: %v", err)
+		}
+		return v.String
 	}
 
-	persisted, err := s.GetSystemSetting(ctx, "jwt_secret")
-	if err != nil {
-		t.Fatalf("GetSystemSetting: %v", err)
-	}
-	if persisted != secret {
-		t.Fatalf("repaired secret was not persisted: row=%q returned=%q", persisted, secret)
-	}
+	t.Run("generates and reuses on a clean database", func(t *testing.T) {
+		clearRow(t)
 
-	again, err := s.BootstrapJWTSecret(ctx, "")
-	if err != nil {
-		t.Fatalf("BootstrapJWTSecret after repair: %v", err)
-	}
-	if again != secret {
-		t.Fatalf("a later start got a different secret: %q != %q", again, secret)
-	}
-}
+		first, err := s.BootstrapJWTSecret(ctx, "")
+		if err != nil {
+			t.Fatalf("BootstrapJWTSecret: %v", err)
+		}
+		if first == "" {
+			t.Fatal("returned an empty secret on first run")
+		}
+		second, err := s.BootstrapJWTSecret(ctx, "")
+		if err != nil {
+			t.Fatalf("BootstrapJWTSecret (second run): %v", err)
+		}
+		if second != first {
+			t.Fatalf("a later start got a different secret: %q != %q", second, first)
+		}
+	})
 
-func TestBootstrapJWTSecretDoesNotOverwriteAHealthyValue(t *testing.T) {
-	env := newTestStore(t)
-	defer env.teardown()
-	s := env.store
-	ctx := context.Background()
+	t.Run("repairs degenerate stored values", func(t *testing.T) {
+		for _, stored := range []any{"", " ", "\t", "   \t ", "\n", nil} {
+			setRow(t, stored)
 
-	if err := s.SetSystemSetting(ctx, "jwt_secret", "already-good-32-bytes-long-ok!!!"); err != nil {
-		t.Fatalf("SetSystemSetting: %v", err)
-	}
+			secret, err := s.BootstrapJWTSecret(ctx, "")
+			if err != nil {
+				t.Errorf("did not repair stored value %#v: %v", stored, err)
+				continue
+			}
+			if strings.TrimSpace(secret) == "" {
+				t.Errorf("returned %q after repairing %#v", secret, stored)
+				continue
+			}
+			if got := readRow(t); got != secret {
+				t.Errorf("repair for %#v was not persisted: row=%q returned=%q", stored, got, secret)
+			}
+		}
+	})
 
-	secret, err := s.BootstrapJWTSecret(ctx, "")
-	if err != nil {
-		t.Fatalf("BootstrapJWTSecret: %v", err)
-	}
-	if secret != "already-good-32-bytes-long-ok!!!" {
-		t.Fatalf("BootstrapJWTSecret = %q, want the stored value untouched", secret)
-	}
-}
+	t.Run("does not overwrite a healthy value", func(t *testing.T) {
+		setRow(t, "already-good-32-bytes-long-ok!!!")
 
-func TestBootstrapJWTSecretGeneratesAndReusesANonEmptySecret(t *testing.T) {
-	env := newTestStore(t)
-	defer env.teardown()
-	s := env.store
-	ctx := context.Background()
+		secret, err := s.BootstrapJWTSecret(ctx, "")
+		if err != nil {
+			t.Fatalf("BootstrapJWTSecret: %v", err)
+		}
+		if secret != "already-good-32-bytes-long-ok!!!" {
+			t.Fatalf("BootstrapJWTSecret = %q, want the stored value untouched", secret)
+		}
+	})
 
-	first, err := s.BootstrapJWTSecret(ctx, "")
-	if err != nil {
-		t.Fatalf("BootstrapJWTSecret: %v", err)
-	}
-	if first == "" {
-		t.Fatal("BootstrapJWTSecret returned an empty secret on first run")
-	}
+	t.Run("prefers a usable environment secret", func(t *testing.T) {
+		setRow(t, "db-secret-32-bytes-long-enough!!")
 
-	second, err := s.BootstrapJWTSecret(ctx, "")
-	if err != nil {
-		t.Fatalf("BootstrapJWTSecret (second run): %v", err)
-	}
-	if second != first {
-		t.Fatalf("second run returned a different secret: %q != %q", second, first)
-	}
-}
+		secret, err := s.BootstrapJWTSecret(ctx, "env-secret-32-bytes-long-enough!")
+		if err != nil {
+			t.Fatalf("BootstrapJWTSecret: %v", err)
+		}
+		if secret != "env-secret-32-bytes-long-enough!" {
+			t.Fatalf("BootstrapJWTSecret = %q, want the env secret", secret)
+		}
+	})
 
-func TestBootstrapJWTSecretPrefersTheEnvironmentSecret(t *testing.T) {
-	env := newTestStore(t)
-	defer env.teardown()
-	ctx := context.Background()
+	t.Run("ignores a whitespace-only environment secret", func(t *testing.T) {
+		setRow(t, "db-secret-32-bytes-long-enough!!")
 
-	got, err := env.store.BootstrapJWTSecret(ctx, "env-secret-32-bytes-long-enough!")
-	if err != nil {
-		t.Fatalf("BootstrapJWTSecret: %v", err)
-	}
-	if got != "env-secret-32-bytes-long-enough!" {
-		t.Fatalf("BootstrapJWTSecret = %q, want the env secret", got)
-	}
+		secret, err := s.BootstrapJWTSecret(ctx, "   ")
+		if err != nil {
+			t.Fatalf("BootstrapJWTSecret: %v", err)
+		}
+		if secret != "db-secret-32-bytes-long-enough!!" {
+			t.Fatalf("BootstrapJWTSecret = %q, want the stored secret; a whitespace-only "+
+				"JWT_SECRET would make every token operation fail at runtime", secret)
+		}
+	})
 }

--- a/CubeOps/internal/store/setting.go
+++ b/CubeOps/internal/store/setting.go
@@ -40,10 +40,10 @@ func (s *Store) GetOrCreateSystemSetting(ctx context.Context, key, value string)
 	return s.GetSystemSetting(ctx, key)
 }
 
-func (s *Store) repairEmptySystemSetting(ctx context.Context, key, value string) error {
+func (s *Store) repairSystemSettingIfStill(ctx context.Context, key, observed, value string) error {
 	return s.db.WithContext(ctx).Exec(
-		"UPDATE t_system_setting SET setting_value = ? WHERE setting_key = ? AND (setting_value IS NULL OR setting_value = '')",
-		value, key,
+		"UPDATE t_system_setting SET setting_value = ? WHERE setting_key = ? AND (setting_value IS NULL OR setting_value = ?)",
+		value, key, observed,
 	).Error
 }
 

--- a/CubeOps/internal/store/setting.go
+++ b/CubeOps/internal/store/setting.go
@@ -40,6 +40,13 @@ func (s *Store) GetOrCreateSystemSetting(ctx context.Context, key, value string)
 	return s.GetSystemSetting(ctx, key)
 }
 
+func (s *Store) repairEmptySystemSetting(ctx context.Context, key, value string) error {
+	return s.db.WithContext(ctx).Exec(
+		"UPDATE t_system_setting SET setting_value = ? WHERE setting_key = ? AND (setting_value IS NULL OR setting_value = '')",
+		value, key,
+	).Error
+}
+
 // SetSystemSetting upserts a system-level setting value.
 func (s *Store) SetSystemSetting(ctx context.Context, key, value string) error {
 	return s.db.WithContext(ctx).Exec(


### PR DESCRIPTION

Closes #1373.

## Motivation

`BootstrapJWTSecret` could hand back an empty string with a `nil` error, after which
`NewJWTManager` stored a zero-length HMAC key. `golang-jwt/v5` treats `[]byte{}` as a perfectly
valid HMAC key, so anyone who guessed the secret was empty could mint a `sub=admin`,
`aud=cubeops:access`, `typ=access` token that passed `VerifyAccessToken` unchanged — full access to
every `/api/v1` route behind `auth.Middleware`.

The default one-click deployment is the affected configuration: it deliberately leaves `JWT_SECRET`
unset so the secret is auto-generated into `t_system_setting`, which is the code path that can
return `""`.

## What this changes

Two independent guards, so neither alone has to be perfect:

1. **`CubeOps/internal/store/db.go`** — `BootstrapJWTSecret` now fails when the resolved secret is
   empty instead of returning it as a success. `main.go` already exits on that error, so startup
   aborts with a clear message rather than coming up insecure.

2. **`CubeOps/internal/auth/jwt.go`** — `JWTManager` refuses a zero-length key in all four token
   operations (`GenerateAccessToken`, `GenerateRefreshToken`, `VerifyAccessToken`,
   `VerifyRefreshToken`) via a shared `checkSecret()` helper. This keeps the exported
   `NewJWTManager` signature unchanged while making forged-token acceptance impossible even if an
   empty secret reaches the manager some other way.

Deliberately **not** changed here:

- `GetSystemSetting` / `GetSetting` / `GetUserPassword` still swallow DB errors. That is the
  upstream cause and is a behaviour change with a wider blast radius, so it is a separate fix
  (see the sibling branch for report finding #5). This PR is safe to land on its own and does not
  depend on it.
- No comment changes; no unrelated cleanup.

## Testing

New: `CubeOps/internal/auth/jwt_empty_secret_test.go`

- `TestEmptySecretRejectedOnGenerate` — both generators refuse an empty key.
- `TestEmptySecretRejectedOnVerify` — both verifiers refuse a token when configured with an empty
  key, including a token that was legitimately signed with a different, non-empty key.
- `TestNonEmptySecretStillWorks` — regression guard that the normal sign/verify round trip is
  untouched.

```
$ cd CubeOps && go test ./...
ok  github.com/tencentcloud/CubeSandbox/CubeOps/internal/auth      3.025s
ok  github.com/tencentcloud/CubeSandbox/CubeOps/internal/store     57.508s
ok  github.com/tencentcloud/CubeSandbox/CubeOps/internal/service   8.063s
... 11 packages ok, 0 failures
```

CI gates checked locally:

- `gofmt -l ./internal ./cmd` — clean (`fmt-check`).
- `go build ./...` — clean.
- `go test ./...` — 11 ok, 0 failures (`unit-test-check` runs `make cubeops-test`, which is
  `go test ./... -v -count=1`).

## Risk / rollout

Low risk, but it **is** a fail-closed change: an operator whose `jwt_secret` row is currently empty
will see CubeOps refuse to start instead of silently accepting forged tokens. That is the intended
behaviour. The remedy is to clear the row so it is regenerated, or to set `JWT_SECRET` explicitly:

```sql
DELETE FROM t_system_setting WHERE setting_key = 'jwt_secret';
```

Existing valid sessions are unaffected — the secret itself is not rotated by this change.
