### PR TITLE
cubemaster: fix the copylocks diagnostic and the labels-cache init race in base/node

### DIFF
--- a/CubeMaster/pkg/base/node/node.go
+++ b/CubeMaster/pkg/base/node/node.go
@@ -112,7 +112,7 @@ type Node struct {
 
 	// schedulingDisabled is the cordon flag (true → block new sandboxes).
 	// Exposed via SchedulingDisabled() / JSON as "SchedulingDisabled".
-	schedulingDisabled atomic.Bool
+	schedulingDisabled int32
 
 	labelsCache *nodeLabelsCacheStore
 }
@@ -133,18 +133,22 @@ func (n *Node) SetSchedulingDisabled(disabled bool) {
 	if n == nil {
 		return
 	}
-	n.schedulingDisabled.Store(disabled)
+	var v int32
+	if disabled {
+		v = 1
+	}
+	atomic.StoreInt32(&n.schedulingDisabled, v)
 }
 
 // SchedulingDisabled reports whether this node is cordoned.
 func (n *Node) SchedulingDisabled() bool {
-	return n != nil && n.schedulingDisabled.Load()
+	return n != nil && atomic.LoadInt32(&n.schedulingDisabled) == 1
 }
 
 // SchedulingAllowed reports whether this node may receive new sandboxes based
 // solely on cordon state (health / metrics are orthogonal).
 func (n *Node) SchedulingAllowed() bool {
-	return n != nil && !n.schedulingDisabled.Load()
+	return n != nil && atomic.LoadInt32(&n.schedulingDisabled) != 1
 }
 
 // MarshalJSON emits SchedulingDisabled from the atomic cordon flag.
