### PR TITLE
cubelet: make Test_HashCode actually test HashCode

### DIFF
--- a/Cubelet/pkg/utils/strings_test.go
+++ b/Cubelet/pkg/utils/strings_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -19,28 +18,32 @@ import (
 func Test_HashCode(t *testing.T) {
 	size := 10000
 	cases := make([]string, 0, size)
-	for i := 0; i < len(cases); i++ {
+	for i := 0; i < size; i++ {
 		cases = append(cases, strconv.Itoa(int(rand.Int31n(int32(size)))))
 	}
 
-	startTime := time.Now().UnixNano()
 	m := make(map[string]uint32, size)
 	for _, c := range cases {
-		code := HashCode(c)
-		m[c] = code
+		m[c] = HashCode(c)
 	}
 	for _, c := range cases {
-		t.Run(c, func(t *testing.T) {
-			code := HashCode(c)
-
-			if code != m[c] {
-				t.Errorf("hashCode diff, %s code:%d, %d difference", c, code, m[c])
-			}
-		})
+		if code := HashCode(c); code != m[c] {
+			t.Fatalf("hashCode not stable for %q: got %d, first saw %d", c, code, m[c])
+		}
 	}
-	useTime := time.Now().UnixNano() - startTime
-	if useTime > 1000000 {
-		t.Errorf("use too much time, use %d ms, each use %d ns", useTime/(1000000), useTime/int64(size))
+	if len(m) == 0 {
+		t.Fatal("no cases were generated")
+	}
+}
+
+func Benchmark_HashCode(b *testing.B) {
+	inputs := make([]string, 0, 1024)
+	for i := 0; i < 1024; i++ {
+		inputs = append(inputs, strconv.Itoa(int(rand.Int31n(1024))))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		HashCode(inputs[i%len(inputs)])
 	}
 }
 


### PR DESCRIPTION
Closes #1422.

## Motivation

`Test_HashCode` looped on `i < len(cases)` where `cases` had just been created with
`make([]string, 0, size)` — length 0. The body never ran, so the test generated no inputs and asserted
nothing about `HashCode`. On master it passes in 0.00s with zero subtests, which is the tell.

The one assertion that *could* fire was a 1 ms wall-clock budget over an empty loop, and it does fire
on a loaded or emulated runner — that is how the bug surfaced.

## What this changes

`Cubelet/pkg/utils/strings_test.go`:

- Loop bound `len(cases)` → `size`, so 10000 inputs are actually generated.
- The stability check now runs directly rather than through 10000 `t.Run` subtests, which keeps the
  output readable and the run fast, and uses `t.Fatalf` so a mismatch stops immediately.
- Added `len(m) == 0` guard so the test can never again silently degrade to asserting nothing.
- The wall-clock assertion is removed and replaced by `Benchmark_HashCode`. Timing belongs in a
  benchmark; a hard millisecond budget in a unit test is inherently flaky and was the only thing this
  test was checking.
- Dropped the now-unused `time` import.

No production code changed. No comment changes.

## Testing

```
$ docker run --rm ... -w /w/Cubelet golang:1.26 go test -count=1 ./pkg/utils/
ok  github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils  41.048s

$ ... go test -run XXX -bench Benchmark_HashCode -benchtime 100x ./pkg/utils/
Benchmark_HashCode-8   100   10.42 ns/op
ok  github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils  0.014s
```

The 41s is the rest of the package (process and copy-file tests), not this test.

Before/after on the same command shows the substantive difference — master reports
`--- PASS ... (0.00s)` with no work done; this branch actually hashes 10000 inputs twice and compares.

CI gates checked locally:

- `gofmt -l ./pkg/utils` — clean (`fmt-check`).
- Package builds and tests in the Linux builder (`unit-test-check` runs `make cubelet-pkg-test`,
  which is `go test -short ./pkg/...`).

Note `go vet ./pkg/utils/` cannot run on macOS — `mount.go:70` uses `unix.Statx_t`, which is
Linux-only. That is pre-existing and unrelated.

## Risk / rollout

None to production. This is a test-only change that turns a no-op test into a real one and removes a
flaky assertion from CI.
