### PR TITLE
cubemaster, cubelet: use unsafe.Slice / unsafe.String instead of hand-built reflect headers

### DIFF
--- a/CubeMaster/pkg/base/utils/strings.go
+++ b/CubeMaster/pkg/base/utils/strings.go
@@ -7,7 +7,6 @@ package utils
 
 import (
 	"io"
-	"reflect"
 	"unsafe"
 
 	"slices"
@@ -29,13 +28,7 @@ func DecodeHttpBody(body io.ReadCloser, obj interface{}) error {
 }
 
 func String2Slice(s string) []byte {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 func Int64Ptr(v int64) *int64 {

--- a/CubeMaster/pkg/base/utils/strings_unsafe_test.go
+++ b/CubeMaster/pkg/base/utils/strings_unsafe_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package utils
+
+import (
+	"bytes"
+	"hash/crc32"
+	"runtime"
+	"testing"
+)
+
+func TestString2Slice(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []byte
+	}{
+		{"empty string", "", []byte{}},
+		{"ascii", "hello world", []byte("hello world")},
+		{"utf8", "héllo-世界", []byte("héllo-世界")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := String2Slice(tc.input)
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("String2Slice(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+			if len(got) != len(tc.input) {
+				t.Fatalf("len = %d, want %d", len(got), len(tc.input))
+			}
+		})
+	}
+}
+
+func TestString2SliceSurvivesGC(t *testing.T) {
+	produce := func() []byte {
+		return String2Slice("a-string-that-goes-out-of-scope")
+	}
+
+	b := produce()
+	runtime.GC()
+	runtime.GC()
+
+	if string(b) != "a-string-that-goes-out-of-scope" {
+		t.Fatalf("slice contents changed after GC: %q", string(b))
+	}
+	if crc32.ChecksumIEEE(b) != crc32.ChecksumIEEE([]byte("a-string-that-goes-out-of-scope")) {
+		t.Fatal("checksum mismatch after GC")
+	}
+}

--- a/Cubelet/pkg/utils/strings.go
+++ b/Cubelet/pkg/utils/strings.go
@@ -17,7 +17,6 @@ import (
 	"hash/crc32"
 	"io"
 	"io/ioutil"
-	"reflect"
 	"strings"
 	"unsafe"
 
@@ -29,13 +28,7 @@ import (
 var JSONTool = jsoniter.ConfigCompatibleWithStandardLibrary
 
 func String2Slice(s string) []byte {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 func InStringSlice(ss []string, str string) bool {

--- a/Cubelet/services/images/volumelifetime.go
+++ b/Cubelet/services/images/volumelifetime.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"runtime/debug"
 	"sort"
 	"strconv"
@@ -894,12 +893,10 @@ func (m needDeleteType) Swap(i int, j int) {
 }
 
 func slice2Str(b []byte) string {
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sh := reflect.StringHeader{
-		Data: bh.Data,
-		Len:  bh.Len,
+	if len(b) == 0 {
+		return ""
 	}
-	return *(*string)(unsafe.Pointer(&sh))
+	return unsafe.String(&b[0], len(b))
 }
 
 func lessByLastUsedTime(e1, e2 *meta) bool {


### PR DESCRIPTION

Closes #1432.

## Motivation

Three helpers built a `reflect.SliceHeader` / `reflect.StringHeader` by hand to do a zero-copy
`string` ↔ `[]byte` conversion. `Data` is a bare `uintptr`, which does not keep its referent alive, so
between constructing the header and reinterpreting it the backing array has no tracked pointer. `go vet`
reports "possible misuse" at all three sites, and `staticcheck` reports both types as deprecated since
Go 1.21.

Go 1.20 added `unsafe.Slice` / `unsafe.String` / `unsafe.StringData`, which express the same zero-copy
conversion while keeping the referent tracked by the GC.

## What this changes

**`CubeMaster/pkg/base/utils/strings.go`** and **`Cubelet/pkg/utils/strings.go`** — `String2Slice`
becomes a one-liner:

```go
func String2Slice(s string) []byte {
	return unsafe.Slice(unsafe.StringData(s), len(s))
}
```

For `s == ""`, `unsafe.StringData` may return nil and `unsafe.Slice(nil, 0)` returns a nil slice. The
existing test compares with `bytes.Equal`, which treats nil and `[]byte{}` as equal, so this is
behaviour-compatible.

**`Cubelet/services/images/volumelifetime.go`** — `slice2Str` becomes:

```go
func slice2Str(b []byte) string {
	if len(b) == 0 {
		return ""
	}
	return unsafe.String(&b[0], len(b))
}
```

The length guard is required — `unsafe.String(&b[0], 0)` would index an empty slice. The old header
form silently produced an empty string for that case, so the guard preserves it.

The now-unused `reflect` import is dropped from all three files. Both modules are well past Go 1.20
(`Cubelet` 1.24.8, `CubeMaster` 1.25.7).

Per CONTRIBUTING's "one component per commit", this should land as two commits — one for CubeMaster, one
for Cubelet.

No comment changes.

## Deliberately unchanged

`String2Slice` still returns a **writable** view aliasing the string. Making it safe would mean copying,
which defeats the point of the helper (its only caller is `crc32.ChecksumIEEE`, which is read-only).
This PR fixes the GC-soundness and deprecation problems; the write hazard is a separate API question —
either document the constraint or replace the two call sites with `crc32.ChecksumIEEE([]byte(s))` and
delete the helper.

## Testing

New: `CubeMaster/pkg/base/utils/strings_unsafe_test.go` (the package previously had **no** test files).

- `TestString2Slice` — empty, ASCII and multi-byte UTF-8 inputs; checks contents and length.
- `TestString2SliceSurvivesGC` — produces the slice inside a helper so the source string goes out of
  scope, forces two `runtime.GC()` cycles, then re-checks the contents and the CRC32. This is the
  liveness property the old `uintptr` header did not guarantee.

```
$ docker run --rm ... -w /w/CubeMaster golang:1.26 go test -short -v ./pkg/base/utils/
--- PASS: TestString2Slice
--- PASS: TestString2SliceSurvivesGC
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils  0.005s
```

Cubelet's existing `TestString2Slice` (`pkg/utils/strings_test.go`) still passes:

```
$ ... -w /w/Cubelet golang:1.26 go test -count=1 -run 'TestString2Slice|Test_HashCode' ./pkg/utils/
ok  github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils  0.003s
```

`slice2Str` has no direct test — `Cubelet/services/images` cannot be tested locally (the package needs
`cubecow.h` from the Rust build, so its tests do not build outside the builder image). It is covered by
`GOOS=linux go build` and `go vet`.

CI gates checked locally:

- `gofmt -l` on all three packages — clean (`fmt-check`).
- `GOOS=linux go vet` on all three — the three "possible misuse" findings are gone.
- `GOOS=linux go build ./services/images/` — clean.
