### PR TITLE
cubeegress: surface policy_store eviction, cap policy size, and make count() truthful

### DIFF
--- a/CubeEgress/lua/policy.lua
+++ b/CubeEgress/lua/policy.lua
@@ -32,6 +32,9 @@ local INDEX_LOCK_TIMEOUT_MS = 1000
 -- (and would bloat policy_store fast).
 local SECRET_MAX_BYTES = 65536
 
+local MAX_RULES_PER_POLICY = 256
+local MAX_INJECTS_PER_RULE = 32
+
 -- ---------- validation ----------
 
 -- IPv4 dotted-quad. No IPv6 for now.
@@ -66,6 +69,10 @@ local function validate_policy(p)
     if n == 0 then
         return false, "policy.rules must have at least one rule"
     end
+    if n > MAX_RULES_PER_POLICY then
+        return false, string.format(
+            "policy.rules has %d rules, max %d", n, MAX_RULES_PER_POLICY)
+    end
     local seen_ids = {}
     for i = 1, n do
         local r = p.rules[i]
@@ -92,6 +99,11 @@ local function validate_policy(p)
         if r.action.inject ~= nil then
             if type(r.action.inject) ~= "table" then
                 return false, "rules[" .. i .. "].action.inject must be array"
+            end
+            if #r.action.inject > MAX_INJECTS_PER_RULE then
+                return false, string.format(
+                    "rules[%d].action.inject has %d entries, max %d",
+                    i, #r.action.inject, MAX_INJECTS_PER_RULE)
             end
             for j, inj in ipairs(r.action.inject) do
                 if type(inj) ~= "table" then
@@ -206,8 +218,12 @@ local function index_add(sandbox_ip)
             if ip == sandbox_ip then return true end
         end
         table.insert(arr, sandbox_ip)
-        local ok, err = d:set(INDEX_KEY, cjson.encode(arr))
+        local ok, err, forcible = d:set(INDEX_KEY, cjson.encode(arr))
         if not ok then error("index set: " .. tostring(err)) end
+        if forcible then
+            ngx.log(ngx.ERR, "policy_store full: writing the policy index evicted ",
+                             "other entries; increase lua_shared_dict policy_store")
+        end
         return true
     end)
 end
@@ -274,8 +290,13 @@ function _M.put(sandbox_ip, policy)
     end
     local encoded = cjson.encode(policy)
     if not encoded then return nil, "policy encode failed" end
-    local set_ok, set_err = shared():set(sandbox_ip, encoded)
+    local set_ok, set_err, forcible = shared():set(sandbox_ip, encoded)
     if not set_ok then return nil, "shared_dict set: " .. tostring(set_err) end
+    if forcible then
+        ngx.log(ngx.ERR, "policy_store full: storing the policy for ", sandbox_ip,
+                         " evicted other sandboxes' policies (they will be denied ",
+                         "egress until re-pushed); increase lua_shared_dict policy_store")
+    end
     local _, idx_err = index_add(sandbox_ip)
     if idx_err then
         -- Best-effort: data is in store but index is stale. Surface it.
@@ -336,7 +357,12 @@ end
 
 -- count() -> integer (number of policies in index)
 function _M.count()
-    return #read_index()
+    local d = shared()
+    local live = 0
+    for _, ip in ipairs(read_index()) do
+        if d:get(ip) then live = live + 1 end
+    end
+    return live
 end
 
 -- bulk_load(policies_map) -> (n_loaded, errors_table)


### PR DESCRIPTION

Closes #1428.

## Motivation

`ngx.shared.DICT:set` returns `(ok, err, forcible)`, where `forcible` means it had to evict LRU entries to
fit the value. `policy.lua` discarded it, so a full `policy_store` silently dropped the policies of running
sandboxes — each of which then hit `deny('no_policy_for_sandbox')` and got a 403 with nothing in the log to
explain it. `policy.count()` compounded this by counting index entries rather than stored ones.

CubeProxy already handles the same signal correctly (`admin_phase.lua:87-91`), so this brings CubeEgress in
line.

## What this changes

`CubeEgress/lua/policy.lua`:

1. **`put()` captures `forcible`** and logs at `ERR` naming the sandbox whose write caused the eviction,
   stating that other sandboxes will be denied egress until re-pushed, and pointing at the dict size.
2. **`index_add()` captures `forcible`** for the index write too, which is the other unbounded value in
   that dict.
3. **`count()` reconciles the index against the store** — it now counts index entries that still resolve,
   so it cannot claim policies that were evicted.
4. **`validate_policy` caps policy size** — `MAX_RULES_PER_POLICY = 256` and
   `MAX_INJECTS_PER_RULE = 32`. Combined with the existing 64 KiB `SECRET_MAX_BYTES`, a single policy is now
   bounded instead of arbitrary.

No comment changes.

## What this does *not* do

It does not stop eviction. That is inherent to a shared dict that is too small for the fleet, and sizing is
an operator decision — `nginx.conf:26` ships `16m`, which at the 64 KiB worst case is on the order of 230
policies. What changes is that the condition is now diagnosable instead of silent, and that one runaway
policy can no longer consume the dict on its own.

## Testing

**Eviction reporting** — 58 policies with a 64 KiB secret each into a 1 MB store, using only `policy.put`:

| | master | this branch |
|---|---|---|
| `policy_store full` ERR lines | **0** | **45** |
| `policy.count()` | 59 (claims evicted entries) | 14 (matches what is stored) |
| victim policy present | false | false (unchanged — the dict is genuinely full) |

**Size caps:**

```
                          this branch                                    master
256 rules (at cap)        accepted                                       accepted
257 rules (over cap)      rejected: policy.rules has 257 rules, max 256   accepted
32 injects (at cap)       accepted                                       accepted
33 injects (over cap)     rejected: rules[1].action.inject has 33 ...     accepted
normal 2 rules            accepted                                       accepted
```

Both exercised against the real `policy.lua` under LuaJIT / `resty --shdict`.

CI gates: the Lua files are not covered by `fmt-check` or `unit-test-check` (no Lua formatter or test runner
is configured), so verification is via the harnesses above.

## Risk / rollout

A `PUT` carrying more than 256 rules or more than 32 injects in one rule now returns 400. Nothing in the tree
generates policies that large — `Cubelet/network/runtime/policy_builder.go` emits one rule per configured L7
rule — but if a control plane does, the cap is a single constant to raise.

New `ERR` lines will appear on any node whose `policy_store` is already undersized. That is the point, but
expect them immediately on upgrade rather than treating them as a regression.
