### PR TITLE
network: Reset stale CubeProxy connections after rollback

### DIFF
--- a/CubeNet/cubevs/dump.go
+++ b/CubeNet/cubevs/dump.go
@@ -196,6 +196,7 @@ var businessMapDumpOrder = []string{
 	MapNameLocalPortMapping,
 	MapNameEgressSessions,
 	MapNameIngressSessions,
+	MapNameOriginalSessions,
 	mapNameSNATIPList,
 	MapNameAllowOutV3,
 	MapNameDenyOut,
@@ -212,6 +213,7 @@ var businessMapDumpers = map[string]businessMapDumper{
 	MapNameLocalPortMapping:     dumpLocalPortMapping,
 	MapNameEgressSessions:       dumpEgressSessions,
 	MapNameIngressSessions:      dumpIngressSessions,
+	MapNameOriginalSessions:     dumpOriginalSessions,
 	mapNameSNATIPList:           dumpSNATIPList,
 	MapNameAllowOutV3:           dumpAllowOutV3,
 	MapNameDenyOut:              dumpDenyOut,
@@ -447,6 +449,48 @@ func dumpEgressSessions(opts DumpOptions, now uint64) (any, error) {
 		})
 	}
 	return entries, wrapIterErr(iter.Err(), MapNameEgressSessions)
+}
+
+func dumpOriginalSessions(opts DumpOptions, now uint64) (any, error) {
+	m, err := loadPinnedMap(MapNameOriginalSessions)
+	if err != nil {
+		return nil, err
+	}
+	defer m.Close()
+
+	entries := make([]EgressSessionDump, 0)
+	var key sessionKey
+	var value session
+	iter := m.Iterate()
+	for iter.Next(&key, &value) {
+		if !ifindexMatches(opts, value.VMIfindex) {
+			continue
+		}
+		expiresAt := value.AccessTime + value.tcpTimeout()
+		entries = append(entries, EgressSessionDump{
+			Key:            dumpSessionKey(key),
+			AccessTimeNS:   value.AccessTime,
+			ExpiresAtNS:    expiresAt,
+			ExpiresInNS:    remainingNS(expiresAt, now),
+			ExpiresIn:      remainingDuration(expiresAt, now),
+			Expired:        expiresAt <= now,
+			NodeIfindex:    value.NodeIfindex,
+			NodeIP:         uint32ToIP(value.NodeIP).String(),
+			VMIfindex:      value.VMIfindex,
+			VMIP:           uint32ToIP(value.VMIP).String(),
+			NodePort:       ntohs(value.NodePort),
+			VMPort:         ntohs(value.VMPort),
+			State:          sessionStateString(key.Protocol, value.State),
+			StateRaw:       value.State,
+			ActiveClose:    value.ActiveClose != 0,
+			ActiveCloseRaw: value.ActiveClose,
+			PacketClass:    "cubeproxy",
+			PacketClassRaw: value.PacketClass,
+			L7Scheme:       l7SchemeToString(value.L7Scheme),
+			L7SchemeRaw:    value.L7Scheme,
+		})
+	}
+	return entries, wrapIterErr(iter.Err(), MapNameOriginalSessions)
 }
 
 func dumpIngressSessions(opts DumpOptions, _ uint64) (any, error) {

--- a/CubeNet/cubevs/reaper.go
+++ b/CubeNet/cubevs/reaper.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	MapNameIngressSessions = "ingress_sessions"
-	MapNameEgressSessions  = "egress_sessions"
+	MapNameIngressSessions  = "ingress_sessions"
+	MapNameEgressSessions   = "egress_sessions"
+	MapNameOriginalSessions = "original_sessions"
 )
 
 const (
@@ -170,6 +171,23 @@ type natSession struct {
 	Reserved    [32]uint8
 }
 
+// session mirrors C struct session, the value of original_sessions.  Keep it
+// distinct from natSession even while their layouts match.
+type session struct {
+	AccessTime  uint64
+	NodeIfindex uint32
+	NodeIP      uint32
+	VMIfindex   uint32
+	VMIP        uint32
+	NodePort    uint16
+	VMPort      uint16
+	State       uint8
+	ActiveClose uint8
+	PacketClass uint8
+	L7Scheme    uint8
+	Reserved    [32]uint8
+}
+
 // timeout returns the timeout for the session in nanoseconds.
 func (s *natSession) tcpTimeout() uint64 {
 	if s.State == uint8(tcpCTTimeWait) && s.ActiveClose == 1 {
@@ -177,6 +195,13 @@ func (s *natSession) tcpTimeout() uint64 {
 		return uint64(tcpTimeouts[tcpCTClose].Nanoseconds())
 	}
 
+	return uint64(tcpTimeouts[tcpConntrackState(s.State)].Nanoseconds())
+}
+
+func (s *session) tcpTimeout() uint64 {
+	if s.State == uint8(tcpCTTimeWait) && s.ActiveClose == 1 {
+		return uint64(tcpTimeouts[tcpCTClose].Nanoseconds())
+	}
 	return uint64(tcpTimeouts[tcpConntrackState(s.State)].Nanoseconds())
 }
 
@@ -246,6 +271,7 @@ func doReap() {
 
 	for range ticker.C {
 		reapSessions()
+		reapOriginalSessions()
 		reapDNSState()
 	}
 }
@@ -268,11 +294,11 @@ func enqueueEvent(event Event) {
 	}
 }
 
-func reportCount(count int) {
+func reportCount(mapName string, count int) {
 	if float64(count) > maxSessions*maxSessionPercentage {
 		enqueueEvent(Event{
 			Error:   ErrSessionsTooMany,
-			Message: fmt.Sprintf("too many sessions: %d/%d", count, maxSessions),
+			Message: fmt.Sprintf("too many sessions in %s: %d/%d", mapName, count, maxSessions),
 		})
 	}
 }
@@ -300,6 +326,18 @@ func sessionClosedNormally(key *sessionKey, sess *natSession) bool {
 	default:
 		return sess.State == uint8(tcpCTClose) || sess.State == uint8(tcpCTTimeWait)
 	}
+}
+
+func originalSessionDisposition(
+	now uint64,
+	key *sessionKey,
+	sess *session,
+	currentVersion uint32,
+	orphan bool,
+) (deleteEntry bool, expired bool, staleGeneration bool) {
+	expired = now > sess.AccessTime+sess.tcpTimeout()
+	staleGeneration = !orphan && key.Version != currentVersion
+	return expired || staleGeneration || orphan, expired, staleGeneration
 }
 
 func deleteSessions(egressSessions, ingressSessions *ebpf.Map,
@@ -399,5 +437,121 @@ func reapSessions() {
 		return
 	}
 
-	reportCount(count)
+	reportCount(MapNameEgressSessions, count)
+}
+
+func reapOriginalSessions() {
+	original, err := loadPinnedMap(MapNameOriginalSessions)
+	if err != nil {
+		enqueueEvent(Event{
+			Error:   err,
+			Message: "failed to load original session map",
+		})
+		return
+	}
+	defer original.Close()
+
+	metadata, err := loadPinnedMap(MapNameIfindexToMVMMetadata)
+	if err != nil {
+		enqueueEvent(Event{
+			Error:   err,
+			Message: "failed to load TAP metadata map for original sessions",
+		})
+		return
+	}
+	defer metadata.Close()
+
+	now, err := currentNS()
+	if err != nil {
+		enqueueEvent(Event{
+			Error:   err,
+			Message: "failed to get current time for original sessions",
+		})
+		return
+	}
+
+	type versionResult struct {
+		version uint32
+		orphan  bool
+		err     error
+	}
+	versions := make(map[uint32]versionResult)
+	var (
+		key   sessionKey
+		value session
+		count int
+	)
+	iter := original.Iterate()
+	for iter.Next(&key, &value) {
+		count++
+
+		result, ok := versions[value.VMIfindex]
+		if !ok {
+			var meta mvmMetadata
+			lookupErr := metadata.Lookup(&value.VMIfindex, &meta)
+			switch {
+			case lookupErr == nil:
+				result.version = meta.Version
+			case errors.Is(lookupErr, ebpf.ErrKeyNotExist):
+				result.orphan = true
+			default:
+				result.err = lookupErr
+				enqueueEvent(Event{
+					Error: lookupErr,
+					Message: fmt.Sprintf(
+						"failed to look up TAP metadata for original session ifindex %d",
+						value.VMIfindex,
+					),
+				})
+			}
+			versions[value.VMIfindex] = result
+		}
+
+		if result.err != nil {
+			continue
+		}
+
+		deleteEntry, expired, staleGeneration := originalSessionDisposition(
+			now,
+			&key,
+			&value,
+			result.version,
+			result.orphan,
+		)
+		if !deleteEntry {
+			continue
+		}
+
+		if err := original.Delete(&key); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+			enqueueEvent(Event{
+				Error:   err,
+				Message: "failed to delete original session",
+			})
+			continue
+		}
+
+		if expired && !staleGeneration && !result.orphan &&
+			value.State != uint8(tcpCTClose) &&
+			value.State != uint8(tcpCTTimeWait) {
+			enqueueEvent(Event{
+				Error: ErrSessionExpiredNotClosed,
+				Message: fmt.Sprintf(
+					"cubeproxy session %s:%d->%s:%d expired in state %s",
+					uint32ToIP(key.SourceIP), ntohs(key.SourcePort),
+					uint32ToIP(key.TargetIP), ntohs(key.TargetPort),
+					tcpConntrackState(value.State),
+				),
+			})
+		}
+	}
+
+	if err := iter.Err(); err != nil {
+		enqueueEvent(Event{
+			Error:   err,
+			Message: "failed to iterate original session map",
+		})
+		return
+	}
+
+	reportCount(MapNameOriginalSessions, count)
 }

