### PR TITLE
cubeapi: refuse to serve unauthenticated off loopback, and always rate limit

### DIFF
--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -111,6 +111,14 @@ struct Cli {
     #[arg(long, value_name = "TYPE")]
     instance_type: Option<String>,
 
+    /// Allow serving without authentication on a non-loopback bind address.
+    ///
+    /// Without this flag cube-api refuses to start when neither CUBE_API_KEY nor
+    /// an auth callback is configured and the bind address is not loopback.
+    /// Overrides the CUBE_API_ALLOW_UNAUTHENTICATED environment variable.
+    #[arg(long)]
+    allow_unauthenticated: bool,
+
     /// Domain string returned in sandbox API responses (default: "cube.app").
     #[arg(long, value_name = "DOMAIN")]
     sandbox_domain: Option<String>,
@@ -175,14 +183,45 @@ fn main() -> anyhow::Result<()> {
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&cfg.log_level)))
         .init();
 
+    let auth_enabled = cfg
+        .auth_callback_url
+        .as_deref()
+        .is_some_and(|u| !u.is_empty())
+        || cfg.cube_api_key.as_deref().is_some_and(|k| !k.is_empty());
+
     tracing::info!(
         debug_mode = cli.debug,
         log_level = %cfg.log_level,
         bind = %cfg.bind,
-        auth_enabled = cfg.auth_callback_url.is_some()
-            || cfg.cube_api_key.is_some(),
+        auth_enabled = auth_enabled,
         "cube-api starting"
     );
+
+    if !auth_enabled {
+        let allow_unauthenticated = cli.allow_unauthenticated
+            || std::env::var("CUBE_API_ALLOW_UNAUTHENTICATED")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
+        if bind_is_loopback(&cfg.bind) {
+            tracing::warn!(
+                bind = %cfg.bind,
+                "cube-api is serving WITHOUT authentication; set CUBE_API_KEY or an auth callback"
+            );
+        } else if allow_unauthenticated {
+            tracing::warn!(
+                bind = %cfg.bind,
+                "cube-api is serving WITHOUT authentication on a non-loopback address because \
+                 --allow-unauthenticated was set; the sandbox control plane is exposed"
+            );
+        } else {
+            anyhow::bail!(
+                "refusing to start: no authentication is configured (CUBE_API_KEY / auth callback) \
+                 and bind address {} is not loopback. Set CUBE_API_KEY, configure an auth callback, \
+                 bind to 127.0.0.1, or pass --allow-unauthenticated to override.",
+                cfg.bind
+            );
+        }
+    }
 
     // ── Tokio runtime ──────────────────────────────────────────────────────
     let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -195,6 +234,18 @@ fn main() -> anyhow::Result<()> {
         .build()?;
 
     rt.block_on(async_main(cfg, cli.debug))
+}
+
+fn bind_is_loopback(bind: &str) -> bool {
+    let host = match bind.rsplit_once(':') {
+        Some((h, _)) => h,
+        None => bind,
+    };
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    match host.parse::<std::net::IpAddr>() {
+        Ok(ip) => ip.is_loopback(),
+        Err(_) => host.eq_ignore_ascii_case("localhost"),
+    }
 }
 
 async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()> {
@@ -272,4 +323,36 @@ async fn shutdown_signal() {
     }
 
     tracing::info!("shutdown signal received");
+}
+
+#[cfg(test)]
+mod startup_tests {
+    use super::bind_is_loopback;
+
+    #[test]
+    fn loopback_binds_are_recognised() {
+        for bind in [
+            "127.0.0.1:3000",
+            "127.9.9.9:3000",
+            "localhost:3000",
+            "LocalHost:3000",
+            "[::1]:3000",
+            "127.0.0.1",
+        ] {
+            assert!(bind_is_loopback(bind), "{bind} should be loopback");
+        }
+    }
+
+    #[test]
+    fn exposed_binds_are_not_loopback() {
+        for bind in [
+            "0.0.0.0:3000",
+            "10.0.0.5:3000",
+            "[::]:3000",
+            "192.168.1.10:3000",
+            "cube-api.internal:3000",
+        ] {
+            assert!(!bind_is_loopback(bind), "{bind} should not be loopback");
+        }
+    }
 }

