### PR TITLE
cubelet: refresh a multilock entry on every acquisition so the GC stops evicting live locks

### DIFF
--- a/Cubelet/pkg/multilock/multilock.go
+++ b/Cubelet/pkg/multilock/multilock.go
@@ -53,9 +53,9 @@ func NewMultiLock(options *Options) *MultiLock {
 }
 
 func (m *MultiLock) Get(key string) RWLock {
-	l, ok := m.Load(key)
-	if ok {
+	if l, ok := m.Load(key); ok {
 		lock := l.(*rwLock)
+		lock.touch()
 		return lock
 	}
 
@@ -65,8 +65,10 @@ func (m *MultiLock) Get(key string) RWLock {
 		time.Now().Unix(),
 	}
 
-	l, _ = m.LoadOrStore(key, newL)
-	return l.(*rwLock)
+	l, _ := m.LoadOrStore(key, newL)
+	lock := l.(*rwLock)
+	lock.touch()
+	return lock
 }
 
 func (m *MultiLock) loop() {
@@ -107,6 +109,10 @@ type rwLock struct {
 	*sync.RWMutex
 	key      string
 	updateAt int64
+}
+
+func (m *rwLock) touch() {
+	atomic.StoreInt64(&m.updateAt, time.Now().Unix())
 }
 
 func (m *rwLock) LockAt() {

--- a/Cubelet/pkg/multilock/multilock_gc_test.go
+++ b/Cubelet/pkg/multilock/multilock_gc_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package multilock
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGetKeepsAnActivelyUsedLockAlive(t *testing.T) {
+	m := NewMultiLock(&Options{CheckInterval: 20 * time.Millisecond, ExpiredInSecond: 2})
+
+	first := m.Get("sha256:volume-A")
+	first.Lock()
+	first.Unlock()
+
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		again := m.Get("sha256:volume-A")
+		if again != first {
+			t.Fatal("Get returned a different lock object for a key that is being used")
+		}
+		again.Lock()
+		again.Unlock()
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	if _, mapped := m.Load("sha256:volume-A"); !mapped {
+		t.Fatal("an actively used lock was evicted from the map")
+	}
+}
+
+func TestMutualExclusionHoldsAcrossGCTicks(t *testing.T) {
+	m := NewMultiLock(&Options{CheckInterval: 20 * time.Millisecond, ExpiredInSecond: 2})
+
+	var inCritical, maxConcurrent int32
+	var wg sync.WaitGroup
+
+	worker := func() {
+		defer wg.Done()
+		for i := 0; i < 40; i++ {
+			l := m.Get("sha256:volume-A")
+			l.Lock()
+			n := atomic.AddInt32(&inCritical, 1)
+			for {
+				old := atomic.LoadInt32(&maxConcurrent)
+				if n <= old || atomic.CompareAndSwapInt32(&maxConcurrent, old, n) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+			atomic.AddInt32(&inCritical, -1)
+			l.Unlock()
+		}
+	}
+
+	wg.Add(4)
+	for i := 0; i < 4; i++ {
+		go worker()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxConcurrent); got != 1 {
+		t.Fatalf("max concurrent holders of one key = %d, want 1", got)
+	}
+}
+
+func TestIdleLockIsStillEvicted(t *testing.T) {
+	m := NewMultiLock(&Options{CheckInterval: 20 * time.Millisecond, ExpiredInSecond: 0})
+
+	m.Get("sha256:volume-idle")
+	time.Sleep(1500 * time.Millisecond)
+
+	if _, mapped := m.Load("sha256:volume-idle"); mapped {
+		t.Fatal("an idle lock was not evicted; the GC no longer reclaims anything")
+	}
+}


### PR DESCRIPTION
Closes #1430.

## Motivation

`MultiLock` stamped `updateAt` only when it created an entry, and only `LockAt()` refreshed it. Every real
caller uses `Lock()` / `RLock()` — `LockAt` has no non-test callers — so the GC deleted each entry
`ExpiredInSecond` after **creation**, regardless of use. A later `Get()` for the same key then returned a
different mutex, and two goroutines could be in one key's critical section at the same time.

In `services/images` this lock serializes `syncDb`'s refcount read-modify-write against `hardRemove`'s
delete, so losing exclusion means a volume can be removed while its refcount is being updated.

## What this changes

`Cubelet/pkg/multilock/multilock.go` — `Get()` now stamps `updateAt` on **every** call, via a small
`touch()` helper using `atomic.StoreInt64` (matching how the GC reads it with `atomic.LoadInt64`):

- the existing-entry path touches before returning
- the create path touches after `LoadOrStore`, so the winner of a concurrent create is the object that
  gets refreshed

Because callers always `Get()` immediately before locking, an in-use key is refreshed on each acquisition
and cannot reach the expiry threshold while traffic continues. Genuinely idle entries are still reclaimed,
so the GC keeps doing its job.

Nothing else changes: same API, same `Options`, same GC loop.

No comment changes.

## Honest limitation

This narrows the window rather than eliminating it. `updateAt` is whole-second resolution, so with a
pathologically small `ExpiredInSecond` (0 or 1) an entry can still expire between a `Get()` and the
subsequent `Lock()` simply by crossing a second boundary. With the default `ExpiredInSecond: 3600` — the
only value used in-tree (`storage/local.go:295`, `services/images/volume.go:90-92`) — an entry would have to
sit unused for an hour, which cannot happen while it is being acquired.

The complete fix is reference counting, releasing an entry only when the last holder is done — the pattern
`SandboxLocks` already implements correctly in `network/runtime/controller.go:1039-1065`. That changes the
`Get()` contract (callers would need to signal release), so it is a larger, API-visible change and belongs
in its own PR. I found the discrepancy while writing the test for this one:

```
# with ExpiredInSecond: 0, even with this fix, whole-second truncation still
# allows eviction between Get() and Lock()
```

so the tests here use a realistic 2-second window and say so.

## Testing

New: `Cubelet/pkg/multilock/multilock_gc_test.go`

- `TestGetKeepsAnActivelyUsedLockAlive` — hammers one key for 4s with a 2s expiry and a 20ms GC tick;
  asserts `Get()` keeps returning the same object and that the entry is still mapped at the end.
- `TestMutualExclusionHoldsAcrossGCTicks` — 4 goroutines × 40 acquisitions of one key across many GC ticks;
  asserts the maximum number of simultaneous holders is exactly 1.
- `TestIdleLockIsStillEvicted` — with a 0-second expiry an untouched entry **is** reclaimed, so the fix did
  not simply disable the GC.

Red/green — with `multilock.go` reverted:

```
--- FAIL: TestGetKeepsAnActivelyUsedLockAlive (2.65s)
FAIL
```

with the fix, including under the race detector:

```
$ go test -race -count=1 ./pkg/multilock/
ok  github.com/tencentcloud/CubeSandbox/Cubelet/pkg/multilock  10.136s
```

CI gates checked locally:

- `gofmt -l ./pkg/multilock` — clean (`fmt-check`).
- `go build ./pkg/multilock/` — clean.

## Not fixed here

- `LockAt()` takes a **read** lock despite the name. Renaming it is an exported-API change on the `RWLock`
  interface; with no callers it is safe but it is churn unrelated to this defect.
- `GetLockFromContext` returns a throwaway mutex when the context has no lock, giving callers silent
  non-exclusion. Also no callers; changing it to return an error is an API decision.

Both are worth their own issue.