--- a/CubeNet/cubevs/reaper_test.go
+++ b/CubeNet/cubevs/reaper_test.go
@@ -1,0 +1,61 @@
+package cubevs
+
+import (
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func TestSessionLayoutMatchesNatSessionWithoutTypeReuse(t *testing.T) {
+	var got session
+	var legacy natSession
+	if unsafe.Sizeof(got) != 64 {
+		t.Fatalf("session size=%d, want 64", unsafe.Sizeof(got))
+	}
+	if unsafe.Sizeof(got) != unsafe.Sizeof(legacy) {
+		t.Fatalf("session size=%d, natSession size=%d", unsafe.Sizeof(got), unsafe.Sizeof(legacy))
+	}
+	if unsafe.Offsetof(got.State) != unsafe.Offsetof(legacy.State) ||
+		unsafe.Offsetof(got.ActiveClose) != unsafe.Offsetof(legacy.ActiveClose) {
+		t.Fatalf("TCP state fields diverged: session=%#v natSession=%#v", got, legacy)
+	}
+}
+
+func TestOriginalSessionDispositionDeletesStaleGeneration(t *testing.T) {
+	now := uint64((4 * time.Hour).Nanoseconds())
+	key := sessionKey{Version: 7}
+	value := session{
+		AccessTime: now - uint64(time.Minute.Nanoseconds()),
+		State:      uint8(tcpCTEstablished),
+	}
+
+	deleteEntry, expired, stale := originalSessionDisposition(now, &key, &value, 8, false)
+	if !deleteEntry || expired || !stale {
+		t.Fatalf("disposition=(delete=%t expired=%t stale=%t), want (true,false,true)",
+			deleteEntry, expired, stale)
+	}
+}
+
+func TestOriginalSessionDispositionKeepsCurrentEstablished(t *testing.T) {
+	now := uint64((4 * time.Hour).Nanoseconds())
+	key := sessionKey{Version: 8}
+	value := session{
+		AccessTime: now - uint64(time.Minute.Nanoseconds()),
+		State:      uint8(tcpCTEstablished),
+	}
+
+	deleteEntry, expired, stale := originalSessionDisposition(now, &key, &value, 8, false)
+	if deleteEntry || expired || stale {
+		t.Fatalf("disposition=(delete=%t expired=%t stale=%t), want all false",
+			deleteEntry, expired, stale)
+	}
+}
+
+func TestOriginalSessionDispositionDeletesOrphan(t *testing.T) {
+	key := sessionKey{Version: 8}
+	value := session{State: uint8(tcpCTEstablished)}
+	deleteEntry, _, _ := originalSessionDisposition(1, &key, &value, 0, true)
+	if !deleteEntry {
+		t.Fatal("orphan original session was retained")
+	}
+}

--- a/CubeNet/cubevs/tap.go
+++ b/CubeNet/cubevs/tap.go
@@ -31,6 +31,11 @@ type tapMetadataMapOps interface {
 	Delete(key interface{}) error
 }
 
+type tapMetadataVersionMapOps interface {
+	Lookup(key, valueOut interface{}) error
+	Update(key, value interface{}, flags ebpf.MapUpdateFlags) error
+}
+
 // ListTAPDevices lists all TAP devices that managed by CubeVS.
 func ListTAPDevices() ([]TAPDevice, error) {
 	m, err := loadPinnedMap(MapNameIfindexToMVMMetadata)
@@ -68,6 +73,38 @@ func AddTAPDevice(ifindex uint32, ip net.IP, id string, version uint32, opts MVM
 		return err
 	}
 	return nil
+}
+
+// BumpTAPDeviceVersion advances the connection generation for an existing TAP.
+// Existing session keys become unreachable immediately because their version no
+// longer matches the metadata used by the datapath.
+func BumpTAPDeviceVersion(ifindex uint32) (oldVersion, newVersion uint32, err error) {
+	m, err := loadPinnedMap(MapNameIfindexToMVMMetadata)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer m.Close()
+
+	return bumpTAPDeviceVersion(m, ifindex)
+}
+
+func bumpTAPDeviceVersion(m tapMetadataVersionMapOps, ifindex uint32) (oldVersion, newVersion uint32, err error) {
+	var meta mvmMetadata
+	if err := m.Lookup(&ifindex, &meta); err != nil {
+		return 0, 0, fmt.Errorf("map.Lookup failed: %w, name: %s", err, MapNameIfindexToMVMMetadata)
+	}
+
+	oldVersion = meta.Version
+	newVersion = oldVersion + 1
+	if newVersion == 0 {
+		newVersion = 1
+	}
+	meta.Version = newVersion
+
+	if err := m.Update(&ifindex, &meta, ebpf.UpdateExist); err != nil {
+		return oldVersion, 0, fmt.Errorf("map.Update failed: %w, name: %s", err, MapNameIfindexToMVMMetadata)
+	}
+	return oldVersion, newVersion, nil
 }
 
 // UpsertTAPDeviceMetadata registers or refreshes TAP metadata without touching

--- a/CubeNet/cubevs/tap_test.go
+++ b/CubeNet/cubevs/tap_test.go
@@ -13,6 +13,30 @@ type fakeTapMetadataMap struct {
 	deleteErr error
 }
 
+type fakeTapVersionMap struct {
+	meta      mvmMetadata
+	lookupErr error
+	updateErr error
+	flags     ebpf.MapUpdateFlags
+}
+
+func (m *fakeTapVersionMap) Lookup(_ interface{}, valueOut interface{}) error {
+	if m.lookupErr != nil {
+		return m.lookupErr
+	}
+	*valueOut.(*mvmMetadata) = m.meta
+	return nil
+}
+
+func (m *fakeTapVersionMap) Update(_, value interface{}, flags ebpf.MapUpdateFlags) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.meta = *value.(*mvmMetadata)
+	m.flags = flags
+	return nil
+}
+
 func (m *fakeTapMetadataMap) Lookup(key, valueOut interface{}) error {
 	if m.lookupErr != nil {
 		return m.lookupErr
@@ -107,5 +131,54 @@ func TestDeleteTAPDeviceMetadataEntriesLookupErrorDoesNotPartiallyDelete(t *test
 	}
 	if _, ok := ifindexMap.entries[ifindex]; !ok {
 		t.Fatal("ifindex metadata was deleted after reverse lookup failed")
+	}
+}
+
+func TestBumpTAPDeviceVersionPreservesMetadata(t *testing.T) {
+	m := &fakeTapVersionMap{meta: mvmMetadata{
+		IP:             0x01020304,
+		Version:        41,
+		UUID:           stringToByteArray("sandbox"),
+		DNSPolicyFlags: 3,
+		Reserved:       [55]uint8{1, 2, 3},
+	}}
+	before := m.meta
+
+	oldVersion, newVersion, err := bumpTAPDeviceVersion(m, 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldVersion != 41 || newVersion != 42 {
+		t.Fatalf("versions=(%d,%d), want (41,42)", oldVersion, newVersion)
+	}
+	if m.meta.Version != 42 {
+		t.Fatalf("stored version=%d, want 42", m.meta.Version)
+	}
+	before.Version = 42
+	if m.meta != before {
+		t.Fatalf("metadata changed beyond version: got=%#v want=%#v", m.meta, before)
+	}
+	if m.flags != ebpf.UpdateExist {
+		t.Fatalf("update flags=%v, want UpdateExist", m.flags)
+	}
+}
+
+func TestBumpTAPDeviceVersionSkipsZeroOnWrap(t *testing.T) {
+	m := &fakeTapVersionMap{meta: mvmMetadata{Version: ^uint32(0)}}
+	oldVersion, newVersion, err := bumpTAPDeviceVersion(m, 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldVersion != ^uint32(0) || newVersion != 1 || m.meta.Version != 1 {
+		t.Fatalf("versions=(%d,%d) stored=%d, want (%d,1,1)",
+			oldVersion, newVersion, m.meta.Version, ^uint32(0))
+	}
+}
+
+func TestBumpTAPDeviceVersionPropagatesLookupError(t *testing.T) {
+	lookupErr := errors.New("lookup failed")
+	_, _, err := bumpTAPDeviceVersion(&fakeTapVersionMap{lookupErr: lookupErr}, 12)
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("error=%v, want %v", err, lookupErr)
 	}
 }

--- a/CubeNet/src/cubevs.h
+++ b/CubeNet/src/cubevs.h
@@ -321,6 +321,28 @@ struct nat_session {
 	__u8 reserved[32];
 };
 
+/* Original-direction session stored in original_sessions.
+ *
+ * Keep this layout aligned with nat_session while the legacy
+ * ingress_sessions + egress_sessions implementation is still present.  The
+ * types are deliberately distinct so the new single-table data path doesn't
+ * inherit the legacy NAT table's lookup semantics.
+ */
+struct session {
+	__u64 access_time;	/* stored in nanoseconds, div is expensive */
+	__u32 node_ifindex;
+	__u32 node_ip;
+	__u32 vm_ifindex;
+	__u32 vm_ip;
+	__u16 node_port;
+	__u16 vm_port;
+	__u8 state;
+	__u8 active_close;
+	__u8 packet_class;
+	__u8 l7_scheme;
+	__u8 reserved[32];
+};
+
 struct ingress_session {
 	__u32 version;
 	__u32 vm_ip;
@@ -389,11 +411,13 @@ static __always_inline int _()
 	int l[sizeof(struct mvm_port) == 8 ? 1 : -1] = {};
 	int n[sizeof(struct session_key) % 20 == 0 ? 1 : -1] = {};
 	int o[sizeof(struct nat_session) == 64 ? 1 : -1] = {};
+	int os[sizeof(struct session) == 64 ? 1 : -1] = {};
+	int osa[sizeof(struct session) == sizeof(struct nat_session) ? 1 : -1] = {};
 	int p[sizeof(struct ingress_session) % 16 == 0 ? 1 : -1] = {};
 	int q[sizeof(struct snat_ip) % 16 == 0 ? 1 : -1] = {};
 	int s[sizeof(struct l7_port_entry) == 4 ? 1 : -1] = {};
 
-	return b[0] + d[0] + dv3[0] + r[0] + rv3[0] + f[0] + g[0] + h[0] + i[0] + l[0] + n[0] + o[0] + p[0] + q[0] + s[0];
+	return b[0] + d[0] + dv3[0] + r[0] + rv3[0] + f[0] + g[0] + h[0] + i[0] + l[0] + n[0] + o[0] + os[0] + osa[0] + p[0] + q[0] + s[0];
 }
 
 static __always_inline __attribute__((used)) __u32 __btf_pin(void)

--- a/CubeNet/src/map.h
+++ b/CubeNet/src/map.h
@@ -83,6 +83,21 @@ struct {
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } ingress_sessions SEC(".maps");
 
+/* Original-direction session table
+ *
+ * The first phase stores CubeProxy passive-accept TCP sessions here.  Reply
+ * packets reconstruct the original key by swapping their 5-tuple and adding
+ * the sandbox's current version, so no separate reply-side entry is needed.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_SESSIONS);
+	__type(key, struct session_key);
+	__type(value, struct session);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} original_sessions SEC(".maps");
+
 /* SNAT IP list
  *
  * key:   index for hash(MVM_IP)

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -129,216 +129,6 @@ enum tcp_nat_result {
 #define TCP_NAT_STATUS(ret)	((enum tcp_nat_result)((__u32)(ret)))
 #define TCP_NAT_IFINDEX(ret)	((__u32)((__u64)(ret) >> 32))
 
-static __always_inline bool tcp_segment_len(const struct iphdr *l3, const struct tcphdr *l4,
-					    __u32 *seg_len)
-{
-	__u16 ip_hlen, tcp_hlen, total_len;
-
-	ip_hlen = BPF_CORE_READ_BITFIELD(l3, ihl);
-	ip_hlen <<= 2;
-	tcp_hlen = BPF_CORE_READ_BITFIELD(l4, doff);
-	tcp_hlen <<= 2;
-	total_len = bpf_ntohs(l3->tot_len);
-	if (ip_hlen < sizeof(struct iphdr) || tcp_hlen < sizeof(struct tcphdr) ||
-	    total_len < ip_hlen + tcp_hlen)
-		return false;
-
-	*seg_len = total_len - ip_hlen - tcp_hlen;
-	if (l4->syn)
-		(*seg_len)++;
-	if (l4->fin)
-		(*seg_len)++;
-
-	return true;
-}
-
-/* Update the IP tot_len field together with the IP header checksum.
- * Uses bpf_l3_csum_replace for the incremental csum update and
- * bpf_skb_store_bytes to write the new value, instead of touching the
- * packet pointer directly.
- */
-static __always_inline int rewrite_l3_tot_len(struct __sk_buff *skb,
-					      __be16 old_tot_len, __be16 new_tot_len)
-{
-	long err;
-
-	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_tot_len, new_tot_len,
-				  sizeof(new_tot_len));
-	if (err)
-		return err;
-
-	return bpf_skb_store_bytes(skb, IP_TOT_LEN_OFF, &new_tot_len,
-				   sizeof(new_tot_len), 0);
-}
-
-/* Set the TCP checksum field of a freshly written TCP header.
- *
- * Pre-condition: the TCP header at @tcp_csum_off..+sizeof(*tcp) is already
- * present in skb with the check field cleared to 0. This helper folds the
- * IPv4 pseudo-header (saddr, daddr, proto, length) and the on-wire TCP
- * header bytes into the checksum via bpf_l4_csum_replace.
- *
- * Per the bpf-helpers(7) man page, calling bpf_l4_csum_replace with
- * from = 0 makes the helper recompute the csum against `to` only — i.e.
- * accumulates `to` into the existing in-place checksum. We start from a
- * zeroed check field and add each 32-bit word in turn.
- */
-static __always_inline int tcp_ipv4_set_checksum(struct __sk_buff *skb,
-						 __u32 tcp_csum_off,
-						 __be32 saddr, __be32 daddr,
-						 const struct tcphdr *tcp)
-{
-	const __u32 *words = (const __u32 *)tcp;
-	/* zero | proto | length, in network byte order */
-	__be32 proto_len = bpf_htonl(((__u32)IPPROTO_TCP << 16) | sizeof(*tcp));
-	__u64 ph_flags = BPF_F_PSEUDO_HDR | sizeof(__u32);
-	__u64 hdr_flags = sizeof(__u32);
-	long err;
-
-	/* Pseudo-header words */
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, saddr, ph_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, daddr, ph_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, proto_len, ph_flags);
-	if (err)
-		return err;
-
-	/* TCP header words: source|dest, seq, ack_seq, doff/flags/window,
-	 * check|urg_ptr. The check word currently contains 0 (caller wrote
-	 * a zeroed check field), so adding it is a no-op for the csum.
-	 */
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[0], hdr_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[1], hdr_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[2], hdr_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[3], hdr_flags);
-	if (err)
-		return err;
-	return bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[4], hdr_flags);
-}
-
-static __always_inline int tcp_reply_reset(struct __sk_buff *skb, __u32 ifindex)
-{
-	struct tcphdr new_tcp = {};
-	struct ethhdr *l2;
-	struct iphdr *l3;
-	struct tcphdr *l4;
-	__be32 old_saddr, old_daddr, new_saddr, new_daddr;
-	__be16 old_tot_len, new_tot_len;
-	__u32 seq, ack_seq, new_skb_len;
-	__u32 seg_len, tcp_off, tcp_csum_off;
-	__u16 ip_hlen, new_ip_len;
-	long err;
-
-	/* bpf_skb_change_tail() may fail on GSO skbs or leave segmentation
-	 * state inconsistent. Fall back to drop instead of sending RST.
-	 */
-	if (skb->gso_segs)
-		return TC_ACT_SHOT;
-
-	if (!__pull_headers(skb, &l2, &l3, &l4))
-		return TC_ACT_SHOT;
-
-	if ((l3->frag_off & IP_FLAG_MF) || (l3->frag_off & IP_FRAG_OFF_MASK))
-		return TC_ACT_SHOT;
-
-	/* Never send a reset in response to a reset. */
-	if (l4->rst)
-		return TC_ACT_SHOT;
-
-	ip_hlen = BPF_CORE_READ_BITFIELD(l3, ihl);
-	ip_hlen <<= 2;
-	seq = l4->seq;
-	ack_seq = l4->ack_seq;
-	if (!tcp_segment_len(l3, l4, &seg_len))
-		return TC_ACT_SHOT;
-
-	new_saddr = l3->daddr;
-	new_daddr = mvm_inner_ip;
-	new_tcp.source = l4->dest;
-	new_tcp.dest = l4->source;
-	new_tcp.doff = sizeof(new_tcp) >> 2;
-	new_tcp.rst = 1;
-	if (l4->ack) {
-		new_tcp.seq = ack_seq;
-	} else {
-		new_tcp.ack_seq = bpf_htonl(bpf_ntohl(seq) + seg_len);
-		new_tcp.ack = 1;
-	}
-	/* Build the new TCP header with check = 0; tcp_ipv4_set_checksum()
-	 * folds the pseudo-header and TCP header words into the checksum
-	 * incrementally via bpf_l4_csum_replace.
-	 */
-
-	new_ip_len = ip_hlen + sizeof(new_tcp);
-	new_skb_len = sizeof(struct ethhdr) + new_ip_len;
-	if (bpf_skb_change_tail(skb, new_skb_len, 0))
-		return TC_ACT_SHOT;
-
-	/* bpf_skb_change_tail invalidates all packet pointers. */
-	if (!__pull_headers(skb, &l2, &l3, &l4))
-		return TC_ACT_SHOT;
-
-	/* Snapshot old IP header fields and rewrite the L2 MAC pair before
-	 * touching the packet via BPF helpers — bpf_skb_store_bytes() and
-	 * bpf_l{3,4}_csum_replace() invalidate l2/l3/l4 pointers.
-	 */
-	old_saddr = l3->saddr;
-	old_daddr = l3->daddr;
-	old_tot_len = l3->tot_len;
-	new_tot_len = bpf_htons(new_ip_len);
-	tcp_off = sizeof(struct ethhdr) + ip_hlen;
-	tcp_csum_off = TCP_CSUM_OFF(ip_hlen);
-	set_mac_pair(l2, cubegw0_macaddr_p1, cubegw0_macaddr_p2,
-		     mvm_macaddr_p1, mvm_macaddr_p2);
-
-	/* Write the new TCP header (with check = 0). */
-	err = bpf_skb_store_bytes(skb, tcp_off, &new_tcp, sizeof(new_tcp), 0);
-	if (err)
-		return TC_ACT_SHOT;
-
-	/* Update IP tot_len + IP csum. */
-	err = rewrite_l3_tot_len(skb, old_tot_len, new_tot_len);
-	if (err)
-		return TC_ACT_SHOT;
-
-	/* Update IP saddr + IP csum. */
-	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_saddr, new_saddr,
-				  sizeof(new_saddr));
-	if (err)
-		return TC_ACT_SHOT;
-	err = bpf_skb_store_bytes(skb, IP_SADDR_OFF, &new_saddr,
-				  sizeof(new_saddr), 0);
-	if (err)
-		return TC_ACT_SHOT;
-
-	/* Update IP daddr + IP csum. */
-	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_daddr, new_daddr,
-				  sizeof(new_daddr));
-	if (err)
-		return TC_ACT_SHOT;
-	err = bpf_skb_store_bytes(skb, IP_DADDR_OFF, &new_daddr,
-				  sizeof(new_daddr), 0);
-	if (err)
-		return TC_ACT_SHOT;
-
-	/* Compute the TCP checksum into the (currently zero) check field. */
-	err = tcp_ipv4_set_checksum(skb, tcp_csum_off, new_saddr, new_daddr,
-				    &new_tcp);
-	if (err)
-		return TC_ACT_SHOT;
-
-	return bpf_redirect(ifindex, 0);
-}
-
 static __always_inline struct snat_ip *pick_snat_ip_port(__u32 mvm_ip, const struct session_key *ekey,
 							 __u16 *selected_port)
 {
@@ -991,6 +781,37 @@ int dns_finish(struct __sk_buff *skb)
 	return finish_udp_nat(skb, mvm_meta);
 }
 
