### PR TITLE
cubeops: fix the data race in the store handler test double

### DIFF
--- a/CubeOps/internal/handler/store_test.go
+++ b/CubeOps/internal/handler/store_test.go
@@ -34,13 +34,13 @@ type cachingFakeFetchOnly struct {
 }
 
 func (f *cachingFakeFetchOnly) FetchLatest(_ context.Context, ref string) *ImageMeta {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	m, ok := f.meta[ref]
 	if !ok {
 		return nil
 	}
-	f.mu.Lock()
 	f.meta[ref] = m
-	f.mu.Unlock()
 	return &m
 }
 


### PR DESCRIPTION
Closes #1420.

## Motivation

`cachingFakeFetchOnly.FetchLatest` read `f.meta` before taking the mutex it then used for the write.
`StoreHandler.inspectAll` fans out one goroutine per curated image, all calling `FetchLatest`
concurrently, so the unguarded read races the guarded write and `go test -race` fails.

Production code is fine — `gcrRegistryClient` uses a `sync.Map` — so this is a test-only defect, but it
is one of the failures standing between the repo and a green `-race` gate.

## What this changes

`CubeOps/internal/handler/store_test.go` — the whole method body is now under the existing mutex via
`defer`:

```go
func (f *cachingFakeFetchOnly) FetchLatest(_ context.Context, ref string) *ImageMeta {
	f.mu.Lock()
	defer f.mu.Unlock()
	m, ok := f.meta[ref]
	if !ok {
		return nil
	}
	f.meta[ref] = m
	return &m
}
```

No production code changed. No comment changes.

## Testing

Red/green on the affected test:

```
master:      go test -race -run TestStore_RefreshStoreMeta_ReturnsAllImages ./internal/handler/
             -> 1 x WARNING: DATA RACE, FAIL

this branch: ok  github.com/tencentcloud/CubeSandbox/CubeOps/internal/handler  1.637s
```

Whole package under the race detector:

```
$ go test -race -count=1 ./internal/handler/
ok  github.com/tencentcloud/CubeSandbox/CubeOps/internal/handler  407.824s
```

(The 407s is the package's existing registry/dockertest coverage under `-race`, not this change.)

CI gates checked locally:

- `gofmt -l ./internal/handler` — clean (`fmt-check`).

## Follow-up worth doing separately

`RegistryClient` implementations must be goroutine-safe because `inspectAll` calls them from N
goroutines, but the interface does not say so — which is why the fake was written without it. Stating
that on the interface would prevent the next fake from repeating this. Not done here to keep the change
test-only.
