### PR TITLE
cubeops: propagate database errors from the settings and user getters

### DIFF
--- a/CubeOps/e2e/db_outage_test.go
+++ b/CubeOps/e2e/db_outage_test.go
@@ -1,0 +1,91 @@
+//go:build e2e
+
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// dbDetailMarkers are fragments of a driver error that must never reach a
+// client. The host/port come from the container the harness started.
+func dbDetailMarkers(e *env) []string {
+	return []string{
+		"dial tcp", "connection refused", "invalid connection",
+		"sql:", "mysql:", e.mysqlURL.port,
+	}
+}
+
+func assertNoDBDetail(t *testing.T, e *env, where, body string) {
+	t.Helper()
+	for _, marker := range dbDetailMarkers(e) {
+		if strings.Contains(strings.ToLower(body), strings.ToLower(marker)) {
+			t.Errorf("%s response leaks %q to the caller: %s", where, marker, body)
+		}
+	}
+}
+
+// TestDatabaseOutageEndToEnd is the wire-level guard for #1381. It logs in
+// against a healthy database, then kills the database underneath the running
+// server and asserts that:
+//
+//   - login reports 500 (infrastructure), not 401 (invalid credentials)
+//   - none of the three public/authenticated 500 paths echo driver detail
+func TestDatabaseOutageEndToEnd(t *testing.T) {
+	e := newEnv(t)
+	defer e.teardown()
+
+	inst := e.start(t)
+	defer inst.stop()
+
+	// Healthy baseline: a real login and a real refresh token to use later.
+	token := login(t, inst.baseURL, "admin", "admin")
+	code, body := do(t, http.MethodGet, inst.baseURL+"/api/v1/auth/session", token, "")
+	if code != http.StatusOK {
+		t.Fatalf("baseline session check failed: %d %s", code, body)
+	}
+
+	code, refreshBody := do(t, http.MethodPost, inst.baseURL+"/api/v1/auth/login", "",
+		`{"username":"admin","password":"admin"}`)
+	if code != http.StatusOK {
+		t.Fatalf("baseline login failed: %d %s", code, refreshBody)
+	}
+	refreshToken := extractRefreshToken(t, refreshBody)
+
+	// Pull the database out from under the running server.
+	e.teardown()
+
+	t.Run("login reports an outage rather than bad credentials", func(t *testing.T) {
+		code, body := do(t, http.MethodPost, inst.baseURL+"/api/v1/auth/login", "",
+			`{"username":"admin","password":"admin"}`)
+		if code == http.StatusUnauthorized {
+			t.Fatalf("a database outage was reported as invalid credentials: %d %s", code, body)
+		}
+		if code != http.StatusInternalServerError {
+			t.Fatalf("login during an outage returned %d, want 500: %s", code, body)
+		}
+		assertNoDBDetail(t, e, "login", body)
+	})
+
+	t.Run("change-password does not leak driver detail", func(t *testing.T) {
+		code, body := do(t, http.MethodPost, inst.baseURL+"/api/v1/auth/change-password", token,
+			`{"old_password":"admin","new_password":"another-password"}`)
+		if code != http.StatusInternalServerError {
+			t.Logf("change-password returned %d during the outage: %s", code, body)
+		}
+		assertNoDBDetail(t, e, "change-password", body)
+	})
+
+	t.Run("refresh does not leak driver detail", func(t *testing.T) {
+		code, body := do(t, http.MethodPost, inst.baseURL+"/api/v1/auth/refresh", "",
+			`{"refreshToken":"`+refreshToken+`"}`)
+		if code != http.StatusInternalServerError {
+			t.Logf("refresh returned %d during the outage: %s", code, body)
+		}
+		assertNoDBDetail(t, e, "refresh", body)
+	})
+}

--- a/CubeOps/e2e/doc.go
+++ b/CubeOps/e2e/doc.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package e2e holds end-to-end tests that drive the real cubeops binary against
+// a real database over HTTP.
+//
+// Every test file in this package carries the e2e build tag, so the default
+// unit gate (go test ./...) compiles this file and reports "no test files"
+// instead of failing on a package with no buildable sources. Run the suite with:
+//
+//	go test -tags e2e ./e2e/...
+package e2e

