### PR TITLE
cubeegress: require an explicit opt-in before injecting credentials over plaintext HTTP

### DIFF
--- a/CubeEgress/lua/access_phase.lua
+++ b/CubeEgress/lua/access_phase.lua
@@ -216,6 +216,9 @@ local function inject_gates(ctx)
         if not ctx.host or ctx.host == "" then
             return false, "g4_missing_host", true
         end
+        if ctx.allow_plaintext_inject ~= true then
+            return false, "g5_plaintext_inject_not_permitted", true
+        end
     end
     return true
 end
@@ -354,9 +357,10 @@ local function allow(decision)
             end
         end
         local ok, reason, sec = inject_gates({
-            scheme = decision.scheme,
-            sni    = decision.sni,
-            host   = decision.host,
+            scheme                 = decision.scheme,
+            sni                    = decision.sni,
+            host                   = decision.host,
+            allow_plaintext_inject = decision.allow_plaintext_inject,
         })
         if not ok then
             decision.inject_dropped = reason
@@ -471,6 +475,7 @@ function _M.decide()
             decision.rule_id     = r.id
             decision.audit_level = (r.action and r.action.audit) or "metadata"
             decision.inject      = r.action and r.action.inject  -- consumed in Pγ
+            decision.allow_plaintext_inject = r.action and r.action.allow_plaintext_inject == true
             if r.action and r.action.allow == true then
                 return allow(decision)
             else

--- a/CubeEgress/lua/policy.lua
+++ b/CubeEgress/lua/policy.lua
@@ -89,6 +89,11 @@ local function validate_policy(p)
             return false, "rules[" .. i .. "].action.allow required (boolean)"
         end
         -- inject is optional; if present must be array of {header, secret, format}.
+        if r.action.allow_plaintext_inject ~= nil
+           and type(r.action.allow_plaintext_inject) ~= "boolean" then
+            return false, string.format(
+                "rules[%d].action.allow_plaintext_inject must be a boolean", i)
+        end
         if r.action.inject ~= nil then
             if type(r.action.inject) ~= "table" then
                 return false, "rules[" .. i .. "].action.inject must be array"


### PR DESCRIPTION
Closes #1410.

On `:8443` the destination is authenticated: `proxy_ssl_verify on` plus `proxy_ssl_name $cube_original_sni`
means an attacker-controlled IP cannot present a valid certificate for someone else's SNI, so G4's
`Host == SNI` check plus the upstream handshake genuinely bind the credential to the intended host.

On `:8080` there is no certificate, so none of that applies. The only HTTP-path check was that `Host` is
non-empty — and `Host` is supplied by the sandbox, which also chooses the destination IP via TPROXY. A
sandbox could therefore connect to its own server, send `Host: api.internal.corp`, and receive the
operator's credential.

## What this changes

Plaintext injection becomes **opt-in per rule** instead of implicit.

**`CubeEgress/lua/access_phase.lua`**

- `inject_gates` gains a check on the HTTP branch: unless the matched rule sets
  `action.allow_plaintext_inject = true`, injection is refused with the new reason
  `g5_plaintext_inject_not_permitted`, flagged as a `security_event`.
- `decide()` carries `r.action.allow_plaintext_inject == true` onto the decision, and the `inject_gates`
  call site passes it through.

**`CubeEgress/lua/policy.lua`** — `validate_policy` rejects a non-boolean `allow_plaintext_inject`, so a
typo like `"true"` fails at install time rather than silently reading as falsy.

The HTTPS path is untouched. The request itself is still **allowed** when the gate fails — consistent with
the existing contract that a gate failure drops the inject rather than blocking traffic — and the existing
pre-clear of inject headers still runs, so a sandbox cannot smuggle its own forged `Authorization` through in
place of the real one.

No comment changes. Note the G5/G6 comment at `access_phase.lua:26-27` is now doubly inaccurate for `:8080`;
I left it alone under the no-comment-changes constraint, but it should be corrected when someone touches that
block.

## Testing

Driving the real `access_phase.lua` end to end:

| case | master | this branch |
|---|---|---|
| HTTPS, `Host == SNI` (legit) | credential injected | credential injected |
| HTTP, spoofed `Host` → attacker IP, default rule | **credential injected** | **`<none>`**, `g5_plaintext_inject_not_permitted` |
| HTTP, rule sets `allow_plaintext_inject = true` | credential injected | credential injected |
| HTTP, rule sets `allow_plaintext_inject = false` | **credential injected** | `<none>`, `g5_plaintext_inject_not_permitted` |

The first row is the regression guard — the fix must not disturb the HTTPS path, which is the normal case.
The last row is worth noting: on master the field is ignored entirely, so even an operator who explicitly
disabled it still leaked.

Field validation:

```
  allow_plaintext_inject=omitted          accepted=true   want=true   OK
  allow_plaintext_inject=true             accepted=true   want=true   OK
  allow_plaintext_inject=false            accepted=true   want=true   OK
  allow_plaintext_inject="yes" (string)   accepted=false  want=false  OK
  allow_plaintext_inject=1 (number)       accepted=false  want=false  OK
```

`loadfile` on both modules → SYNTAX OK.

CI gates: the Lua files are not covered by `fmt-check` or `unit-test-check`.

## Why opt-in rather than an outright ban or a dst-IP check

- **Outright ban** would break the case `inject_gates`' own comment calls out — "operators may legitimately
  need to inject credentials into plaintext traffic on trusted networks (e.g. intra-cluster 80)".
- **Resolving the Host and requiring `ctx.dst_ip` to be in the resolved set** is the stronger fix, but it puts
  a DNS dependency on the request path and races DNS changes; it also needs a decision about caching and
  failure modes. Worth doing, and it would let the opt-in be removed again.

Opt-in is the smallest change that makes the default safe and makes the risky configuration explicit and
greppable.

## Deployment impact — read before merging

**Any existing rule that injects over plaintext HTTP will stop injecting** until
`allow_plaintext_inject: true` is added to it. Operators relying on intra-cluster `:80` injection must update
those rules. The failure is visible rather than silent: the decision carries
`inject_dropped = g5_plaintext_inject_not_permitted` and raises a `security_event`, so it shows up in the
audit stream immediately.