@@ -197,7 +201,6 @@ func (n *Node) Clone() *Node {
 	schedulingDisabled := n.SchedulingDisabled()
 	cloned := *n
 	cloned.LocalCreateNum = localCreateNum
-	cloned.schedulingDisabled = atomic.Bool{}
 	cloned.SetSchedulingDisabled(schedulingDisabled)
 	cloned.labelsCache = nil
 	if n.VirtualNodeQuotaArray != nil {
@@ -217,9 +220,6 @@ func (n *Node) Clone() *Node {
 }
 
 func (n *Node) labelsCacheStore() *nodeLabelsCacheStore {
-	if n.labelsCache != nil {
-		return n.labelsCache
-	}
 	nodeLabelsCacheInitMu.Lock()
 	defer nodeLabelsCacheInitMu.Unlock()
 	if n.labelsCache == nil {
@@ -270,9 +270,10 @@ func (n *Node) Labels() map[string]string {
 }
 
 func (n *Node) InvalidateLabelsCache() {
-	if n.labelsCache != nil {
-		n.labelsCache.cache.Store(nil)
+	if n == nil {
+		return
 	}
+	n.labelsCacheStore().cache.Store(nil)
 }
 
 type NodeList []*Node

--- a/CubeMaster/pkg/base/node/node_concurrency_test.go
+++ b/CubeMaster/pkg/base/node/node_concurrency_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package node
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestLabelsCacheInitIsRaceFree(t *testing.T) {
+	n := &Node{Zone: "z1", ClusterLabel: "c1", CPUType: "amd64", QuotaMem: 1024, QuotaCpu: 2000}
+
+	const readers = 32
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				if got := n.Labels(); got == nil {
+					t.Error("Labels() returned nil")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestLabelsCacheInvalidateIsRaceFree(t *testing.T) {
+	n := &Node{Zone: "z1", ClusterLabel: "c1"}
+
+	var wg sync.WaitGroup
+	wg.Add(16)
+	for i := 0; i < 8; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				n.Labels()
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				n.InvalidateLabelsCache()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestCloneCarriesSchedulingDisabled(t *testing.T) {
+	n := &Node{InsID: "n1", NodeLabels: map[string]string{"a": "b"}}
+	n.SetSchedulingDisabled(true)
+
+	c := n.Clone()
+	if !c.SchedulingDisabled() {
+		t.Fatal("clone lost the cordon flag")
+	}
+	if c.SchedulingAllowed() {
+		t.Fatal("clone reports scheduling allowed while cordoned")
+	}
+
+	c.SetSchedulingDisabled(false)
+	if !n.SchedulingDisabled() {
+		t.Fatal("mutating the clone changed the original cordon flag")
+	}
+	if c.SchedulingDisabled() {
+		t.Fatal("clone did not accept the new cordon value")
+	}
+}
+
+func BenchmarkLabels(b *testing.B) {
+	n := &Node{Zone: "z1", ClusterLabel: "c1", CPUType: "amd64", QuotaMem: 1024, QuotaCpu: 2000}
+	n.Labels()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n.Labels()
+	}
+}
+
+func BenchmarkLabelsParallel(b *testing.B) {
+	n := &Node{Zone: "z1", ClusterLabel: "c1", CPUType: "amd64", QuotaMem: 1024, QuotaCpu: 2000}
+	n.Labels()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			n.Labels()
+		}
+	})
+}


### PR DESCRIPTION
Closes #1434.

## Motivation

Two problems in `pkg/base/node`:

1. `go vet` reports `assignment copies lock value to cloned` at `node.go:198`, because `cloned := *n`
   copies `schedulingDisabled atomic.Bool` and `atomic.Bool` embeds `noCopy`.
2. `labelsCacheStore()` is double-checked locking with an unsynchronized fast-path read, so concurrent
   `Labels()` callers race on `n.labelsCache`. `InvalidateLabelsCache()` read the same field
   unsynchronized.

## What this changes

**`schedulingDisabled atomic.Bool` → `int32`,** accessed with `atomic.StoreInt32` / `atomic.LoadInt32`
inside the existing `SetSchedulingDisabled` / `SchedulingDisabled` / `SchedulingAllowed` methods. This
removes the `noCopy` type from the struct, so the vet diagnostic goes away. The exported API and the
JSON shape are unchanged — `MarshalJSON` / `UnmarshalJSON` already go through the accessors. The
now-redundant `cloned.schedulingDisabled = atomic.Bool{}` line in `Clone` is dropped, since
`SetSchedulingDisabled` on the next line sets the value.

**`labelsCacheStore()` takes the mutex for the whole function,** removing the unsynchronized fast-path
read. `InvalidateLabelsCache()` now routes through it instead of touching the field directly, and gains
a nil-receiver guard to match the other methods.

No comment changes.

## What this does NOT fix, and why

`cloned := *n` remains a **non-atomic read** of `LocalCreateNum` and `schedulingDisabled` while other
goroutines mutate them atomically. Changing `atomic.Bool` to `int32` silences vet's *copylocks* check
but does not make that read atomic — the race detector still flags it.

I wrote a test for it, watched it fail, and removed the test rather than ship a fix I had not actually
made:

```
--- FAIL: TestCloneConcurrentWithCordonToggleIsRaceFree
WARNING: DATA RACE
```

A real fix needs one of:

- **field-by-field copy in `Clone`**, excluding the atomically-managed fields — correct, but `Node` has
  ~40 fields and a future field silently not being cloned is a worse bug than this one;
- **moving the atomic fields behind a pointer** (`counters *nodeCounters`) so `*n` copies only the
  pointer — clean, but `LocalCreateNum` is an exported field used across the module and in JSON;
- **a per-node mutex held by both `Clone` and the writers** — reintroduces `noCopy` unless it also sits
  behind a pointer.

All three are larger than a correctness patch should be, and the existing comment already documents the
snapshot as best-effort. Worth its own issue and its own decision.

## Testing

New: `CubeMaster/pkg/base/node/node_concurrency_test.go`

- `TestLabelsCacheInitIsRaceFree` — 32 goroutines × 200 `Labels()` calls on a fresh node, which is what
  triggered the DCL race.
- `TestLabelsCacheInvalidateIsRaceFree` — 8 readers against 8 invalidators.
- `TestCloneCarriesSchedulingDisabled` — the cordon flag survives `Clone`, and clone and original are
  independent afterwards (guards the `int32` conversion).
- `BenchmarkLabels` / `BenchmarkLabelsParallel` — so the lock cost is measurable rather than assumed.

Red/green, on the same test file:

| | master | this branch |
|---|---|---|
| data races in `TestLabelsCache*` | **3** | 0 |
| `go vet ./pkg/base/node/` | copylocks at `node.go:198` | clean |

```
$ go test -race -count=1 ./pkg/base/node/
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node  1.677s
```

## Performance: the honest number

Taking the mutex on the `Labels()` fast path is not free:

| benchmark | master (racy, lock-free) | this branch |
|---|---|---|
| `BenchmarkLabels` | 4.95 ns/op | 13.78 ns/op |
| `BenchmarkLabelsParallel` (8 procs) | 8.57 ns/op | 86.91 ns/op |

The parallel figure is a 10x ratio, so it deserves a straight answer rather than being buried: it is
8 cores hammering **one** node's `Labels()`, which is the worst case and not the real access pattern.
In absolute terms a full affinity sweep over 3000 nodes goes from ~0.026 ms to ~0.26 ms per scheduling
decision. I judged that acceptable against a data race, but if the reviewer disagrees the alternative is
to drop the lazy init entirely — embed `nodeLabelsCacheStore` by value, or initialise it eagerly — which
keeps the fast path lock-free. Embedding by value reintroduces the copylocks diagnostic via
`atomic.Pointer`; eager init means nodes built from struct literals silently lose label caching. Both are
real trade-offs, which is why I did not pick one unilaterally.

CI gates checked locally:

- `gofmt -l ./pkg/base/node` — clean (`fmt-check`).
- `GOOS=linux go vet ./pkg/base/node/` — clean.
- `GOOS=linux go build ./...` — clean for the whole module.

`pkg/localcache` has one failure, `Test_local_appendNodeByCluster` — confirmed **pre-existing on
master**, unrelated to this change.