--- a/CubeAPI/src/routes.rs
+++ b/CubeAPI/src/routes.rs
@@ -216,10 +216,9 @@ fn with_auth_and_rate_limit(
     state: &AppState,
     auth_configured: bool,
 ) -> Router<AppState> {
+    let routes = routes.layer(middleware::from_fn_with_state(state.clone(), rate_limit));
     if auth_configured {
-        routes
-            .layer(middleware::from_fn_with_state(state.clone(), rate_limit))
-            .layer(middleware::from_fn_with_state(state.clone(), unified_auth))
+        routes.layer(middleware::from_fn_with_state(state.clone(), unified_auth))
     } else {
         routes
     }
@@ -252,6 +251,32 @@ mod tests {
     };
     use axum_test::TestServer;
     use serde_json::Value;
+
+    async fn unauthenticated_server(rate_limit_per_sec: u32) -> TestServer {
+        let mut config = ServerConfig::default();
+        config.cubemaster_url = "http://127.0.0.1:9".to_string();
+        config.auth_callback_url = None;
+        config.cube_api_key = None;
+        config.rate_limit_per_sec = rate_limit_per_sec;
+
+        let state = AppState::new(config, arc(NoopLogger)).await;
+        TestServer::new(build_router(state)).expect("router should build")
+    }
+
+    #[tokio::test]
+    async fn rate_limit_applies_when_auth_is_not_configured() {
+        let server = unauthenticated_server(1).await;
+
+        let mut statuses = Vec::new();
+        for _ in 0..5 {
+            statuses.push(server.get("/sandboxes").await.status_code());
+        }
+
+        assert!(
+            statuses.contains(&StatusCode::TOO_MANY_REQUESTS),
+            "unauthenticated routes must still be rate limited, got {statuses:?}"
+        );
+    }
 
     async fn test_server() -> TestServer {
         let mut config = ServerConfig::default();


### PR DESCRIPTION
Closes #1414.

## Motivation

`default_bind()` is `0.0.0.0:3000`, `cube_api_key` / `auth_callback_url` default to unset, and unset means
"allow every request". So the default `cube-api` process exposes sandbox create / delete / exec / snapshot /
rollback on every interface, with only an `INFO`-level `auth_enabled=false` field to hint at it.

The same branch that skips auth also skips rate limiting, so the least protected configuration is also the
one with no abuse ceiling.

## What this changes

**`CubeAPI/src/routes.rs`** — the rate-limit layer moves out of the `auth_configured` branch:

```rust
let routes = routes.layer(middleware::from_fn_with_state(state.clone(), rate_limit));
if auth_configured {
    routes.layer(middleware::from_fn_with_state(state.clone(), unified_auth))
} else {
    routes
}
```

Layer order for the authenticated case is unchanged — `unified_auth` is still applied last and therefore
still runs first.

**`CubeAPI/src/main.rs`** — after tracing is initialised and before the runtime starts:

- `auth_enabled` is computed once with the same expression `build_router` uses, and reused in the startup
  event so the two can't drift.
- Loopback bind, no auth → `WARN` and start.
- Non-loopback bind, no auth → **refuse to start** with an error naming the bind address and the four ways
  out (set `CUBE_API_KEY`, configure a callback, bind loopback, or override).
- The override is `--allow-unauthenticated` / `CUBE_API_ALLOW_UNAUTHENTICATED=1`, which starts but `WARN`s
  every time.

`bind_is_loopback` parses the host out of `host:port`, strips `[ ]` for IPv6, and uses
`IpAddr::is_loopback` so the whole `127.0.0.0/8` range and `::1` are covered; a non-IP host is loopback only
if it is literally `localhost`. An unresolvable hostname is treated as non-loopback, which is the safe
direction.

The only comment-shaped lines added are the `///` block above `--allow-unauthenticated`. Those are not
commentary: clap derives `--help` text from doc comments, so removing them would leave the new flag
undescribed in `cube-api --help` while every neighbouring flag is documented. Say the word and I will drop
them.

## Testing

**Startup matrix**, real binary, `RUST_LOG=info`:

| configuration | this branch | master |
|---|---|---|
| no auth, default `0.0.0.0:3000` | `refusing to start: no authentication is configured …`, **exit 1** | `cube-api listening on 0.0.0.0:3000`, no warning, serving |
| no auth, `CUBE_API_ALLOW_UNAUTHENTICATED=1` | `WARN … serving WITHOUT authentication on a non-loopback address …` then listening | same as above |
| no auth, `CUBE_API_BIND=127.0.0.1:3000` | `WARN … serving WITHOUT authentication; set CUBE_API_KEY or an auth callback` then listening | listening, no warning |
| `CUBE_API_KEY=secret`, `0.0.0.0` | listening, no warning | listening |
| `CUBE_API_KEY=` (empty) | **exit 1** | listening |

The empty-string row matters: `.is_some_and(|k| !k.is_empty())` matches what `build_router` already does,
so an empty `CUBE_API_KEY` counts as no auth in both places rather than only in the router.

**Rate limiting** — new test `rate_limit_applies_when_auth_is_not_configured` builds a router with
`auth_callback_url = None`, `cube_api_key = None`, `rate_limit_per_sec = 1` and fires five requests:

```
fix reverted:  FAILED — unauthenticated routes must still be rate limited, got [500, 500, 500, 500, 500]
fix restored:  ok
```

The 500s are the mock CubeMaster being unreachable — the point is that the request reached the handler at
all, five times over a 1/s quota.

**`bind_is_loopback`** — two tests over `127.0.0.1:3000`, `127.9.9.9:3000`, `localhost:3000`,
`LocalHost:3000`, `[::1]:3000`, `127.0.0.1` (all loopback) and `0.0.0.0:3000`, `10.0.0.5:3000`, `[::]:3000`,
`192.168.1.10:3000`, `cube-api.internal:3000` (all not).

**CI gates:**

```
cargo fmt --check   -> FMT CLEAN
cargo build         -> clean
cargo test          -> 112 passed; 0 failed
```

`cargo clippy --all-targets -- -D warnings` fails, but it fails on master too, with the same lint classes
(`field assignment outside of initializer`, `map_or`, `redundant closure`, `impl can be derived`, doc
indentation). Clippy is not wired into any workflow or Makefile target, so there is no gate to regress. My
new test adds one more `field assignment outside of initializer` instance, matching the style of every other
test in that module.

## Not fixed here

`CorsLayer::permissive()` at `routes.rs:229-236` is still unconditional. Restricting it needs an
allowed-origins config field and a decision about what the default should be for the E2B-compatible clients —
that is a separate change with its own compatibility surface, and bundling it would make this one hard to
revert independently. It is written up in the issue.

## Risk / rollout

**This is a breaking change for anyone running `cube-api` with no auth on a non-loopback bind.** That is the
intent — the failure is loud and the message says exactly what to do. Two migration paths, in preference
order:

1. Set `CUBE_API_KEY` or an auth callback. This is what production should do anyway.
2. Set `CUBE_API_ALLOW_UNAUTHENTICATED=1` (or pass `--allow-unauthenticated`) to keep the old behaviour, at
   the cost of a `WARN` per start.

Local development on `127.0.0.1` is unaffected apart from the warning. Deployments that already configure
auth see no behaviour change at all except that unauthenticated-mode rate limiting now exists — and in
those deployments there is no unauthenticated mode.

Worth checking before merge: any container image or compose/helm default that starts `cube-api` on
`0.0.0.0` without `CUBE_API_KEY` will now fail to start until it sets one of the two variables above.
