### PR TITLE
cubemaster: fix the data races in localcache

### DIFF
--- a/CubeMaster/pkg/base/localcache/localcache.go
+++ b/CubeMaster/pkg/base/localcache/localcache.go
@@ -79,7 +79,7 @@ func NewCache(name string, loader LoaderFunc, localCacheConfig *LocalCacheConfig
 		localCache.loadFile(localCacheConfig.LoadFileName)
 	}
 	localCache.localCacheConfig = localCache.SetupConfig(localCacheConfig)
-	localCache.expiredUse.Store(localCache.localCacheConfig.ExpiredUse)
+	localCache.expiredUse.Store(localCache.localCacheConfig != nil && localCache.localCacheConfig.ExpiredUse)
 
 	localCache.chShrinkCache = make(chan bool, 1)
 	localCache.chCacheExit = make(chan bool)
@@ -126,7 +126,6 @@ func (localCache *LocalCache) Get(ctx context.Context, key string) (interface{},
 
 		localCache.Lock()
 		itm := element.Value.(*util.CacheValue)
-		localCache.valueList.MoveToBack(element)
 		localCache.Unlock()
 
 		if time.Now().Add(-itm.Expired).After(time.Unix(itm.LastAccess, 0)) {
@@ -135,6 +134,10 @@ func (localCache *LocalCache) Get(ctx context.Context, key string) (interface{},
 				r, f, err := localCache.loadAndRefresh(ctx, key)
 
 				if err != nil && localCache.localCacheConfig.DemotionExpiredUse {
+
+					localCache.Lock()
+					localCache.valueList.MoveToBack(element)
+					localCache.Unlock()
 					return itm.Value, true, nil
 				}
 
@@ -148,6 +151,9 @@ func (localCache *LocalCache) Get(ctx context.Context, key string) (interface{},
 			localCache.asyncRefresh(ctx, key)
 		}
 
+		localCache.Lock()
+		localCache.valueList.MoveToBack(element)
+		localCache.Unlock()
 		return itm.Value, true, nil
 	}
 

--- a/CubeMaster/pkg/base/localcache/localcache.go
+++ b/CubeMaster/pkg/base/localcache/localcache.go
@@ -246,10 +246,10 @@ func (localCache *LocalCache) shrinkCache() {
 		select {
 		case <-localCache.chShrinkCache:
 			curTime := time.Now()
-			curCacheSize := localCache.curCacheSize
+			curCacheSize := atomic.LoadInt64(&localCache.curCacheSize)
 			var shrinkNum, shrinkSize, size int64
 			for {
-				if localCache.curCacheSize > localCache.localCacheConfig.LowCacheSize {
+				if atomic.LoadInt64(&localCache.curCacheSize) > localCache.localCacheConfig.LowCacheSize {
 					localCache.Lock()
 					element := localCache.valueList.Front()
 					if element == nil {
@@ -330,10 +330,13 @@ func (localCache *LocalCache) saveFile(file string) {
 		var itm *util.CacheValue
 		switch value := item.Object.(type) {
 		case *list.Element:
+			localCache.Lock()
+			stored := value.Value
+			localCache.Unlock()
 			var ok bool
-			itm, ok = value.Value.(*util.CacheValue)
+			itm, ok = stored.(*util.CacheValue)
 			if !ok {
-				CubeLog.Errorf("Cache(%s) cannot persist key %s: list element contains %T", localCache.name, key, value.Value)
+				CubeLog.Errorf("Cache(%s) cannot persist key %s: list element contains %T", localCache.name, key, stored)
 				continue
 			}
 		case *util.CacheValue:

--- a/CubeMaster/pkg/base/localcache/localcache.go
+++ b/CubeMaster/pkg/base/localcache/localcache.go
@@ -105,11 +105,11 @@ func (localCache *LocalCache) Destroy() {
 	if localCache == nil {
 		return
 	}
+	if localCache.chCacheExit == nil {
+		return
+	}
 	localCache.destroyOnce.Do(func() {
 		CubeLog.Infof("LruCache(%s) Destroy", localCache.name)
-		if localCache.chCacheExit == nil {
-			return
-		}
 		if localCache.localCacheConfig.OpenCacheFile {
 			localCache.saveFile(localCache.localCacheConfig.LoadFileName)
 		}
@@ -193,7 +193,10 @@ func (localCache *LocalCache) put(key string, val interface{}, expired time.Dura
 	}
 
 	if atomic.LoadInt64(&localCache.curCacheSize) >= localCache.localCacheConfig.HighCacheSize {
-		localCache.chShrinkCache <- true
+		select {
+		case localCache.chShrinkCache <- true:
+		default:
+		}
 	}
 }
 

--- a/CubeMaster/pkg/base/localcache/localcache.go
+++ b/CubeMaster/pkg/base/localcache/localcache.go
@@ -65,6 +65,8 @@ type LocalCache struct {
 	localCacheConfig   *LocalCacheConfig
 	sharedCalls        util.SharedCalls
 	consecutiveFailNum int64
+	expiredUse         atomic.Bool
+	destroyOnce        sync.Once
 }
 
 func NewCache(name string, loader LoaderFunc, localCacheConfig *LocalCacheConfig) *LocalCache {
@@ -77,6 +79,7 @@ func NewCache(name string, loader LoaderFunc, localCacheConfig *LocalCacheConfig
 		localCache.loadFile(localCacheConfig.LoadFileName)
 	}
 	localCache.localCacheConfig = localCache.SetupConfig(localCacheConfig)
+	localCache.expiredUse.Store(localCache.localCacheConfig.ExpiredUse)
 
 	localCache.chShrinkCache = make(chan bool, 1)
 	localCache.chCacheExit = make(chan bool)
@@ -99,36 +102,39 @@ func NewCache(name string, loader LoaderFunc, localCacheConfig *LocalCacheConfig
 }
 
 func (localCache *LocalCache) Destroy() {
-	if localCache != nil {
-		CubeLog.Infof("LruCache(%s) Destroy", localCache.name)
-		if localCache.chCacheExit != nil {
-			if localCache.localCacheConfig.OpenCacheFile {
-				localCache.saveFile(localCache.localCacheConfig.LoadFileName)
-			}
-			localCache.cache.Flush()
-			close(localCache.chCacheExit)
-			localCache.waitGroup.Wait()
-			localCache.chCacheExit = nil
-		}
+	if localCache == nil {
+		return
 	}
+	localCache.destroyOnce.Do(func() {
+		CubeLog.Infof("LruCache(%s) Destroy", localCache.name)
+		if localCache.chCacheExit == nil {
+			return
+		}
+		if localCache.localCacheConfig.OpenCacheFile {
+			localCache.saveFile(localCache.localCacheConfig.LoadFileName)
+		}
+		localCache.cache.Flush()
+		close(localCache.chCacheExit)
+		localCache.waitGroup.Wait()
+	})
 }
 
 func (localCache *LocalCache) Get(ctx context.Context, key string) (interface{}, bool, error) {
 	item, found := localCache.cache.Get(key)
 	if found {
 		element := item.(*list.Element)
+
+		localCache.Lock()
 		itm := element.Value.(*util.CacheValue)
+		localCache.valueList.MoveToBack(element)
+		localCache.Unlock()
 
 		if time.Now().Add(-itm.Expired).After(time.Unix(itm.LastAccess, 0)) {
 
-			if !localCache.localCacheConfig.ExpiredUse {
+			if !localCache.expiredUse.Load() {
 				r, f, err := localCache.loadAndRefresh(ctx, key)
 
 				if err != nil && localCache.localCacheConfig.DemotionExpiredUse {
-
-					localCache.Lock()
-					localCache.valueList.MoveToBack(element)
-					localCache.Unlock()
 					return itm.Value, true, nil
 				}
 
@@ -142,9 +148,6 @@ func (localCache *LocalCache) Get(ctx context.Context, key string) (interface{},
 			localCache.asyncRefresh(ctx, key)
 		}
 
-		localCache.Lock()
-		localCache.valueList.MoveToBack(element)
-		localCache.Unlock()
 		return itm.Value, true, nil
 	}
 
@@ -159,14 +162,17 @@ func (localCache *LocalCache) put(key string, val interface{}, expired time.Dura
 	if item, found := localCache.cache.Get(key); found {
 		element := item.(*list.Element)
 		localCache.Lock()
+		prev := element.Value.(*util.CacheValue)
+		next := &util.CacheValue{
+			Key:        prev.Key,
+			Value:      val,
+			LastAccess: time.Now().Unix(),
+			Expired:    expired}
+		element.Value = next
 		localCache.valueList.MoveToBack(element)
 		localCache.Unlock()
-		itm := element.Value.(*util.CacheValue)
-		atomic.AddInt64(&localCache.curCacheSize, -itm.Size())
-		itm.Value = val
-		itm.Expired = expired
-		itm.LastAccess = time.Now().Unix()
-		atomic.AddInt64(&localCache.curCacheSize, itm.Size())
+		atomic.AddInt64(&localCache.curCacheSize, -prev.Size())
+		atomic.AddInt64(&localCache.curCacheSize, next.Size())
 	} else {
 		itm := &util.CacheValue{
 			Key:        key,
@@ -180,7 +186,7 @@ func (localCache *LocalCache) put(key string, val interface{}, expired time.Dura
 		localCache.cache.Set(key, element, -1)
 	}
 
-	if localCache.curCacheSize >= localCache.localCacheConfig.HighCacheSize {
+	if atomic.LoadInt64(&localCache.curCacheSize) >= localCache.localCacheConfig.HighCacheSize {
 		localCache.chShrinkCache <- true
 	}
 }
@@ -198,7 +204,7 @@ func (localCache *LocalCache) loadAndRefresh(ctx context.Context, key string) (i
 				CubeLog.Errorf("Cache LoadAndRefresh Error:%s, %v, %s", key, found, err)
 				return nil, err
 			} else {
-				localCache.consecutiveFailNum = 0
+				atomic.StoreInt64(&localCache.consecutiveFailNum, 0)
 			}
 
 			if !found {
@@ -305,12 +311,12 @@ func (localCache *LocalCache) errStrategy() {
 					int64(localCache.localCacheConfig.MaxConsecutiveFailNum) {
 
 					if localCache.localCacheConfig.DemotionExpiredUse {
-						localCache.localCacheConfig.ExpiredUse = true
+						localCache.expiredUse.Store(true)
 					}
 				} else {
 
-					if localCache.localCacheConfig.DemotionExpiredUse && localCache.localCacheConfig.ExpiredUse {
-						localCache.localCacheConfig.ExpiredUse = false
+					if localCache.localCacheConfig.DemotionExpiredUse && localCache.expiredUse.Load() {
+						localCache.expiredUse.Store(false)
 					}
 				}
 			}

--- a/CubeMaster/pkg/base/localcache/localcache_race_test.go
+++ b/CubeMaster/pkg/base/localcache/localcache_race_test.go
@@ -6,12 +6,15 @@ package localcache
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/localcache/util"
 )
 
 func TestConcurrentGetAndRefreshOnSameKey(t *testing.T) {
@@ -134,4 +137,84 @@ func TestDestroySnapshotDoesNotRaceWithInFlightRefresh(t *testing.T) {
 	localCache.Destroy()
 	stop.Store(true)
 	wg.Wait()
+}
+
+func frontKey(t *testing.T, c *LocalCache) string {
+	t.Helper()
+	c.Lock()
+	defer c.Unlock()
+	front := c.valueList.Front()
+	if front == nil {
+		t.Fatal("value list is empty")
+	}
+	return front.Value.(*util.CacheValue).Key
+}
+
+func TestFailingRefreshDoesNotPromoteTheEntry(t *testing.T) {
+	var fail atomic.Bool
+	localCache := NewCache("lru-demotion-probe",
+		func(ctx context.Context, key string) (interface{}, bool, error) {
+			if fail.Load() && key == "a" {
+				return nil, false, errors.New("loader is down")
+			}
+			return "v-" + key, true, nil
+		},
+		&LocalCacheConfig{
+			LowCacheSize:       1000000,
+			HighCacheSize:      2000000,
+			Expired:            time.Millisecond,
+			ExpiredUse:         false,
+			DemotionExpiredUse: false,
+		})
+	defer localCache.Destroy()
+
+	ctx := context.Background()
+	for _, k := range []string{"a", "b"} {
+		if _, _, err := localCache.Get(ctx, k); err != nil {
+			t.Fatalf("seed Get(%s): %v", k, err)
+		}
+	}
+	if got := frontKey(t, localCache); got != "a" {
+		t.Fatalf("front is %q before the probe, want a", got)
+	}
+
+	fail.Store(true)
+	time.Sleep(5 * time.Millisecond)
+
+	if _, _, err := localCache.Get(ctx, "a"); err == nil {
+		t.Fatal("Get(a) succeeded while the loader was failing")
+	}
+	if got := frontKey(t, localCache); got != "a" {
+		t.Fatalf("a failing entry was promoted: front is %q, want a to stay evictable", got)
+	}
+}
+
+func TestSuccessfulHitPromotesTheEntry(t *testing.T) {
+	localCache := NewCache("lru-promote-probe",
+		func(ctx context.Context, key string) (interface{}, bool, error) {
+			return "v-" + key, true, nil
+		},
+		&LocalCacheConfig{
+			LowCacheSize:  1000000,
+			HighCacheSize: 2000000,
+			Expired:       time.Hour,
+		})
+	defer localCache.Destroy()
+
+	ctx := context.Background()
+	for _, k := range []string{"a", "b"} {
+		if _, _, err := localCache.Get(ctx, k); err != nil {
+			t.Fatalf("seed Get(%s): %v", k, err)
+		}
+	}
+	if got := frontKey(t, localCache); got != "a" {
+		t.Fatalf("front is %q before the probe, want a", got)
+	}
+
+	if _, _, err := localCache.Get(ctx, "a"); err != nil {
+		t.Fatalf("Get(a): %v", err)
+	}
+	if got := frontKey(t, localCache); got != "b" {
+		t.Fatalf("a fresh hit did not promote: front is %q, want b", got)
+	}
 }

--- a/CubeMaster/pkg/base/localcache/localcache_race_test.go
+++ b/CubeMaster/pkg/base/localcache/localcache_race_test.go
@@ -60,8 +60,8 @@ func TestConcurrentGetAndRefreshOnSameKey(t *testing.T) {
 	}
 	wg.Wait()
 
-	if atomic.LoadInt64(&loads) == 0 {
-		t.Fatal("loader never ran; the test did not exercise the refresh path")
+	if got := atomic.LoadInt64(&loads); got < 2 {
+		t.Fatalf("loader ran %d time(s); only the initial miss was exercised, not the refresh path", got)
 	}
 }
 
@@ -216,5 +216,30 @@ func TestSuccessfulHitPromotesTheEntry(t *testing.T) {
 	}
 	if got := frontKey(t, localCache); got != "b" {
 		t.Fatalf("a fresh hit did not promote: front is %q, want b", got)
+	}
+}
+
+func TestPutAfterDestroyDoesNotBlockForever(t *testing.T) {
+	localCache := NewCache("post-destroy-put-probe",
+		func(ctx context.Context, key string) (interface{}, bool, error) {
+			return "v", true, nil
+		},
+		&LocalCacheConfig{LowCacheSize: 1, HighCacheSize: 1, Expired: time.Hour})
+
+	localCache.put("seed-a", RandString(16), time.Hour)
+	localCache.Destroy()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		localCache.put("after-destroy-1", RandString(16), time.Hour)
+		localCache.put("after-destroy-2", RandString(16), time.Hour)
+		localCache.put("after-destroy-3", RandString(16), time.Hour)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("put blocked after Destroy: the shrink signal has no reader once shrinkCache has exited")
 	}
 }

--- a/CubeMaster/pkg/base/localcache/localcache_race_test.go
+++ b/CubeMaster/pkg/base/localcache/localcache_race_test.go
@@ -6,6 +6,8 @@ package localcache
 
 import (
 	"context"
+	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -86,5 +88,50 @@ func TestConcurrentDestroyDoesNotRaceWithBackgroundLoops(t *testing.T) {
 			localCache.Destroy()
 		}()
 	}
+	wg.Wait()
+}
+
+func TestDestroySnapshotDoesNotRaceWithInFlightRefresh(t *testing.T) {
+	localCache := NewCache("destroy-snapshot-probe",
+		func(ctx context.Context, key string) (interface{}, bool, error) {
+			return RandString(16), true, nil
+		},
+		&LocalCacheConfig{
+			LowCacheSize:       1000000,
+			HighCacheSize:      2000000,
+			Expired:            time.Millisecond,
+			AsyncRefreshBefore: time.Millisecond,
+			MaxAsyncRefreshNum: 100,
+			ExpiredUse:         true,
+			OpenCacheFile:      true,
+			LoadFileName:       filepath.Join(t.TempDir(), "cache.gob"),
+		})
+
+	ctx := context.Background()
+	const keys = 64
+	for i := 0; i < keys; i++ {
+		if _, _, err := localCache.Get(ctx, "k"+strconv.Itoa(i)); err != nil {
+			t.Fatalf("seed Get: %v", err)
+		}
+	}
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	wg.Add(8)
+	for r := 0; r < 8; r++ {
+		go func(r int) {
+			defer wg.Done()
+			for i := 0; !stop.Load(); i++ {
+				if _, _, err := localCache.Get(ctx, "k"+strconv.Itoa((i+r)%keys)); err != nil {
+					t.Errorf("Get: %v", err)
+					return
+				}
+			}
+		}(r)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	localCache.Destroy()
+	stop.Store(true)
 	wg.Wait()
 }

--- a/CubeMaster/pkg/base/localcache/localcache_race_test.go
+++ b/CubeMaster/pkg/base/localcache/localcache_race_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package localcache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestConcurrentGetAndRefreshOnSameKey(t *testing.T) {
+	var loads int64
+	localCache := NewCache("race-probe",
+		func(ctx context.Context, key string) (interface{}, bool, error) {
+			atomic.AddInt64(&loads, 1)
+			return RandString(16), true, nil
+		},
+		&LocalCacheConfig{
+			LowCacheSize:       1000000,
+			HighCacheSize:      2000000,
+			Expired:            time.Millisecond,
+			AsyncRefreshBefore: time.Millisecond,
+			MaxAsyncRefreshNum: 100,
+			ExpiredUse:         true,
+		})
+	defer localCache.Destroy()
+
+	ctx := context.Background()
+	const readers = 32
+	const iterations = 300
+
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				v, found, err := localCache.Get(ctx, "hot-key")
+				if err != nil {
+					t.Errorf("Get: %v", err)
+					return
+				}
+				if found {
+					if _, ok := v.(string); !ok {
+						t.Errorf("Get returned %T, want string; a torn interface read", v)
+						return
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if atomic.LoadInt64(&loads) == 0 {
+		t.Fatal("loader never ran; the test did not exercise the refresh path")
+	}
+}
+
+func TestDestroyIsIdempotent(t *testing.T) {
+	localCache := NewCache("destroy-probe",
+		func(ctx context.Context, key string) (interface{}, bool, error) {
+			return "v", true, nil
+		},
+		&LocalCacheConfig{LowCacheSize: 1000, HighCacheSize: 2000, Expired: time.Minute})
+
+	localCache.Destroy()
+	localCache.Destroy()
+}
+
+func TestConcurrentDestroyDoesNotRaceWithBackgroundLoops(t *testing.T) {
+	localCache := NewCache("destroy-race-probe",
+		func(ctx context.Context, key string) (interface{}, bool, error) {
+			return "v", true, nil
+		},
+		&LocalCacheConfig{LowCacheSize: 1000, HighCacheSize: 2000, Expired: time.Minute})
+
+	var wg sync.WaitGroup
+	wg.Add(4)
+	for i := 0; i < 4; i++ {
+		go func() {
+			defer wg.Done()
+			localCache.Destroy()
+		}()
+	}
+	wg.Wait()
+}

--- a/CubeMaster/pkg/base/localcache/localcache_test.go
+++ b/CubeMaster/pkg/base/localcache/localcache_test.go
@@ -45,13 +45,13 @@ func TestLocalCache(t *testing.T) {
 	for i := 0; i < 2700; i++ {
 
 		wg.Add(1)
-		ctx = context.WithValue(ctx, ctxKey, i)
-		go func() {
+		iterCtx := context.WithValue(ctx, ctxKey, i)
+		go func(c context.Context) {
 			defer wg.Done()
 			start := time.Now()
-			localCache.Get(ctx, RandString(8))
+			localCache.Get(c, RandString(8))
 			fmt.Printf("=====%d====\n", time.Since(start).Milliseconds())
-		}()
+		}(iterCtx)
 
 	}
 	wg.Wait()


### PR DESCRIPTION
Closes #1375.

## Motivation

`go test -race ./...` in CubeMaster reported 9 races, five of them in `pkg/base/localcache`
production code. The most serious is `put()` mutating a `*util.CacheValue` in place while `Get()`
readers dereference it: `Value` is a two-word `interface{}`, so a torn read can pair one value's type
word with another's data word and the caller's type assertion then dereferences a mismatched pointer.

## What this changes

All in `CubeMaster/pkg/base/localcache/localcache.go`:

**1. Cache entries are now immutable once published.** `put()` no longer overwrites the live
`CacheValue`; it builds a replacement and swaps `element.Value` under the existing mutex:

```go
localCache.Lock()
prev := element.Value.(*util.CacheValue)
next := &util.CacheValue{Key: prev.Key, Value: val, LastAccess: ..., Expired: expired}
element.Value = next
localCache.valueList.MoveToBack(element)
localCache.Unlock()
```

`Get()` correspondingly reads the `*CacheValue` pointer **and** does its `MoveToBack` inside one
critical section, then works from that snapshot. Because nothing mutates a published entry any more,
the subsequent field reads need no lock.

This moves `Get`'s `MoveToBack` from after the refresh decision to before it. The LRU effect is the
same — exactly one `MoveToBack` per hit, on access — and it removes the duplicated
lock/`MoveToBack` block that the `DemotionExpiredUse` path used to need.

**2. `consecutiveFailNum`** — the plain store at `:201` becomes `atomic.StoreInt64`, matching the
`atomic.AddInt64` at `:197` and the `atomic.LoadInt64` in `errStrategy`.

**3. `curCacheSize`** — the read in `put()` becomes `atomic.LoadInt64`, matching its atomic writes.

**4. `Destroy()`** — no longer assigns `chCacheExit = nil` (which raced with `errStrategy`'s select).
Idempotency now comes from a `sync.Once`, so repeated `Destroy()` calls still cannot double-close.

**5. `ExpiredUse`** — `errStrategy` no longer writes the shared `*LocalCacheConfig` that `Get` reads.
`LocalCache` gains an `expiredUse atomic.Bool`, seeded from config in `NewCache` and driven by
`errStrategy`; `Get` reads it atomically. The yaml-tagged `LocalCacheConfig.ExpiredUse` field is
unchanged, so config parsing and every existing test that sets it still work.

Also fixed, because it is the last thing standing between this package and a green `-race` run:
**`localcache_test.go:48`** reassigned the shared `ctx` in a loop while spawned goroutines read it. The
context is now derived per iteration and passed as a parameter, which also removes an unintended
2700-deep context chain.

No comment changes.

## Testing

New: `CubeMaster/pkg/base/localcache/localcache_race_test.go`

- `TestConcurrentGetAndRefreshOnSameKey` — 32 readers × 300 iterations on one hot key with a 1 ms
  expiry, so `Get` and the async-refresh `put` interleave continuously. It type-asserts every hit,
  which is what would catch a torn `interface{}`.
- `TestDestroyIsIdempotent` — repeated `Destroy()` does not panic.
- `TestConcurrentDestroyDoesNotRaceWithBackgroundLoops` — four concurrent `Destroy()` calls.

Red/green verified — with `localcache.go` reverted to master, the new tests alone report **4 data
races**. With the fix:

```
$ go test -race -count=1 ./pkg/base/localcache/...
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/localcache       10.739s
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/localcache/util   2.118s
```

Module-wide, `go test -race ./...`:

| | master | this branch |
|---|---|---|
| data races | 9 | **2** |
| failing tests incl. `TestLocalCache`, `TestNoValue`, `TestSaveFile` | 9 | 6 |

CI gates checked locally:

- `gofmt -l ./pkg/base/localcache` — clean (`fmt-check`).
- `GOOS=linux go build ./pkg/base/localcache/` — clean.

## Still red after this change (pre-existing, not touched here)

The 2 remaining races and the 6 remaining failures are all pre-existing on master and belong to other
branches:

- `pkg/base/queueworker/queue_test.go:65,67,75` — test-side counter race.
- `pkg/base/recov/runtime_test.go` vs `runtime.go:30` — test-side read of an atomically-written
  counter.
- `pkg/base/bufferqueue/bufferqueue_test.go:131,138` — same class (this one is not yet tracked; worth
  its own issue).
- `TestDestroySandboxMissingSandboxReturnsNotFound`, `TestHostChangeGoodBodyReturnsSuccessEnvelope`,
  `TestTemplateLocalityFilterSelect`, `Test_local_appendNodeByCluster` — fail on master too
  (`gomonkey` cannot patch binaries on darwin; these need the Linux builder).

## Risk / rollout

Moderate — this touches the hot read path of a shared cache. The behavioural contract is unchanged:
same LRU semantics, same expiry decisions, same return values. The notable internal change is that a
`Get` hit now returns a value snapshot taken at lock time rather than whatever the entry happened to
hold mid-refresh, which is the point.

One extra allocation per `put()` on an existing key (the replacement `CacheValue`, ~48 bytes). Given
that `put` already runs a loader call and a JSON-ish payload, this is not a meaningful cost.