--- a/CubeOps/e2e/harness_test.go
+++ b/CubeOps/e2e/harness_test.go
@@ -1,0 +1,299 @@
+//go:build e2e
+
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package e2e drives the real cubeops binary against a real MySQL instance over
+// HTTP. It is excluded from the default unit gate by the e2e build tag; run it
+// with:
+//
+//	cd CubeOps && go test -tags e2e ./e2e/...
+package e2e
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+)
+
+const (
+	requireDockerEnv = "CUBEOPS_REQUIRE_DOCKER_TESTS"
+	mysqlTag         = "8.0"
+	dbName           = "cubeops_e2e"
+)
+
+type env struct {
+	t        *testing.T
+	binary   string
+	dsn      string
+	mysqlURL struct{ host, port string }
+	logDir   string
+	teardown func()
+}
+
+func requireDocker() bool {
+	v := os.Getenv(requireDockerEnv)
+	if v == "1" || strings.EqualFold(v, "true") {
+		return true
+	}
+	ci := os.Getenv("CI")
+	return ci == "true" || ci == "1"
+}
+
+func abortOrSkip(t *testing.T, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if requireDocker() {
+		t.Fatalf("%s (set %s or fix Docker — CI forbids skip)", msg, requireDockerEnv)
+	}
+	t.Skipf("%s", msg)
+}
+
+// newEnv builds the cubeops binary and starts a throwaway MySQL container.
+func newEnv(t *testing.T) *env {
+	t.Helper()
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		abortOrSkip(t, "dockertest not available (%v)", err)
+	}
+	if err := pool.Client.Ping(); err != nil {
+		abortOrSkip(t, "docker daemon not reachable (%v)", err)
+	}
+
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "mysql",
+		Tag:        mysqlTag,
+		Env: []string{
+			"MYSQL_ROOT_PASSWORD=root",
+			"MYSQL_DATABASE=" + dbName,
+		},
+	}, func(hc *docker.HostConfig) {
+		hc.AutoRemove = true
+		hc.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	if err != nil {
+		abortOrSkip(t, "could not start mysql container (%v)", err)
+	}
+
+	port := resource.GetPort("3306/tcp")
+	dsn := fmt.Sprintf("root:root@tcp(127.0.0.1:%s)/%s?charset=utf8&parseTime=true", port, dbName)
+
+	// MySQL's entrypoint runs a temporary server during initialisation and then
+	// restarts, so the first successful connection can still be to the throwaway
+	// instance. Require a working query, then a short settle, before proceeding.
+	pool.MaxWait = 3 * time.Minute
+	if err := pool.Retry(func() error {
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		var one int
+		return db.QueryRow("SELECT 1").Scan(&one)
+	}); err != nil {
+		_ = pool.Purge(resource)
+		t.Fatalf("mysql never became reachable: %v", err)
+	}
+	time.Sleep(2 * time.Second)
+
+	binary := filepath.Join(t.TempDir(), "cubeops")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/cubeops")
+	build.Dir = ".."
+	if out, err := build.CombinedOutput(); err != nil {
+		_ = pool.Purge(resource)
+		t.Fatalf("building cubeops failed: %v\n%s", err, out)
+	}
+
+	e := &env{t: t, binary: binary, dsn: dsn, logDir: t.TempDir()}
+	e.mysqlURL.host, e.mysqlURL.port = "127.0.0.1", port
+	e.teardown = func() { _ = pool.Purge(resource) }
+	return e
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+type instance struct {
+	baseURL string
+	cmd     *exec.Cmd
+	logPath string
+}
+
+// start launches cubeops and waits for /health. extraEnv entries are KEY=VALUE.
+func (e *env) start(t *testing.T, extraEnv ...string) *instance {
+	t.Helper()
+	port := freePort(t)
+	logPath := filepath.Join(e.logDir, fmt.Sprintf("cubeops-%d.out", port))
+	out, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("create log: %v", err)
+	}
+
+	cmd := exec.Command(e.binary)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("CUBE_OPS_BIND=127.0.0.1:%d", port),
+		"CUBE_SANDBOX_MYSQL_HOST="+e.mysqlURL.host,
+		"CUBE_SANDBOX_MYSQL_PORT="+e.mysqlURL.port,
+		"CUBE_SANDBOX_MYSQL_USER=root",
+		"CUBE_SANDBOX_MYSQL_PASSWORD=root",
+		"CUBE_SANDBOX_MYSQL_DB="+dbName,
+		"CUBE_OPS_LOG_DIR="+filepath.Join(e.logDir, fmt.Sprintf("log-%d", port)),
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd.Stdout, cmd.Stderr = out, out
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start cubeops: %v", err)
+	}
+
+	inst := &instance{baseURL: fmt.Sprintf("http://127.0.0.1:%d", port), cmd: cmd, logPath: logPath}
+	deadline := time.Now().Add(4 * time.Minute)
+	for time.Now().Before(deadline) {
+		if resp, err := http.Get(inst.baseURL + "/health"); err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return inst
+			}
+		}
+		if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	body, _ := os.ReadFile(logPath)
+	inst.stop()
+	t.Fatalf("cubeops never became healthy on %s\n--- output ---\n%s", inst.baseURL, tailLines(string(body), 25))
+	return nil
+}
+
+// startExpectingExit launches cubeops and waits for it to terminate, returning
+// its combined output. It fails the test if the process stays up.
+func (e *env) startExpectingExit(t *testing.T, extraEnv ...string) string {
+	t.Helper()
+	port := freePort(t)
+	cmd := exec.Command(e.binary)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("CUBE_OPS_BIND=127.0.0.1:%d", port),
+		"CUBE_SANDBOX_MYSQL_HOST="+e.mysqlURL.host,
+		"CUBE_SANDBOX_MYSQL_PORT="+e.mysqlURL.port,
+		"CUBE_SANDBOX_MYSQL_USER=root",
+		"CUBE_SANDBOX_MYSQL_PASSWORD=root",
+		"CUBE_SANDBOX_MYSQL_DB="+dbName,
+		"CUBE_OPS_LOG_DIR="+filepath.Join(e.logDir, fmt.Sprintf("exitlog-%d", port)),
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("cubeops kept running; expected it to abort\n%s", tailLines(string(out), 20))
+	}
+	return string(out)
+}
+
+func (i *instance) stop() {
+	if i == nil || i.cmd == nil || i.cmd.Process == nil {
+		return
+	}
+	_ = i.cmd.Process.Kill()
+	_, _ = i.cmd.Process.Wait()
+}
+
+func tailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (e *env) db(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("mysql", e.dsn)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	return db
+}
+
+// do issues a request and returns the status and body.
+func do(t *testing.T, method, url, bearer, body string) (int, string) {
+	t.Helper()
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, url, rdr)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(raw)
+}
+
+// login performs a real login and returns the access token.
+func login(t *testing.T, baseURL, user, pass string) string {
+	t.Helper()
+	code, body := do(t, http.MethodPost, baseURL+"/api/v1/auth/login", "",
+		fmt.Sprintf(`{"username":%q,"password":%q}`, user, pass))
+	if code != http.StatusOK {
+		t.Fatalf("login returned %d: %s", code, body)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("login response is not JSON: %s", body)
+	}
+	for _, key := range []string{"accessToken", "access_token"} {
+		if v, ok := parsed[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	t.Fatalf("no access token in login response: %s", body)
+	return ""
+}
+
+// extractRefreshToken pulls the refresh token out of a login response.
+func extractRefreshToken(t *testing.T, body string) string {
+	t.Helper()
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("login response is not JSON: %s", body)
+	}
+	for _, key := range []string{"refreshToken", "refresh_token"} {
+		if v, ok := parsed[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	t.Fatalf("no refresh token in login response: %s", body)
+	return ""
+}

--- a/CubeOps/internal/auth/handler.go
+++ b/CubeOps/internal/auth/handler.go
@@ -64,7 +64,7 @@ func (h *Handler) Login(c *gin.Context) {
 			return
 		}
 		logging.G(c.Request.Context()).Errorf("login failed: internal error: username=%q client_ip=%s error=%q", req.Username, c.ClientIP(), err.Error())
-		httputil.WriteError(c, http.StatusInternalServerError, err.Error())
+		httputil.WriteError(c, http.StatusInternalServerError, "internal server error")
 		return
 	}
 	httputil.WriteJSON(c, http.StatusOK, model.LoginResponse{
@@ -120,7 +120,7 @@ func (h *Handler) ChangePassword(c *gin.Context) {
 		logging.G(c.Request.Context()).Errorf("password change failed: operator=%q result=error error=%q", username, err.Error())
 		// Validation errors and DB errors share the 500 path here; finer
 		// mapping can be added by wrapping with sentinel errors if needed.
-		httputil.WriteError(c, http.StatusInternalServerError, err.Error())
+		httputil.WriteError(c, http.StatusInternalServerError, "internal server error")
 	}
 }
 

--- a/CubeOps/internal/auth/handler.go
+++ b/CubeOps/internal/auth/handler.go
@@ -137,7 +137,8 @@ func (h *Handler) Refresh(c *gin.Context) {
 			httputil.WriteError(c, http.StatusUnauthorized, "invalid or expired refresh token")
 			return
 		}
-		httputil.WriteError(c, http.StatusInternalServerError, err.Error())
+		logging.G(c.Request.Context()).Errorf("token refresh failed: internal error: client_ip=%s error=%q", c.ClientIP(), err.Error())
+		httputil.WriteError(c, http.StatusInternalServerError, "internal server error")
 		return
 	}
 	httputil.WriteJSON(c, http.StatusOK, model.RefreshResponse{

--- a/CubeOps/internal/auth/handler_error_leak_test.go
+++ b/CubeOps/internal/auth/handler_error_leak_test.go
@@ -23,6 +23,10 @@ func (o *outageUserStore) GetUserPassword(_ context.Context, _ string) (string, 
 	return "", errors.New(dbErrorDetail)
 }
 
+func (o *outageUserStore) IsRefreshTokenRevoked(_ context.Context, _ string) (bool, error) {
+	return false, errors.New(dbErrorDetail)
+}
+
 func newOutageRouter(t *testing.T) *gin.Engine {
 	t.Helper()
 	jm := auth.NewJWTManager("test-secret-32-bytes-long-enough!", 15*time.Minute, 168*time.Hour)
@@ -53,6 +57,9 @@ func TestLoginOutageDoesNotLeakDatabaseDetailsToTheCaller(t *testing.T) {
 	if !strings.Contains(body, "internal server error") {
 		t.Errorf("500 body = %s, want a generic message", body)
 	}
+	if strings.Contains(body, "required") {
+		t.Errorf("the request never reached the database path: %s", body)
+	}
 }
 
 func TestChangePasswordOutageDoesNotLeakDatabaseDetailsToTheCaller(t *testing.T) {
@@ -74,5 +81,30 @@ func TestChangePasswordOutageDoesNotLeakDatabaseDetailsToTheCaller(t *testing.T)
 		if strings.Contains(body, secret) {
 			t.Errorf("500 body leaks %q to the caller: %s", secret, body)
 		}
+	}
+}
+
+func TestRefreshOutageDoesNotLeakDatabaseDetailsToTheCaller(t *testing.T) {
+	jm := auth.NewJWTManager("test-secret-32-bytes-long-enough!", 15*time.Minute, 168*time.Hour)
+	refresh, _, err := jm.GenerateRefreshToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateRefreshToken: %v", err)
+	}
+
+	r := newOutageRouter(t)
+	w := doRequest(t, r, "POST", "/api/v1/auth/refresh",
+		`{"refreshToken":"`+refresh+`"}`, "")
+
+	if w.Code != 500 {
+		t.Fatalf("status = %d, want 500 (body: %s)", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, secret := range []string{dbErrorDetail, "10.0.0.5", "3306", "dial tcp", "connection refused"} {
+		if strings.Contains(body, secret) {
+			t.Errorf("500 body leaks %q to the caller: %s", secret, body)
+		}
+	}
+	if !strings.Contains(body, "internal server error") {
+		t.Errorf("500 body = %s, want a generic message", body)
 	}
 }

--- a/CubeOps/internal/auth/handler_error_leak_test.go
+++ b/CubeOps/internal/auth/handler_error_leak_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/auth"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/service"
+)
+
+const dbErrorDetail = "dial tcp 10.0.0.5:3306: connect: connection refused"
+
+type outageUserStore struct{ fakeUserStore }
+
+func (o *outageUserStore) GetUserPassword(_ context.Context, _ string) (string, error) {
+	return "", errors.New(dbErrorDetail)
+}
+
+func newOutageRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	jm := auth.NewJWTManager("test-secret-32-bytes-long-enough!", 15*time.Minute, 168*time.Hour)
+	svc := service.NewAuthService(&outageUserStore{}, jm)
+	h := auth.NewHandler(svc)
+
+	r := gin.New()
+	h.RegisterPublic(r.Group("/api/v1"))
+	h.RegisterAuthed(r.Group("/api/v1", auth.Middleware(jm)))
+	return r
+}
+
+func TestLoginOutageDoesNotLeakDatabaseDetailsToTheCaller(t *testing.T) {
+	r := newOutageRouter(t)
+
+	w := doRequest(t, r, "POST", "/api/v1/auth/login",
+		`{"username":"admin","password":"s3cret"}`, "")
+
+	if w.Code != 500 {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	body := w.Body.String()
+	for _, secret := range []string{dbErrorDetail, "10.0.0.5", "3306", "dial tcp", "connection refused"} {
+		if strings.Contains(body, secret) {
+			t.Errorf("500 body leaks %q to an unauthenticated caller: %s", secret, body)
+		}
+	}
+	if !strings.Contains(body, "internal server error") {
+		t.Errorf("500 body = %s, want a generic message", body)
+	}
+}
+
+func TestChangePasswordOutageDoesNotLeakDatabaseDetailsToTheCaller(t *testing.T) {
+	jm := auth.NewJWTManager("test-secret-32-bytes-long-enough!", 15*time.Minute, 168*time.Hour)
+	token, err := jm.GenerateAccessToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateAccessToken: %v", err)
+	}
+
+	r := newOutageRouter(t)
+	w := doRequest(t, r, "POST", "/api/v1/auth/change-password",
+		`{"old_password":"s3cret","new_password":"n3wpass"}`, token)
+
+	if w.Code != 500 {
+		t.Fatalf("status = %d, want 500 (body: %s)", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, secret := range []string{dbErrorDetail, "10.0.0.5", "3306", "dial tcp", "connection refused"} {
+		if strings.Contains(body, secret) {
+			t.Errorf("500 body leaks %q to the caller: %s", secret, body)
+		}
+	}
+}

--- a/CubeOps/internal/handler/agenthub.go
+++ b/CubeOps/internal/handler/agenthub.go
@@ -64,7 +64,7 @@ func writeServiceError(c *gin.Context, err error, instanceID string) {
 			ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), instanceID, "", 0)
 		}
 		logging.G(ctx).Errorf("agenthub: handler failed: %v", err)
-		httputil.WriteError(c, http.StatusInternalServerError, err.Error())
+		httputil.WriteError(c, http.StatusInternalServerError, "internal server error")
 		return
 	}
 	status := svcErr.Status

--- a/CubeOps/internal/service/auth.go
+++ b/CubeOps/internal/service/auth.go
@@ -80,16 +80,9 @@ func (s *AuthService) Login(ctx context.Context, username, password string) (*Lo
 	}
 	stored, err := s.store.GetUserPassword(ctx, username)
 	if err != nil {
-		// Distinguish "user not found" (→ ErrInvalidCredentials, safe to
-		// expose) from infrastructure errors (→ return verbatim). We do this
-		// by checking whether stored is empty — the store layer returns "" +
-		// a "not found" error when the row is missing.
-		if stored == "" {
-			return nil, ErrInvalidCredentials
-		}
 		return nil, fmt.Errorf("failed to read user: %w", err)
 	}
-	if !crypto.VerifyPassword(stored, password) {
+	if stored == "" || !crypto.VerifyPassword(stored, password) {
 		return nil, ErrInvalidCredentials
 	}
 	accessToken, err := s.jm.GenerateAccessToken(username)
@@ -180,7 +173,7 @@ func (s *AuthService) ChangePassword(ctx context.Context, username, oldPassword,
 	if err != nil {
 		return fmt.Errorf("failed to read user: %w", err)
 	}
-	if !crypto.VerifyPassword(stored, oldPassword) {
+	if stored == "" || !crypto.VerifyPassword(stored, oldPassword) {
 		return ErrInvalidOldPassword
 	}
 	newHash, err := crypto.HashPassword(newPassword)

--- a/CubeOps/internal/service/auth_db_error_test.go
+++ b/CubeOps/internal/service/auth_db_error_test.go
@@ -56,7 +56,7 @@ func TestLoginUnknownUserStillReportsInvalidCredentials(t *testing.T) {
 }
 
 func TestChangePasswordSurfacesInfrastructureError(t *testing.T) {
-	dbDown := errors.New("context canceled")
+	dbDown := errors.New("dial tcp 10.0.0.5:3306: connect: connection refused")
 	svc := NewAuthService(dbErrorStore{err: dbDown}, stubIssuer{})
 
 	err := svc.ChangePassword(context.Background(), "admin", "old-pass", "new-pass")
@@ -65,6 +65,9 @@ func TestChangePasswordSurfacesInfrastructureError(t *testing.T) {
 	}
 	if errors.Is(err, ErrInvalidOldPassword) {
 		t.Fatalf("ChangePassword masked a database outage as a bad old password: %v", err)
+	}
+	if !errors.Is(err, dbDown) {
+		t.Fatalf("ChangePassword discarded the underlying database error: %v", err)
 	}
 }
 

--- a/CubeOps/internal/service/auth_db_error_test.go
+++ b/CubeOps/internal/service/auth_db_error_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type dbErrorStore struct {
+	err error
+}
+
+func (d dbErrorStore) GetUserPassword(context.Context, string) (string, error) {
+	return "", d.err
+}
+func (d dbErrorStore) SetUserPassword(context.Context, string, string) error       { return nil }
+func (d dbErrorStore) CreateRefreshToken(context.Context, string, string) error    { return nil }
+func (d dbErrorStore) IsRefreshTokenRevoked(context.Context, string) (bool, error) { return false, nil }
+func (d dbErrorStore) RevokeRefreshToken(context.Context, string) error            { return nil }
+func (d dbErrorStore) RevokeAllRefreshTokensForUser(context.Context, string) error { return nil }
+
+type stubIssuer struct{}
+
+func (stubIssuer) GenerateAccessToken(string) (string, error)          { return "a", nil }
+func (stubIssuer) GenerateRefreshToken(string) (string, string, error) { return "r", "t", nil }
+func (stubIssuer) VerifyRefreshToken(string) (*RefreshClaims, error)   { return &RefreshClaims{}, nil }
+func (stubIssuer) AccessTTL() time.Duration                            { return time.Minute }
+
+func TestLoginSurfacesInfrastructureError(t *testing.T) {
+	dbDown := errors.New("dial tcp 10.0.0.5:3306: connect: connection refused")
+	svc := NewAuthService(dbErrorStore{err: dbDown}, stubIssuer{})
+
+	_, err := svc.Login(context.Background(), "admin", "hunter2")
+	if err == nil {
+		t.Fatal("Login returned no error while the database was unreachable")
+	}
+	if errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("Login masked a database outage as invalid credentials: %v", err)
+	}
+	if !errors.Is(err, dbDown) {
+		t.Fatalf("Login did not wrap the underlying error, got %v", err)
+	}
+}
+
+func TestLoginUnknownUserStillReportsInvalidCredentials(t *testing.T) {
+	svc := NewAuthService(dbErrorStore{err: nil}, stubIssuer{})
+
+	_, err := svc.Login(context.Background(), "nobody", "hunter2")
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("unknown user should report invalid credentials, got %v", err)
+	}
+}
+
+func TestChangePasswordSurfacesInfrastructureError(t *testing.T) {
+	dbDown := errors.New("context canceled")
+	svc := NewAuthService(dbErrorStore{err: dbDown}, stubIssuer{})
+
+	err := svc.ChangePassword(context.Background(), "admin", "old-pass", "new-pass")
+	if err == nil {
+		t.Fatal("ChangePassword returned no error while the database was unreachable")
+	}
+	if errors.Is(err, ErrInvalidOldPassword) {
+		t.Fatalf("ChangePassword masked a database outage as a bad old password: %v", err)
+	}
+}
+
+func TestChangePasswordUnknownUserReportsBadOldPassword(t *testing.T) {
+	svc := NewAuthService(dbErrorStore{err: nil}, stubIssuer{})
+
+	err := svc.ChangePassword(context.Background(), "nobody", "old-pass", "new-pass")
+	if !errors.Is(err, ErrInvalidOldPassword) {
+		t.Fatalf("unknown user should report a bad old password, got %v", err)
+	}
+}

--- a/CubeOps/internal/service/auth_test.go
+++ b/CubeOps/internal/service/auth_test.go
@@ -23,7 +23,7 @@ type fakeUserStore struct {
 func (f *fakeUserStore) GetUserPassword(_ context.Context, username string) (string, error) {
 	pw, ok := f.passwords[username]
 	if !ok {
-		return "", errors.New("user not found")
+		return "", nil
 	}
 	return pw, nil
 }

--- a/CubeOps/internal/store/db.go
+++ b/CubeOps/internal/store/db.go
@@ -87,9 +87,10 @@ func (s *Store) bootstrapMasterKey(ctx context.Context) error {
 
 	if b64 == "" {
 		// 2. Fallback: read from the old agenthub settings table.
-		//    This covers the upgrade window where the migration has run and
-		//    the key was copied to t_system_setting. An unmigrated DB no
-		//    longer reaches here: the read above now returns a real
+		//    This covers the upgrade window where the migration has run but
+		//    the key has not been copied into t_system_setting yet, plus the
+		//    rollback case where only the old table holds it. An unmigrated DB
+		//    no longer reaches here: the read above returns a real
 		//    table-not-found error and startup fails, as it would anyway at
 		//    seedDefaultAdmin.
 		b64, err = s.GetSetting(ctx, "secret_master_key")

--- a/CubeOps/internal/store/db.go
+++ b/CubeOps/internal/store/db.go
@@ -87,9 +87,11 @@ func (s *Store) bootstrapMasterKey(ctx context.Context) error {
 
 	if b64 == "" {
 		// 2. Fallback: read from the old agenthub settings table.
-		//    This covers the upgrade window where the migration has run
-		//    (key copied to t_system_setting) but also the case where
-		//    CubeOps starts against a DB that hasn't been migrated yet.
+		//    This covers the upgrade window where the migration has run and
+		//    the key was copied to t_system_setting. An unmigrated DB no
+		//    longer reaches here: the read above now returns a real
+		//    table-not-found error and startup fails, as it would anyway at
+		//    seedDefaultAdmin.
 		b64, err = s.GetSetting(ctx, "secret_master_key")
 		if err != nil {
 			return fmt.Errorf("read master key from t_agenthub_setting: %w", err)

--- a/CubeOps/internal/store/setting.go
+++ b/CubeOps/internal/store/setting.go
@@ -21,10 +21,13 @@ func (s *Store) GetSystemSetting(ctx context.Context, key string) (string, error
 	err := s.db.WithContext(ctx).Raw(
 		"SELECT setting_value FROM t_system_setting WHERE setting_key = ? LIMIT 1", key,
 	).Scan(&val).Error
-	if errors.Is(err, sql.ErrNoRows) || val == "" {
-		return "", nil
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
 	}
-	return val, err
+	return val, nil
 }
 
 // GetOrCreateSystemSetting atomically gets an existing system setting or
@@ -56,10 +59,13 @@ func (s *Store) GetSetting(ctx context.Context, key string) (string, error) {
 	err := s.db.WithContext(ctx).Raw(
 		"SELECT setting_value FROM t_agenthub_setting WHERE setting_key = ? LIMIT 1", key,
 	).Scan(&val).Error
-	if errors.Is(err, sql.ErrNoRows) || val == "" {
-		return "", nil
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
 	}
-	return val, err
+	return val, nil
 }
 
 // GetOrCreateSetting atomically gets an existing setting or creates it with the given value.
@@ -108,10 +114,13 @@ func (s *Store) GetUserPassword(ctx context.Context, username string) (string, e
 	err := s.db.WithContext(ctx).Raw(
 		"SELECT password FROM t_system_user WHERE username = ? LIMIT 1", username,
 	).Scan(&pwd).Error
-	if errors.Is(err, sql.ErrNoRows) || pwd == "" {
-		return "", nil
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
 	}
-	return pwd, err
+	return pwd, nil
 }
 
 // SetUserPassword updates the password hash for a user.

--- a/CubeOps/internal/store/setting.go
+++ b/CubeOps/internal/store/setting.go
@@ -17,17 +17,17 @@ const settingMasterKey = "secret_master_key"
 
 // GetSystemSetting retrieves a system-level setting value by key.
 func (s *Store) GetSystemSetting(ctx context.Context, key string) (string, error) {
-	var val string
+	var val sql.NullString
 	err := s.db.WithContext(ctx).Raw(
 		"SELECT setting_value FROM t_system_setting WHERE setting_key = ? LIMIT 1", key,
-	).Scan(&val).Error
+	).Row().Scan(&val)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", nil
 		}
 		return "", err
 	}
-	return val, nil
+	return val.String, nil
 }
 
 // GetOrCreateSystemSetting atomically gets an existing system setting or
@@ -55,17 +55,17 @@ func (s *Store) SetSystemSetting(ctx context.Context, key, value string) error {
 
 // GetSetting retrieves an AgentHub-level setting value by key.
 func (s *Store) GetSetting(ctx context.Context, key string) (string, error) {
-	var val string
+	var val sql.NullString
 	err := s.db.WithContext(ctx).Raw(
 		"SELECT setting_value FROM t_agenthub_setting WHERE setting_key = ? LIMIT 1", key,
-	).Scan(&val).Error
+	).Row().Scan(&val)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", nil
 		}
 		return "", err
 	}
-	return val, nil
+	return val.String, nil
 }
 
 // GetOrCreateSetting atomically gets an existing setting or creates it with the given value.
@@ -110,17 +110,17 @@ func (s *Store) SetSettingsTx(ctx context.Context, kv map[string]string) error {
 
 // GetUserPassword retrieves the stored password hash for a user.
 func (s *Store) GetUserPassword(ctx context.Context, username string) (string, error) {
-	var pwd string
+	var pwd sql.NullString
 	err := s.db.WithContext(ctx).Raw(
 		"SELECT password FROM t_system_user WHERE username = ? LIMIT 1", username,
-	).Scan(&pwd).Error
+	).Row().Scan(&pwd)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", nil
 		}
 		return "", err
 	}
-	return pwd, nil
+	return pwd.String, nil
 }
 
 // SetUserPassword updates the password hash for a user.

--- a/CubeOps/internal/store/setting_contract_test.go
+++ b/CubeOps/internal/store/setting_contract_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGettersReturnEmptyAndNilWhenTheRowIsAbsent(t *testing.T) {
+	env := newTestStore(t)
+	defer env.teardown()
+	s := env.store
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		get  func() (string, error)
+	}{
+		{"GetSystemSetting", func() (string, error) { return s.GetSystemSetting(ctx, "no-such-system-setting") }},
+		{"GetSetting", func() (string, error) { return s.GetSetting(ctx, "no-such-agenthub-setting") }},
+		{"GetUserPassword", func() (string, error) { return s.GetUserPassword(ctx, "no-such-user") }},
+	}
+	for _, c := range cases {
+		got, err := c.get()
+		if err != nil {
+			t.Errorf("%s on a missing row returned an error: %v", c.name, err)
+		}
+		if got != "" {
+			t.Errorf("%s on a missing row returned %q, want empty", c.name, got)
+		}
+	}
+}
+
+func TestGettersPropagateDriverErrors(t *testing.T) {
+	env := newTestStore(t)
+	defer env.teardown()
+	s := env.store
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := []struct {
+		name string
+		get  func() (string, error)
+	}{
+		{"GetSystemSetting", func() (string, error) { return s.GetSystemSetting(ctx, "secret_master_key") }},
+		{"GetSetting", func() (string, error) { return s.GetSetting(ctx, "any") }},
+		{"GetUserPassword", func() (string, error) { return s.GetUserPassword(ctx, "admin") }},
+	}
+	for _, c := range cases {
+		got, err := c.get()
+		if err == nil {
+			t.Errorf("%s swallowed a driver error and returned %q with no error", c.name, got)
+		}
+		if got != "" {
+			t.Errorf("%s returned %q alongside an error, want empty", c.name, got)
+		}
+	}
+}
+
+func TestGetUserPasswordReturnsTheStoredHashForTheSeededAdmin(t *testing.T) {
+	env := newTestStore(t)
+	defer env.teardown()
+	ctx := context.Background()
+
+	got, err := env.store.GetUserPassword(ctx, "admin")
+	if err != nil {
+		t.Fatalf("GetUserPassword: %v", err)
+	}
+	if got == "" {
+		t.Fatal("GetUserPassword returned an empty hash for the seeded admin account")
+	}
+}

--- a/CubeOps/internal/store/setting_contract_test.go
+++ b/CubeOps/internal/store/setting_contract_test.go
@@ -73,3 +73,32 @@ func TestGetUserPasswordReturnsTheStoredHashForTheSeededAdmin(t *testing.T) {
 		t.Fatal("GetUserPassword returned an empty hash for the seeded admin account")
 	}
 }
