### PR TITLE
cubeproxy: fail closed when the admin token is unset, and compare it in constant time

### DIFF
--- a/CubeProxy/lua/admin_phase.lua
+++ b/CubeProxy/lua/admin_phase.lua
@@ -34,14 +34,40 @@ local function reply_error(status, msg)
     reply(status, { error = msg })
 end
 
+local function constant_time_equal(a, b)
+    if type(a) ~= "string" or type(b) ~= "string" then
+        return false
+    end
+    if #a ~= #b then
+        return false
+    end
+    local diff = 0
+    for i = 1, #a do
+        if string.byte(a, i) ~= string.byte(b, i) then
+            diff = diff + 1
+        end
+    end
+    return diff == 0
+end
+
+local function is_loopback(addr)
+    return addr == "127.0.0.1" or addr == "::1"
+end
+
 local function check_token()
     local expected = ngx.var.cube_admin_token
-    if not expected or expected == "" then
+    if expected and expected ~= "" then
+        if not constant_time_equal(ngx.var.http_x_cube_admin_token, expected) then
+            reply_error(ngx.HTTP_FORBIDDEN, "admin token mismatch")
+        end
         return
     end
-    local got = ngx.var.http_x_cube_admin_token
-    if got ~= expected then
-        reply_error(ngx.HTTP_FORBIDDEN, "admin token mismatch")
+    if not is_loopback(ngx.var.remote_addr) then
+        ngx.log(ngx.ERR, "admin API reached from ", tostring(ngx.var.remote_addr),
+                         " with no $cube_admin_token configured; refusing. ",
+                         "Set CUBE_PROXY_ADMIN_TOKEN or bind the admin server to loopback.")
+        reply_error(ngx.HTTP_SERVICE_UNAVAILABLE,
+            "admin token not configured; refusing non-loopback request")
     end
 end
 


### PR DESCRIPTION
Closes #1412.

## Motivation

`check_token()` returned immediately when `$cube_admin_token` was empty, leaving every `/admin/*` endpoint
unauthenticated. That was tolerable while the admin server was loopback-only, but the container entrypoint
defaults the listener to `0.0.0.0` and only injects the token when `CUBE_PROXY_ADMIN_TOKEN` is set — so the
two controls fail open together, and `POST /admin/meta/upsert` can repoint a sandbox's traffic at an
attacker-chosen backend from anywhere.

## What this changes

`CubeProxy/lua/admin_phase.lua`:

1. **Fail closed off-loopback when no token is configured.** With `$cube_admin_token` empty, requests from
   `127.0.0.1` / `::1` are still served — preserving the documented "accepts any loopback request"
   behaviour that local tooling relies on — and anything else gets `503` plus an `ERR` log line naming the
   peer and telling the operator to set `CUBE_PROXY_ADMIN_TOKEN` or bind to loopback.
2. **Constant-time token comparison.** `got ~= expected` short-circuits on the first differing byte.
   `constant_time_equal` checks length first, then compares every byte without early exit.

I deliberately did **not** make an unset token a hard startup failure. That would break the loopback-only
development and single-node paths that legitimately run without one, and the exposure being fixed here is
specifically the network-reachable case.

No comment changes. No `bit` library dependency — the comparison uses plain byte equality accumulated over
the whole string, so it works under any LuaJIT build.

## Testing

Two server blocks — one with an empty token, one with `s3cret-token-value` — both bound to `0.0.0.0`, probed
from loopback and from the container's routable address:

| case | master | this branch |
|---|---|---|
| no token, loopback, `GET /admin/healthz` | 200 | 200 |
| no token, off-host, `POST /admin/meta/upsert` | **200** | **503** |
| no token, off-host, `GET /admin/last_active` | 200 | **503** |
| token set, correct token | 200 | 200 |
| token set, wrong token | 403 | 403 |
| token set, wrong token of the **same length** | — | 403 |
| token set, missing token | 403 | 403 |
| token set, loopback, correct token | 200 | 200 |

The same-length case matters: it is the one that exercises the byte loop rather than the length check.

`loadfile` on the module → SYNTAX OK.

CI gates: the Lua files are not covered by `fmt-check` or `unit-test-check` (no Lua formatter or test runner
configured), so verification is the live OpenResty probe above.

## Deployment impact

A deployment that today reaches the admin API over the network **without** a token will start getting 503s.
That is the vulnerability being closed, but it is a breaking change for such a setup. The fix is one of:

- set `CUBE_PROXY_ADMIN_TOKEN` (the Helm chart and Terraform already generate one), or
- set `CUBE_PROXY_ADMIN_LISTEN=127.0.0.1` and reach the admin API locally.

Worth pairing with a follow-up that makes the chart's generated token mandatory rather than
conditional, so the empty-token path cannot be selected by accident.