### PR TITLE
fix(sdk/go): prevent concurrent double-close on Watcher response body

### DIFF
--- a/sdk/go/envd.go
+++ b/sdk/go/envd.go
@@ -487,13 +487,22 @@ type Watcher struct {
 	once   sync.Once
 }
 
-// Close terminates the watcher and releases resources.
-func (w *Watcher) Close() error {
+// closeBody closes the response body exactly once, whether the stream ended
+// naturally (readLoop) or was torn down early (Close).
+func (w *Watcher) closeBody() error {
+	var err error
 	w.once.Do(func() {
 		w.cancel()
-		w.body.Close()
+		if w.body != nil {
+			err = w.body.Close()
+		}
 	})
-	return nil
+	return err
+}
+
+// Close terminates the watcher and releases resources.
+func (w *Watcher) Close() error {
+	return w.closeBody()
 }
 
 type watchDirFrame struct {
@@ -551,7 +560,7 @@ func (s *Sandbox) watchDir(ctx context.Context, path string, options ...fileRequ
 func (w *Watcher) readLoop() {
 	defer close(w.events)
 	defer close(w.errs)
-	defer w.body.Close()
+	defer func() { _ = w.closeBody() }()
 
 	for {
 		flags, payload, err := readConnectEnvelope(w.body)

--- a/sdk/go/envd.go
+++ b/sdk/go/envd.go
@@ -479,25 +479,25 @@ type Watcher struct {
 	Events <-chan WatchEvent
 	Errors <-chan error
 
-	events chan WatchEvent
-	errs   chan error
-	ctx    context.Context
-	cancel context.CancelFunc
-	body   io.ReadCloser
-	once   sync.Once
+	events   chan WatchEvent
+	errs     chan error
+	ctx      context.Context
+	cancel   context.CancelFunc
+	body     io.ReadCloser
+	closeErr error
+	once     sync.Once
 }
 
 // closeBody closes the response body exactly once, whether the stream ended
 // naturally (readLoop) or was torn down early (Close).
 func (w *Watcher) closeBody() error {
-	var err error
 	w.once.Do(func() {
 		w.cancel()
 		if w.body != nil {
-			err = w.body.Close()
+			w.closeErr = w.body.Close()
 		}
 	})
-	return err
+	return w.closeErr
 }
 
 // Close terminates the watcher and releases resources.

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -4,6 +4,7 @@
 package cubesandbox
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -16,6 +17,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1428,6 +1431,84 @@ func TestFilesWatchDirErrorFromServer(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected error on Errors channel")
+	}
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closeCount int32
+}
+
+func (t *trackingReadCloser) Close() error {
+	atomic.AddInt32(&t.closeCount, 1)
+	return nil
+}
+
+func TestWatcherClosesBodyExactlyOnce(t *testing.T) {
+	body := &trackingReadCloser{
+		Reader: bytes.NewReader(connectEnvelope(connectEndStreamFlag, `{}`)),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan WatchEvent, 64)
+	errs := make(chan error, 1)
+	w := &Watcher{
+		Events: events,
+		Errors: errs,
+		events: events,
+		errs:   errs,
+		ctx:    ctx,
+		cancel: cancel,
+		body:   body,
+	}
+
+	w.readLoop()
+
+	// After readLoop exits on natural stream end, Close() should be a no-op
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if count := atomic.LoadInt32(&body.closeCount); count != 1 {
+		t.Fatalf("expected body to be closed exactly once, got %d", count)
+	}
+}
+
+func TestWatcherConcurrentClose(t *testing.T) {
+	pr, pw := io.Pipe()
+	body := &trackingReadCloser{
+		Reader: pr,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan WatchEvent, 64)
+	errs := make(chan error, 1)
+	w := &Watcher{
+		Events: events,
+		Errors: errs,
+		events: events,
+		errs:   errs,
+		ctx:    ctx,
+		cancel: cancel,
+		body:   body,
+	}
+
+	go w.readLoop()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = w.Close()
+		}()
+	}
+
+	_ = pw.Close()
+	wg.Wait()
+
+	if count := atomic.LoadInt32(&body.closeCount); count != 1 {
+		t.Fatalf("expected body to be closed exactly once under concurrent Close(), got %d", count)
 	}
 }
 

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -1512,6 +1512,97 @@ func TestWatcherConcurrentClose(t *testing.T) {
 	}
 }
 
+type errCloser struct {
+	io.Reader
+	err error
+}
+
+func (e *errCloser) Close() error {
+	return e.err
+}
+
+func TestWatcherCloseErrorPreserved(t *testing.T) {
+	expectedErr := errors.New("underlying close failed")
+	body := &errCloser{
+		Reader: bytes.NewReader(connectEnvelope(connectEndStreamFlag, `{}`)),
+		err:    expectedErr,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan WatchEvent, 64)
+	errs := make(chan error, 1)
+	w := &Watcher{
+		Events: events,
+		Errors: errs,
+		events: events,
+		errs:   errs,
+		ctx:    ctx,
+		cancel: cancel,
+		body:   body,
+	}
+
+	w.readLoop()
+
+	// Both first Close() and subsequent Close() calls should reliably return the captured closeErr
+	if err := w.Close(); !errors.Is(err, expectedErr) {
+		t.Fatalf("expected %v, got %v", expectedErr, err)
+	}
+	if err := w.Close(); !errors.Is(err, expectedErr) {
+		t.Fatalf("expected subsequent Close() to preserve %v, got %v", expectedErr, err)
+	}
+}
+
+func TestFilesWatchDirConcurrentCloseLiveServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", connectContentType)
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		w.Write(connectFrame(0, []byte(`{"start":{}}`)))
+		flusher.Flush()
+
+		// Stream events until client disconnects
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ticker.C:
+				_, _ = w.Write(connectFrame(0, []byte(`{"filesystem":{"name":"x.txt","type":"EVENT_TYPE_CREATE"}}`)))
+				flusher.Flush()
+			}
+		}
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: 5 * time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs-concurrent"}
+
+	watcher, err := sb.Files().WatchDir(context.Background(), "/tmp")
+	if err != nil {
+		t.Fatalf("WatchDir: %v", err)
+	}
+
+	// Consume at least 1 event to ensure stream is active
+	<-watcher.Events
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = watcher.Close()
+		}()
+	}
+
+	wg.Wait()
+
+	// Drain remaining events safely
+	for range watcher.Events {
+	}
+}
+
 func TestBuildTemplateForwardsCreateFromImageOptions(t *testing.T) {
 	var got map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Problem Description

Fixes #1404

In `sdk/go/envd.go`, `Watcher` has a lifecycle and concurrency defect where the underlying HTTP response body (`io.ReadCloser`) is subject to unsynchronized duplicate closing and race conditions between `readLoop()` and `Watcher.Close()`:

1. **Unsynchronized Double Close on Natural Stream End**:
   When `readLoop` exits on stream termination (or server EOF), its deferred `w.body.Close()` runs directly on `w.body`. If the caller subsequently calls `watcher.Close()`, `w.once.Do` runs and executes `w.body.Close()` a second time.
2. **Concurrent Close Race**:
   If a caller invokes `watcher.Close()` while `readLoop` is blocking on `readConnectEnvelope(w.body)`, `w.Close()` closes `w.body`, causing `readConnectEnvelope` to return with an error and exit `readLoop`. `readLoop` then executes its deferred `w.body.Close()`, causing two concurrent goroutines to execute `w.body.Close()` without synchronization. In Go `net/http`, `io.ReadCloser` does not guarantee a safe concurrent double-close.
3. **Inconsistency with PTY Streaming Pattern**:
   In `sdk/go/pty.go`, `PtyHandle` encapsulates body closing with a single-close helper guarded by `sync.Once`:
   ```go
   func (h *PtyHandle) closeBody() error {
       var err error
       h.once.Do(func() { err = h.body.Close() })
       return err
   }
   ```
   `Watcher` deviated from this pattern by bypassing `w.once` in `readLoop`.

---

## Proposed Changes

1. **Introduce `closeBody()` on `Watcher`**:
   Encapsulate context cancellation and `w.body.Close()` inside `w.once.Do`, returning the close error.
2. **Unify Exit Paths**:
   - `Watcher.Close()` delegates directly to `w.closeBody()`.
   - `Watcher.readLoop()` defers `func() { _ = w.closeBody() }()`.
3. **Unit Tests**:
   Add `TestWatcherClosesBodyExactlyOnce` and `TestWatcherConcurrentClose` in `sdk/go/sdk_test.go` to guarantee exact single-close behavior under both natural completion and concurrent multi-goroutine termination.

---

## Verification

### 1. Fail-First Reproduction (Before Fix)
```text
=== RUN   TestWatcherClosesBodyExactlyOnce
    sdk_test.go:1473: expected body to be closed exactly once, got 2
--- FAIL: TestWatcherClosesBodyExactlyOnce (0.00s)
=== RUN   TestWatcherConcurrentClose
    sdk_test.go:1511: expected body to be closed exactly once under concurrent Close(), got 2
--- FAIL: TestWatcherConcurrentClose (0.00s)
FAIL
FAIL	github.com/tencentcloud/CubeSandbox/sdk/go	0.032s
```

### 2. Post-Fix Verification (20 Stress Rounds)
```bash
go test -v -count=20 ./...
# Result: PASS (ok github.com/tencentcloud/CubeSandbox/sdk/go 4.867s)
```

### 3. Governance Compliance
- Production code diff: ~10 lines.
- All Go files formatted via `gofmt`.
