### PR TITLE
perf(clm): Reduce cross-replica resume wakeup latency

### DIFF
--- a/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
+++ b/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/config"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/cubemasterclient"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/discovery"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/eventbus"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/httpapi"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/proxypush"
@@ -67,6 +68,18 @@ func run() error {
 	stream := redisstream.New(rdb, logger.Named("redis"))
 	masterClient := cubemasterclient.New(cfg.CubeMasterURL, cfg.HTTPTimeout)
 	reg := registry.New()
+
+	// The eventbus carries best-effort cross-replica wakeup hints. Redis
+	// remains the source of truth and the wait path retains polling fallback.
+	var bus *eventbus.Bus
+	if cfg.EventBusEnabled {
+		bus = eventbus.New()
+		stream.SetNotifyEnabled(true)
+		stream.SetLocalBus(bus)
+		logger.Info("eventbus enabled")
+	} else {
+		logger.Info("eventbus disabled (waitForRunning will poll)")
+	}
 
 	rootCtx, cancel := signalContext()
 	defer cancel()
@@ -147,6 +160,7 @@ func run() error {
 		ProxyPush:    pushClient,
 		StateLockTTL: cfg.StateLockTTL,
 		Log:          logger.Named("resumer"),
+		EventBus:     bus,
 	})
 
 	sweep := sweeper.New(sweeper.Options{
@@ -170,6 +184,9 @@ func run() error {
 	if discSvc != nil {
 		loopCount++
 	}
+	if cfg.EventBusEnabled {
+		loopCount++
+	}
 	stateSyncDeps := statesync.Deps{
 		Registry:  reg,
 		Redis:     stream,
@@ -187,6 +204,10 @@ func run() error {
 	go func() { errs <- apiSrv.Run(rootCtx) }()
 	if discSvc != nil {
 		go func() { errs <- discSvc.Run(rootCtx) }()
+	}
+	if cfg.EventBusEnabled {
+		sub := eventbus.NewSubscriber(rdb, bus, logger.Named("eventbus"))
+		go func() { errs <- sub.Run(rootCtx) }()
 	}
 
 	// First loop to return wins; we cancel siblings via context and drain.

--- a/cube-lifecycle-manager/internal/config/config.go
+++ b/cube-lifecycle-manager/internal/config/config.go
@@ -85,6 +85,12 @@ type Config struct {
 	HeartbeatTTL time.Duration
 	// DiscoveryRefresh: cadence of the Redis heartbeat scan.
 	DiscoveryRefresh time.Duration
+
+	// EventBusEnabled toggles Pub/Sub wakeup hints for cross-replica resume
+	// waiters. When false, state writes stay on the legacy Redis Set/Del
+	// path and resumer.waitForRunning uses its 100ms polling ticker.
+	// Set CUBE_LCM_EVENTBUS_ENABLED=false as a kill switch.
+	EventBusEnabled bool
 }
 
 // Default returns a config populated with safe defaults; callers then override
@@ -112,6 +118,7 @@ func Default() *Config {
 		UseStaticFleet:   false,
 		HeartbeatTTL:     15 * time.Second,
 		DiscoveryRefresh: 3 * time.Second,
+		EventBusEnabled:  true,
 	}
 }
 
@@ -222,7 +229,14 @@ func Load() (*Config, error) {
 			c.DiscoveryRefresh = d
 		}
 	}
-
+	if v := os.Getenv("CUBE_LCM_EVENTBUS_ENABLED"); v != "" {
+		enabled, err := strconv.ParseBool(v)
+		if err != nil {
+			addErr("CUBE_LCM_EVENTBUS_ENABLED", err)
+		} else {
+			c.EventBusEnabled = enabled
+		}
+	}
 	if c.ConsumerName == "" {
 		host, err := os.Hostname()
 		if err != nil {

--- a/cube-lifecycle-manager/internal/config/config_test.go
+++ b/cube-lifecycle-manager/internal/config/config_test.go
@@ -49,6 +49,22 @@ func TestValidateRedisEmpty(t *testing.T) {
 	assert.Contains(t, err.Error(), "CUBE_LCM_REDIS_ADDR")
 }
 
+func TestEventBusEnabledDefaultAndKillSwitch(t *testing.T) {
+	assert.True(t, Default().EventBusEnabled)
+
+	t.Setenv("CUBE_LCM_EVENTBUS_ENABLED", "false")
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.False(t, cfg.EventBusEnabled)
+}
+
+func TestEventBusEnabledRejectsInvalidValue(t *testing.T) {
+	t.Setenv("CUBE_LCM_EVENTBUS_ENABLED", "disable")
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CUBE_LCM_EVENTBUS_ENABLED")
+}
+
 func TestParseSentinelAddrs(t *testing.T) {
 	assert.Equal(t, []string{"10.0.0.11:26379", "10.0.0.12:26379"}, parseSentinelAddrs("10.0.0.11, 10.0.0.12"))
 	assert.Equal(t, []string{"10.0.0.11:26379", "10.0.0.12:26380"}, parseSentinelAddrs("10.0.0.11:26379,10.0.0.12:26380"))

--- a/cube-lifecycle-manager/internal/eventbus/bus.go
+++ b/cube-lifecycle-manager/internal/eventbus/bus.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Package eventbus fans Redis Pub/Sub wakeup hints out to local waiters.
+// It deliberately keeps no event history: Redis remains the source of truth,
+// and callers read the current state after every wakeup.
+package eventbus
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Bus is safe for concurrent use.
+type Bus struct {
+	mu      sync.Mutex
+	waiters map[string]map[chan struct{}]struct{}
+}
+
+func New() *Bus {
+	return &Bus{
+		waiters: make(map[string]map[chan struct{}]struct{}),
+	}
+}
+
+// Publish fans a wakeup hint out to current waiters. It never blocks and does
+// not retain the event for future waiters.
+func (b *Bus) Publish(sandboxID string) {
+	if sandboxID == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for ch := range b.waiters[sandboxID] {
+		select {
+		case ch <- struct{}{}:
+		default:
+			// A hint is already pending. Redis will be read when it is
+			// consumed, so another hint adds no information.
+		}
+	}
+}
+
+// Wait registers a listener. The caller must invoke cancel when done.
+func (b *Bus) Wait(sandboxID string) (<-chan struct{}, func()) {
+	ch := make(chan struct{}, 1)
+
+	b.mu.Lock()
+	set, ok := b.waiters[sandboxID]
+	if !ok {
+		set = make(map[chan struct{}]struct{}, 1)
+		b.waiters[sandboxID] = set
+	}
+	set[ch] = struct{}{}
+	b.mu.Unlock()
+
+	var cancelled atomic.Bool
+	cancel := func() {
+		if !cancelled.CompareAndSwap(false, true) {
+			return
+		}
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if set, ok := b.waiters[sandboxID]; ok {
+			delete(set, ch)
+			if len(set) == 0 {
+				delete(b.waiters, sandboxID)
+			}
+		}
+	}
+	return ch, cancel
+}

--- a/cube-lifecycle-manager/internal/eventbus/bus_test.go
+++ b/cube-lifecycle-manager/internal/eventbus/bus_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package eventbus
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBus_WaitReceivesLivePublish(t *testing.T) {
+	b := New()
+	ch, cancel := b.Wait("sbx")
+	defer cancel()
+
+	b.Publish("sbx")
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("Wait channel did not receive live publish")
+	}
+}
+
+func TestBus_DoesNotReplayPastPublish(t *testing.T) {
+	b := New()
+	b.Publish("sbx")
+
+	ch, cancel := b.Wait("sbx")
+	defer cancel()
+
+	select {
+	case <-ch:
+		t.Fatal("past event must not be replayed")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestBus_MultipleWaitersAllReceive(t *testing.T) {
+	b := New()
+	const waiterCount = 8
+
+	chs := make([]<-chan struct{}, waiterCount)
+	cancels := make([]func(), waiterCount)
+	for i := range chs {
+		chs[i], cancels[i] = b.Wait("sbx")
+	}
+	defer func() {
+		for _, cancel := range cancels {
+			cancel()
+		}
+	}()
+
+	b.Publish("sbx")
+	for i, ch := range chs {
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatalf("waiter %d did not receive event", i)
+		}
+	}
+}
+
+func TestBus_CancelPreventsFurtherDelivery(t *testing.T) {
+	b := New()
+	ch, cancel := b.Wait("sbx")
+	cancel()
+	cancel() // idempotent
+
+	b.Publish("sbx")
+	select {
+	case <-ch:
+		t.Fatal("post-cancel delivery")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestBus_ConcurrentPublishAndCancel(t *testing.T) {
+	b := New()
+	const waiterCount = 100
+
+	cancels := make([]func(), waiterCount)
+	for i := range cancels {
+		_, cancels[i] = b.Wait("sbx")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(waiterCount + 1)
+	for _, cancel := range cancels {
+		cancel := cancel
+		go func() {
+			defer wg.Done()
+			cancel()
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		for i := 0; i < waiterCount; i++ {
+			b.Publish("sbx")
+		}
+	}()
+	wg.Wait()
+}
+
+func TestBus_EmptySandboxIDIgnored(t *testing.T) {
+	b := New()
+	ch, cancel := b.Wait("")
+	defer cancel()
+
+	b.Publish("")
+	select {
+	case <-ch:
+		t.Fatal("empty-id publish should be a no-op")
+	case <-time.After(20 * time.Millisecond):
+	}
+}

--- a/cube-lifecycle-manager/internal/eventbus/subscriber.go
+++ b/cube-lifecycle-manager/internal/eventbus/subscriber.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package eventbus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
+)
+
+// Subscriber owns the always-on Redis Pub/Sub subscription that feeds the
+// in-process Bus. go-redis handles reconnecting and resubscribing.
+type Subscriber struct {
+	rdb redis.UniversalClient
+	bus *Bus
+	log *zap.Logger
+}
+
+// NewSubscriber constructs a Subscriber. The Bus + Redis client are
+// borrowed, not owned; caller is responsible for Close on the client.
+func NewSubscriber(rdb redis.UniversalClient, bus *Bus, log *zap.Logger) *Subscriber {
+	return &Subscriber{rdb: rdb, bus: bus, log: log}
+}
+
+// Run keeps retrying subscription setup until the context is cancelled.
+// Pub/Sub is an optimization, so a transient setup failure must not stop CLM.
+func (s *Subscriber) Run(ctx context.Context) error {
+	const retryDelay = time.Second
+	for {
+		err := s.runOnce(ctx)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		s.log.Warn("eventbus subscriber unavailable; retrying",
+			zap.Duration("retry_delay", retryDelay),
+			zap.Error(err))
+
+		timer := time.NewTimer(retryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *Subscriber) runOnce(ctx context.Context) error {
+	pubsub := s.rdb.Subscribe(ctx, lifecycle.EventChannel)
+	defer func() { _ = pubsub.Close() }()
+
+	if _, err := pubsub.Receive(ctx); err != nil {
+		return fmt.Errorf("subscribe %s: %w", lifecycle.EventChannel, err)
+	}
+
+	ch := pubsub.Channel(redis.WithChannelSize(256))
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg, ok := <-ch:
+			if !ok {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return errChannelClosed
+			}
+			var ev lifecycle.StateNotify
+			if err := json.Unmarshal([]byte(msg.Payload), &ev); err != nil {
+				s.log.Warn("eventbus decode failed",
+					zap.String("channel", msg.Channel),
+					zap.Int("payload_bytes", len(msg.Payload)),
+					zap.Error(err))
+				continue
+			}
+			s.bus.Publish(ev.SandboxID)
+		}
+	}
+}
+
+var errChannelClosed = errors.New("pubsub channel closed")

--- a/cube-lifecycle-manager/internal/httpapi/server_test.go
+++ b/cube-lifecycle-manager/internal/httpapi/server_test.go
@@ -49,6 +49,15 @@ func (f *fakeStore) GetState(_ context.Context, sid string) (string, bool, error
 	return v, ok, nil
 }
 
+// WriteState / ClearStateNotify are the notify-emitting equivalents.
+// The httpapi tests only assert on state values, not notify payloads.
+func (f *fakeStore) WriteState(ctx context.Context, sid, state string, ttl time.Duration) error {
+	return f.SetState(ctx, sid, state, ttl)
+}
+func (f *fakeStore) ClearStateNotify(ctx context.Context, sid string) error {
+	return f.ClearState(ctx, sid)
+}
+
 type fakeMaster struct {
 	calls    int32
 	failNext bool

--- a/cube-lifecycle-manager/internal/lifecycle/schema.go
+++ b/cube-lifecycle-manager/internal/lifecycle/schema.go
@@ -28,11 +28,25 @@ const (
 	// EventStreamMaxLen caps the stream so an offline sidecar cannot drive
 	// unbounded Redis growth.
 	EventStreamMaxLen = 100000
+
+	// EventChannel carries best-effort state-change wakeup hints. Redis
+	// state keys remain the source of truth.
+	EventChannel = "cube:v1:shared:sandbox:lifecycle:notify"
 )
 
-// StateKey returns the per-sandbox pause/resume coordination key. Values are
-// "running" | "pausing" | "paused" | "resuming". The sidecar uses SETNX with
-// TTL to coordinate concurrent pause/resume across replicas.
+// StateKilled is a state-key marker for a sandbox killed by the sweeper. It is
+// intentionally not part of the {paused, running} terminal set emitted on the
+// events stream.
+const StateKilled = "killed"
+
+// StateNotify is a best-effort wakeup hint. Consumers must read the state key
+// after receiving it instead of trusting the payload as current truth.
+type StateNotify struct {
+	SandboxID string `json:"sandbox_id"`
+}
+
+// StateKey returns the per-sandbox coordination key. Values include running,
+// pausing, paused, resuming, killing, and killed.
 func StateKey(sandboxID string) string {
 	return "cube:v1:shared:sandbox:lifecycle:state:" + sandboxID
 }

--- a/cube-lifecycle-manager/internal/lifecycle/schema_test.go
+++ b/cube-lifecycle-manager/internal/lifecycle/schema_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package lifecycle
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStateNotify_JSONRoundTrip(t *testing.T) {
+	in := StateNotify{
+		SandboxID: "sbx-1",
+	}
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out StateNotify
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if in != out {
+		t.Fatalf("round-trip lost fields: in=%+v out=%+v", in, out)
+	}
+}
+
+func TestEventChannel(t *testing.T) {
+	const want = "cube:v1:shared:sandbox:lifecycle:notify"
+	if EventChannel != want {
+		t.Fatalf("EventChannel = %q, want %q", EventChannel, want)
+	}
+}

--- a/cube-lifecycle-manager/internal/redisstream/stream.go
+++ b/cube-lifecycle-manager/internal/redisstream/stream.go
@@ -20,15 +20,48 @@ import (
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
 )
 
+// notifyPublishTimeout bounds the best-effort Redis PUBLISH. It is detached
+// from the caller context so a cancelled request cannot drop the hint.
+const notifyPublishTimeout = 500 * time.Millisecond
+
 // Client wraps a go-redis client with lifecycle-shaped methods.
 type Client struct {
 	rdb redis.UniversalClient
 	log *zap.Logger
+
+	// notifyEnabled toggles the Pub/Sub companion emitted alongside every
+	// terminal state write. Off by default so a rollout can enable the
+	// subscriber side first; flipped on via SetNotifyEnabled(true) from
+	// main once Config.EventBusEnabled is true.
+	notifyEnabled bool
+	// localBus, when non-nil, receives every StateNotify locally before it
+	// hits Redis. Same-replica waiters wake without a Pub/Sub round-trip.
+	// Nil is legal and simply means "publish to Redis only".
+	localBus localPublisher
+}
+
+// localPublisher is the subset of eventbus.Bus we need. Kept as an
+// interface here so redisstream does not import eventbus and create a
+// dependency cycle (eventbus already imports lifecycle; main.go stitches
+// the two together).
+type localPublisher interface {
+	Publish(sandboxID string)
 }
 
 func New(rdb redis.UniversalClient, log *zap.Logger) *Client {
 	return &Client{rdb: rdb, log: log}
 }
+
+// SetNotifyEnabled toggles the Pub/Sub publish that accompanies WriteState /
+// ClearStateNotify. When disabled, those methods behave exactly like the
+// legacy SetState / ClearState. Safe to call at startup only.
+func (c *Client) SetNotifyEnabled(on bool) { c.notifyEnabled = on }
+
+// SetLocalBus wires a same-process fan-out that receives every StateNotify
+// synchronously alongside the Redis PUBLISH. Same-replica waiters can
+// therefore be woken with zero Redis round-trip. Passing nil disables the
+// local fan-out. Safe to call at startup only.
+func (c *Client) SetLocalBus(bus localPublisher) { c.localBus = bus }
 
 // Bootstrap returns every sandbox in cube:v1:shared:sandbox:lifecycle:meta.
 // Empty result is fine — it just means CubeMaster hasn't published anything yet.
@@ -168,6 +201,67 @@ func (c *Client) GetState(ctx context.Context, sandboxID string) (string, bool, 
 		return "", false, err
 	}
 	return v, true, nil
+}
+
+// WriteState performs SetState and, when notifications are enabled,
+// publishes a best-effort wakeup hint. Redis remains the source of truth.
+//
+// Failures on the notify path are logged, not returned: the durable Redis
+// write is the source of truth. Waiters degrade to fallback polling and
+// still converge.
+func (c *Client) WriteState(ctx context.Context, sandboxID, state string, ttl time.Duration) error {
+	if err := c.SetState(ctx, sandboxID, state, ttl); err != nil {
+		return err
+	}
+	c.publishNotify(sandboxID)
+	return nil
+}
+
+// ClearStateNotify is the ClearState + Pub/Sub companion used on rollback.
+func (c *Client) ClearStateNotify(ctx context.Context, sandboxID string) error {
+	if err := c.ClearState(ctx, sandboxID); err != nil {
+		return err
+	}
+	c.publishNotify(sandboxID)
+	return nil
+}
+
+// publishNotify fans a hint out locally and over Redis Pub/Sub. It never
+// returns an error: any notify failure degrades to fallback polling.
+func (c *Client) publishNotify(sandboxID string) {
+	if !c.notifyEnabled {
+		return
+	}
+
+	// Local fan-out first: same-replica waiters wake immediately, even if
+	// the Redis PUBLISH below is slow or the caller context is already done.
+	if c.localBus != nil {
+		c.localBus.Publish(sandboxID)
+	}
+
+	payload, err := json.Marshal(lifecycle.StateNotify{SandboxID: sandboxID})
+	if err != nil {
+		// Should never happen — StateNotify is a plain struct.
+		c.log.Warn("state notify marshal failed",
+			zap.String("sandbox_id", sandboxID), zap.Error(err))
+		return
+	}
+
+	// Detach from the caller context and run off the owner path: a cancelled
+	// request must not drop the hint, and resume/pause/kill must not wait
+	// on the extra Redis RTT. Waiters still converge via fallback polling.
+	go c.publishNotifyRedis(sandboxID, payload)
+}
+
+func (c *Client) publishNotifyRedis(sandboxID string, payload []byte) {
+	ctx, cancel := context.WithTimeout(context.Background(), notifyPublishTimeout)
+	defer cancel()
+	if err := c.rdb.Publish(ctx, lifecycle.EventChannel, payload).Err(); err != nil {
+		c.log.Warn("state notify publish failed",
+			zap.String("sandbox_id", sandboxID),
+			zap.String("channel", lifecycle.EventChannel),
+			zap.Error(err))
+	}
 }
 
 func decodeEvent(msg redis.XMessage) *Event {

--- a/cube-lifecycle-manager/internal/redisstream/stream_test.go
+++ b/cube-lifecycle-manager/internal/redisstream/stream_test.go
@@ -5,13 +5,123 @@
 package redisstream
 
 import (
+	"context"
 	"encoding/json"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
 
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
 )
+
+// stubRedis implements the Set/Del/Publish subset WriteState and
+// ClearStateNotify need. Other UniversalClient methods panic if called.
+type stubRedis struct {
+	redis.UniversalClient
+	publishCh chan publishCall
+}
+
+type publishCall struct {
+	ctx     context.Context
+	channel string
+	payload string
+}
+
+func (s *stubRedis) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) *redis.StatusCmd {
+	cmd := redis.NewStatusCmd(ctx)
+	cmd.SetVal("OK")
+	return cmd
+}
+
+func (s *stubRedis) Del(ctx context.Context, keys ...string) *redis.IntCmd {
+	cmd := redis.NewIntCmd(ctx)
+	cmd.SetVal(1)
+	return cmd
+}
+
+func (s *stubRedis) Publish(ctx context.Context, channel string, message interface{}) *redis.IntCmd {
+	var payload string
+	switch v := message.(type) {
+	case string:
+		payload = v
+	case []byte:
+		payload = string(v)
+	default:
+		payload = ""
+	}
+	s.publishCh <- publishCall{ctx: ctx, channel: channel, payload: payload}
+	cmd := redis.NewIntCmd(ctx)
+	cmd.SetVal(1)
+	return cmd
+}
+
+type recordingBus struct {
+	mu   sync.Mutex
+	ids  []string
+	done chan struct{}
+}
+
+func (b *recordingBus) Publish(sandboxID string) {
+	b.mu.Lock()
+	b.ids = append(b.ids, sandboxID)
+	b.mu.Unlock()
+	select {
+	case <-b.done:
+	default:
+		close(b.done)
+	}
+}
+
+func TestWriteState_PublishDetachedAndNonBlocking(t *testing.T) {
+	rdb := &stubRedis{publishCh: make(chan publishCall)}
+	bus := &recordingBus{done: make(chan struct{})}
+	c := New(rdb, zap.NewNop())
+	c.SetNotifyEnabled(true)
+	c.SetLocalBus(bus)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	if err := c.WriteState(ctx, "sbx", "running", time.Second); err != nil {
+		t.Fatalf("WriteState: %v", err)
+	}
+	if time.Since(started) > 50*time.Millisecond {
+		t.Fatal("WriteState blocked on Redis PUBLISH")
+	}
+
+	select {
+	case <-bus.done:
+	case <-time.After(time.Second):
+		t.Fatal("local bus was not published synchronously")
+	}
+
+	select {
+	case call := <-rdb.publishCh:
+		if call.channel != lifecycle.EventChannel {
+			t.Fatalf("channel = %q", call.channel)
+		}
+		if call.payload != `{"sandbox_id":"sbx"}` {
+			t.Fatalf("payload = %q", call.payload)
+		}
+		if call.ctx == ctx {
+			t.Fatal("PUBLISH used the cancelled caller context")
+		}
+		deadline, ok := call.ctx.Deadline()
+		if !ok {
+			t.Fatal("PUBLISH context has no timeout")
+		}
+		remain := time.Until(deadline)
+		if remain <= 0 || remain > notifyPublishTimeout+50*time.Millisecond {
+			t.Fatalf("PUBLISH timeout remaining = %v, want (0, %v]", remain, notifyPublishTimeout)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Redis PUBLISH was not issued")
+	}
+}
 
 func metaEntry(t *testing.T, op, sid string, meta lifecycle.SandboxLifecycleMeta) redis.XMessage {
 	t.Helper()

--- a/cube-lifecycle-manager/internal/resumer/iface.go
+++ b/cube-lifecycle-manager/internal/resumer/iface.go
@@ -16,6 +16,10 @@ type stateStore interface {
 	SetState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
 	ClearState(ctx context.Context, sandboxID string) error
 	GetState(ctx context.Context, sandboxID string) (string, bool, error)
+	// WriteState / ClearStateNotify are the notify-emitting equivalents of
+	// SetState / ClearState. The concrete client can disable notifications.
+	WriteState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
+	ClearStateNotify(ctx context.Context, sandboxID string) error
 }
 
 // resumePauser describes the slice of CubeMaster client we need.
@@ -29,4 +33,11 @@ type resumePauser interface {
 type stateNotifier interface {
 	SetState(ctx context.Context, sandboxID, state string) error
 	DeleteMeta(ctx context.Context, sandboxID string) error
+}
+
+// waitBus is the eventbus subset we consume: register a listener that
+// receives the next StateNotify for a sandbox, plus the cancel func the
+// listener MUST call before returning. Concrete impl is *eventbus.Bus.
+type waitBus interface {
+	Wait(sandboxID string) (<-chan struct{}, func())
 }

--- a/cube-lifecycle-manager/internal/resumer/resumer.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/cubemasterclient"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/registry"
 )
 
@@ -31,6 +32,11 @@ type Options struct {
 	ProxyPush    stateNotifier
 	StateLockTTL time.Duration
 	Log          *zap.Logger
+	// EventBus, when non-nil, wakes waitForRunning via cross-replica
+	// StateNotify events. Nil is legal — the wait path degrades to
+	// polling only (the 100ms ticker), which is what happens when the
+	// eventbus feature flag is off.
+	EventBus waitBus
 }
 
 // Resumer coalesces concurrent resume requests for the same sandbox into a
@@ -47,6 +53,7 @@ type Resumer struct {
 const (
 	proxyStatePushTimeout = 3 * time.Second
 	proxyStatePushRetries = 2
+	waitPollInterval      = 100 * time.Millisecond
 )
 
 // call represents one in-flight resume operation. Every goroutine waiting on
@@ -127,7 +134,7 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 		// auto-resume, and release the lock we just SET so the sweeper
 		// doesn't skip decisions for its TTL window.
 		if !entry.Meta.AutoResume {
-			_ = r.o.Redis.ClearState(ctx, sandboxID)
+			_ = r.o.Redis.ClearStateNotify(ctx, sandboxID)
 			return errors.New("auto_resume not enabled for sandbox")
 		}
 		if err := r.callCubeMasterResume(ctx, sandboxID, entry.Meta.InstanceType); err != nil {
@@ -163,7 +170,7 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 	//     misleading. The proxy's log_phase will eventually overwrite
 	//     this via the periodic last_active poll, but we want the right
 	//     answer immediately, not 5–10 seconds later.
-	if err := r.o.Redis.SetState(ctx, sandboxID, "running", r.o.StateLockTTL); err != nil {
+	if err := r.o.Redis.WriteState(ctx, sandboxID, "running", r.o.StateLockTTL); err != nil {
 		r.o.Log.Warn("write running state failed",
 			zap.String("sandbox_id", sandboxID), zap.Error(err))
 	}
@@ -224,7 +231,7 @@ func (r *Resumer) callCubeMasterResume(ctx context.Context, sandboxID, instanceT
 		// from under us. Evict everywhere and surface as an error to
 		// the HTTP caller so CubeProxy returns 5xx (the dataplane
 		// request can't be served either way).
-		_ = r.o.Redis.ClearState(ctx, sandboxID)
+		_ = r.o.Redis.ClearStateNotify(ctx, sandboxID)
 		_ = r.o.ProxyPush.DeleteMeta(ctx, sandboxID)
 		r.o.Registry.Delete(sandboxID)
 		r.o.Log.Info("sandbox not found on cubemaster during resume; evicted",
@@ -242,7 +249,7 @@ func (r *Resumer) callCubeMasterResume(ctx context.Context, sandboxID, instanceT
 	default:
 		// Real failure: clear the resuming key so a future request can
 		// retry, and surface the error.
-		_ = r.o.Redis.ClearState(ctx, sandboxID)
+		_ = r.o.Redis.ClearStateNotify(ctx, sandboxID)
 		return errors.New("cubemaster resume: " + resumeErr.Error())
 	}
 }
@@ -318,45 +325,102 @@ func (r *Resumer) acquireResumeOwnership(ctx context.Context, sandboxID string) 
 // as a successful no-op (state will be re-asserted into the proxy dict).
 var errAlreadyRunning = errors.New("sandbox already running")
 
-// waitForRunning is invoked when AcquireState lost the SETNX race — i.e.
-// some other key/holder occupies cube:v1:shared:sandbox:lifecycle:state:<id>.
-// We poll that key for one of three terminal outcomes:
+// waitForRunning is invoked when acquireResumeOwnership observed a peer's
+// transition lock ("pausing" or "resuming") and we must not fire our own
+// duplicate RPC. It resolves the peer's outcome when:
 //
 //   - state == "running"    → peer succeeded, request can proceed.
 //   - state == "paused"     → peer gave up; bail with an error so
 //     CubeProxy returns 503 and the next request
 //     gets a fresh resume attempt.
-//   - key expired (!ok)     → peer crashed mid-flight; do NOT treat this
-//     as success — return a clear error so the
-//     caller can retry. Without this guard we
-//     would silently let through a request to a
-//     still-paused sandbox.
+//   - state == "killed"     → peer (sweeper) destroyed the sandbox.
+//   - key expired (!ok)     → peer crashed mid-flight; return an error so
+//     the caller re-enters Resume() cleanly.
+//
+// Implementation modes:
+//
+//   - When Options.EventBus is nil (feature flag off), we degrade to the
+//     100ms Redis GET ticker.
+//   - When Options.EventBus is non-nil, we register a listener before the
+//     first GET. Pub/Sub only wakes the waiter; Redis is read after every
+//     hint. The 100ms poll remains as a lost-message fallback.
 func (r *Resumer) waitForRunning(ctx context.Context, sandboxID string) error {
-	const pollEvery = 200 * time.Millisecond
-	t := time.NewTicker(pollEvery)
+	if r.o.EventBus == nil {
+		return r.waitForRunningLegacy(ctx, sandboxID)
+	}
+	return r.waitForRunningEventBus(ctx, sandboxID)
+}
+
+// waitForRunningLegacy is the feature-flag OFF polling loop.
+func (r *Resumer) waitForRunningLegacy(ctx context.Context, sandboxID string) error {
+	t := time.NewTicker(waitPollInterval)
 	defer t.Stop()
 	for {
 		state, ok, err := r.o.Redis.GetState(ctx, sandboxID)
 		if err != nil {
 			return err
 		}
-		switch {
-		case !ok:
-			// Peer's lock expired without writing a terminal state. Don't
-			// pretend everything is fine — the sandbox is in an unknown
-			// state. The caller will surface a 503 and the next request
-			// re-enters Resume() and re-acquires the lock cleanly.
-			return errors.New("peer resume lock expired without resolution")
-		case state == "running":
-			return nil
-		case state == "paused":
-			return errors.New("peer resume left sandbox paused")
-			// pausing / resuming → keep polling
+		if err, done := classifyState(state, ok); done {
+			return err
 		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-t.C:
+		}
+	}
+}
+
+// classifyState maps a GetState (state, ok) pair onto a wait decision.
+// done=true means the waiter should return (err is nil on success).
+// done=false means the state is still in-flight ("pausing" / "resuming" /
+// "killing" / unknown) and the caller should keep waiting.
+func classifyState(state string, ok bool) (err error, done bool) {
+	switch {
+	case !ok:
+		return errors.New("peer resume lock expired without resolution"), true
+	case state == "running":
+		return nil, true
+	case state == "paused":
+		return errors.New("peer resume left sandbox paused"), true
+	case state == lifecycle.StateKilled:
+		return errors.New("peer killed sandbox during resume"), true
+	default:
+		// "pausing" / "resuming" / anything else — keep waiting.
+		return nil, false
+	}
+}
+
+func (r *Resumer) waitForRunningEventBus(ctx context.Context, sandboxID string) error {
+	listener, cancel := r.o.EventBus.Wait(sandboxID)
+	defer cancel()
+
+	readState := func() (error, bool) {
+		state, ok, err := r.o.Redis.GetState(ctx, sandboxID)
+		if err != nil {
+			return err, true
+		}
+		return classifyState(state, ok)
+	}
+
+	if err, done := readState(); done {
+		return err
+	}
+
+	fallback := time.NewTicker(waitPollInterval)
+	defer fallback.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-listener:
+			if err, done := readState(); done {
+				return err
+			}
+		case <-fallback.C:
+			if err, done := readState(); done {
+				return err
+			}
 		}
 	}
 }

--- a/cube-lifecycle-manager/internal/resumer/resumer_test.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer_test.go
@@ -14,6 +14,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/eventbus"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/registry"
 )
@@ -26,6 +27,11 @@ type fakeStore struct {
 	// element is non-empty, AcquireState seeds that state value into the
 	// map (simulating a peer holding the lock) and returns false.
 	preLocked map[string]string
+	// bus, when non-nil, receives every WriteState / ClearStateNotify
+	// event. This mirrors redisstream.Client.SetLocalBus in production.
+	bus      *eventbus.Bus
+	getCount int
+	afterGet func(int)
 }
 
 func newFakeStore() *fakeStore {
@@ -62,9 +68,49 @@ func (f *fakeStore) ClearState(_ context.Context, sid string) error {
 
 func (f *fakeStore) GetState(_ context.Context, sid string) (string, bool, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	v, ok := f.states[sid]
+	f.getCount++
+	count := f.getCount
+	afterGet := f.afterGet
+	f.mu.Unlock()
+	if afterGet != nil {
+		afterGet(count)
+	}
 	return v, ok, nil
+}
+
+// WriteState mirrors redisstream.Client.WriteState: it performs the state
+// mutation and, when a local bus is attached (see attachBus), fans out a
+// StateNotify to it.
+func (f *fakeStore) WriteState(_ context.Context, sid, state string, _ time.Duration) error {
+	f.mu.Lock()
+	f.states[sid] = state
+	bus := f.bus
+	f.mu.Unlock()
+	if bus != nil {
+		bus.Publish(sid)
+	}
+	return nil
+}
+
+func (f *fakeStore) ClearStateNotify(_ context.Context, sid string) error {
+	f.mu.Lock()
+	delete(f.states, sid)
+	bus := f.bus
+	f.mu.Unlock()
+	if bus != nil {
+		bus.Publish(sid)
+	}
+	return nil
+}
+
+// attachBus wires the fakeStore to a local eventbus.Bus so that state
+// writes fan out to any waiter registered on that bus. Mirrors what
+// redisstream.Client.SetLocalBus does in production.
+func (f *fakeStore) attachBus(b *eventbus.Bus) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bus = b
 }
 
 func (f *fakeStore) state(sid string) string {
@@ -439,6 +485,219 @@ func TestResumer_RunningStatePushRetriesAsynchronously(t *testing.T) {
 			push.mu.Unlock()
 			if got != tt.wantPushes {
 				t.Fatalf("got %d successful pushes, want %d", got, tt.wantPushes)
+			}
+		})
+	}
+}
+
+// newTestResumerWithBus is the eventbus-mode counterpart of newTestResumer.
+// It also attaches the bus to the fakeStore so WriteState / ClearStateNotify
+// calls fan out just like they do in production.
+func newTestResumerWithBus(reg *registry.Registry, store *fakeStore, master *fakeMaster, push *fakePush, bus *eventbus.Bus) *Resumer {
+	store.attachBus(bus)
+	return New(Options{
+		Registry:     reg,
+		Redis:        store,
+		CubeMaster:   master,
+		ProxyPush:    push,
+		StateLockTTL: 30 * time.Second,
+		Log:          zap.NewNop(),
+		EventBus:     bus,
+	})
+}
+
+func observeStoreGets(store *fakeStore) <-chan int {
+	ch := make(chan int, 16)
+	store.mu.Lock()
+	store.afterGet = func(count int) { ch <- count }
+	store.mu.Unlock()
+	return ch
+}
+
+func waitForGetCount(t *testing.T, ch <-chan int, want int) {
+	t.Helper()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case count := <-ch:
+			if count >= want {
+				return
+			}
+		case <-timer.C:
+			t.Fatalf("timed out waiting for GET count %d", want)
+		}
+	}
+}
+
+func TestResumer_EventBusWakesWaiterFast(t *testing.T) {
+	reg := registry.New()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx", InstanceType: "cubebox", AutoResume: true,
+	})
+	store := newFakeStore()
+	store.states["sbx"] = "resuming" // peer's in-flight lock
+
+	bus := eventbus.New()
+	master := &fakeMaster{}
+	push := &fakePush{}
+	r := newTestResumerWithBus(reg, store, master, push, bus)
+	gets := observeStoreGets(store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() { result <- r.Resume(ctx, "sbx") }()
+
+	// GET #1 observes the peer lock; GET #2 is waitForRunning's initial
+	// read after listener registration. Publish only after both occurred.
+	waitForGetCount(t, gets, 2)
+	_ = store.WriteState(context.Background(), "sbx", "running", time.Minute)
+
+	if err := <-result; err != nil {
+		t.Fatalf("waiter should have observed running via eventbus, got %v", err)
+	}
+	if got := atomic.LoadInt32(&master.calls); got != 0 {
+		t.Fatalf("waiter must not call master.Resume, got %d", got)
+	}
+}
+
+func TestResumer_EventBeforeWaitResolvedByGet(t *testing.T) {
+	reg := registry.New()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx", InstanceType: "cubebox", AutoResume: true,
+	})
+	store := newFakeStore()
+	store.states["sbx"] = "resuming"
+
+	bus := eventbus.New()
+	master := &fakeMaster{}
+	push := &fakePush{}
+	r := newTestResumerWithBus(reg, store, master, push, bus)
+
+	firstGetRead := make(chan struct{})
+	releaseFirstGet := make(chan struct{})
+	store.afterGet = func(count int) {
+		if count == 1 {
+			close(firstGetRead)
+			<-releaseFirstGet
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() { result <- r.Resume(ctx, "sbx") }()
+
+	<-firstGetRead
+	_ = store.SetState(context.Background(), "sbx", "running", time.Minute)
+	bus.Publish("sbx") // Wait has not registered yet; this hint is discarded.
+	close(releaseFirstGet)
+
+	if err := <-result; err != nil {
+		t.Fatalf("initial GET after Wait should have observed running, got %v", err)
+	}
+}
+
+func TestResumer_EventBusIgnoresStaleHint(t *testing.T) {
+	reg := registry.New()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx", InstanceType: "cubebox", AutoResume: true,
+	})
+	store := newFakeStore()
+	store.states["sbx"] = "resuming"
+
+	bus := eventbus.New()
+	// This event predates Wait and must not be replayed.
+	bus.Publish("sbx")
+
+	master := &fakeMaster{}
+	push := &fakePush{}
+	r := newTestResumerWithBus(reg, store, master, push, bus)
+	gets := observeStoreGets(store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() { result <- r.Resume(ctx, "sbx") }()
+
+	waitForGetCount(t, gets, 2)
+	bus.Publish("sbx") // stale/duplicate hint while Redis is still resuming
+	waitForGetCount(t, gets, 3)
+	select {
+	case err := <-result:
+		t.Fatalf("stale hint completed wait unexpectedly: %v", err)
+	default:
+	}
+
+	_ = store.WriteState(context.Background(), "sbx", "running", time.Minute)
+	if err := <-result; err != nil {
+		t.Fatalf("stale hint must not fail the current resume: %v", err)
+	}
+}
+
+// TestResumer_EventBusFallbackPolls confirms the Scenario 3 safety net:
+// when the notifier drops a message, the 100ms poll still converges.
+func TestResumer_EventBusFallbackPolls(t *testing.T) {
+	reg := registry.New()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx", InstanceType: "cubebox", AutoResume: true,
+	})
+	store := newFakeStore()
+	store.states["sbx"] = "resuming"
+
+	// Bus is provided but the peer flips state via SetState (bypassing the
+	// bus's Publish) — simulates a dropped notify.
+	bus := eventbus.New()
+	// Deliberately do NOT attach the bus to the store, so WriteState fanout
+	// wouldn't fire even if used.
+	master := &fakeMaster{}
+	push := &fakePush{}
+	r := New(Options{
+		Registry:     reg,
+		Redis:        store,
+		CubeMaster:   master,
+		ProxyPush:    push,
+		StateLockTTL: 30 * time.Second,
+		Log:          zap.NewNop(),
+		EventBus:     bus,
+	})
+	gets := observeStoreGets(store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() { result <- r.Resume(ctx, "sbx") }()
+
+	waitForGetCount(t, gets, 2)
+	_ = store.SetState(context.Background(), "sbx", "running", time.Minute)
+	waitForGetCount(t, gets, 3) // no hint: this read must come from fallback
+
+	if err := <-result; err != nil {
+		t.Fatalf("fallback poll should have observed running, got %v", err)
+	}
+}
+
+func TestClassifyState(t *testing.T) {
+	tests := []struct {
+		name    string
+		state   string
+		ok      bool
+		wantErr bool
+		done    bool
+	}{
+		{name: "running", state: "running", ok: true, done: true},
+		{name: "paused", state: "paused", ok: true, wantErr: true, done: true},
+		{name: "killed", state: lifecycle.StateKilled, ok: true, wantErr: true, done: true},
+		{name: "missing", ok: false, wantErr: true, done: true},
+		{name: "resuming", state: "resuming", ok: true},
+		{name: "pausing", state: "pausing", ok: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err, done := classifyState(tt.state, tt.ok)
+			if done != tt.done || (err != nil) != tt.wantErr {
+				t.Fatalf("classifyState(%q, %v) = (%v, %v)", tt.state, tt.ok, err, done)
 			}
 		})
 	}

--- a/cube-lifecycle-manager/internal/statesync/handler.go
+++ b/cube-lifecycle-manager/internal/statesync/handler.go
@@ -124,7 +124,7 @@ func Handle(ctx context.Context, d Deps, ev redisstream.Event) {
 		return
 	}
 
-	if err := d.Redis.SetState(ctx, ev.SandboxID, newState, d.TTL); err != nil {
+	if err := d.Redis.WriteState(ctx, ev.SandboxID, newState, d.TTL); err != nil {
 		log.Warn("state event: set state failed",
 			zap.String("sandbox_id", ev.SandboxID),
 			zap.String("new", newState), zap.Error(err))

--- a/cube-lifecycle-manager/internal/statesync/handler_test.go
+++ b/cube-lifecycle-manager/internal/statesync/handler_test.go
@@ -51,6 +51,13 @@ func (f *fakeRedis) SetState(_ context.Context, sid, state string, _ time.Durati
 	return nil
 }
 
+// WriteState is the notify-emitting equivalent of SetState. statesync
+// tests don't inspect the StateNotify payload; forward to SetState so
+// setCalls / setErr semantics stay unchanged.
+func (f *fakeRedis) WriteState(ctx context.Context, sid, state string, ttl time.Duration) error {
+	return f.SetState(ctx, sid, state, ttl)
+}
+
 type fakeProxy struct {
 	mu    sync.Mutex
 	calls []string // "sid=state"

--- a/cube-lifecycle-manager/internal/statesync/iface.go
+++ b/cube-lifecycle-manager/internal/statesync/iface.go
@@ -14,6 +14,9 @@ import (
 type stateStore interface {
 	GetState(ctx context.Context, sandboxID string) (string, bool, error)
 	SetState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
+	// WriteState is the notify-emitting equivalent of SetState. See
+	// internal/resumer/iface.go for the contract.
+	WriteState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
 }
 
 // stateNotifier is the subset of proxypush.Client we use.

--- a/cube-lifecycle-manager/internal/sweeper/iface.go
+++ b/cube-lifecycle-manager/internal/sweeper/iface.go
@@ -18,6 +18,10 @@ type stateStore interface {
 	SetState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
 	ClearState(ctx context.Context, sandboxID string) error
 	GetState(ctx context.Context, sandboxID string) (string, bool, error)
+	// WriteState / ClearStateNotify are the notify-emitting equivalents.
+	// See internal/resumer/iface.go for the same contract.
+	WriteState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
+	ClearStateNotify(ctx context.Context, sandboxID string) error
 }
 
 // pauseKiller is the subset of cubemasterclient.Client that the sweeper needs.

--- a/cube-lifecycle-manager/internal/sweeper/sweeper.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper.go
@@ -237,7 +237,7 @@ func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 		case errors.As(pauseErr, &apiErr) && apiErr.IsNotFound():
 			// Sandbox doesn't exist on CubeMaster anymore. Clean up local
 			// state and stop chasing it.
-			_ = s.o.Redis.ClearState(ctx, sid)
+			_ = s.o.Redis.ClearStateNotify(ctx, sid)
 			_ = s.o.ProxyPush.DeleteMeta(ctx, sid)
 			s.o.Registry.Delete(sid)
 			s.o.Log.Info("sandbox not found on cubemaster; evicting from registry",
@@ -259,13 +259,13 @@ func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 			// Real failure. Roll back: clear the pausing state so a future
 			// sweep can retry, and tell CubeProxy the sandbox is back to
 			// running (it never actually paused).
-			_ = s.o.Redis.ClearState(ctx, sid)
+			_ = s.o.Redis.ClearStateNotify(ctx, sid)
 			_ = s.o.ProxyPush.SetState(ctx, sid, "running")
 			return errors.New("cubemaster pause: " + pauseErr.Error())
 		}
 	}
 
-	if err := s.o.Redis.SetState(ctx, sid, "paused", s.o.StateLockTTL); err != nil {
+	if err := s.o.Redis.WriteState(ctx, sid, "paused", s.o.StateLockTTL); err != nil {
 		s.o.Log.Warn("write paused state failed",
 			zap.String("sandbox_id", sid), zap.Error(err))
 	}
@@ -330,13 +330,13 @@ func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 				zap.String("sandbox_id", sid),
 				zap.Int("ret_code", apiErr.RetCode))
 		default:
-			_ = s.o.Redis.ClearState(ctx, sid)
+			_ = s.o.Redis.ClearStateNotify(ctx, sid)
 			_ = s.o.ProxyPush.SetState(ctx, sid, "running")
 			return errors.New("cubemaster kill: " + killErr.Error())
 		}
 	}
 
-	if err := s.o.Redis.SetState(ctx, sid, "killed", s.o.StateLockTTL); err != nil {
+	if err := s.o.Redis.WriteState(ctx, sid, "killed", s.o.StateLockTTL); err != nil {
 		s.o.Log.Warn("write killed state failed",
 			zap.String("sandbox_id", sid), zap.Error(err))
 	}

--- a/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
@@ -69,6 +69,17 @@ func (f *fakeStore) ClearState(_ context.Context, sid string) error {
 	return nil
 }
 
+// WriteState / ClearStateNotify are the notify-emitting equivalents. The
+// sweeper tests don't inspect notify payloads yet, so we simply forward
+// to the legacy SetState / ClearState behaviour.
+func (f *fakeStore) WriteState(ctx context.Context, sid, state string, ttl time.Duration) error {
+	return f.SetState(ctx, sid, state, ttl)
+}
+
+func (f *fakeStore) ClearStateNotify(ctx context.Context, sid string) error {
+	return f.ClearState(ctx, sid)
+}
+
 func (f *fakeStore) state(sid string) string {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/deploy/kubernetes/chart/templates/lifecycle-manager.yaml
+++ b/deploy/kubernetes/chart/templates/lifecycle-manager.yaml
@@ -76,6 +76,8 @@ spec:
               value: {{ .Values.lifecycleManager.bootstrapWarmup | quote }}
             - name: CUBE_LCM_STATE_LOCK_TTL
               value: {{ .Values.lifecycleManager.stateLockTTL | quote }}
+            - name: CUBE_LCM_EVENTBUS_ENABLED
+              value: {{ .Values.lifecycleManager.eventBusEnabled | quote }}
             - name: CUBE_LCM_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -384,6 +384,7 @@ lifecycleManager:
   idleSweepInterval: 5s
   bootstrapWarmup: 30s
   stateLockTTL: 60s
+  eventBusEnabled: true
   # Shared with CubeProxy admin endpoints (X-Cube-Admin-Token). Empty means
   # the chart auto-generates and persists one in the release Secret.
   adminToken: ""

--- a/docs/dev/redis-key-spec.md
+++ b/docs/dev/redis-key-spec.md
@@ -64,6 +64,7 @@ The following are the standard keys currently registered in the system (`v1`). N
 | Sandbox lifecycle registry | `cube:v1:shared:sandbox:lifecycle:meta` | Hash | shared | CubeMaster | cube-lifecycle-manager | none (lifecycle via `HDEL`) |
 | Sandbox lifecycle events | `cube:v1:shared:sandbox:lifecycle:events` | Stream | shared | CubeMaster | cube-lifecycle-manager | MAXLEN ~ 100000 |
 | Sandbox lifecycle state | `cube:v1:shared:sandbox:lifecycle:state:{sandboxID}` | String | shared | cube-lifecycle-manager | cube-lifecycle-manager | SET TTL (default 60s) |
+| Sandbox lifecycle wakeup | `cube:v1:shared:sandbox:lifecycle:notify` | Pub/Sub channel | shared | cube-lifecycle-manager | cube-lifecycle-manager | n/a (best-effort hint) |
 | Sandbox op lock (pause/resume/delete) | `cube:v1:master:lock:sandbox:{sandboxID}` | String | master | CubeMaster | CubeMaster | SET NX EX by op: pause **180s**, resume/delete **120s**, other **60s**; unlock = token-matched Lua GET+DEL (no renew) |
 | CubeProxy replica registry | `cube:v1:shared:cube_proxy:registry` | Hash | shared | CubeProxy | cube-lifecycle-manager | none (evicted on heartbeat expiry via `HDEL`) |
 | CubeProxy replica heartbeat | `cube:v1:shared:cube_proxy:heartbeat` | Sorted Set | shared | CubeProxy | cube-lifecycle-manager | none (`ZREMRANGEBYSCORE` on expiry, default 15s) |

--- a/docs/zh/dev/redis-key-spec.md
+++ b/docs/zh/dev/redis-key-spec.md
@@ -64,6 +64,7 @@ cube:{ver}:{scope}:{resource}[:{sub}...]:{id}
 | 沙箱 lifecycle 注册表 | `cube:v1:shared:sandbox:lifecycle:meta` | Hash | shared | CubeMaster | cube-lifecycle-manager | 无（生命周期由 `HDEL` 管理） |
 | 沙箱 lifecycle 事件流 | `cube:v1:shared:sandbox:lifecycle:events` | Stream | shared | CubeMaster | cube-lifecycle-manager | MAXLEN ~ 100000 |
 | 沙箱 lifecycle 状态 | `cube:v1:shared:sandbox:lifecycle:state:{sandboxID}` | String | shared | cube-lifecycle-manager | cube-lifecycle-manager | SET TTL（默认 60s） |
+| 沙箱 lifecycle 唤醒通知 | `cube:v1:shared:sandbox:lifecycle:notify` | Pub/Sub channel | shared | cube-lifecycle-manager | cube-lifecycle-manager | 不适用（best-effort 提示） |
 | 沙箱操作锁（pause/resume/delete） | `cube:v1:master:lock:sandbox:{sandboxID}` | String | master | CubeMaster | CubeMaster | 按操作 SET NX EX：pause **180s**，resume/delete **120s**，其它 **60s**；解锁为 token 匹配的 Lua GET+DEL（不续期） |
 | CubeProxy 副本注册表 | `cube:v1:shared:cube_proxy:registry` | Hash | shared | CubeProxy | cube-lifecycle-manager | 无（心跳超时后由 `HDEL` 清理） |
 | CubeProxy 副本心跳 | `cube:v1:shared:cube_proxy:heartbeat` | Sorted Set | shared | CubeProxy | cube-lifecycle-manager | 无（`ZREMRANGEBYSCORE` 清理，默认 15s 过期） |


### PR DESCRIPTION
Use Redis Pub/Sub as a best-effort wakeup hint while keeping Redis state as the source of truth and retaining the polling fallback.

Closes #1047