### PR TITLE
sdk: recognise non-ASCII domains so the allow_out deny-all guard fires

### DIFF
--- a/sdk/go/policy.go
+++ b/sdk/go/policy.go
@@ -6,6 +6,7 @@ package cubesandbox
 import (
 	"net"
 	"strings"
+	"unicode"
 )
 
 // L7 egress policy types — host/path/SNI matching, audit, credential
@@ -136,9 +137,13 @@ func isValidDNSDomainName(domain string) bool {
 			return false
 		}
 		for _, ch := range label {
-			if !(ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9' || ch == '-') {
-				return false
+			if ch == '-' || ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9' {
+				continue
 			}
+			if unicode.IsLetter(ch) || unicode.IsDigit(ch) || unicode.IsNumber(ch) {
+				continue
+			}
+			return false
 		}
 	}
 	return true

--- a/sdk/go/policy_domain_guard_test.go
+++ b/sdk/go/policy_domain_guard_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubesandbox
+
+import "testing"
+
+func TestAllowOutDomainGuardFiresForUnicodeDomains(t *testing.T) {
+	domains := []string{
+		"example.com",
+		"exаmple.com",
+		"bücher.example",
+		"例子.com",
+		"café.example.com",
+		"xn--bcher-kva.example",
+		"*.café.example.com",
+	}
+
+	for _, d := range domains {
+		t.Run(d, func(t *testing.T) {
+			if !isDomainAllowOutTarget(d) {
+				t.Fatalf("isDomainAllowOutTarget(%q) = false, want true", d)
+			}
+			if err := validateAllowOutDomainsRequireDenyAll([]string{d}, nil, false); err == nil {
+				t.Fatalf("guard did not fire for %q with public egress enabled", d)
+			}
+			if err := validateAllowOutDomainsRequireDenyAll([]string{d}, []string{"0.0.0.0/0"}, false); err != nil {
+				t.Fatalf("guard fired for %q despite deny-all: %v", d, err)
+			}
+			if err := validateAllowOutDomainsRequireDenyAll([]string{d}, nil, true); err != nil {
+				t.Fatalf("guard fired for %q despite defaultDenyAll: %v", d, err)
+			}
+		})
+	}
+}
+
+func TestNonDomainTargetsStillNotTreatedAsDomains(t *testing.T) {
+	nonDomains := []string{
+		"10.0.0.1",
+		"10.0.0.0/8",
+		"::1",
+		"999.1.2.3",
+		"1.2.3.4",
+		"",
+		"has space",
+		"under_score.example.com",
+		"double**star.example.com",
+	}
+
+	for _, target := range nonDomains {
+		if isDomainAllowOutTarget(target) {
+			t.Errorf("isDomainAllowOutTarget(%q) = true, want false", target)
+		}
+	}
+}

--- a/sdk/node/src/policy.ts
+++ b/sdk/node/src/policy.ts
@@ -244,7 +244,7 @@ function isValidDnsDomainName(domain: string): boolean {
       label.length <= 63 &&
       !label.startsWith("-") &&
       !label.endsWith("-") &&
-      /^[a-zA-Z0-9-]+$/.test(label),
+      /^[\p{L}\p{N}0-9-]+$/u.test(label),
   );
 }
 

--- a/sdk/node/test/policy-domain-guard.test.ts
+++ b/sdk/node/test/policy-domain-guard.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { validateAllowOutDomainsRequireDenyAll } from "../src/policy";
+
+const UNICODE_DOMAINS = [
+  "example.com",
+  "exаmple.com",
+  "bücher.example",
+  "例子.com",
+  "café.example.com",
+  "xn--bcher-kva.example",
+  "*.café.example.com",
+];
+
+const NON_DOMAINS = ["10.0.0.1", "10.0.0.0/8", "::1", "999.1.2.3", "", "has space"];
+
+describe("allow_out domain guard", () => {
+  for (const d of UNICODE_DOMAINS) {
+    it(`fires for ${d} when public egress is on`, () => {
+      expect(() => validateAllowOutDomainsRequireDenyAll([d], [], false)).toThrow();
+    });
+
+    it(`does not fire for ${d} when deny-all is present`, () => {
+      expect(() => validateAllowOutDomainsRequireDenyAll([d], ["0.0.0.0/0"], false)).not.toThrow();
+      expect(() => validateAllowOutDomainsRequireDenyAll([d], [], true)).not.toThrow();
+    });
+  }
+
+  for (const t of NON_DOMAINS) {
+    it(`does not treat ${JSON.stringify(t)} as a domain`, () => {
+      expect(() => validateAllowOutDomainsRequireDenyAll([t], [], false)).not.toThrow();
+    });
+  }
+});


