### PR TITLE
cubemaster: make the scheduler filter intersection duplicate-safe

### DIFF
--- a/CubeMaster/pkg/scheduler/schedule.go
+++ b/CubeMaster/pkg/scheduler/schedule.go
@@ -151,9 +151,14 @@ func parallelRunFilters(selCtx *selctx.SelectorCtx, filters []filter.Selector) (
 			if tmp, err := f.Select(selCtx); err != nil {
 				return err
 			} else {
+				counted := make(map[string]struct{}, len(tmp))
 				for _, n := range tmp {
-
-					tmpStat.Add(n.ID(), 1)
+					id := n.ID()
+					if _, duplicate := counted[id]; duplicate {
+						continue
+					}
+					counted[id] = struct{}{}
+					tmpStat.Add(id, 1)
 				}
 			}
 			return nil

--- a/CubeMaster/pkg/scheduler/schedule_intersection_test.go
+++ b/CubeMaster/pkg/scheduler/schedule_intersection_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/selector/filter"
+)
+
+type stubFilter struct {
+	id  string
+	out node.NodeList
+}
+
+func (f *stubFilter) Select(_ *selctx.SelectorCtx) (node.NodeList, error) { return f.out, nil }
+func (f *stubFilter) ID() string                                          { return f.id }
+
+func stubNode(id string) *node.Node {
+	n := &node.Node{}
+	n.InsID = id
+	return n
+}
+
+func idsOf(list node.NodeList) []string {
+	out := make([]string, 0, list.Len())
+	for _, n := range list {
+		out = append(out, n.ID())
+	}
+	return out
+}
+
+func TestParallelRunFiltersExcludesNodeRejectedByAnyFilter(t *testing.T) {
+	good, rejected := stubNode("node-good"), stubNode("node-rejected")
+
+	ctx := &selctx.SelectorCtx{Ctx: context.Background()}
+	ctx.SetNodes(node.NodeList{good, rejected})
+
+	filters := []filter.Selector{
+		&stubFilter{id: "a", out: node.NodeList{good, rejected, rejected}},
+		&stubFilter{id: "b", out: node.NodeList{good}},
+	}
+
+	got, err := parallelRunFilters(ctx, filters)
+	if err != nil {
+		t.Fatalf("parallelRunFilters: %v", err)
+	}
+
+	ids := idsOf(got)
+	if len(ids) != 1 || ids[0] != "node-good" {
+		t.Fatalf("intersection = %v, want [node-good]; a node rejected by filter b survived", ids)
+	}
+}
+
+func TestParallelRunFiltersKeepsNodeAcceptedByAll(t *testing.T) {
+	a, b := stubNode("node-a"), stubNode("node-b")
+
+	ctx := &selctx.SelectorCtx{Ctx: context.Background()}
+	ctx.SetNodes(node.NodeList{a, b})
+
+	filters := []filter.Selector{
+		&stubFilter{id: "a", out: node.NodeList{a, b}},
+		&stubFilter{id: "b", out: node.NodeList{b, a}},
+	}
+
+	got, err := parallelRunFilters(ctx, filters)
+	if err != nil {
+		t.Fatalf("parallelRunFilters: %v", err)
+	}
+	if got.Len() != 2 {
+		t.Fatalf("intersection = %v, want both nodes", idsOf(got))
+	}
+}
+
+func TestParallelRunFiltersDuplicatesDoNotAdmitOnTheirOwn(t *testing.T) {
+	only := stubNode("node-only")
+
+	ctx := &selctx.SelectorCtx{Ctx: context.Background()}
+	ctx.SetNodes(node.NodeList{only})
+
+	filters := []filter.Selector{
+		&stubFilter{id: "a", out: node.NodeList{only, only, only}},
+		&stubFilter{id: "b", out: node.NodeList{}},
+		&stubFilter{id: "c", out: node.NodeList{only}},
+	}
+
+	got, err := parallelRunFilters(ctx, filters)
+	if err != nil {
+		t.Fatalf("parallelRunFilters: %v", err)
+	}
+	if got.Len() != 0 {
+		t.Fatalf("intersection = %v, want empty; filter b returned nothing", idsOf(got))
+	}
+}


### PR DESCRIPTION

Closes #1436.

## Motivation

`parallelRunFilters` computes "nodes that passed every filter" by counting occurrences:

```go
for _, n := range tmp { tmpStat.Add(n.ID(), 1) }
...
if expectedCnt == tmpStat.Get(n.ID()) { result.Append(n) }
```

That is only equivalent to set intersection if every filter returns each node **at most once**. If a
single filter emits a duplicate, its contribution is 2, and with two filters a node that the other
filter *rejected* still reaches `expectedCnt` and gets scheduled.

Filters enforce placement constraints, so the failure mode is a sandbox landing on a node a filter
explicitly excluded — and it is silent.

## What this changes

`CubeMaster/pkg/scheduler/schedule.go` — each filter goroutine now counts each node ID at most once:

```go
counted := make(map[string]struct{}, len(tmp))
for _, n := range tmp {
    id := n.ID()
    if _, duplicate := counted[id]; duplicate {
        continue
    }
    counted[id] = struct{}{}
    tmpStat.Add(id, 1)
}
```

The `AtomicMapStat` tally and the `expectedCnt ==` check are unchanged, so the counting scheme stays
as-is — it is now simply fed one increment per (filter, node) pair, which makes the comparison a real
intersection. The dedupe map is goroutine-local, so it adds no contention.

No comment changes.

## Testing

New: `CubeMaster/pkg/scheduler/schedule_intersection_test.go`

- `TestParallelRunFiltersExcludesNodeRejectedByAnyFilter` — the issue's exact scenario: filter A
  emits `bad` twice, filter B rejects it; the result must be `[node-good]` only.
- `TestParallelRunFiltersKeepsNodeAcceptedByAll` — regression guard that a genuine full intersection
  still returns everything, including when filters return nodes in different orders.
- `TestParallelRunFiltersDuplicatesDoNotAdmitOnTheirOwn` — three filters, one emitting the node three
  times and one returning nothing; the result must be empty.

Red/green verified — with `schedule.go` reverted to master:

```
--- FAIL: TestParallelRunFiltersExcludesNodeRejectedByAnyFilter
FAIL
```

and with the fix, including under the race detector (the counting happens across goroutines):

```
$ go test -count=1 -race ./pkg/scheduler/
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler  1.375s
```

CI gates checked locally:

- `gofmt -l ./pkg/scheduler` — clean (`fmt-check`).
- `GOOS=linux go build ./pkg/scheduler/` — clean.

## Deliberately out of scope

`parallelRunFilters` also discards the context from `errgroup.WithContext` (`schedule.go:139`), so
filter goroutines do not observe cancellation when a sibling fails. Honouring it means threading the
derived context into `filter.Selector.Select`, which currently reads `selCtx.Ctx` — an interface-level
change across every filter implementation. That is a separate change and does not belong in a
correctness fix; it costs wasted work on a failing select, not a wrong result.
