### PR TITLE
agent: make bootstrap.sh work on Debian/Ubuntu and fail loudly

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# Check if the user is running this script as root
+set -euo pipefail
+
 if [ "$(id -u)" != "0" ]; then
-    echo "This script must be run as root"
+    echo "This script must be run as root" >&2
     exit 1
 fi
 
@@ -12,50 +13,43 @@ LIBSECCOMP_VERSION=2.5.1
 LIBSECCOMP_URL=https://github.com/seccomp/libseccomp/archive/refs/tags/v${LIBSECCOMP_VERSION}.tar.gz
 PACKAGE_MANAGER="yum"
 
-
 detect_package_manager() {
-		
-	if [ "Darwin" == "$(uname -s)" ]; then
-		show_error_message "Darwin" || exit 1
-	else
-		# Here we will use package managers to determine which operating system the user is using.
+    if [ "$(uname -s)" = "Darwin" ]; then
+        echo "Fatal error: macOS is not a supported build host for libseccomp" >&2
+        exit 1
+    fi
 
-		# Debian or any derivative of it
-		if hash 2>/dev/null apt-get; then
-			PACKAGE_MANAGER="apt-get"   || exit 1
-		# Fedora
-		elif hash 2>/dev/null dnf; then
-			PACKAGE_MANAGER="dnf"
-		# CentOS and its derivatives
-		elif hash 2>/dev/null yum; then
-			PACKAGE_MANAGER="yum"
-		# Unsupported platform
-		else
-			printf "\e[31;1mFatal error: \e[0;31mUnsupported platform, please open an issue\[0m" || exit 1
-		fi
-	fi
+    if hash 2>/dev/null apt-get; then
+        PACKAGE_MANAGER="apt-get"
+    elif hash 2>/dev/null dnf; then
+        PACKAGE_MANAGER="dnf"
+    elif hash 2>/dev/null yum; then
+        PACKAGE_MANAGER="yum"
+    else
+        printf '\e[31;1mFatal error: \e[0;31mUnsupported platform, please open an issue\e[0m\n' >&2
+        exit 1
+    fi
 }
 
+detect_package_manager
 
-detect_package_manager || exit 1
-
-if [ ! -d ${STATIC_LIBSECCOMP_DIR} ]; then
-	pushd .
-	rm -rf ${TMP_COMPILE_DIR}
-	mkdir -p ${TMP_COMPILE_DIR}
-	cd ${TMP_COMPILE_DIR}
-	wget -c ${LIBSECCOMP_URL}
-	tar zxvf v${LIBSECCOMP_VERSION}.tar.gz
-	cd libseccomp-${LIBSECCOMP_VERSION}
-	${PACKAGE_MANAGER} -y install gperf libtool || exit 1
-	sh ./autogen.sh 
-	./configure CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -O2" --enable-shared --enable-static --prefix=${STATIC_LIBSECCOMP_DIR}
-
-	make -j $(nproc)
-	mkdir -p ${STATIC_LIBSECCOMP_DIR}
-	make install
-	popd
-	rm -rf ${TMP_COMPILE_DIR}
+if [ ! -d "${STATIC_LIBSECCOMP_DIR}" ]; then
+    rm -rf "${TMP_COMPILE_DIR}"
+    mkdir -p "${TMP_COMPILE_DIR}"
+    (
+        cd "${TMP_COMPILE_DIR}"
+        wget -c "${LIBSECCOMP_URL}"
+        tar zxvf "v${LIBSECCOMP_VERSION}.tar.gz"
+        cd "libseccomp-${LIBSECCOMP_VERSION}"
+        "${PACKAGE_MANAGER}" -y install gperf libtool
+        sh ./autogen.sh
+        ./configure CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -O2" \
+            --enable-shared --enable-static --prefix="${STATIC_LIBSECCOMP_DIR}"
+        make -j "$(nproc)"
+        mkdir -p "${STATIC_LIBSECCOMP_DIR}"
+        make install
+    )
+    rm -rf "${TMP_COMPILE_DIR}"
 fi
 
 echo "Bootstrap complete!"