+/* Touch the reply direction (sandbox -> world) of a CubeProxy connection.
+ * snat() has already changed l3->saddr to the sandbox's external identity,
+ * while snat_tcp() has not yet changed the listen port to the host port.
+ * Swapping this tuple therefore reconstructs the exact original key.
+ */
+static __always_inline int
+touch_cubeproxy_reply_session(const struct iphdr *l3,
+			      const struct tcphdr *l4,
+			      const struct mvm_meta *mvm_meta)
+{
+	struct session_key key = {};
+	struct session *sess;
+	__u64 now;
+
+	key.src_ip = l3->daddr;
+	key.dst_ip = l3->saddr;
+	key.src_port = l4->dest;
+	key.dst_port = l4->source;
+	key.version = mvm_meta->version;
+	key.protocol = IPPROTO_TCP;
+
+	sess = bpf_map_lookup_elem(&original_sessions, &key);
+	if (!sess)
+		return -1;
+
+	now = bpf_ktime_get_ns();
+	update_original_session(IP_CT_DIR_REPLY, sess, now,
+				l4->syn, l4->ack, l4->fin, l4->rst);
+	return 0;
+}
+
 /* This filter will be attached to the ingress path of Sandbox TAP devices.
  * It performs a SNAT/VXLAN-ENCAP and redirects the packets to target devices.
  */
