### PR TITLE
cubeops: reject empty inputs in VerifyPassword

### DIFF
--- a/CubeOps/internal/crypto/aes_gcm.go
+++ b/CubeOps/internal/crypto/aes_gcm.go
@@ -189,6 +189,9 @@ func HashPassword(password string) (string, error) {
 // VerifyPassword verifies a candidate password against a stored value.
 // bcrypt hashes start with $2; anything else is treated as legacy plaintext.
 func VerifyPassword(stored, candidate string) bool {
+	if stored == "" || candidate == "" {
+		return false
+	}
 	if strings.HasPrefix(stored, "$2") {
 		return bcrypt.CompareHashAndPassword([]byte(stored), []byte(candidate)) == nil
 	}

--- a/CubeOps/internal/crypto/verify_password_empty_test.go
+++ b/CubeOps/internal/crypto/verify_password_empty_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package crypto
+
+import "testing"
+
+func TestVerifyPasswordRejectsEmptyInputs(t *testing.T) {
+	cases := []struct {
+		name      string
+		stored    string
+		candidate string
+	}{
+		{"both empty", "", ""},
+		{"empty stored, non-empty candidate", "", "hunter2"},
+		{"non-empty stored, empty candidate", "legacy-password", ""},
+		{"empty stored, empty-looking bcrypt candidate", "", "$2a$10$abcdefghijklmnopqrstuv"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if VerifyPassword(tc.stored, tc.candidate) {
+				t.Fatalf("VerifyPassword(%q, %q) = true, want false", tc.stored, tc.candidate)
+			}
+		})
+	}
+}
+
+func TestVerifyPasswordStillAcceptsValidCredentials(t *testing.T) {
+	hashed, err := HashPassword("correct horse")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	if !VerifyPassword(hashed, "correct horse") {
+		t.Fatal("bcrypt round trip rejected the correct password")
+	}
+	if VerifyPassword(hashed, "wrong horse") {
+		t.Fatal("bcrypt accepted the wrong password")
+	}
+	if !VerifyPassword("legacy-password", "legacy-password") {
+		t.Fatal("legacy plaintext comparison rejected a matching password")
+	}
+	if VerifyPassword("legacy-password", "wrong") {
+		t.Fatal("legacy plaintext comparison accepted a wrong password")
+	}
+}


### PR DESCRIPTION
Closes #1418.

## Motivation

`VerifyPassword` treats a stored value without a `$2` prefix as legacy plaintext and compares it with
`subtle.ConstantTimeCompare`. Two empty slices compare equal, so `VerifyPassword("", "")` returned
`true` — an empty stored credential authenticating an empty candidate.

It is not reachable through the current callers, because `Login` and `ChangePassword` both reject empty
passwords first. It is still worth closing: `GetUserPassword` maps an absent user to `stored == ""`, so
the safety of the whole login path rests on a guard in the caller rather than in the primitive.

## What this changes

`CubeOps/internal/crypto/aes_gcm.go` — an explicit guard at the top of `VerifyPassword`:

```go
if stored == "" || candidate == "" {
	return false
}
```

Both directions are rejected: an empty stored value can never match, and an empty candidate can never
authenticate. Everything below is untouched — bcrypt still handles `$2`-prefixed hashes, and the legacy
plaintext path still uses the constant-time comparison.

No comment changes.

## Testing

New: `CubeOps/internal/crypto/verify_password_empty_test.go`

- `TestVerifyPasswordRejectsEmptyInputs` — both empty; empty stored with a real candidate; real stored
  with an empty candidate; and empty stored against a bcrypt-shaped candidate.
- `TestVerifyPasswordStillAcceptsValidCredentials` — bcrypt round trip accepts the right password and
  rejects the wrong one, and the legacy plaintext path still works both ways. This is the regression
  guard that the new early return did not break the two real paths.

Red/green — with `aes_gcm.go` reverted:

```
--- FAIL: TestVerifyPasswordRejectsEmptyInputs/both_empty
```

with the fix, and the whole module:

```
$ cd CubeOps && go test ./...
12 packages ok, 0 failures
```

CI gates checked locally:

- `gofmt -l ./internal/crypto` — clean (`fmt-check`).
- `go test ./...` — 12 ok (`unit-test-check` → `make cubeops-test`).

## Note on the legacy plaintext path

This PR does not remove the legacy plaintext branch, which still means a row containing a bare password
authenticates. Removing it is a migration question (existing installs may hold un-hashed rows) and
belongs in its own change. The empty-input guard is orthogonal and safe to land now.
