### PR TITLE
build(make): split clean into go-build-dirs and rust-target-dirs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,9 @@ make cubemaster
 make cubelet
 make agent
 make shim
+
+# Remove local Go/Rust build artifacts (not global caches)
+make clean
 ```
 
 See the [Makefile](./Makefile) for the full list of build targets.

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -59,6 +59,9 @@ make cubemaster
 make cubelet
 make agent
 make shim
+
+# 清理本地 Go/Rust 编译产物（不清全局缓存）
+make clean
 ```
 
 完整的构建目标列表请参见 [Makefile](./Makefile)。

--- a/CubeMaster/Makefile
+++ b/CubeMaster/Makefile
@@ -120,7 +120,7 @@ lint:
 
 
 clean:
-	@rm -rf docker/cubemaster
+	@rm -rf docker/cubemaster $(BUILD_DIR)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,7 @@ KERNEL_IMAGE_TARGET ?= vmlinux
 KERNEL_BUILD_JOBS ?=
 KERNEL_CROSS_COMPILE ?=
 
-# Top-level Rust project directories. Each owns its own Cargo workspace and
-# `target/`; sub-crates share their workspace's target dir, so cleaning these
-# five removes all Rust build artifacts in the repo.
+# Top-level Rust project directories. Each owns its own Cargo workspace.
 RUST_PROJECT_DIRS := \
 	$(ROOT_DIR)/CubeAPI \
 	$(ROOT_DIR)/CubeShim \
@@ -55,6 +53,30 @@ RUST_PROJECT_DIRS := \
 	$(ROOT_DIR)/guest-init \
 	$(ROOT_DIR)/cubecow \
 	$(ROOT_DIR)/hypervisor
+
+# Cargo workspaces visited by `make clean`.
+RUST_CARGO_CLEAN_DIRS := \
+	$(RUST_PROJECT_DIRS) \
+	$(ROOT_DIR)/agent/libs
+
+# Local Go build outputs and installed binaries. Intentionally excludes
+# `_output/kernel` and `_output/release`, which are expensive to rebuild.
+GO_BUILD_ARTIFACT_DIRS := \
+	$(ROOT_DIR)/CubeMaster/build \
+	$(ROOT_DIR)/CubeMaster/coverage \
+	$(ROOT_DIR)/CubeMaster/docker/cubemaster \
+	$(ROOT_DIR)/Cubelet/build \
+	$(ROOT_DIR)/Cubelet/coverage \
+	$(ROOT_DIR)/CubeOps/bin \
+	$(ROOT_DIR)/CubeProxy/bin \
+	$(ROOT_DIR)/cube-lifecycle-manager/bin \
+	$(ROOT_DIR)/examples/cube-bench/bin \
+	$(CUBELET_COW_THIRD_PARTY_DIR) \
+	$(OUTPUT_DIR) \
+	$(AGENT_EXT4_OUTPUT_DIR)
+
+GO_BUILD_ARTIFACT_FILES := \
+	$(ROOT_DIR)/cubecow/examples/go-test/cubecow-test
 
 BINARIES := \
 	agent \
@@ -143,7 +165,9 @@ help:
 	@printf "  guest-kernel  Build guest kernel vmlinux/Image (KERNEL_SRC=...; native or cross x86_64<->aarch64)\n"
 	@printf "  all           Build all default binaries in Docker\n"
 	@printf "  manual-release Build binaries and package manual update tarball\n"
-	@printf "  clean-rust-target-dirs Remove target/ in every top-level Rust project\n"
+	@printf "  clean         Remove local Go/Rust build artifacts (not global caches)\n"
+	@printf "  clean-go-build-dirs Remove Go component build/bin dirs and _output/{bin,cube-agent}\n"
+	@printf "  clean-rust-target-dirs cargo clean every Rust workspace in Docker\n"
 	@printf "  web-install   Install WebUI npm dependencies\n"
 	@printf "  web-dev       Start WebUI Vite dev server\n"
 	@printf "  web-build     Build WebUI static assets\n"
@@ -244,14 +268,35 @@ cubecow-clean:
 	rm -rf "$(CUBELET_COW_THIRD_PARTY_DIR)"
 	cd "$(CUBECOW_DIR)" && cargo clean
 
-.PHONY: clean-rust-target-dirs
-clean-rust-target-dirs:
-	@for dir in $(RUST_PROJECT_DIRS); do \
-		if [ -d "$$dir/target" ]; then \
-			printf '  %-8s %s\n' "RM" "$$dir/target"; \
-			rm -rf "$$dir/target"; \
+.PHONY: clean-go-build-dirs
+clean-go-build-dirs:
+	@for dir in $(GO_BUILD_ARTIFACT_DIRS); do \
+		if [ -d "$$dir" ]; then \
+			printf '  %-8s %s\n' "RM" "$$dir"; \
+			rm -rf "$$dir"; \
 		fi; \
 	done
+	@for f in $(GO_BUILD_ARTIFACT_FILES); do \
+		if [ -e "$$f" ]; then \
+			printf '  %-8s %s\n' "RM" "$$f"; \
+			rm -f "$$f"; \
+		fi; \
+	done
+
+.PHONY: clean-rust-target-dirs
+clean-rust-target-dirs:
+ifeq ($(IN_CUBE_SANDBOX_BUILDER),1)
+	@for dir in $(RUST_CARGO_CLEAN_DIRS); do \
+		printf '  %-8s %s\n' "CARGO" "clean $$dir"; \
+		cargo clean --manifest-path "$$dir/Cargo.toml"; \
+	done
+else
+	$(MAKE) builder-image
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make clean-rust-target-dirs'
+endif
+
+.PHONY: clean
+clean: clean-go-build-dirs clean-rust-target-dirs
 
 .PHONY: cubecow-smoke
 cubecow-smoke: builder-image


### PR DESCRIPTION
## Summary

`make clean` previously only removed `target/` under the top-level Rust projects. This PR splits it into two targets:

- **`clean-go-build-dirs`** — removes local Go build/bin dirs and `_output/{bin,cube-agent}`. Intentionally keeps `_output/kernel` and `_output/release` (expensive to rebuild).
- **`clean-rust-target-dirs`** — runs `cargo clean` inside the Docker builder for every top-level Rust workspace plus `agent/libs`, instead of `rm -rf target/`.

`make clean` now invokes both.

## Changes

- `Makefile`: add `clean-go-build-dirs`, rework `clean-rust-target-dirs` to use `cargo clean`, add combined `clean` target, update `help` text
- `CubeMaster/Makefile`: `clean` also removes `$(BUILD_DIR)`
- `CONTRIBUTING.md` / `CONTRIBUTING_zh.md`: document `make clean`