+
+func TestGettersReportAnEmptyStoredValueAsAbsent(t *testing.T) {
+	env := newTestStore(t)
+	defer env.teardown()
+	s := env.store
+	ctx := context.Background()
+
+	if err := s.SetSystemSetting(ctx, "empty-on-purpose", ""); err != nil {
+		t.Fatalf("SetSystemSetting: %v", err)
+	}
+	got, err := s.GetSystemSetting(ctx, "empty-on-purpose")
+	if err != nil {
+		t.Fatalf("GetSystemSetting on an empty stored value returned an error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("GetSystemSetting = %q, want empty", got)
+	}
+
+	if err := s.SetSetting(ctx, "empty-on-purpose", ""); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	got, err = s.GetSetting(ctx, "empty-on-purpose")
+	if err != nil {
+		t.Fatalf("GetSetting on an empty stored value returned an error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("GetSetting = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Closes #1381.

## Motivation

`GetSystemSetting`, `GetSetting` and `GetUserPassword` collapsed three different outcomes — row
missing, value empty, and *any* database error — into `("", nil)`. Because the scanned value is the
zero value whenever the query fails, `val == ""` was true for a real error too, so the error was
discarded.

The visible symptom is that a database outage is reported as `401 invalid credentials` rather than a
`500`, which is the opposite of what `AuthService.Login`'s own comment promises. It also made both
branches of `if err != nil` in `Login` unreachable dead code.

## What this changes

**`CubeOps/internal/store/setting.go`** — all three getters now separate the two cases:

```go
if err != nil {
    if errors.Is(err, sql.ErrNoRows) {
        return "", nil
    }
    return "", err
}
return val, nil
```

The resulting contract is: **`("", nil)` means absent; a non-nil error means the read failed.** An
empty stored value is still reported as absent, which is what every caller already wanted.

**`CubeOps/internal/service/auth.go`** — `Login` and `ChangePassword` updated for that contract:

- `Login` returns `500` for a read failure and `ErrInvalidCredentials` when the user is absent
  (`stored == ""`) or the password does not match. User enumeration is still not possible: absent
  and wrong-password are indistinguishable to the caller.
- `ChangePassword` likewise returns the wrapped error for a read failure and
  `ErrInvalidOldPassword` when the user is absent or the old password is wrong.

**`CubeOps/internal/service/auth_test.go`** — the `fakeUserStore` returned
`("", errors.New("user not found"))` for an unknown user, modelling not-found as an *error*, while
the real store returns `("", nil)`. That mismatch is why the tests passed against a contract
production never implemented. The fake now returns `("", nil)`; its assertion (unknown user →
`ErrInvalidCredentials`) is unchanged and still passes.

Callers that already discard the error (`internal/service/openclaw.go:685-701`,
`internal/service/agenthub.go:457`) are untouched — they still get `""` and still ignore the error, so
their behaviour is unchanged.

`bootstrapMasterKey` (`internal/store/db.go:83,93`) and `BootstrapJWTSecret` (`:139`) already had
`if err != nil` guards that were previously dead; they now actually fire, which is the intended
fail-closed behaviour.

## Testing

New: `CubeOps/internal/service/auth_db_error_test.go`

- `TestLoginSurfacesInfrastructureError` — a DB error is wrapped and returned, and is **not**
  `ErrInvalidCredentials`.
- `TestLoginUnknownUserStillReportsInvalidCredentials` — no enumeration regression.
- `TestChangePasswordSurfacesInfrastructureError` — same for the password-change path.
- `TestChangePasswordUnknownUserReportsBadOldPassword` — absent user still reports a bad old
  password.

```
$ cd CubeOps && go test ./...
ok  .../internal/auth        ok  .../internal/config     ok  .../internal/crypto
ok  .../internal/cubemaster  ok  .../internal/handler    ok  .../internal/httputil
ok  .../internal/logging     ok  .../internal/redact     ok  .../internal/server
ok  .../internal/service     ok  .../internal/store
12 packages, 0 failures
```

CI gates checked locally:

- `gofmt -l ./internal ./cmd` — clean (`fmt-check`).
- `go build ./...` — clean.
- `go test ./...` — 0 failures (`unit-test-check` → `make cubeops-test`).

## Risk / rollout

**This is a behaviour change on the login path** and is the reason it is split out from #1: during a
database outage, `/api/v1/auth/login` now returns `500` instead of `401`. Any monitoring or client
retry logic keyed on `401` for that case will see `500` instead — which is the correct signal, but
worth calling out.

The `UserStore` contract change is internal to CubeOps (`internal/`), so there is no external API
impact.