### PR TITLE
fix(cubemaster): order alias claims across rebuilds

### DIFF
--- a/CubeMaster/pkg/templatecenter/image_job_runner.go
+++ b/CubeMaster/pkg/templatecenter/image_job_runner.go
@@ -188,8 +188,7 @@ func runTemplateImageJob(ctx context.Context, jobID string, req *types.CreateTem
 	if persistErr != nil {
 		err = persistErr
 	} else {
-		claimAlias := aliasToClaimAtFinalize(ctx, req.TemplateID, jobID)
-		info, claimWarning, err = finalizeTemplateReplicas(ctx, req.TemplateID, generatedReq.InstanceType, constants.GetAppSnapshotVersion(generatedReq.Annotations), claimAlias, replicas)
+		info, claimWarning, err = finalizeTemplateReplicas(ctx, req.TemplateID, jobID, generatedReq.InstanceType, constants.GetAppSnapshotVersion(generatedReq.Annotations), replicas)
 	}
 	if err != nil {
 		if builtFreshArtifact {

--- a/CubeMaster/pkg/templatecenter/job_repo.go
+++ b/CubeMaster/pkg/templatecenter/job_repo.go
@@ -11,12 +11,25 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func getTemplateImageJobRecordByID(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
 	record := &models.TemplateImageJob{}
 	if err := store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
 		Where("job_id = ?", jobID).First(record).Error; err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+func getCreateRedoImageJobByIDTx(tx *gorm.DB, templateID, jobID string) (*models.TemplateImageJob, error) {
+	record := &models.TemplateImageJob{}
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Table(constants.TemplateImageJobTableName).
+		Where("template_id = ? AND job_id = ? AND operation IN ?", templateID, jobID, createRedoJobOperations).
+		First(record).Error
+	if err != nil {
 		return nil, err
 	}
 	return record, nil
@@ -42,6 +55,19 @@ func getLatestCreateRedoImageJobByTemplateIDTx(tx *gorm.DB, templateID string) (
 	err := tx.Table(constants.TemplateImageJobTableName).
 		Where("template_id = ? AND operation IN ?", templateID, createRedoJobOperations).
 		Order("attempt_no desc, id desc").First(record).Error
+	if err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+// getNewestCreateRedoImageJobByTemplateIDTx uses the global row ID rather
+// than attempt_no because alias arbitration follows persisted submission order.
+func getNewestCreateRedoImageJobByTemplateIDTx(tx *gorm.DB, templateID string) (*models.TemplateImageJob, error) {
+	record := &models.TemplateImageJob{}
+	err := tx.Table(constants.TemplateImageJobTableName).
+		Where("template_id = ? AND operation IN ?", templateID, createRedoJobOperations).
+		Order("id desc").First(record).Error
 	if err != nil {
 		return nil, err
 	}

--- a/CubeMaster/pkg/templatecenter/redo.go
+++ b/CubeMaster/pkg/templatecenter/redo.go
@@ -451,8 +451,7 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 	// refreshTemplateReplicaSummary claims the alias *before* publishing the
 	// READY status so a client that observes the template as READY can always
 	// resolve the alias (closes the redo/claim publish-ordering race).
-	claimAlias := aliasToClaimAtFinalize(ctx, req.TemplateID, jobID)
-	claimWarning, err := refreshTemplateReplicaSummary(ctx, req.TemplateID, claimAlias)
+	claimWarning, err := refreshTemplateReplicaSummary(ctx, req.TemplateID, jobID)
 	if err != nil {
 		_ = updateTemplateImageJob(ctx, jobID, map[string]any{
 			"status":          JobStatusFailed,

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -442,7 +442,7 @@ func CreateTemplate(ctx context.Context, req *sandboxtypes.CreateCubeSandboxReq)
 	}
 	// The synchronous CreateCubeSandboxReq path carries no template alias (that
 	// is exclusive to CreateTemplateFromImageReq), so no alias is claimed here.
-	info, _, finalizeErr := finalizeTemplateReplicas(ctx, templateID, createReq.InstanceType, constants.GetAppSnapshotVersion(createReq.Annotations), "", replicas)
+	info, _, finalizeErr := finalizeTemplateReplicas(ctx, templateID, "", createReq.InstanceType, constants.GetAppSnapshotVersion(createReq.Annotations), replicas)
 	return info, finalizeErr
 }
 
@@ -669,7 +669,7 @@ func ensureRuntimeTemplateRequest(req *sandboxtypes.CreateCubeSandboxReq) {
 // already resolves — closing the create/claim publish-ordering race. The
 // returned claimWarning is non-empty when the alias could not be claimed for a
 // non-duplicate reason.
-func refreshTemplateReplicaSummary(ctx context.Context, templateID, alias string) (claimWarning string, err error) {
+func refreshTemplateReplicaSummary(ctx context.Context, templateID, jobID string) (claimWarning string, err error) {
 	replicas, err := ListReplicas(ctx, templateID)
 	if err != nil {
 		return "", err
@@ -679,14 +679,8 @@ func refreshTemplateReplicaSummary(ctx context.Context, templateID, alias string
 		current = append(current, replicaModelToStatus(replica))
 	}
 	status, lastError := summarizeStatus(current)
-	// NB: claimAliasForReadyTemplate and UpdateDefinitionStatus each use their own
-	// DB transaction. A crash between the two leaves the alias claimed but the
-	// status at its previous value — strictly safer than the reverse ordering, but
-	// not fully atomic.
-	if status != StatusFailed {
-		claimWarning, _ = claimAliasForReadyTemplate(ctx, templateID, alias)
-	}
-	if err := UpdateDefinitionStatus(ctx, templateID, status, lastError); err != nil {
+	_, claimWarning, err = publishTemplateStatusWithAlias(ctx, templateID, jobID, status, lastError)
+	if err != nil {
 		return "", err
 	}
 	localcache.InvalidateImageState(templateID)
@@ -697,8 +691,8 @@ func refreshTemplateReplicaSummary(ctx context.Context, templateID, alias string
 
 // createDefinitionWithOptions wraps createDefinitionTx in a real DB transaction
 // so the INSERT is atomic. Alias claiming is NOT done here — it happens
-// separately when the template reaches a non-FAILED status, before that status
-// is published (see claimAliasForReadyTemplate).
+// separately when the template reaches a non-FAILED status, as part of the
+// transaction that publishes that status.
 func createDefinitionWithOptions(ctx context.Context, templateID string, storedReq *sandboxtypes.CreateCubeSandboxReq, instanceType, version string, opts definitionCreateOptions) error {
 	return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		return createDefinitionTx(ctx, tx, templateID, storedReq, instanceType, version, opts)
@@ -745,21 +739,13 @@ func ensureTemplateDefinitionWithOptions(ctx context.Context, templateID string,
 // mutually-exclusive results: on success the alias is reflected in
 // TemplateInfo.DisplayName and the warning is empty; on a non-duplicate claim
 // failure the warning is set and DisplayName stays empty.
-func finalizeTemplateReplicas(ctx context.Context, templateID, instanceType, version, alias string, replicas []ReplicaStatus) (*TemplateInfo, string, error) {
+func finalizeTemplateReplicas(ctx context.Context, templateID, jobID, instanceType, version string, replicas []ReplicaStatus) (*TemplateInfo, string, error) {
 	setTemplateLocalityCache(templateID, replicas)
 	registerReadyTemplateReplicas(templateID, replicas)
 
 	status, lastError := summarizeStatus(replicas)
-	claimWarning := ""
-	displayName := ""
-	// NB: claimAliasForReadyTemplate and UpdateDefinitionStatus each use their own
-	// DB transaction. A crash between the two leaves the alias claimed but the
-	// status at its previous value — strictly safer than the reverse ordering, but
-	// not fully atomic.
-	if status != StatusFailed {
-		claimWarning, displayName = claimAliasForReadyTemplate(ctx, templateID, alias)
-	}
-	if err := UpdateDefinitionStatus(ctx, templateID, status, lastError); err != nil {
+	displayName, claimWarning, err := publishTemplateStatusWithAlias(ctx, templateID, jobID, status, lastError)
+	if err != nil {
 		return nil, "", err
 	}
 	info := &TemplateInfo{
@@ -980,88 +966,250 @@ func ResolveTemplateIdentifier(ctx context.Context, identifier string) (string, 
 	return def.TemplateID, nil
 }
 
-// claimTemplateAlias atomically claims an alias for a template.
-//
-// requireReady=true is the operator SetTemplateAlias path (design §3.6 I2):
-// it MAY release the alias from any other holder (last-commit-wins transfer),
-// then claims the target only if status='READY'.
-//
-// requireReady=false is the create/redo finalize path: it MUST NOT release
-// other holders. If another template already occupies alias_key, the UPDATE
-// hits the unique index (1062/23505) and claimAliasForReadyTemplate treats
-// that as "READY without alias". Idempotent re-claim of an alias the target
-// already holds is confirmed via COUNT, not RowsAffected (MySQL rows-changed).
-func claimTemplateAlias(ctx context.Context, templateID, alias string, requireReady bool) error {
-	alias = strings.TrimSpace(alias)
-	if alias == "" {
+func claimTemplateAliasTx(tx *gorm.DB, templateID, alias string) error {
+	if err := tx.Table(constants.TemplateDefinitionTableName).
+		Where("alias_key = ? AND template_id <> ?", alias, templateID).
+		Update("display_name", "").Error; err != nil {
+		return fmt.Errorf("release stale alias %q fail: %w", alias, err)
+	}
+	if err := tx.Table(constants.TemplateDefinitionTableName).
+		Where("template_id = ? AND status = ?", templateID, StatusReady).
+		Update("display_name", alias).Error; err != nil {
+		return fmt.Errorf("claim alias %q for template %s fail: %w", alias, templateID, err)
+	}
+	var claimed int64
+	if err := tx.Table(constants.TemplateDefinitionTableName).
+		Where("template_id = ? AND alias_key = ? AND status = ?", templateID, alias, StatusReady).
+		Count(&claimed).Error; err != nil {
+		return fmt.Errorf("confirm alias claim for template %s fail: %w", templateID, err)
+	}
+	if claimed > 0 {
 		return nil
 	}
-	if !isReady() {
-		return ErrTemplateStoreNotInitialized
+	var exists int64
+	if err := tx.Table(constants.TemplateDefinitionTableName).
+		Where("template_id = ?", templateID).Count(&exists).Error; err != nil {
+		return fmt.Errorf("confirm existence for template %s fail: %w", templateID, err)
 	}
+	if exists > 0 {
+		return ErrTemplateNotReady
+	}
+	return ErrTemplateNotFound
+}
+
+func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, status, lastError string) (displayName, claimWarning string, err error) {
+	if !isReady() {
+		return "", "", ErrTemplateStoreNotInitialized
+	}
+	alias := ""
+	claimantJobRowID := uint(0)
+	expectedStatus := ""
+	claimed := false
+	displacedTemplateID := ""
+	claimWarning = ""
+	var claimErr error
+	run := func() error {
+		return retryOnceOnDeadlock(func() error {
+			alias = ""
+			claimantJobRowID = 0
+			expectedStatus = ""
+			claimed = false
+			displacedTemplateID = ""
+			claimWarning = ""
+			claimErr = nil
+			return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+				target, err := lockTemplateDefinitionTx(tx, templateID)
+				if err != nil {
+					return err
+				}
+				if target.Status == StatusDeleting {
+					return ErrTemplateNotFound
+				}
+				expectedStatus = target.Status
+				if jobID != "" {
+					job, err := getCreateRedoImageJobByIDTx(tx, templateID, jobID)
+					if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+						claimErr = err
+						return err
+					}
+					if err == nil {
+						claimantJobRowID = job.ID
+						alias = strings.TrimSpace(aliasFromRequestJSON(job.RequestJSON))
+						if strings.TrimSpace(target.DisplayName) != "" {
+							alias = strings.TrimSpace(target.DisplayName)
+						}
+					}
+				}
+				if status != StatusFailed && alias != "" {
+					claimResult, err := claimTemplateAliasByJobOrderTx(tx, templateID, claimantJobRowID, alias)
+					if err != nil {
+						claimErr = err
+						return err
+					}
+					claimed = claimResult.Claimed
+					displacedTemplateID = claimResult.DisplacedTemplateID
+					claimWarning = claimResult.Warning
+				}
+				return tx.Table(constants.TemplateDefinitionTableName).
+					Where("template_id = ?", templateID).
+					Updates(map[string]any{
+						"status":     status,
+						"last_error": lastError,
+						"updated_at": time.Now(),
+					}).Error
+			})
+		})
+	}
+	err = run()
+	if err != nil && isDuplicateAliasError(err) {
+		err = run()
+	}
+	if err == nil {
+		if claimed {
+			if displacedTemplateID != "" {
+				log.G(ctx).Warnf("alias %q transferred from template %s to newer template build %s", alias, displacedTemplateID, templateID)
+			}
+			return alias, claimWarning, nil
+		}
+		if claimWarning != "" {
+			log.G(ctx).Warnf("template %s is %s without alias %q: %s", templateID, status, alias, claimWarning)
+			return "", claimWarning, nil
+		}
+		if alias != "" && status != StatusFailed {
+			log.G(ctx).Infof("alias %q belongs to a newer template build; template %s is %s without alias", alias, templateID, status)
+		}
+		return "", "", nil
+	}
+	if claimErr == nil {
+		return "", "", err
+	}
+	if statusErr := publishTemplateStatusWithoutAlias(ctx, templateID, expectedStatus, status, lastError); statusErr != nil {
+		return "", "", statusErr
+	}
+	if isDuplicateAliasError(claimErr) {
+		return "", "", nil
+	}
+	return "", fmt.Sprintf("template is ready but alias %q could not be claimed: %v", alias, claimErr), nil
+}
+
+func publishTemplateStatusWithoutAlias(ctx context.Context, templateID, expectedStatus, status, lastError string) error {
 	return retryOnceOnDeadlock(func() error {
 		return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			return claimTemplateAliasTx(tx, templateID, alias, requireReady)
+			target, err := lockTemplateDefinitionTx(tx, templateID)
+			if err != nil {
+				return err
+			}
+			if target.Status == StatusDeleting {
+				return ErrTemplateNotFound
+			}
+			if target.Status != expectedStatus {
+				return fmt.Errorf("template %s status changed from %s to %s while publishing without alias", templateID, expectedStatus, target.Status)
+			}
+			result := tx.Table(constants.TemplateDefinitionTableName).
+				Where("template_id = ? AND status = ?", templateID, expectedStatus).
+				Updates(map[string]any{
+					"status":     status,
+					"last_error": lastError,
+					"updated_at": time.Now(),
+				})
+			if result.Error != nil {
+				return result.Error
+			}
+			var published int64
+			if err := tx.Table(constants.TemplateDefinitionTableName).
+				Where("template_id = ? AND status <> ?", templateID, StatusDeleting).
+				Count(&published).Error; err != nil {
+				return err
+			}
+			if published == 0 {
+				return ErrTemplateNotFound
+			}
+			return nil
 		})
 	})
 }
 
-func claimTemplateAliasTx(tx *gorm.DB, templateID, alias string, requireReady bool) error {
-	// Status predicate for the claim/confirm. The shared create/redo path
-	// (claimAliasForReadyTemplate) only excludes DELETING — it legitimately
-	// claims at PARTIALLY_READY, before READY is published. The operator
-	// SetTemplateAlias path (requireReady) additionally requires READY so a
-	// target that starts rebuilding between GetDefinition and the claim can't
-	// receive an alias (design §3.5).
-	statusExpr := "status <> ?"
-	statusVal := StatusDeleting
-	if requireReady {
-		statusExpr = "status = ?"
-		statusVal = StatusReady
+type orderedAliasClaimResult struct {
+	Claimed             bool
+	DisplacedTemplateID string
+	Warning             string
+}
+
+func claimTemplateAliasByJobOrderTx(tx *gorm.DB, templateID string, claimantJobRowID uint, alias string) (orderedAliasClaimResult, error) {
+	var result orderedAliasClaimResult
+	holder := &models.TemplateDefinition{}
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Table(constants.TemplateDefinitionTableName).
+		Where("alias_key = ?", alias).
+		First(holder).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		update := tx.Table(constants.TemplateDefinitionTableName).
+			Where("template_id = ? AND status <> ?", templateID, StatusDeleting).
+			Update("display_name", alias)
+		if update.Error != nil {
+			return result, fmt.Errorf("claim alias %q for template %s fail: %w", alias, templateID, update.Error)
+		}
+		result.Claimed = update.RowsAffected > 0
+		return result, nil
 	}
-	// Release is operator-only. Create/redo must not clear a READY (or
-	// FAILED/DELETING) holder — uniqueness is enforced by alias_key.
-	if requireReady {
+	if err != nil {
+		return result, err
+	}
+	if holder.TemplateID == templateID {
+		result.Claimed = true
+		return result, nil
+	}
+	if holder.Status == StatusDeleting {
 		if err := tx.Table(constants.TemplateDefinitionTableName).
-			Where("alias_key = ? AND template_id <> ?",
-				alias, templateID).
+			Where("template_id = ? AND alias_key = ? AND status = ?", holder.TemplateID, alias, StatusDeleting).
 			Update("display_name", "").Error; err != nil {
-			return fmt.Errorf("release stale alias %q fail: %w", alias, err)
+			return result, fmt.Errorf("release alias %q from deleting template %s fail: %w", alias, holder.TemplateID, err)
 		}
+		if err := syncCreateRedoImageJobAliasTx(tx, holder.TemplateID, ""); err != nil {
+			return result, err
+		}
+		update := tx.Table(constants.TemplateDefinitionTableName).
+			Where("template_id = ? AND status <> ?", templateID, StatusDeleting).
+			Update("display_name", alias)
+		if update.Error != nil {
+			return result, fmt.Errorf("claim alias %q for template %s fail: %w", alias, templateID, update.Error)
+		}
+		result.Claimed = update.RowsAffected > 0
+		return result, nil
+	}
+
+	// Order template generations globally by persisted row ID. The holder's
+	// newest generation is intentionally conservative even if it requested a
+	// different alias; alias-scoped or operator ordering needs persisted claim
+	// provenance rather than the per-template attempt number.
+	holderJob, err := getNewestCreateRedoImageJobByTemplateIDTx(tx, holder.TemplateID)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		result.Warning = fmt.Sprintf("alias %q could not be ordered because holder template %s has no CREATE/REDO job metadata", alias, holder.TemplateID)
+		return result, nil
+	}
+	if err != nil {
+		return result, err
+	}
+	if claimantJobRowID <= holderJob.ID {
+		return result, nil
+	}
+
+	if err := tx.Table(constants.TemplateDefinitionTableName).
+		Where("template_id = ? AND alias_key = ?", holder.TemplateID, alias).
+		Update("display_name", "").Error; err != nil {
+		return result, fmt.Errorf("release alias %q from template %s fail: %w", alias, holder.TemplateID, err)
+	}
+	if err := syncCreateRedoImageJobAliasTx(tx, holder.TemplateID, ""); err != nil {
+		return result, err
 	}
 	if err := tx.Table(constants.TemplateDefinitionTableName).
-		Where(fmt.Sprintf("template_id = ? AND %s", statusExpr), templateID, statusVal).
+		Where("template_id = ? AND status <> ?", templateID, StatusDeleting).
 		Update("display_name", alias).Error; err != nil {
-		return fmt.Errorf("claim alias %q for template %s fail: %w", alias, templateID, err)
+		return result, fmt.Errorf("claim alias %q for template %s fail: %w", alias, templateID, err)
 	}
-	// Confirm the target still exists, holds the alias, and satisfies the
-	// status predicate. If it was hard-deleted / flipped to DELETING /
-	// (operator path) no longer READY between GetDefinition and this
-	// transaction, the confirm matches 0 rows and returning here rolls
-	// back the release so the original holder keeps its alias. A SELECT
-	// (not RowsAffected) avoids MySQL's rows-changed conflation.
-	var claimed int64
-	if err := tx.Table(constants.TemplateDefinitionTableName).
-		Where(fmt.Sprintf("template_id = ? AND alias_key = ? AND %s", statusExpr), templateID, alias, statusVal).
-		Count(&claimed).Error; err != nil {
-		return fmt.Errorf("confirm alias claim for template %s fail: %w", templateID, err)
-	}
-	if claimed == 0 {
-		// Operator path: distinguish "deleted" (404) from "exists but no
-		// longer READY" (409, retry once it rebuilds to READY).
-		if requireReady {
-			var exists int64
-			if err := tx.Table(constants.TemplateDefinitionTableName).
-				Where("template_id = ?", templateID).Count(&exists).Error; err != nil {
-				return fmt.Errorf("confirm existence for template %s fail: %w", templateID, err)
-			}
-			if exists > 0 {
-				return ErrTemplateNotReady
-			}
-		}
-		return ErrTemplateNotFound
-	}
-	return nil
+	result.Claimed = true
+	result.DisplacedTemplateID = holder.TemplateID
+	return result, nil
 }
 
 func lockTemplateDefinitionTx(tx *gorm.DB, templateID string) (*models.TemplateDefinition, error) {
@@ -1141,31 +1289,6 @@ func retryOnceOnDeadlock(run func() error) error {
 // HTTP 409 / RetCode=ErrorCode_Conflict without duplicating the driver
 // detection logic. See design §3.3.
 func IsDuplicateAliasError(err error) bool { return isDuplicateAliasError(err) }
-
-// claimAliasForReadyTemplate is the shared alias-claim helper used by both the
-// image-job and redo paths. It is called for a template that has reached a
-// non-FAILED status, and — per the create/claim ordering fix — runs *before*
-// that status is published, so a client that later observes READY is guaranteed
-// the alias already resolves. Returns a warning string (non-empty only if the
-// claim failed for a non-duplicate reason) and the claimed DisplayName
-// (the alias itself on success); the two are mutually exclusive.
-func claimAliasForReadyTemplate(ctx context.Context, templateID, alias string) (claimWarning, displayName string) {
-	alias = strings.TrimSpace(alias)
-	if alias == "" {
-		return "", ""
-	}
-	if claimErr := claimTemplateAlias(ctx, templateID, alias, false); claimErr != nil {
-		if isDuplicateAliasError(claimErr) {
-			log.G(ctx).Infof("alias %q concurrently claimed by another template; template %s is READY without alias", alias, templateID)
-			return "", ""
-		}
-		log.G(ctx).Warnf("claim alias %q for template %s fail: %v", alias, templateID, claimErr)
-		return fmt.Sprintf("template is ready but alias %q could not be claimed: %v", alias, claimErr), ""
-	}
-	// The claim just wrote display_name = alias, so the claimed display name is
-	// the alias itself — no read-back needed.
-	return "", alias
-}
 
 // SetTemplateAlias atomically sets, transfers, or clears the alias (display_name)
 // of an existing template-kind definition.
@@ -1260,7 +1383,7 @@ func setTemplateAliasLocked(ctx context.Context, templateID, alias string) error
 			} else if err != nil && !errors.Is(err, ErrTemplateNotFound) {
 				return err
 			}
-			if err := claimTemplateAliasTx(tx, templateID, alias, true); err != nil {
+			if err := claimTemplateAliasTx(tx, templateID, alias); err != nil {
 				return err
 			}
 			if err := syncCreateRedoImageJobAliasTx(tx, templateID, alias); err != nil {
@@ -1315,36 +1438,6 @@ func aliasFromRequestJSON(payload string) string {
 	}
 	a, _ := m["alias"].(string)
 	return a
-}
-
-// currentJobAlias re-reads the alias from the image job's stored RequestJSON.
-// Returns ok=false only on a read failure so finalize can skip claim (design
-// §3.6); a successfully-read "" is a real "cleared". Callers MUST NOT fall
-// back to a submit-time frozen alias when ok is false.
-func currentJobAlias(ctx context.Context, jobID string) (string, bool) {
-	job, err := getTemplateImageJobRecordByID(ctx, jobID)
-	if err != nil || job == nil {
-		return "", false
-	}
-	return aliasFromRequestJSON(job.RequestJSON), true
-}
-
-// aliasToClaimAtFinalize is the create/redo finalize alias (design §3.6):
-//  1. currentJobAlias ok=false → skip claim (empty)
-//  2. definition.DisplayName nonempty → claim DisplayName (covers operator SET
-//     during an in-flight redo; does NOT cover CLEAR)
-//  3. otherwise claim the job alias (first create, or operator CLEAR that
-//     already synced RequestJSON to "")
-func aliasToClaimAtFinalize(ctx context.Context, templateID, jobID string) string {
-	jobAlias, ok := currentJobAlias(ctx, jobID)
-	if !ok {
-		return ""
-	}
-	def, err := GetDefinition(ctx, templateID)
-	if err == nil && strings.TrimSpace(def.DisplayName) != "" {
-		return strings.TrimSpace(def.DisplayName)
-	}
-	return jobAlias
 }
 
 // syncCreateRedoImageJobAliasTx writes the operator alias into every CREATE

--- a/CubeMaster/pkg/templatecenter/store_alias_docker_test.go
+++ b/CubeMaster/pkg/templatecenter/store_alias_docker_test.go
@@ -42,17 +42,26 @@ func runAliasStoreCases(t *testing.T, db *gorm.DB) {
 	t.Run("GetByAliasExcludesSnapshots", func(t *testing.T) {
 		testGetByAliasExcludesSnapshots(t, db)
 	})
-	t.Run("ConcurrentCreateRedoIsMutex", func(t *testing.T) {
-		testConcurrentCreateRedoIsMutex(t, db)
+	t.Run("NewerBuildTransfersAlias", func(t *testing.T) {
+		testNewerBuildTransfersAlias(t, db)
 	})
-	t.Run("CreateRedoDoesNotStealReadyHolder", func(t *testing.T) {
-		testCreateRedoDoesNotStealReadyHolder(t, db)
+	t.Run("OlderBuildCannotReclaimAlias", func(t *testing.T) {
+		testOlderBuildCannotReclaimAlias(t, db)
 	})
-	t.Run("IdempotentReclaimOwnAlias", func(t *testing.T) {
-		testIdempotentReclaimOwnAlias(t, db)
+	t.Run("ConcurrentBuildClaimsConvergeToNewer", func(t *testing.T) {
+		testConcurrentBuildClaimsConvergeToNewer(t, db)
 	})
-	t.Run("FailedHolderOccupiesAliasKey", func(t *testing.T) {
-		testFailedHolderOccupiesAliasKey(t, db)
+	t.Run("UnorderedBuildDoesNotStealAlias", func(t *testing.T) {
+		testUnorderedBuildDoesNotStealAlias(t, db)
+	})
+	t.Run("BuildClaimsAliasFromDeletingHolderWithoutJob", func(t *testing.T) {
+		testBuildClaimsAliasFromDeletingHolderWithoutJob(t, db)
+	})
+	t.Run("BuildClearsDeletingHolderJobAlias", func(t *testing.T) {
+		testBuildClearsDeletingHolderJobAlias(t, db)
+	})
+	t.Run("PublishStatusClaimsTrimmedAlias", func(t *testing.T) {
+		testPublishStatusClaimsTrimmedAlias(t, db)
 	})
 	t.Run("SetAliasSyncsCreateRedoLeavesOthers", func(t *testing.T) {
 		testSetAliasSyncsCreateRedoLeavesOthers(t, db)
@@ -142,126 +151,220 @@ func testGetByAliasExcludesSnapshots(t *testing.T, db *gorm.DB) {
 		"a snapshot's alias must NOT resolve; got err=%v", err)
 }
 
-func testConcurrentCreateRedoIsMutex(t *testing.T, db *gorm.DB) {
-	suf := aliasCaseSuffix()
-	tplA := "tpl-conc-a-" + suf
-	tplB := "tpl-conc-b-" + suf
-	alias := "alias-conc-" + suf
-	insertReadyTemplate(t, db, tplA, "")
-	insertReadyTemplate(t, db, tplB, "")
-	cleanupTemplatesAndJobs(t, db, []string{tplA, tplB}, nil)
-
-	type result struct{ err error }
-	resCh := make(chan result, 2)
-	for _, id := range []string{tplA, tplB} {
-		go func(templateID string) {
-			resCh <- result{err: claimTemplateAlias(context.Background(), templateID, alias, false)}
-		}(id)
-	}
-	r1, r2 := <-resCh, <-resCh
-
-	successes, duplicates := 0, 0
-	for _, r := range []result{r1, r2} {
-		if r.err == nil {
-			successes++
-			continue
-		}
-		assert.True(t, isDuplicateAliasError(r.err),
-			"if a claim fails it must be a duplicate-key error; got: %v", r.err)
-		duplicates++
-	}
-	assert.Equal(t, 1, successes, "exactly one claim must succeed")
-	assert.Equal(t, 1, duplicates, "the loser must see a duplicate-key error")
-
-	got, err := GetTemplateByAlias(context.Background(), alias)
-	require.NoError(t, err)
-	assert.True(t, got.TemplateID == tplA || got.TemplateID == tplB,
-		"alias must resolve to one of the two templates; got %s", got.TemplateID)
-
-	otherID := tplA
-	if got.TemplateID == tplA {
-		otherID = tplB
-	}
-	otherDef, err := GetDefinition(context.Background(), otherID)
-	require.NoError(t, err)
-	assert.Empty(t, otherDef.DisplayName,
-		"the non-owning template's display_name must be empty; got %q", otherDef.DisplayName)
+func insertCreateJob(t *testing.T, db *gorm.DB, templateID, jobID, alias string) {
+	t.Helper()
+	insertImageJob(t, db, &models.TemplateImageJob{
+		JobID:       jobID,
+		TemplateID:  templateID,
+		RequestID:   "req-" + jobID,
+		Operation:   JobOperationCreate,
+		Status:      JobStatusReady,
+		RequestJSON: `{"alias":"` + alias + `"}`,
+	})
 }
 
-func testCreateRedoDoesNotStealReadyHolder(t *testing.T, db *gorm.DB) {
+func testNewerBuildTransfersAlias(t *testing.T, db *gorm.DB) {
 	suf := aliasCaseSuffix()
-	tplReady := "tpl-ready-" + suf
-	tplNew := "tpl-new-" + suf
-	alias := "alias-steal-" + suf
-	insertReadyTemplate(t, db, tplReady, alias)
-	insertReadyTemplate(t, db, tplNew, "")
-	cleanupTemplatesAndJobs(t, db, []string{tplReady, tplNew}, nil)
+	oldTemplateID := "tpl-ordered-old-" + suf
+	newTemplateID := "tpl-ordered-new-" + suf
+	oldJobID := "job-ordered-old-" + suf
+	newJobID := "job-ordered-new-" + suf
+	alias := "alias-ordered-" + suf
+	insertReadyTemplate(t, db, oldTemplateID, alias)
+	insertTemplate(t, db, newTemplateID, StatusPending, "")
+	insertCreateJob(t, db, oldTemplateID, oldJobID, alias)
+	insertImageJob(t, db, &models.TemplateImageJob{
+		JobID:       newJobID,
+		TemplateID:  newTemplateID,
+		RequestID:   "req-" + newJobID,
+		Operation:   JobOperationCreate,
+		Status:      JobStatusRunning,
+		RequestJSON: `{"alias":"` + alias + `"}`,
+	})
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, []string{oldJobID, newJobID})
 
-	err := claimTemplateAlias(context.Background(), tplNew, alias, false)
-	require.Error(t, err)
-	assert.True(t, isDuplicateAliasError(err), "create/redo collision must be duplicate-key; got %v", err)
+	displayName, warning, err := publishTemplateStatusWithAlias(
+		context.Background(), newTemplateID, newJobID, StatusReady, "",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, warning)
+	assert.Equal(t, alias, displayName)
 
-	readyDef, err := GetDefinition(context.Background(), tplReady)
+	holder, err := GetTemplateByAlias(context.Background(), alias)
 	require.NoError(t, err)
-	assert.Equal(t, alias, readyDef.DisplayName,
-		"READY holder display_name must never be cleared by create/redo claim")
-
-	newDef, err := GetDefinition(context.Background(), tplNew)
+	assert.Equal(t, newTemplateID, holder.TemplateID)
+	oldDef, err := GetDefinition(context.Background(), oldTemplateID)
 	require.NoError(t, err)
-	assert.Empty(t, newDef.DisplayName, "losing create/redo claimant must stay without alias")
-
-	require.NoError(t, claimTemplateAlias(context.Background(), tplNew, alias, true),
-		"operator path must still be able to transfer the alias")
-	readyDef, err = GetDefinition(context.Background(), tplReady)
+	assert.Empty(t, oldDef.DisplayName)
+	newDef, err := GetDefinition(context.Background(), newTemplateID)
 	require.NoError(t, err)
-	assert.Empty(t, readyDef.DisplayName)
-	newDef, err = GetDefinition(context.Background(), tplNew)
-	require.NoError(t, err)
+	assert.Equal(t, StatusReady, newDef.Status)
 	assert.Equal(t, alias, newDef.DisplayName)
+	var oldJob models.TemplateImageJob
+	require.NoError(t, db.Where("job_id = ?", oldJobID).First(&oldJob).Error)
+	assert.Empty(t, aliasFromRequestJSON(oldJob.RequestJSON))
 }
 
-func testIdempotentReclaimOwnAlias(t *testing.T, db *gorm.DB) {
+func testOlderBuildCannotReclaimAlias(t *testing.T, db *gorm.DB) {
 	suf := aliasCaseSuffix()
-	tplID := "tpl-reclaim-" + suf
-	alias := "alias-reclaim-" + suf
-	insertReadyTemplate(t, db, tplID, alias)
-	cleanupTemplatesAndJobs(t, db, []string{tplID}, nil)
+	oldTemplateID := "tpl-late-old-" + suf
+	newTemplateID := "tpl-late-new-" + suf
+	oldJobID := "job-late-old-" + suf
+	newJobID := "job-late-new-" + suf
+	alias := "alias-late-" + suf
+	insertReadyTemplate(t, db, oldTemplateID, "")
+	insertCreateJob(t, db, oldTemplateID, oldJobID, alias)
+	insertReadyTemplate(t, db, newTemplateID, alias)
+	insertCreateJob(t, db, newTemplateID, newJobID, alias)
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, []string{oldJobID, newJobID})
 
-	require.NoError(t, claimTemplateAlias(context.Background(), tplID, alias, false))
-	def, err := GetDefinition(context.Background(), tplID)
+	displayName, warning, err := publishTemplateStatusWithAlias(
+		context.Background(), oldTemplateID, oldJobID, StatusReady, "",
+	)
 	require.NoError(t, err)
+	assert.Empty(t, warning)
+	assert.Empty(t, displayName)
+
+	holder, err := GetTemplateByAlias(context.Background(), alias)
+	require.NoError(t, err)
+	assert.Equal(t, newTemplateID, holder.TemplateID)
+}
+
+func testConcurrentBuildClaimsConvergeToNewer(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	oldTemplateID := "tpl-concurrent-old-" + suf
+	newTemplateID := "tpl-concurrent-new-" + suf
+	oldJobID := "job-concurrent-old-" + suf
+	newJobID := "job-concurrent-new-" + suf
+	alias := "alias-concurrent-ordered-" + suf
+	insertReadyTemplate(t, db, oldTemplateID, "")
+	insertReadyTemplate(t, db, newTemplateID, "")
+	insertCreateJob(t, db, oldTemplateID, oldJobID, alias)
+	insertCreateJob(t, db, newTemplateID, newJobID, alias)
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, []string{oldJobID, newJobID})
+
+	errCh := make(chan error, 2)
+	go func() {
+		_, _, err := publishTemplateStatusWithAlias(context.Background(), oldTemplateID, oldJobID, StatusReady, "")
+		errCh <- err
+	}()
+	go func() {
+		_, _, err := publishTemplateStatusWithAlias(context.Background(), newTemplateID, newJobID, StatusReady, "")
+		errCh <- err
+	}()
+	require.NoError(t, <-errCh)
+	require.NoError(t, <-errCh)
+
+	holder, err := GetTemplateByAlias(context.Background(), alias)
+	require.NoError(t, err)
+	assert.Equal(t, newTemplateID, holder.TemplateID)
+}
+
+func testUnorderedBuildDoesNotStealAlias(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	holderID := "tpl-unordered-holder-" + suf
+	claimantID := "tpl-unordered-claimant-" + suf
+	claimantJobID := "job-unordered-claimant-" + suf
+	alias := "alias-unordered-" + suf
+	insertReadyTemplate(t, db, holderID, alias)
+	insertTemplate(t, db, claimantID, StatusPending, "")
+	insertCreateJob(t, db, claimantID, claimantJobID, alias)
+	cleanupTemplatesAndJobs(t, db, []string{holderID, claimantID}, []string{claimantJobID})
+
+	displayName, warning, err := publishTemplateStatusWithAlias(
+		context.Background(), claimantID, claimantJobID, StatusReady, "",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, warning, "has no CREATE/REDO job metadata")
+	assert.Empty(t, displayName)
+
+	holder, err := GetTemplateByAlias(context.Background(), alias)
+	require.NoError(t, err)
+	assert.Equal(t, holderID, holder.TemplateID)
+}
+
+func testBuildClaimsAliasFromDeletingHolderWithoutJob(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	holderID := "tpl-deleting-holder-" + suf
+	claimantID := "tpl-deleting-claimant-" + suf
+	claimantJobID := "job-deleting-claimant-" + suf
+	alias := "alias-deleting-holder-" + suf
+	insertTemplate(t, db, holderID, StatusDeleting, alias)
+	insertTemplate(t, db, claimantID, StatusPending, "")
+	insertCreateJob(t, db, claimantID, claimantJobID, alias)
+	cleanupTemplatesAndJobs(t, db, []string{holderID, claimantID}, []string{claimantJobID})
+
+	displayName, warning, err := publishTemplateStatusWithAlias(
+		context.Background(), claimantID, claimantJobID, StatusReady, "",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, warning)
+	assert.Equal(t, alias, displayName)
+
+	holder, err := GetTemplateByAlias(context.Background(), alias)
+	require.NoError(t, err)
+	assert.Equal(t, claimantID, holder.TemplateID)
+	deletingDef, err := GetDefinition(context.Background(), holderID)
+	require.NoError(t, err)
+	assert.Empty(t, deletingDef.DisplayName)
+}
+
+func testBuildClearsDeletingHolderJobAlias(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	holderID := "tpl-deleting-job-holder-" + suf
+	claimantID := "tpl-deleting-job-claimant-" + suf
+	holderJobID := "job-deleting-holder-" + suf
+	claimantJobID := "job-deleting-job-claimant-" + suf
+	alias := "alias-deleting-job-holder-" + suf
+	insertTemplate(t, db, holderID, StatusDeleting, alias)
+	insertTemplate(t, db, claimantID, StatusPending, "")
+	insertCreateJob(t, db, holderID, holderJobID, alias)
+	insertCreateJob(t, db, claimantID, claimantJobID, alias)
+	cleanupTemplatesAndJobs(t, db, []string{holderID, claimantID}, []string{holderJobID, claimantJobID})
+
+	displayName, warning, err := publishTemplateStatusWithAlias(
+		context.Background(), claimantID, claimantJobID, StatusReady, "",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, warning)
+	assert.Equal(t, alias, displayName)
+
+	var holderJob models.TemplateImageJob
+	require.NoError(t, db.Where("job_id = ?", holderJobID).First(&holderJob).Error)
+	assert.Empty(t, aliasFromRequestJSON(holderJob.RequestJSON))
+}
+
+func testPublishStatusClaimsTrimmedAlias(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	templateID := "tpl-publish-" + suf
+	jobID := "job-publish-" + suf
+	alias := "alias-publish-" + suf
+	insertTemplate(t, db, templateID, StatusPending, "")
+	insertImageJob(t, db, &models.TemplateImageJob{
+		JobID:       jobID,
+		TemplateID:  templateID,
+		RequestID:   "req-" + jobID,
+		Operation:   JobOperationCreate,
+		Status:      JobStatusRunning,
+		RequestJSON: `{"alias":"  ` + alias + `  "}`,
+	})
+	cleanupTemplatesAndJobs(t, db, []string{templateID}, []string{jobID})
+
+	displayName, warning, err := publishTemplateStatusWithAlias(
+		context.Background(), templateID, jobID, StatusReady, "",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, warning)
+	assert.Equal(t, alias, displayName)
+
+	def, err := GetDefinition(context.Background(), templateID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusReady, def.Status)
 	assert.Equal(t, alias, def.DisplayName)
-}
 
-func testFailedHolderOccupiesAliasKey(t *testing.T, db *gorm.DB) {
-	suf := aliasCaseSuffix()
-	tplFailed := "tpl-failed-" + suf
-	tplReady := "tpl-ready-" + suf
-	alias := "alias-failed-" + suf
-	insertTemplate(t, db, tplFailed, StatusFailed, alias)
-	insertReadyTemplate(t, db, tplReady, "")
-	cleanupTemplatesAndJobs(t, db, []string{tplFailed, tplReady}, nil)
-
-	err := claimTemplateAlias(context.Background(), tplReady, alias, false)
-	require.Error(t, err)
-	assert.True(t, isDuplicateAliasError(err), "FAILED holder must occupy alias_key; got %v", err)
-
-	readyDef, err := GetDefinition(context.Background(), tplReady)
+	holder, err := GetTemplateByAlias(context.Background(), alias)
 	require.NoError(t, err)
-	assert.Empty(t, readyDef.DisplayName, "READY challenger must stay without alias")
-
-	failedDef, err := GetDefinition(context.Background(), tplFailed)
-	require.NoError(t, err)
-	assert.Equal(t, alias, failedDef.DisplayName, "FAILED holder must keep the alias")
-
-	require.NoError(t, claimTemplateAlias(context.Background(), tplReady, alias, true),
-		"operator path must still be able to transfer the alias off a FAILED holder")
-	failedDef, err = GetDefinition(context.Background(), tplFailed)
-	require.NoError(t, err)
-	assert.Empty(t, failedDef.DisplayName)
-	readyDef, err = GetDefinition(context.Background(), tplReady)
-	require.NoError(t, err)
-	assert.Equal(t, alias, readyDef.DisplayName)
+	assert.Equal(t, templateID, holder.TemplateID)
 }
 
 func testSetAliasSyncsCreateRedoLeavesOthers(t *testing.T, db *gorm.DB) {
@@ -345,7 +448,7 @@ func testOperatorClaimRejectsNonReadyTarget(t *testing.T, db *gorm.DB) {
 	insertTemplate(t, db, tplID, StatusPending, "")
 	cleanupTemplatesAndJobs(t, db, []string{tplID}, nil)
 
-	err := claimTemplateAlias(context.Background(), tplID, alias, true)
+	err := SetTemplateAlias(context.Background(), tplID, alias)
 	require.ErrorIs(t, err, ErrTemplateNotReady)
 
 	def, err := GetDefinition(context.Background(), tplID)

--- a/CubeMaster/pkg/templatecenter/store_test.go
+++ b/CubeMaster/pkg/templatecenter/store_test.go
@@ -165,7 +165,7 @@ func TestCreateTemplateUsesRequestedDistributionScope(t *testing.T) {
 		}
 		return []ReplicaStatus{{NodeID: "node-a", NodeIP: "10.0.0.1", InstanceType: req.InstanceType, Status: ReplicaStatusReady}}, nil
 	})
-	patches.ApplyFunc(finalizeTemplateReplicas, func(ctx context.Context, templateID, instanceType, version, alias string, replicas []ReplicaStatus) (*TemplateInfo, string, error) {
+	patches.ApplyFunc(finalizeTemplateReplicas, func(ctx context.Context, templateID, jobID, instanceType, version string, replicas []ReplicaStatus) (*TemplateInfo, string, error) {
 		return &TemplateInfo{TemplateID: templateID, InstanceType: instanceType, Version: version, Replicas: replicas}, "", nil
 	})
 	patches.ApplyFunc(cleanupTemplateReplicas, func(ctx context.Context, templateID string) error {
@@ -199,19 +199,15 @@ func TestFinalizeTemplateReplicasClaimsAliasBeforePublishingReady(t *testing.T) 
 	defer patches.Reset()
 
 	var order []string
-	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string, requireReady bool) error {
-		order = append(order, "claim")
-		return nil
-	})
-	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+	patches.ApplyFunc(publishTemplateStatusWithAlias, func(ctx context.Context, templateID, jobID, status, lastError string) (string, string, error) {
 		order = append(order, "publish:"+status)
-		return nil
+		return "my-alias", "", nil
 	})
 	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
 	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
 
 	replicas := []ReplicaStatus{{NodeID: "node-a", NodeIP: "10.0.0.1", Status: ReplicaStatusReady}}
-	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-order", "cubebox", "v2", "my-alias", replicas)
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-order", "job-order", "cubebox", "v2", replicas)
 	if err != nil {
 		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
 	}
@@ -224,7 +220,7 @@ func TestFinalizeTemplateReplicasClaimsAliasBeforePublishingReady(t *testing.T) 
 	if info.DisplayName != "my-alias" {
 		t.Fatalf("expected DisplayName propagated, got %q", info.DisplayName)
 	}
-	if !reflect.DeepEqual(order, []string{"claim", "publish:" + StatusReady}) {
+	if !reflect.DeepEqual(order, []string{"publish:" + StatusReady}) {
 		t.Fatalf("alias must be claimed before READY is published; got order=%v", order)
 	}
 }
@@ -236,24 +232,21 @@ func TestFinalizeTemplateReplicasSkipsAliasClaimWhenFailed(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	claimed := false
-	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string, requireReady bool) error {
-		claimed = true
-		return nil
-	})
-	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
-		return nil
+	publishedStatus := ""
+	patches.ApplyFunc(publishTemplateStatusWithAlias, func(ctx context.Context, templateID, jobID, status, lastError string) (string, string, error) {
+		publishedStatus = status
+		return "", "", nil
 	})
 	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
 	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
 
 	replicas := []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusFailed, ErrorMessage: "boom"}}
-	_, _, err := finalizeTemplateReplicas(context.Background(), "tpl-failed", "cubebox", "v2", "my-alias", replicas)
+	_, _, err := finalizeTemplateReplicas(context.Background(), "tpl-failed", "job-failed", "cubebox", "v2", replicas)
 	if err == nil {
 		t.Fatalf("expected error for all-failed template")
 	}
-	if claimed {
-		t.Fatalf("alias must not be claimed for a FAILED template")
+	if publishedStatus != StatusFailed {
+		t.Fatalf("expected FAILED to be published, got %q", publishedStatus)
 	}
 }
 
@@ -266,13 +259,9 @@ func TestFinalizeTemplateReplicasClaimsAliasForPartiallyReady(t *testing.T) {
 	defer patches.Reset()
 
 	var order []string
-	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string, requireReady bool) error {
-		order = append(order, "claim")
-		return nil
-	})
-	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+	patches.ApplyFunc(publishTemplateStatusWithAlias, func(ctx context.Context, templateID, jobID, status, lastError string) (string, string, error) {
 		order = append(order, "publish:"+status)
-		return nil
+		return "my-alias", "", nil
 	})
 	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
 	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
@@ -281,7 +270,7 @@ func TestFinalizeTemplateReplicasClaimsAliasForPartiallyReady(t *testing.T) {
 		{NodeID: "node-a", Status: ReplicaStatusReady},
 		{NodeID: "node-b", Status: ReplicaStatusFailed, ErrorMessage: "boom"},
 	}
-	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-partial", "cubebox", "v2", "my-alias", replicas)
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-partial", "job-partial", "cubebox", "v2", replicas)
 	if err != nil {
 		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
 	}
@@ -291,7 +280,7 @@ func TestFinalizeTemplateReplicasClaimsAliasForPartiallyReady(t *testing.T) {
 	if info == nil || info.Status != StatusPartiallyReady {
 		t.Fatalf("expected PARTIALLY_READY info, got %#v", info)
 	}
-	if !reflect.DeepEqual(order, []string{"claim", "publish:" + StatusPartiallyReady}) {
+	if !reflect.DeepEqual(order, []string{"publish:" + StatusPartiallyReady}) {
 		t.Fatalf("alias must be claimed before status is published; got order=%v", order)
 	}
 }
@@ -305,8 +294,9 @@ func TestFinalizeTemplateReplicasSurfacesClaimWarningOnNonDuplicateError(t *test
 	defer patches.Reset()
 
 	published := false
-	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string, requireReady bool) error {
-		return errors.New("db unavailable")
+	patches.ApplyFunc(publishTemplateStatusWithAlias, func(ctx context.Context, templateID, jobID, status, lastError string) (string, string, error) {
+		published = true
+		return "", "template is ready but alias could not be claimed", nil
 	})
 	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
 		published = true
@@ -316,7 +306,7 @@ func TestFinalizeTemplateReplicasSurfacesClaimWarningOnNonDuplicateError(t *test
 	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
 
 	replicas := []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}
-	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-warn", "cubebox", "v2", "my-alias", replicas)
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-warn", "job-warn", "cubebox", "v2", replicas)
 	if err != nil {
 		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
 	}
@@ -339,8 +329,8 @@ func TestFinalizeTemplateReplicasSwallowsDuplicateAliasError(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string, requireReady bool) error {
-		return &mysql.MySQLError{Number: 1062, Message: "duplicate entry"}
+	patches.ApplyFunc(publishTemplateStatusWithAlias, func(ctx context.Context, templateID, jobID, status, lastError string) (string, string, error) {
+		return "", "", nil
 	})
 	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
 		return nil
@@ -349,7 +339,7 @@ func TestFinalizeTemplateReplicasSwallowsDuplicateAliasError(t *testing.T) {
 	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
 
 	replicas := []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}
-	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-dup", "cubebox", "v2", "my-alias", replicas)
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-dup", "job-dup", "cubebox", "v2", replicas)
 	if err != nil {
 		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
 	}
@@ -368,26 +358,18 @@ func TestFinalizeTemplateReplicasSkipsClaimForEmptyAlias(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	claimed := false
-	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string, requireReady bool) error {
-		claimed = true
-		return nil
-	})
 	published := false
-	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+	patches.ApplyFunc(publishTemplateStatusWithAlias, func(ctx context.Context, templateID, jobID, status, lastError string) (string, string, error) {
 		published = true
-		return nil
+		return "", "", nil
 	})
 	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
 	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
 
 	replicas := []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}
-	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-noalias", "cubebox", "v2", "", replicas)
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-noalias", "job-noalias", "cubebox", "v2", replicas)
 	if err != nil {
 		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
-	}
-	if claimed {
-		t.Fatalf("no alias must be claimed when alias is empty")
 	}
 	if !published || claimWarning != "" || info == nil || info.DisplayName != "" {
 		t.Fatalf("expected READY published, no warning, empty DisplayName; got warning=%q info=%#v", claimWarning, info)
@@ -407,25 +389,21 @@ func TestRefreshTemplateReplicaSummaryClaimsAliasBeforePublishingReady(t *testin
 	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
 		return []models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusReady}}, nil
 	})
-	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string, requireReady bool) error {
-		order = append(order, "claim")
-		return nil
-	})
-	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+	patches.ApplyFunc(publishTemplateStatusWithAlias, func(ctx context.Context, templateID, jobID, status, lastError string) (string, string, error) {
 		order = append(order, "publish:"+status)
-		return nil
+		return "my-alias", "", nil
 	})
 	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
 	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
 
-	claimWarning, err := refreshTemplateReplicaSummary(context.Background(), "tpl-redo", "my-alias")
+	claimWarning, err := refreshTemplateReplicaSummary(context.Background(), "tpl-redo", "job-redo")
 	if err != nil {
 		t.Fatalf("refreshTemplateReplicaSummary returned error: %v", err)
 	}
 	if claimWarning != "" {
 		t.Fatalf("unexpected claim warning: %q", claimWarning)
 	}
-	if !reflect.DeepEqual(order, []string{"claim", "publish:" + StatusReady}) {
+	if !reflect.DeepEqual(order, []string{"publish:" + StatusReady}) {
 		t.Fatalf("redo path must claim the alias before publishing READY; got order=%v", order)
 	}
 }
@@ -436,25 +414,22 @@ func TestRefreshTemplateReplicaSummarySkipsAliasClaimWhenFailed(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	claimed := false
+	publishedStatus := ""
 	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
 		return []models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusFailed, ErrorMessage: "boom"}}, nil
 	})
-	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string, requireReady bool) error {
-		claimed = true
-		return nil
-	})
-	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
-		return nil
+	patches.ApplyFunc(publishTemplateStatusWithAlias, func(ctx context.Context, templateID, jobID, status, lastError string) (string, string, error) {
+		publishedStatus = status
+		return "", "", nil
 	})
 	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
 	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
 
-	if _, err := refreshTemplateReplicaSummary(context.Background(), "tpl-redo-failed", "my-alias"); err != nil {
+	if _, err := refreshTemplateReplicaSummary(context.Background(), "tpl-redo-failed", "job-redo-failed"); err != nil {
 		t.Fatalf("refreshTemplateReplicaSummary returned error: %v", err)
 	}
-	if claimed {
-		t.Fatalf("alias must not be claimed for a FAILED template on the redo path")
+	if publishedStatus != StatusFailed {
+		t.Fatalf("expected FAILED to be published, got %q", publishedStatus)
 	}
 }
 
@@ -887,74 +862,6 @@ func TestSyncCreateRedoImageJobAliasTx_UpdateFailureIsFatal(t *testing.T) {
 	assert.Contains(t, err.Error(), "update failed")
 }
 
-// TestCurrentJobAlias_ReadsSyncedAlias verifies currentJobAlias re-reads the
-// alias from the job's RequestJSON at finalize time (the in-memory req.Alias is
-// frozen at submit, so only a DB re-read honors an operator change made after
-// the build started — design §3.6, the P1 fix).
-func TestCurrentJobAlias_ReadsSyncedAlias(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
-		return &models.TemplateImageJob{JobID: jobID, RequestJSON: `{"alias":"synced","source_image_ref":"img"}`}, nil
-	})
-	a, ok := currentJobAlias(context.Background(), "job-1")
-	assert.True(t, ok)
-	assert.Equal(t, "synced", a)
-}
-
-// TestCurrentJobAlias_HonorsClearedAlias verifies a cleared job RequestJSON
-// yields ("", true) — so finalize honors an operator clear instead of falling
-// back to the frozen create-time alias.
-func TestCurrentJobAlias_HonorsClearedAlias(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
-		return &models.TemplateImageJob{JobID: jobID, RequestJSON: `{"source_image_ref":"img"}`}, nil // alias cleared
-	})
-	a, ok := currentJobAlias(context.Background(), "job-1")
-	assert.True(t, ok)
-	assert.Equal(t, "", a)
-}
-
-// TestCurrentJobAlias_ReadErrorSkipsClaim verifies a read failure returns
-// ok=false so finalize skips claim instead of falling back to a frozen alias.
-func TestCurrentJobAlias_ReadErrorSkipsClaim(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
-		return nil, errors.New("db unavailable")
-	})
-	a, ok := currentJobAlias(context.Background(), "job-1")
-	assert.False(t, ok)
-	assert.Equal(t, "", a)
-	assert.Equal(t, "", aliasToClaimAtFinalize(context.Background(), "tpl-1", "job-1"),
-		"finalize must skip claim on read failure; never fall back to a frozen alias")
-}
-
-func TestAliasToClaimAtFinalize_PrefersDisplayName(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
-		return &models.TemplateImageJob{JobID: jobID, RequestJSON: `{"alias":"from-job"}`}, nil
-	})
-	patches.ApplyFunc(GetDefinition, func(ctx context.Context, templateID string) (*models.TemplateDefinition, error) {
-		return &models.TemplateDefinition{TemplateID: templateID, DisplayName: "from-def"}, nil
-	})
-	assert.Equal(t, "from-def", aliasToClaimAtFinalize(context.Background(), "tpl-1", "job-1"))
-}
-
-func TestAliasToClaimAtFinalize_UsesJobAliasWhenDisplayNameEmpty(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
-		return &models.TemplateImageJob{JobID: jobID, RequestJSON: `{"alias":"from-job"}`}, nil
-	})
-	patches.ApplyFunc(GetDefinition, func(ctx context.Context, templateID string) (*models.TemplateDefinition, error) {
-		return &models.TemplateDefinition{TemplateID: templateID, DisplayName: ""}, nil
-	})
-	assert.Equal(t, "from-job", aliasToClaimAtFinalize(context.Background(), "tpl-1", "job-1"))
-}
-
 // TestSetTemplateAlias_ValidatesAlias verifies that invalid alias strings
 // are rejected before any DB access, and that the rejection wraps
 // ErrInvalidAlias so the HTTP handler can map it to 400 (vs. raw DB errors
@@ -1064,16 +971,4 @@ func TestSyncCreateRedoImageJobAliasTx_NoJobsSucceeds(t *testing.T) {
 	})
 	require.NoError(t, syncCreateRedoImageJobAliasTx(&gorm.DB{}, "tpl-commit-origin", "new"),
 		"commit-origin templates with no CREATE/REDO jobs must still succeed")
-}
-
-func TestAliasToClaimAtFinalize_ClearedJobAndEmptyDisplayNameSkips(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
-		return &models.TemplateImageJob{JobID: jobID, RequestJSON: `{"source_image_ref":"img"}`}, nil
-	})
-	patches.ApplyFunc(GetDefinition, func(ctx context.Context, templateID string) (*models.TemplateDefinition, error) {
-		return &models.TemplateDefinition{TemplateID: templateID, DisplayName: ""}, nil
-	})
-	assert.Equal(t, "", aliasToClaimAtFinalize(context.Background(), "tpl-1", "job-1"))
 }

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -1666,7 +1666,7 @@ func TestRunRedoTemplateImageJobReloadsArtifactAfterBuildLock(t *testing.T) {
 	patches.ApplyFunc(createTemplateReplicasOnNodes, func(ctx context.Context, templateID string, req *types.CreateCubeSandboxReq, targets []*node.Node, opts replicaRunOptions) ([]ReplicaStatus, error) {
 		return []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}, nil
 	})
-	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID, alias string) (string, error) {
+	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID, jobID string) (string, error) {
 		return "", nil
 	})
 	patches.ApplyFunc(GetTemplateInfo, func(ctx context.Context, templateID string) (*TemplateInfo, error) {
@@ -1960,7 +1960,7 @@ func TestRunRedoTemplateImageJobRebuildsMissingArtifactBeforeRedistribution(t *t
 	patches.ApplyFunc(createTemplateReplicasOnNodes, func(ctx context.Context, templateID string, req *types.CreateCubeSandboxReq, targets []*node.Node, opts replicaRunOptions) ([]ReplicaStatus, error) {
 		return []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}, nil
 	})
-	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID, alias string) (string, error) {
+	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID, jobID string) (string, error) {
 		return "", nil
 	})
 	patches.ApplyFunc(GetTemplateInfo, func(ctx context.Context, templateID string) (*TemplateInfo, error) {
@@ -2067,7 +2067,7 @@ func TestRunRedoTemplateImageJobRegeneratesRequestForRedoTemplateID(t *testing.T
 		capturedReq = req
 		return []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}, nil
 	})
-	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID, alias string) (string, error) {
+	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID, jobID string) (string, error) {
 		return "", nil
 	})
 	patches.ApplyFunc(GetTemplateInfo, func(ctx context.Context, templateID string) (*TemplateInfo, error) {


### PR DESCRIPTION
## Summary

Nightly observed a newly rebuilt READY template losing its requested alias because the existing holder always won.

- Order CREATE/REDO alias claims by persisted job submission order so newer rebuilds win and older, slower builds cannot reclaim the alias.
- Serialize final alias selection with operator alias updates by locking and rereading the job/definition state in one transaction.
- Normalize job-derived aliases before claiming them.
- Publish alias ownership and template status atomically, preserving the previous holder if publication fails.
- Keep status-only fallback publication row-locked, DELETING-safe, conditional on the status remaining unchanged, and confirm it by matched-row count for MySQL compatibility.
- Clear a displaced holder's CREATE/REDO request aliases in the same transaction, including DELETING holders, so later rebuilds do not reclaim stale aliases.
- Surface database and missing-ordering-metadata claim failures as job warnings; log live-holder transfers at warning level.
- Keep DELETING targets from being resurrected by in-flight finalization, and allow their hidden aliases to transfer atomically to a valid build.
- Cover production-path ordering, concurrent convergence, missing ordering metadata, displaced job synchronization, DELETING holders, and trimmed aliases on MySQL/PostgreSQL fixtures.

Operator-assigned aliases currently participate in the same generation ordering and can be transferred by a newer CREATE/REDO claim. Exact operator-versus-build, alias-scoped, and legacy-holder ordering cannot be derived safely from `updated_at` or definition creation time; it requires separately persisted alias claim provenance and is deferred from this fix.

## Test plan

- [x] `go test -short ./pkg/templatecenter`
- [x] `make cubemaster`
- [ ] MySQL/PostgreSQL Docker-backed alias suites (local builder has no Docker socket; covered by repository CI environment)
- [ ] `cases/templates/test_alias.py::test_template_alias_rebuild_reassignment`

The ordering path depends on generated `alias_key`, row locks, and MySQL/PostgreSQL transaction semantics; SQLite would not provide equivalent concurrency coverage. Default short tests cover orchestration, while the shared MySQL/PostgreSQL suite exercises the real claim/publish implementation.

Assisted-by: Claude Code:claude-opus-4.7