@@ -1075,6 +896,9 @@ int from_cube(struct __sk_buff *skb)
 		if (host_port) {
 			if (l4->syn && !l4->ack)
 				return TC_ACT_SHOT;
+			if (touch_cubeproxy_reply_session(l3, l4, mvm_meta) < 0)
+				return tcp_reply_reset(skb, ifindex,
+						       RESET_TO_SANDBOX);
 
 			err = snat_tcp(skb, ifindex, l2, l3, l4, l4->source, *host_port);
 			if (err)
@@ -1101,7 +925,8 @@ int from_cube(struct __sk_buff *skb)
 		switch (classify_egress_flow(ifindex, daddr, 0)) {
 		case FLOW_REJECT:
 			if (proto == IPPROTO_TCP)
-				return tcp_reply_reset(skb, ifindex);
+				return tcp_reply_reset(skb, ifindex,
+						       RESET_TO_SANDBOX);
 			return TC_ACT_SHOT;
 		default:
 			return bpf_redirect(cubegw0_ifindex, BPF_F_INGRESS);
@@ -1115,7 +940,7 @@ int from_cube(struct __sk_buff *skb)
 		if (TCP_NAT_STATUS(tcp_ret) == TCP_L7PROXY_OK)
 			return bpf_redirect(TCP_NAT_IFINDEX(tcp_ret), BPF_F_INGRESS);
 		if (TCP_NAT_STATUS(tcp_ret) == TCP_NAT_RESET)
-			return tcp_reply_reset(skb, ifindex);
+			return tcp_reply_reset(skb, ifindex, RESET_TO_SANDBOX);
 	}
 
 	if (proto == IPPROTO_UDP) {

--- a/CubeNet/src/nodenic.bpf.c
+++ b/CubeNet/src/nodenic.bpf.c
@@ -17,6 +17,70 @@
 #include "dns_query.h"
 #include "dns_response.h"
 
+/* Track CubeProxy passive-accept connections in their establishment
+ * direction (world -> sandbox).  The key uses the sandbox-visible listen
+ * port, not the host port, so the reply path can reconstruct it before SNAT.
+ */
+static __always_inline int
+touch_cubeproxy_session(const struct iphdr *l3, const struct tcphdr *l4,
+			const struct mvm_port *mvm_port)
+{
+	struct mvm_meta *mvm_meta;
+	struct session_key key = {};
+	struct session new_session = {};
+	struct session *sess;
+	bool syn, ack, fin, rst;
+	__u64 now;
+
+	mvm_meta = bpf_map_lookup_elem(&ifindex_to_mvmmeta, &mvm_port->ifindex);
+	if (!mvm_meta)
+		return -1;
+
+	key.src_ip = l3->saddr;
+	key.dst_ip = mvm_meta->ip;
+	key.src_port = l4->source;
+	key.dst_port = mvm_port->listen_port;
+	key.version = mvm_meta->version;
+	key.protocol = IPPROTO_TCP;
+
+	now = bpf_ktime_get_ns();
+	syn = l4->syn;
+	ack = l4->ack;
+	fin = l4->fin;
+	rst = l4->rst;
+
+	sess = bpf_map_lookup_elem(&original_sessions, &key);
+	if (sess) {
+		update_original_session(IP_CT_DIR_ORIGINAL, sess, now,
+					syn, ack, fin, rst);
+		return 0;
+	}
+
+	/* Mid-stream packets from an older generation must not recreate state. */
+	if (!(syn && !ack && !fin && !rst))
+		return -1;
+
+	new_session.access_time = now;
+	new_session.vm_ifindex = mvm_port->ifindex;
+	new_session.vm_ip = mvm_meta->ip;
+	new_session.vm_port = mvm_port->listen_port;
+	new_session.state = TCP_CONNTRACK_SYN_SENT;
+
+	if (bpf_map_update_elem(&original_sessions, &key, &new_session,
+				BPF_NOEXIST) == 0)
+		return 0;
+
+	/* A concurrent SYN may have won the BPF_NOEXIST race. Treat that as a
+	 * retransmission instead of resetting a valid new connection.
+	 */
+	sess = bpf_map_lookup_elem(&original_sessions, &key);
+	if (!sess)
+		return -1;
+	update_original_session(IP_CT_DIR_ORIGINAL, sess, now,
+				syn, ack, fin, rst);
+	return 0;
+}
+
 static int tcp_nat_proxy(struct __sk_buff *skb, struct ethhdr *l2, struct iphdr *l3, struct tcphdr *l4,
 			 struct mvm_port *mvm_port)
 {
@@ -374,8 +438,12 @@ static int do_tcp_nat(struct __sk_buff *skb)
 	if (skb->ifindex == nodenic_ifindex) {
 		dport = l4->dest;
 		mvm_port = bpf_map_lookup_elem(&remote_port_mapping, &dport);
-		if (mvm_port)
+		if (mvm_port) {
+			if (touch_cubeproxy_session(l3, l4, mvm_port) < 0)
+				return tcp_reply_reset(skb, nodenic_ifindex,
+						       RESET_TO_WORLD);
 			return tcp_nat_proxy(skb, l2, l3, l4, mvm_port);
+		}
 	}
 
 	return tcp_nat_session(skb, l2, l3, l4);

--- a/CubeNet/src/tcp.h
+++ b/CubeNet/src/tcp.h
@@ -5,7 +5,9 @@
 
 #include <vmlinux.h>
 #include "cubevs.h"
+#include "l2l3.h"
 #include "session.h"
+#include "skb.h"
 
 /* What TCP flags are set from RST/SYN/FIN/ACK. */
 enum tcp_bit_set {
@@ -266,8 +268,17 @@ static __always_inline long snat_tcp(struct __sk_buff *skb,
 	return 0;
 }
 
-static __always_inline void update_session(enum ip_conntrack_dir dir, struct nat_session *sess,
-					   __u64 now_ns, bool syn, bool ack, bool fin, bool rst)
+/* Shared TCP state transition core for the legacy nat_session value and the
+ * new single-table session value.  Keep the wrappers typed: casting map values
+ * between the two structs would hide future ABI drift from the compiler.
+ */
+static __always_inline void update_tcp_session_fields(enum ip_conntrack_dir dir,
+						       __u64 *access_time,
+						       __u8 *state,
+						       __u8 *active_close,
+						       __u64 now_ns,
+						       bool syn, bool ack,
+						       bool fin, bool rst)
 {
 	/* __u8 (not enum): keeps old_state in a single unsigned register. With a
 	 * signed enum, older clang (14) narrows the value with `&= 255` masks that
@@ -278,7 +289,8 @@ static __always_inline void update_session(enum ip_conntrack_dir dir, struct nat
 	__u8 old_state, new_state;
 	unsigned int index;
 
-	session_lazy_refresh(sess, now_ns);
+	if (now_ns - *access_time > SESSION_REFRESH_INTERVAL_NS)
+		*access_time = now_ns;
 
 	/* update CT state */
 	if (dir > IP_CT_DIR_REPLY) {
@@ -292,7 +304,7 @@ static __always_inline void update_session(enum ip_conntrack_dir dir, struct nat
 		return;
 	}
 
-	old_state = sess->state;
+	old_state = *state;
 	if (old_state > TCP_CONNTRACK_SYN_SENT2) {
 		/* TCP_CONNTRACK_SYN_SENT2 = TCP_CONNTRACK_LISTEN = 9
 		 * If we reach here, the state should be either
@@ -313,8 +325,8 @@ static __always_inline void update_session(enum ip_conntrack_dir dir, struct nat
 		 */
 		if ((old_state == TCP_CONNTRACK_FIN_WAIT ||
 		     old_state == TCP_CONNTRACK_CLOSE_WAIT) &&
-		    ((sess->active_close && dir == IP_CT_DIR_ORIGINAL) ||
-		     (!sess->active_close && dir == IP_CT_DIR_REPLY)))
+		    ((*active_close && dir == IP_CT_DIR_ORIGINAL) ||
+		     (!*active_close && dir == IP_CT_DIR_REPLY)))
 			new_state = old_state;
 
 		/* Record only a real original-direction transition that initiates
@@ -326,12 +338,219 @@ static __always_inline void update_session(enum ip_conntrack_dir dir, struct nat
 		if (dir == IP_CT_DIR_ORIGINAL &&
 		    new_state == TCP_CONNTRACK_FIN_WAIT &&
 		    new_state != old_state)
-			sess->active_close = 1;
+			*active_close = 1;
 	}
 
 	/* no store if state remain unchanged */
 	if (new_state != old_state)
-		sess->state = new_state;
+		*state = new_state;
+}
+
+static __always_inline void update_session(enum ip_conntrack_dir dir,
+					   struct nat_session *sess,
+					   __u64 now_ns, bool syn, bool ack,
+					   bool fin, bool rst)
+{
+	update_tcp_session_fields(dir, &sess->access_time, &sess->state,
+				  &sess->active_close, now_ns,
+				  syn, ack, fin, rst);
+}
+
+static __always_inline void update_original_session(enum ip_conntrack_dir dir,
+						    struct session *sess,
+						    __u64 now_ns, bool syn,
+						    bool ack, bool fin, bool rst)
+{
+	update_tcp_session_fields(dir, &sess->access_time, &sess->state,
+				  &sess->active_close, now_ns,
+				  syn, ack, fin, rst);
+}
+
+enum reset_dir {
+	RESET_TO_SANDBOX = 0,
+	RESET_TO_WORLD = 1,
+};
+
+static __always_inline bool tcp_segment_len(const struct iphdr *l3,
+					    const struct tcphdr *l4,
+					    __u32 *seg_len)
+{
+	__u16 ip_hlen, tcp_hlen, total_len;
+
+	ip_hlen = BPF_CORE_READ_BITFIELD(l3, ihl);
+	ip_hlen <<= 2;
+	tcp_hlen = BPF_CORE_READ_BITFIELD(l4, doff);
+	tcp_hlen <<= 2;
+	total_len = bpf_ntohs(l3->tot_len);
+	if (ip_hlen < sizeof(struct iphdr) || tcp_hlen < sizeof(struct tcphdr) ||
+	    total_len < ip_hlen + tcp_hlen)
+		return false;
+
+	*seg_len = total_len - ip_hlen - tcp_hlen;
+	if (l4->syn)
+		(*seg_len)++;
+	if (l4->fin)
+		(*seg_len)++;
+
+	return true;
+}
+
+static __always_inline int rewrite_l3_tot_len(struct __sk_buff *skb,
+					      __be16 old_tot_len,
+					      __be16 new_tot_len)
+{
+	long err;
+
+	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_tot_len, new_tot_len,
+				  sizeof(new_tot_len));
+	if (err)
+		return err;
+
+	return bpf_skb_store_bytes(skb, IP_TOT_LEN_OFF, &new_tot_len,
+				   sizeof(new_tot_len), 0);
+}
+
+static __always_inline int tcp_ipv4_set_checksum(struct __sk_buff *skb,
+						 __u32 tcp_csum_off,
+						 __be32 saddr, __be32 daddr,
+						 const struct tcphdr *tcp)
+{
+	const __u32 *words = (const __u32 *)tcp;
+	__be32 proto_len = bpf_htonl(((__u32)IPPROTO_TCP << 16) | sizeof(*tcp));
+	__u64 ph_flags = BPF_F_PSEUDO_HDR | sizeof(__u32);
+	__u64 hdr_flags = sizeof(__u32);
+	long err;
+
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, saddr, ph_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, daddr, ph_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, proto_len, ph_flags);
+	if (err)
+		return err;
+
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[0], hdr_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[1], hdr_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[2], hdr_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[3], hdr_flags);
+	if (err)
+		return err;
+	return bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[4], hdr_flags);
+}
+
+/* Turn the offending segment into an RFC 793 reset and send it back to the
+ * selected side.  Any construction failure degrades to a plain drop.
+ */
+static __always_inline int tcp_reply_reset(struct __sk_buff *skb, __u32 ifindex,
+					   enum reset_dir dir)
+{
+	struct tcphdr new_tcp = {};
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+	__be32 old_saddr, old_daddr, new_saddr, new_daddr;
+	__be16 old_tot_len, new_tot_len;
+	__u32 seq, ack_seq, new_skb_len;
+	__u32 seg_len, tcp_off, tcp_csum_off;
+	__u16 ip_hlen, new_ip_len;
+	long err;
+
+	if (dir > RESET_TO_WORLD)
+		return TC_ACT_SHOT;
+
+	if (skb->gso_segs)
+		return TC_ACT_SHOT;
+
+	if (!__pull_headers(skb, &l2, &l3, &l4))
+		return TC_ACT_SHOT;
+
+	if ((l3->frag_off & IP_FLAG_MF) || (l3->frag_off & IP_FRAG_OFF_MASK))
+		return TC_ACT_SHOT;
+
+	if (l4->rst)
+		return TC_ACT_SHOT;
+
+	ip_hlen = BPF_CORE_READ_BITFIELD(l3, ihl);
+	ip_hlen <<= 2;
+	seq = l4->seq;
+	ack_seq = l4->ack_seq;
+	if (!tcp_segment_len(l3, l4, &seg_len))
+		return TC_ACT_SHOT;
+
+	new_saddr = l3->daddr;
+	new_daddr = dir == RESET_TO_WORLD ? l3->saddr : mvm_inner_ip;
+	new_tcp.source = l4->dest;
+	new_tcp.dest = l4->source;
+	new_tcp.doff = sizeof(new_tcp) >> 2;
+	new_tcp.rst = 1;
+	if (l4->ack) {
+		new_tcp.seq = ack_seq;
+	} else {
+		new_tcp.ack_seq = bpf_htonl(bpf_ntohl(seq) + seg_len);
+		new_tcp.ack = 1;
+	}
+
+	new_ip_len = ip_hlen + sizeof(new_tcp);
+	new_skb_len = sizeof(struct ethhdr) + new_ip_len;
+	if (bpf_skb_change_tail(skb, new_skb_len, 0))
+		return TC_ACT_SHOT;
+
+	if (!__pull_headers(skb, &l2, &l3, &l4))
+		return TC_ACT_SHOT;
+
+	old_saddr = l3->saddr;
+	old_daddr = l3->daddr;
+	old_tot_len = l3->tot_len;
+	new_tot_len = bpf_htons(new_ip_len);
+	tcp_off = sizeof(struct ethhdr) + ip_hlen;
+	tcp_csum_off = TCP_CSUM_OFF(ip_hlen);
+	if (dir == RESET_TO_WORLD)
+		set_mac_pair(l2, nodenic_macaddr_p1, nodenic_macaddr_p2,
+			     nodegw_macaddr_p1, nodegw_macaddr_p2);
+	else
+		set_mac_pair(l2, cubegw0_macaddr_p1, cubegw0_macaddr_p2,
+			     mvm_macaddr_p1, mvm_macaddr_p2);
+
+	err = bpf_skb_store_bytes(skb, tcp_off, &new_tcp, sizeof(new_tcp), 0);
+	if (err)
+		return TC_ACT_SHOT;
+
+	err = rewrite_l3_tot_len(skb, old_tot_len, new_tot_len);
+	if (err)
+		return TC_ACT_SHOT;
+
+	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_saddr, new_saddr,
+				  sizeof(new_saddr));
+	if (err)
+		return TC_ACT_SHOT;
+	err = bpf_skb_store_bytes(skb, IP_SADDR_OFF, &new_saddr,
+				  sizeof(new_saddr), 0);
+	if (err)
+		return TC_ACT_SHOT;
+
+	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_daddr, new_daddr,
+				  sizeof(new_daddr));
+	if (err)
+		return TC_ACT_SHOT;
+	err = bpf_skb_store_bytes(skb, IP_DADDR_OFF, &new_daddr,
+				  sizeof(new_daddr), 0);
+	if (err)
+		return TC_ACT_SHOT;
+
+	err = tcp_ipv4_set_checksum(skb, tcp_csum_off, new_saddr, new_daddr,
+				    &new_tcp);
+	if (err)
+		return TC_ACT_SHOT;
+
+	return bpf_redirect(ifindex, 0);
 }
 
 static __always_inline bool create_new_sessions(struct __sk_buff *skb,

--- a/CubeNet/src/tcp_state_test.bpf.c
+++ b/CubeNet/src/tcp_state_test.bpf.c
@@ -81,4 +81,33 @@ int test_update_session(struct __sk_buff *skb)
 	return TC_ACT_OK;
 }
 