### PR DESCRIPTION
Closes #1416.

## Motivation

`validateAllowOutDomainsRequireDenyAll` bails out early when nothing in `allowOut` looks like a domain.
Go and Node validated labels with an ASCII-only character class, so any non-ASCII or IDN domain was not
classified as a domain and the guard silently did not run — the user was told nothing and kept public
egress enabled while believing it was restricted. Python, which uses `str.isalnum()`, does fire.

Homoglyphs are the sharp edge: `exаmple.com` with a Cyrillic `а` is visually identical to the ASCII form
and was completely unguarded in two of the three SDKs.

## What this changes

- `sdk/go/policy.go` — `isValidDNSDomainName` accepts a label character if it is `-`, ASCII
  alphanumeric, or `unicode.IsLetter` / `IsDigit` / `IsNumber`, which is the Go equivalent of Python's
  `str.isalnum()`.
- `sdk/node/src/policy.ts` — the label regex becomes `/^[\p{L}\p{N}0-9-]+$/u`.

Python is already correct and is unchanged. Everything else about the classifier is untouched: IPs,
CIDRs, dotted-decimal lookalikes, `*` handling, length limits and the leading/trailing `-` rules all
behave exactly as before.

No comment changes.

## Why widen the classifier rather than narrow Python

The classifier answers "is this a domain rather than an IP or CIDR?", and a non-ASCII string is
definitively not an IP or a CIDR. Widening makes the guard **fire**, which is the fail-safe direction: the
user gets a clear error telling them to add deny-all. Narrowing Python would have made all three SDKs
consistently *skip* the guard, i.e. consistent but silently unsafe.

I did not add IDNA/punycode encoding. That would be the fuller fix, but it means a new dependency in
`sdk/go` (`golang.org/x/net/idna`) for a module that deliberately has almost none, and it is a separate
decision. Classification alone is enough to close the guard hole.

## Recommended follow-up (not in this PR)

`Cubelet/network/runtime/policy_builder.go:220-246` (`isValidL7DomainName`) is also ASCII-only, so a
non-ASCII SNI/Host match is silently dropped from the cubevs L7 allow list rather than rejected. Now that
the SDKs pass such entries through instead of ignoring them, that server-side path deserves its own issue
— either punycode-normalise or reject explicitly.

## Testing

New:

- `sdk/go/policy_domain_guard_test.go` — `TestAllowOutDomainGuardFiresForUnicodeDomains` over seven
  domains (ASCII, Cyrillic homoglyph, umlaut, CJK, accented, punycode, wildcard+accented). For each it
  asserts the entry is classified as a domain, that the guard fires with public egress on, and that it
  does **not** fire when `deny_out` contains `0.0.0.0/0` or `defaultDenyAll` is set.
  `TestNonDomainTargetsStillNotTreatedAsDomains` covers IPs, CIDRs, IPv6, dotted-decimal lookalikes,
  empty, whitespace, underscore and double-star — so widening the charset did not turn non-domains into
  domains.
- `sdk/node/test/policy-domain-guard.test.ts` — the same matrix, 20 cases.

Red/green:

```
Go, with policy.go reverted:
  --- FAIL: TestAllowOutDomainGuardFiresForUnicodeDomains
      isDomainAllowOutTarget("exаmple.com") = false, want true
      isDomainAllowOutTarget("bücher.example") = false, want true
      isDomainAllowOutTarget("例子.com") = false, want true

Node, with policy.ts reverted:
  × fires for exаmple.com / bücher.example / 例子.com / café.example.com / *.café.example.com
  Failed Tests 5
```

All three SDK suites with the fix:

```
sdk/go     ok  github.com/tencentcloud/CubeSandbox/sdk/go  0.383s
sdk/node   Test Files 16 passed | 1 skipped     Tests 206 passed | 1 skipped
sdk/python 225 passed in 0.39s
```

CI gates checked locally:

- `gofmt -l .` in `sdk/go` — clean (`fmt-check`).
- `npx tsc --noEmit` in `sdk/node` — clean.
- All three suites pass (`sdk-test-check`).

## Risk / rollout

**This turns a silent no-op into an error.** Anyone who currently passes a non-ASCII domain in `allowOut`
without deny-all gets an `ApiError` where they previously got none. That is the point of the guard, and
Python users already saw this error — but it is a visible behaviour change for Go and Node callers on
upgrade. The remedy is the one the error message states: set `allowInternetAccess: false` or add
`0.0.0.0/0` to `denyOut`.
