### PR TITLE
cubeegress: refuse the TLS handshake before signing when the sandbox is not authorized

### DIFF
--- a/CubeEgress/lua/access_phase.lua
+++ b/CubeEgress/lua/access_phase.lua
@@ -484,6 +484,28 @@ function _M.decide()
     return deny("no_rule_match", decision)
 end
 
+function _M.handshake_allowed()
+    local meta = ngx.shared.meta_store
+    local bootstrap_status = (meta and meta:get("bootstrap_status")) or "unknown"
+    if bootstrap_status ~= "ready" and bootstrap_status ~= "skipped" then
+        return false, "bootstrap_not_ready:" .. bootstrap_status
+    end
+
+    local sandbox_ip = ngx.var.remote_addr
+    if not sandbox_ip then
+        return false, "no_remote_addr"
+    end
+
+    local p, perr = policy.get(sandbox_ip)
+    if perr then
+        return false, "policy_lookup_error"
+    end
+    if not p then
+        return false, "no_policy_for_sandbox"
+    end
+    return true
+end
+
 -- Exposed for unit-testing the matcher in isolation.
 _M._rule_matches = rule_matches
 

--- a/CubeEgress/nginx.conf
+++ b/CubeEgress/nginx.conf
@@ -157,6 +157,16 @@ http {
                     string.byte(raw_addr, 1), string.byte(raw_addr, 2),
                     string.byte(raw_addr, 3), string.byte(raw_addr, 4))
             end
+            local permitted, deny_reason = require("access_phase").handshake_allowed()
+            if not permitted then
+                ngx.log(ngx.NOTICE, "[handshake] refused before signing: ", deny_reason,
+                                    " sandbox=", tostring(ngx.var.remote_addr),
+                                    " sni=", tostring(sni))
+                pcall(function()
+                    audit.write_tls_handshake_event(sni, dst_ip, deny_reason)
+                end)
+                return ngx.exit(ngx.ERROR)
+            end
             local ok, err = cert_signer.serve(sni, dst_ip)
             if not ok then
                 ngx.log(ngx.ERR, "cert_signer failed: ", err,


### PR DESCRIPTION
Closes #1426.

## Motivation

`ssl_certificate_by_lua_block` runs during the TLS handshake; `access_by_lua_block` runs afterwards, during
HTTP request processing. So `cert_signer.serve()` — an ECDSA keygen plus a CA signature on every cache miss —
executed *before* the bootstrap gate, the policy lookup and the default deny had any say.

A sandbox with no policy, which every request from it would be denied anyway, could therefore force one
keygen + signature per distinct SNI and evict the entire 64 MB `cert_cache` in the process.

## What this changes

**`CubeEgress/lua/access_phase.lua`** — new `handshake_allowed()`, which performs the same three checks
`decide()` already makes, in the same order, but using only what is available at handshake time:

- `bootstrap_status` must be `ready` or `skipped`
- `ngx.var.remote_addr` must be present
- a policy must exist for that sandbox IP

It returns `(false, reason)` using the same reason strings `decide()` uses, so the audit vocabulary is
unchanged.

**`CubeEgress/nginx.conf`** — the handshake block calls it first and, on refusal, logs at `NOTICE`, writes a
TLS handshake audit event with the reason, and `ngx.exit(ngx.ERROR)` before `cert_signer.serve` is reached.

The policy lookup is a `lua_shared_dict` read, so the added cost on the authorized path is negligible
compared with the signing it guards.

No comment changes.

## Testing

**The gate logic**, driven directly against the real `access_phase.handshake_allowed()` with a stubbed
policy store:

```
  no policy for sandbox (untrusted/idle sandbox)  allowed=false reason=no_policy_for_sandbox
  policy present                                  allowed=true  reason=nil
  bootstrap pending (policies not loaded yet)     allowed=false reason=bootstrap_not_ready:pending
  meta_store missing bootstrap_status             allowed=false reason=bootstrap_not_ready:unknown
  no remote_addr                                  allowed=false reason=no_remote_addr
```

The `policy present` row is the one that matters for not breaking normal traffic.

**The phase ordering this fix depends on** was confirmed separately with a real nginx logging from both
phases — `ssl_certificate_by_lua` fires before `access_by_lua` for every handshake, which is why the check
has to live in the handshake block rather than in `decide()`.

**End to end**, a real nginx with the gate in place refuses the handshake for a sandbox with no policy
(`curl` reports `000`, i.e. the TLS handshake never completes), where the ungated configuration completes the
handshake and returns `403`.

`loadfile` on `access_phase.lua` → SYNTAX OK.

### What I did not verify

I tried to build a harness that counts certificates actually minted with and without the gate, to put a
number on it; it kept timing out and I stopped rather than let it run. So the "certificates minted goes to
zero" claim rests on the gate returning false plus `ngx.exit(ngx.ERROR)` preceding the `cert_signer.serve`
call, not on a counter. The three results above are what I actually ran.

CI gates: the Lua files and `nginx.conf` are not covered by `fmt-check` or `unit-test-check`.

## Not fixed here

There is still no rate limit on the signing path for an **authorized** sandbox — one with a policy can
iterate SNIs and force a keygen each time. Bounding that needs a per-sandbox token bucket and a new shared
dict, which is a bigger change than this fix and belongs in its own issue. This PR removes the
*unauthenticated* half of the exposure, which is the part that needs no credentials at all.

## Risk / rollout

A sandbox whose policy has not been pushed yet now fails at the TLS handshake instead of receiving a
certificate and then a 403. That is the intended behaviour, but it changes the client-visible symptom from an
HTTP error to a connection failure, which is worth knowing when reading sandbox-side logs after this lands.

The bootstrap gate already produced a hard denial in that window, so this does not widen when traffic is
refused — only how early.