### PR DESCRIPTION
Closes #1424.

## Motivation

`agent/bootstrap.sh` declared `#!/bin/sh` but used bash-only constructs, so on any host where `/bin/sh` is
dash — Debian, Ubuntu, i.e. exactly the hosts the script's own `apt-get` detection targets — it emitted
errors and carried on. With no `set -e`, a failed download or compile still finished with
`Bootstrap complete!` and exit 0, so a broken libseccomp build surfaced much later as a confusing link
error.

## What this changes

`agent/bootstrap.sh`, six changes:

1. **`#!/usr/bin/env bash`** — the script genuinely needs bash, so it now asks for it rather than assuming
   `/bin/sh` provides bash semantics.
2. **`set -euo pipefail`** — a failing `wget`, `tar`, `configure`, `make` or `make install` now aborts
   instead of being ignored.
3. **`pushd` / `popd` → a subshell** around the build. This is both dash-safe and more robust than the
   original: the working directory is restored even if the build fails, which `popd` after an error never
   did.
4. **`[ "Darwin" == ... ]` → `[ "$(uname -s)" = "Darwin" ]`**, and the undefined `show_error_message` call
   is replaced with an explicit message and `exit 1`.
5. **The unsupported-platform branch now `exit 1`s** instead of printing and continuing with the default
   `yum`. The escape sequence is corrected to `\e[0m`.
6. Every variable expansion is quoted, so a path containing a space cannot split.

The build steps themselves — the URL, the `configure` flags, the install prefix — are unchanged.

No comments added.

## Testing

All on `debian:12`, where `/bin/sh` → `dash`.

**Happy path does not regress** (libseccomp pre-installed so the build is skipped):

```
$ docker run --rm -v "$PWD":/w debian:12 bash -c 'mkdir -p /usr/local/lib64/libseccomp; bash /w/agent/bootstrap.sh; echo "exit=$?"'
Bootstrap complete!
exit=0

$ ... sh -c 'mkdir -p /usr/local/lib64/libseccomp; /w/agent/bootstrap.sh; echo "exit=$?"'   # executed directly, shebang picks bash
Bootstrap complete!
exit=0
```

No `[: Darwin: unexpected operator`, which master emits on this exact command.

**Non-root is rejected:**

```
$ docker run --rm -u 1000 ... bash /w/agent/bootstrap.sh; echo "exit=$?"
This script must be run as root
exit=1
```

**Unsupported platform now stops at detection** (no `apt-get`/`dnf`/`yum` on `PATH`):

```
this branch:  Fatal error: Unsupported platform, please open an issue
              exit=1
master:       tar: not found / cd: can't cd to libseccomp-2.5.1 / yum: not found
              (falls through into the build with the default yum)
```

**Syntax and bashism scan:**

```
$ bash -n /w/agent/bootstrap.sh                       -> OK
$ grep -nE "pushd|popd|\[ .* == " bootstrap.sh        -> none found
$ grep -c show_error_message bootstrap.sh             -> 0
$ grep -n "^set " bootstrap.sh                        -> set -euo pipefail
```

I did not run a full libseccomp compile — that needs a network fetch plus a toolchain and takes several
minutes; the build steps are byte-identical to master apart from quoting, and the failure modes above are
what the change is about.

CI gates: this file is not covered by `fmt-check` (no shell formatter is configured) and is not built by
`unit-test-check`. `shellcheck` is not in the repo's tooling, so there is no lint gate to satisfy.

## Not fixed here

The libseccomp tarball is fetched over the network with **no checksum verification** (`:12`, `:47`). That is a
supply-chain concern worth its own issue and a pinned digest — I did not want to invent a hash I could not
verify offline.