+/* Keep the independently typed original_sessions value covered by verifier
+ * loading without doubling the packet-driven state-machine test's branch
+ * graph.
+ */
+SEC("tc")
+int test_update_original_session(struct __sk_buff *skb)
+{
+	struct session sess = {
+		.access_time = 1,
+		.state = TCP_CONNTRACK_SYN_SENT,
+	};
+
+	update_original_session(IP_CT_DIR_REPLY, &sess, 2,
+				true, true, false, false);
+	return sess.state == TCP_CONNTRACK_SYN_RECV ? TC_ACT_OK : TC_ACT_SHOT;
+}
+
+SEC("tc")
+int test_tcp_reset_to_sandbox(struct __sk_buff *skb)
+{
+	return tcp_reply_reset(skb, 1, RESET_TO_SANDBOX);
+}
+
+SEC("tc")
+int test_tcp_reset_to_world(struct __sk_buff *skb)
+{
+	return tcp_reply_reset(skb, 1, RESET_TO_WORLD);
+}
+
 char __license[] SEC("license") = "Dual BSD/GPL";

--- a/Cubelet/network/plugin.go
+++ b/Cubelet/network/plugin.go
@@ -91,6 +91,26 @@ func (m *delegateNetworkManager) ID() string {
 	return constants.NetworkID.ID()
 }
 
+// InvalidateSandboxConnections exposes the embedded runtime's generation bump
+// to the cubebox rollback service without leaking runtime implementation
+// details across plugin boundaries.
+func (m *delegateNetworkManager) CheckSandboxConnections(ctx context.Context, sandboxID string) error {
+	if m == nil || m.tapPlugin == nil || m.tapPlugin.networkRuntime == nil {
+		return fmt.Errorf("network runtime is not initialized")
+	}
+	return m.tapPlugin.networkRuntime.CheckSandboxConnections(ctx, sandboxID)
+}
+
+func (m *delegateNetworkManager) InvalidateSandboxConnections(
+	ctx context.Context,
+	sandboxID string,
+) (oldVersion uint32, newVersion uint32, err error) {
+	if m == nil || m.tapPlugin == nil || m.tapPlugin.networkRuntime == nil {
+		return 0, 0, fmt.Errorf("network runtime is not initialized")
+	}
+	return m.tapPlugin.networkRuntime.InvalidateSandboxConnections(ctx, sandboxID)
+}
+
 func (m *delegateNetworkManager) Init(ctx context.Context, opts *workflow.InitInfo) error {
 	log.G(ctx).Errorf("Init doing")
 	defer log.G(ctx).Errorf("Init end")

--- a/Cubelet/network/plugin_tap_create_test.go
+++ b/Cubelet/network/plugin_tap_create_test.go
@@ -37,6 +37,11 @@ type fakeNetworkRuntime struct {
 	getTapFileCalls    int
 	lastTapSandboxID   string
 	lastTapName        string
+	invalidateCalls    []string
+	invalidateErr      error
+	checkErr           error
+	oldVersion         uint32
+	newVersion         uint32
 }
 
 func (c *fakeNetworkRuntime) EnsureNetwork(_ context.Context, req *networkruntime.EnsureNetworkRequest) (*networkruntime.EnsureNetworkResponse, error) {
@@ -114,6 +119,21 @@ func (c *fakeNetworkRuntime) GetTapFile(sandboxID, tapName string) (*os.File, er
 	return nil, errors.New("tap fd unavailable")
 }
 
+func (c *fakeNetworkRuntime) InvalidateSandboxConnections(
+	_ context.Context,
+	sandboxID string,
+) (uint32, uint32, error) {
+	c.invalidateCalls = append(c.invalidateCalls, sandboxID)
+	if c.invalidateErr != nil {
+		return c.oldVersion, 0, c.invalidateErr
+	}
+	return c.oldVersion, c.newVersion, nil
+}
+
+func (c *fakeNetworkRuntime) CheckSandboxConnections(_ context.Context, _ string) error {
+	return c.checkErr
+}
+
 func (c *fakeNetworkRuntime) DumpEgressPolicies(context.Context) (map[string]map[string]any, error) {
 	if c.dumpPolicies != nil {
 		return c.dumpPolicies, nil
@@ -163,6 +183,22 @@ func TestTapCreateWithNetworkRuntimeCallsEnsureNetwork(t *testing.T) {
 	shimInfo, ok := opts.NetworkInfo.(*networktypes.ShimNetReq)
 	if !ok || shimInfo == nil || len(shimInfo.Interfaces) != 1 || shimInfo.Interfaces[0].Name != "z192.168.0.40" {
 		t.Fatalf("NetworkInfo not populated from runtime response: %+v", opts.NetworkInfo)
+	}
+}
+
+func TestDelegateNetworkManagerInvalidatesSandboxConnections(t *testing.T) {
+	fakeClient := &fakeNetworkRuntime{oldVersion: 4, newVersion: 5}
+	manager := &delegateNetworkManager{tapPlugin: &local{networkRuntime: fakeClient}}
+
+	oldVersion, newVersion, err := manager.InvalidateSandboxConnections(context.Background(), "sandbox")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldVersion != 4 || newVersion != 5 {
+		t.Fatalf("versions=(%d,%d), want (4,5)", oldVersion, newVersion)
+	}
+	if len(fakeClient.invalidateCalls) != 1 || fakeClient.invalidateCalls[0] != "sandbox" {
+		t.Fatalf("invalidate calls=%v, want [sandbox]", fakeClient.invalidateCalls)
 	}
 }
 

--- a/Cubelet/network/runtime/controller.go
+++ b/Cubelet/network/runtime/controller.go
@@ -67,6 +67,9 @@ type NetworkController struct {
 	locks   *SandboxLocks
 	states  map[string]*managedState
 	tapPool *TapPool
+	// pendingConnectionInvalidations is a best-effort maintenance queue for
+	// rollbacks whose synchronous CubeVS version bump failed. Guarded by mu.
+	pendingConnectionInvalidations map[string]struct{}
 	// tapFds retains one runtime-owned fd per idle pooled TAP. The fd moves to
 	// the owning managedState at acquireTap and returns here on release, so the
 	// GetTapFile hot path only duplicates and never pays a TUNSETIFF. Guarded

--- a/Cubelet/network/runtime/cubevs_adapter.go
+++ b/Cubelet/network/runtime/cubevs_adapter.go
@@ -21,6 +21,7 @@ type CubeVSAdapter interface {
 	AddTAPDevice(ifindex uint32, ip net.IP, sandboxID string, version uint32, opts cubevs.MVMOptions) error
 	UpsertTAPDevice(ifindex uint32, ip net.IP, sandboxID string, version uint32, opts cubevs.MVMOptions) error
 	UpsertTAPDeviceMetadata(ifindex uint32, ip net.IP, sandboxID string, version uint32) error
+	BumpTAPDeviceVersion(ifindex uint32) (oldVersion uint32, newVersion uint32, err error)
 	GetTAPDevice(ifindex uint32) (*cubevs.TAPDevice, error)
 	CleanupTAPPolicy(ifindex uint32) error
 	DeleteTAPDeviceMetadata(ifindex uint32, ip net.IP) error
@@ -50,6 +51,10 @@ func (realCubeVSAdapter) UpsertTAPDevice(ifindex uint32, ip net.IP, sandboxID st
 
 func (realCubeVSAdapter) UpsertTAPDeviceMetadata(ifindex uint32, ip net.IP, sandboxID string, version uint32) error {
 	return cubevs.UpsertTAPDeviceMetadata(ifindex, ip, sandboxID, version)
+}
+
+func (realCubeVSAdapter) BumpTAPDeviceVersion(ifindex uint32) (oldVersion uint32, newVersion uint32, err error) {
+	return cubevs.BumpTAPDeviceVersion(ifindex)
 }
 
 func (realCubeVSAdapter) GetTAPDevice(ifindex uint32) (*cubevs.TAPDevice, error) {

--- a/Cubelet/network/runtime/cubevs_adapter_test.go
+++ b/Cubelet/network/runtime/cubevs_adapter_test.go
@@ -22,6 +22,10 @@ type fakeCubeVSAdapter struct {
 	cleanupPolicyErr       error
 	deleteMetadataErr      error
 	deletePortMappingErr   error
+	bumpTAPDeviceErr       error
+	bumpTAPDeviceCalls     []uint32
+	bumpOldVersion         uint32
+	bumpNewVersion         uint32
 	recorder               *createOrderRecorder
 }
 
@@ -39,6 +43,19 @@ func (f *fakeCubeVSAdapter) UpsertTAPDevice(ifindex uint32, _ net.IP, _ string, 
 
 func (f *fakeCubeVSAdapter) UpsertTAPDeviceMetadata(_ uint32, _ net.IP, _ string, _ uint32) error {
 	return nil
+}
+
+func (f *fakeCubeVSAdapter) BumpTAPDeviceVersion(ifindex uint32) (uint32, uint32, error) {
+	f.bumpTAPDeviceCalls = append(f.bumpTAPDeviceCalls, ifindex)
+	if f.bumpTAPDeviceErr != nil {
+		return f.bumpOldVersion, 0, f.bumpTAPDeviceErr
+	}
+	oldVersion := f.bumpOldVersion
+	newVersion := f.bumpNewVersion
+	if newVersion == 0 {
+		newVersion = oldVersion + 1
+	}
+	return oldVersion, newVersion, nil
 }
 
 func (f *fakeCubeVSAdapter) GetTAPDevice(ifindex uint32) (*cubevs.TAPDevice, error) {

--- a/Cubelet/network/runtime/invalidation.go
+++ b/Cubelet/network/runtime/invalidation.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+func (s *NetworkController) activeSandboxTAPIfindex(sandboxID string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.states[sandboxID]
+	if !ok || state == nil {
+		return 0, fmt.Errorf("active network state not found for sandbox %q", sandboxID)
+	}
+	if state.TapIfIndex <= 0 {
+		return 0, fmt.Errorf(
+			"active network state for sandbox %q has invalid TAP ifindex %d",
+			sandboxID,
+			state.TapIfIndex,
+		)
+	}
+	return state.TapIfIndex, nil
+}
+
+// CheckSandboxConnections verifies that rollback can later invalidate the
+// active sandbox without changing its current connection generation.
+func (s *NetworkController) CheckSandboxConnections(ctx context.Context, sandboxID string) error {
+	if sandboxID == "" {
+		return fmt.Errorf("sandbox ID is empty")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	unlock := func() {}
+	if s.locks != nil {
+		unlock = s.locks.Lock(sandboxID)
+	}
+	defer unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	ifindex, err := s.activeSandboxTAPIfindex(sandboxID)
+	if err != nil {
+		return err
+	}
+	if _, err := s.cubevsAdapter.GetTAPDevice(uint32(ifindex)); err != nil {
+		return fmt.Errorf(
+			"check CubeVS metadata for sandbox %q TAP ifindex %d: %w",
+			sandboxID,
+			ifindex,
+			err,
+		)
+	}
+	return nil
+}
+
+// InvalidateSandboxConnections advances the CubeVS connection generation for
+// an active sandbox. It shares the lifecycle lock used by EnsureNetwork and
+// ReleaseNetwork so an ifindex cannot be invalidated after being reassigned.
+func (s *NetworkController) InvalidateSandboxConnections(
+	ctx context.Context,
+	sandboxID string,
+) (oldVersion uint32, newVersion uint32, err error) {
+	if sandboxID == "" {
+		return 0, 0, fmt.Errorf("sandbox ID is empty")
+	}
+
+	if err := ctx.Err(); err != nil {
+		s.enqueueConnectionInvalidation(sandboxID)
+		return 0, 0, err
+	}
+
+	unlock := func() {}
+	if s.locks != nil {
+		unlock = s.locks.Lock(sandboxID)
+	}
+	defer unlock()
+
+	if err := ctx.Err(); err != nil {
+		s.enqueueConnectionInvalidation(sandboxID)
+		return 0, 0, err
+	}
+
+	ifindex, err := s.activeSandboxTAPIfindex(sandboxID)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	start := time.Now()
+	oldVersion, newVersion, err = s.cubevsAdapter.BumpTAPDeviceVersion(uint32(ifindex))
+	if err != nil {
+		s.enqueueConnectionInvalidation(sandboxID)
+		return oldVersion, 0, fmt.Errorf(
+			"invalidate CubeVS connections for sandbox %q TAP ifindex %d: %w",
+			sandboxID, ifindex, err,
+		)
+	}
+	s.clearConnectionInvalidation(sandboxID)
+
+	CubeLog.WithContext(ctx).Infof(
+		"network runtime invalidated sandbox connections: sandbox_id=%s tap_ifindex=%d old_version=%d new_version=%d latency=%s",
+		sandboxID, ifindex, oldVersion, newVersion, time.Since(start),
+	)
+	return oldVersion, newVersion, nil
+}
+
+func (s *NetworkController) enqueueConnectionInvalidation(sandboxID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pendingConnectionInvalidations == nil {
+		s.pendingConnectionInvalidations = make(map[string]struct{})
+	}
+	s.pendingConnectionInvalidations[sandboxID] = struct{}{}
+}
+
+func (s *NetworkController) clearConnectionInvalidation(sandboxID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.pendingConnectionInvalidations, sandboxID)
+}
+
+func (s *NetworkController) retryPendingConnectionInvalidations() {
+	s.mu.Lock()
+	sandboxIDs := make([]string, 0, len(s.pendingConnectionInvalidations))
+	for sandboxID := range s.pendingConnectionInvalidations {
+		sandboxIDs = append(sandboxIDs, sandboxID)
+	}
+	s.mu.Unlock()
+
+	for _, sandboxID := range sandboxIDs {
+		unlock := func() {}
+		if s.locks != nil {
+			unlock = s.locks.Lock(sandboxID)
+		}
+
+		s.mu.Lock()
+		_, pending := s.pendingConnectionInvalidations[sandboxID]
+		s.mu.Unlock()
+		if !pending {
+			unlock()
+			continue
+		}
+
+		ifindex, err := s.activeSandboxTAPIfindex(sandboxID)
+		if err != nil {
+			s.clearConnectionInvalidation(sandboxID)
+			unlock()
+			CubeLog.WithContext(context.Background()).Warnf(
+				"dropping pending connection invalidation without active network: sandbox_id=%s err=%v",
+				sandboxID,
+				err,
+			)
+			continue
+		}
+
+		oldVersion, newVersion, err := s.cubevsAdapter.BumpTAPDeviceVersion(uint32(ifindex))
+		if err == nil {
+			s.clearConnectionInvalidation(sandboxID)
+		}
+		unlock()
+		if err != nil {
+			CubeLog.WithContext(context.Background()).Warnf(
+				"network maintenance failed to invalidate sandbox connections: sandbox_id=%s tap_ifindex=%d err=%v",
+				sandboxID,
+				ifindex,
+				err,
+			)
+			continue
+		}
+		CubeLog.WithContext(context.Background()).Infof(
+			"network maintenance invalidated sandbox connections: sandbox_id=%s tap_ifindex=%d old_version=%d new_version=%d",
+			sandboxID,
+			ifindex,
+			oldVersion,
+			newVersion,
+		)
+	}
+}

--- a/Cubelet/network/runtime/invalidation_test.go
+++ b/Cubelet/network/runtime/invalidation_test.go
@@ -1,0 +1,94 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeNet/cubevs"
+)
+
+func TestInvalidateSandboxConnectionsBumpsActiveTAP(t *testing.T) {
+	adapter := &fakeCubeVSAdapter{bumpOldVersion: 7, bumpNewVersion: 8}
+	controller := &NetworkController{
+		locks:         NewSandboxLocks(),
+		states:        map[string]*managedState{"sandbox": {persistedState: persistedState{SandboxID: "sandbox", TapIfIndex: 42}}},
+		cubevsAdapter: adapter,
+		version:       3,
+	}
+
+	oldVersion, newVersion, err := controller.InvalidateSandboxConnections(context.Background(), "sandbox")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldVersion != 7 || newVersion != 8 {
+		t.Fatalf("versions=(%d,%d), want (7,8)", oldVersion, newVersion)
+	}
+	if len(adapter.bumpTAPDeviceCalls) != 1 || adapter.bumpTAPDeviceCalls[0] != 42 {
+		t.Fatalf("bump calls=%v, want [42]", adapter.bumpTAPDeviceCalls)
+	}
+	if controller.version != 3 {
+		t.Fatalf("controller allocator version=%d, want unchanged 3", controller.version)
+	}
+}
+
+func TestCheckSandboxConnectionsRequiresCubeVSMetadata(t *testing.T) {
+	adapter := &fakeCubeVSAdapter{
+		getTAPDeviceByIndex: map[uint32]*cubevs.TAPDevice{
+			42: {Ifindex: 42},
+		},
+	}
+	controller := &NetworkController{
+		locks:         NewSandboxLocks(),
+		states:        map[string]*managedState{"sandbox": {persistedState: persistedState{SandboxID: "sandbox", TapIfIndex: 42}}},
+		cubevsAdapter: adapter,
+	}
+	if err := controller.CheckSandboxConnections(context.Background(), "sandbox"); err != nil {
+		t.Fatal(err)
+	}
+
+	delete(adapter.getTAPDeviceByIndex, 42)
+	if err := controller.CheckSandboxConnections(context.Background(), "sandbox"); err == nil {
+		t.Fatal("missing CubeVS metadata returned nil error")
+	}
+}
+
+func TestInvalidateSandboxConnectionsRequiresActiveState(t *testing.T) {
+	controller := &NetworkController{
+		locks:         NewSandboxLocks(),
+		states:        make(map[string]*managedState),
+		cubevsAdapter: &fakeCubeVSAdapter{},
+	}
+
+	if _, _, err := controller.InvalidateSandboxConnections(context.Background(), "missing"); err == nil {
+		t.Fatal("missing active state returned nil error")
+	}
+}
+
+func TestInvalidateSandboxConnectionsPropagatesCubeVSError(t *testing.T) {
+	bumpErr := errors.New("map update failed")
+	adapter := &fakeCubeVSAdapter{bumpOldVersion: 7, bumpTAPDeviceErr: bumpErr}
+	controller := &NetworkController{
+		locks:         NewSandboxLocks(),
+		states:        map[string]*managedState{"sandbox": {persistedState: persistedState{SandboxID: "sandbox", TapIfIndex: 42}}},
+		cubevsAdapter: adapter,
+	}
+
+	oldVersion, newVersion, err := controller.InvalidateSandboxConnections(context.Background(), "sandbox")
+	if !errors.Is(err, bumpErr) {
+		t.Fatalf("error=%v, want %v", err, bumpErr)
+	}
+	if oldVersion != 7 || newVersion != 0 {
+		t.Fatalf("versions=(%d,%d), want (7,0)", oldVersion, newVersion)
+	}
+	if _, pending := controller.pendingConnectionInvalidations["sandbox"]; !pending {
+		t.Fatal("failed invalidation was not queued for maintenance")
+	}
+
+	adapter.bumpTAPDeviceErr = nil
+	adapter.bumpNewVersion = 8
+	controller.retryPendingConnectionInvalidations()
+	if _, pending := controller.pendingConnectionInvalidations["sandbox"]; pending {
+		t.Fatal("successful maintenance retry did not clear pending invalidation")
+	}
+}

--- a/Cubelet/network/runtime/network_runtime.go
+++ b/Cubelet/network/runtime/network_runtime.go
@@ -32,6 +32,12 @@ type NetworkRuntime interface {
 	Health(ctx context.Context) error
 	// GetTapFile returns a caller-owned live TAP fd for the sandbox handoff path.
 	GetTapFile(sandboxID, tapName string) (*os.File, error)
+	// CheckSandboxConnections verifies the active TAP and CubeVS metadata
+	// without changing the current connection generation.
+	CheckSandboxConnections(ctx context.Context, sandboxID string) error
+	// InvalidateSandboxConnections advances the active sandbox's CubeVS
+	// connection generation. Existing TCP sessions no longer match afterwards.
+	InvalidateSandboxConnections(ctx context.Context, sandboxID string) (oldVersion uint32, newVersion uint32, err error)
 
 	// DumpEgressPolicies returns every active sandbox's L7 egress
 	// policy in the JSON shape CubeEgress's bootstrap.lua expects.

--- a/Cubelet/network/runtime/tap_cleaner.go
+++ b/Cubelet/network/runtime/tap_cleaner.go
@@ -333,6 +333,7 @@ func (s *NetworkController) startMaintenanceLoop() {
 		ticker := time.NewTicker(maintenanceInterval)
 		defer ticker.Stop()
 		for range ticker.C {
+			s.retryPendingConnectionInvalidations()
 			s.handleCleaningEntries()
 		}
 	}()

--- a/Cubelet/services/cubebox/rollback.go
+++ b/Cubelet/services/cubebox/rollback.go
@@ -29,6 +29,9 @@ const (
 	shimUpdateRollbackAction            = "RollbackSnapshot"
 	shimUpdatePauseSnapshotAnnotation   = "cube.shimapi.update.pause.snapshot_config"
 	shimUpdatePauseToSnapshotAction     = "PauseToSnapshot"
+
+	connectionInvalidationAttempts   = 3
+	connectionInvalidationRetryDelay = 50 * time.Millisecond
 )
 
 type rollbackRestoreConfig struct {
@@ -78,6 +81,11 @@ func (s *service) RollbackSandbox(ctx context.Context, req *cubebox.RollbackSand
 		"snapshotID": req.GetSnapshotID(),
 		"newGen":     req.GetNewGen(),
 	})
+	if s.connectionInvalidator == nil {
+		rsp.Ret.RetCode = errorcode.ErrorCode_PreConditionFailed
+		rsp.Ret.RetMsg = "network connection invalidator is unavailable"
+		return rsp, nil
+	}
 
 	cb, err := s.cubeboxMgr.cubeboxManger.Get(ctx, req.GetSandboxID())
 	if err != nil {
@@ -145,6 +153,11 @@ func (s *service) RollbackSandbox(ctx context.Context, req *cubebox.RollbackSand
 		rsp.Ret.RetMsg = fmt.Sprintf("failed to build restore config: %v", err)
 		return rsp, nil
 	}
+	if err := s.connectionInvalidator.CheckSandboxConnections(ctx, req.GetSandboxID()); err != nil {
+		rsp.Ret.RetCode = errorcode.ErrorCode_PreConditionFailed
+		rsp.Ret.RetMsg = fmt.Sprintf("network connection invalidation preflight failed: %v", err)
+		return rsp, nil
+	}
 
 	rollbackTime := time.Now().UTC()
 	var rollbackTask containerd.Task
@@ -182,6 +195,24 @@ func (s *service) RollbackSandbox(ctx context.Context, req *cubebox.RollbackSand
 	}
 	cleanupNewRootfs = false
 
+	oldVersion, newVersion, invalidateErr := s.invalidateSandboxConnectionsWithRetry(
+		ctx,
+		req.GetSandboxID(),
+		connectionInvalidationAttempts,
+		connectionInvalidationRetryDelay,
+	)
+	if invalidateErr != nil {
+		warning := fmt.Sprintf("network connection invalidation deferred: %v", invalidateErr)
+		rsp.Ret.RetMsg = appendRollbackMessage(rsp.Ret.RetMsg, warning)
+		stepLog.Errorf("rollback restored VM but failed to invalidate historical connections: %v", invalidateErr)
+	} else {
+		stepLog.Infof(
+			"rollback invalidated historical connections: oldVersion=%d newVersion=%d",
+			oldVersion,
+			newVersion,
+		)
+	}
+
 	// Scrub any "terminated" markers a concurrent path may have stamped
 	// onto the in-memory Status while shim's delete_vm + resume_vm_with_config
 	// was running. We do NOT consult containerd here: the shim has already
@@ -214,7 +245,10 @@ func (s *service) RollbackSandbox(ctx context.Context, req *cubebox.RollbackSand
 	}
 	if err := storage.DeleteObject(ctx, currentRootfs.Name, currentRootfs.Kind); err != nil {
 		rsp.OldRootfsDeleted = false
-		rsp.Ret.RetMsg = fmt.Sprintf("rollback succeeded; old rootfs cleanup deferred: %v", err)
+		rsp.Ret.RetMsg = appendRollbackMessage(
+			rsp.Ret.RetMsg,
+			fmt.Sprintf("rollback succeeded; old rootfs cleanup deferred: %v", err),
+		)
 		stepLog.Warnf("rollback succeeded but failed to delete old rootfs %s: %v", currentRootfs.Name, err)
 	} else {
 		rsp.OldRootfsDeleted = true
@@ -222,6 +256,48 @@ func (s *service) RollbackSandbox(ctx context.Context, req *cubebox.RollbackSand
 
 	stepLog.Infof("RollbackSandbox completed successfully: newRootfs=%s oldRootfs=%s oldDeleted=%t", rsp.RootfsVol, rsp.OldRootfsVol, rsp.OldRootfsDeleted)
 	return rsp, nil
+}
+
+func appendRollbackMessage(current, message string) string {
+	if current == "" {
+		return message
+	}
+	return current + "; " + message
+}
+
+func (s *service) invalidateSandboxConnectionsWithRetry(
+	ctx context.Context,
+	sandboxID string,
+	attempts int,
+	delay time.Duration,
+) (oldVersion uint32, newVersion uint32, err error) {
+	if s.connectionInvalidator == nil {
+		return 0, 0, fmt.Errorf("network connection invalidator is unavailable")
+	}
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		oldVersion, newVersion, err = s.connectionInvalidator.InvalidateSandboxConnections(ctx, sandboxID)
+		if err == nil {
+			return oldVersion, newVersion, nil
+		}
+		if attempt == attempts {
+			break
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return oldVersion, 0, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return oldVersion, 0, err
 }
 
 func runRollbackWithPreparedGuestMetrics(

--- a/Cubelet/services/cubebox/rollback_test.go
+++ b/Cubelet/services/cubebox/rollback_test.go
@@ -17,6 +17,26 @@ import (
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 )
 
+type fakeSandboxConnectionInvalidator struct {
+	errs  []error
+	calls int
+}
+
+func (f *fakeSandboxConnectionInvalidator) CheckSandboxConnections(context.Context, string) error {
+	return nil
+}
+
+func (f *fakeSandboxConnectionInvalidator) InvalidateSandboxConnections(
+	_ context.Context,
+	_ string,
+) (uint32, uint32, error) {
+	f.calls++
+	if f.calls <= len(f.errs) && f.errs[f.calls-1] != nil {
+		return 7, 0, f.errs[f.calls-1]
+	}
+	return 7, 8, nil
+}
+
 func TestRollbackDisksFromSnapshotSpecReplacesCurrentRootfs(t *testing.T) {
 	spec := &CubeboxSnapshotSpec{
 		Disk: json.RawMessage(`[
@@ -32,6 +52,39 @@ func TestRollbackDisksFromSnapshotSpecReplacesCurrentRootfs(t *testing.T) {
 	assert.Equal(t, "disk-0", disks[0].ID)
 	assert.Equal(t, "/dev/mapper/data", disks[1].Path)
 	assert.NotEmpty(t, disks[0].RateLimiterConfig)
+}
+
+func TestInvalidateSandboxConnectionsWithRetry(t *testing.T) {
+	transient := errors.New("transient map failure")
+	invalidator := &fakeSandboxConnectionInvalidator{errs: []error{transient, transient}}
+	s := &service{connectionInvalidator: invalidator}
+
+	oldVersion, newVersion, err := s.invalidateSandboxConnectionsWithRetry(
+		context.Background(),
+		"sandbox",
+		3,
+		0,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(7), oldVersion)
+	assert.Equal(t, uint32(8), newVersion)
+	assert.Equal(t, 3, invalidator.calls)
+}
+
+func TestInvalidateSandboxConnectionsWithRetryExhausted(t *testing.T) {
+	permanent := errors.New("permanent map failure")
+	invalidator := &fakeSandboxConnectionInvalidator{errs: []error{permanent, permanent}}
+	s := &service{connectionInvalidator: invalidator}
+
+	_, newVersion, err := s.invalidateSandboxConnectionsWithRetry(
+		context.Background(),
+		"sandbox",
+		2,
+		0,
+	)
+	require.ErrorIs(t, err, permanent)
+	assert.Zero(t, newVersion)
+	assert.Equal(t, 2, invalidator.calls)
 }
 
 func TestRollbackDisksFromSnapshotSpecRejectsMissingRootfs(t *testing.T) {

--- a/Cubelet/services/cubebox/service.go
+++ b/Cubelet/services/cubebox/service.go
@@ -138,6 +138,15 @@ func init() {
 				return nil, fmt.Errorf("not a cubebox manager")
 			}
 
+			np, err := ic.GetByID(constants.InternalPlugin, constants.NetworkID.ID())
+			if err != nil {
+				return nil, err
+			}
+			connectionInvalidator, ok := np.(SandboxConnectionInvalidator)
+			if !ok {
+				return nil, fmt.Errorf("network plugin does not support sandbox connection invalidation")
+			}
+
 			p, err := ic.GetByID(constants.WorkflowPlugin, constants.WorkflowID.ID())
 			if err != nil {
 				return nil, err
@@ -156,6 +165,7 @@ func init() {
 				events:                ep.(*exchange.Exchange),
 				numaNodeIndex:         0,
 				sandboxLifecycleLocks: utils.NewResourceLocks(),
+				connectionInvalidator: connectionInvalidator,
 				otherRuntime: &ociRuntime{
 					cubeboxMgr: cb,
 				},
@@ -198,8 +208,17 @@ type service struct {
 	cubebox.UnimplementedCubeboxMgrServer
 	numaNodeIndex         uint32
 	sandboxLifecycleLocks *utils.ResourceLocks
+	connectionInvalidator SandboxConnectionInvalidator
 
 	otherRuntime *ociRuntime
+}
+
+type SandboxConnectionInvalidator interface {
+	CheckSandboxConnections(context.Context, string) error
+	InvalidateSandboxConnections(
+		context.Context,
+		string,
+	) (oldVersion uint32, newVersion uint32, err error)
 }
 
 func (s *service) RegisterTCP(server *grpc.Server) error {


### PR DESCRIPTION
Track CubeProxy TCP flows in versioned original_sessions and return directional RSTs for stale generations. Bump TAP versions after restore with preflight, retry, maintenance cleanup, and focused tests.

Fixes #992.