### PR TITLE
cubeapi: match the Bearer auth scheme case-insensitively

### DIFF
--- a/CubeAPI/src/middleware/auth.rs
+++ b/CubeAPI/src/middleware/auth.rs
@@ -18,6 +18,15 @@ enum AuthCredential {
     ApiKey(String),
 }
 
+fn strip_bearer_prefix(value: &str) -> Option<&str> {
+    let (scheme, rest) = value.split_once(' ')?;
+    if scheme.eq_ignore_ascii_case("bearer") {
+        Some(rest)
+    } else {
+        None
+    }
+}
+
 /// Extract the auth credential from request headers (Bearer takes priority over X-API-Key).
 fn extract_credential(request: &Request) -> Option<AuthCredential> {
     let headers = request.headers();
@@ -25,7 +34,7 @@ fn extract_credential(request: &Request) -> Option<AuthCredential> {
     // Prefer Authorization: Bearer
     if let Some(auth_val) = headers.get("Authorization") {
         if let Ok(auth_str) = auth_val.to_str() {
-            if let Some(token) = auth_str.strip_prefix("Bearer ") {
+            if let Some(token) = strip_bearer_prefix(auth_str) {
                 let token = token.trim().to_string();
                 if !token.is_empty() {
                     return Some(AuthCredential::Bearer(token));


### PR DESCRIPTION

Closes #1438.

## Motivation

`extract_credential` used `auth_str.strip_prefix("Bearer ")`, so only that exact casing was accepted. RFC
7235 §2.1 defines the auth-scheme as a case-insensitive token, and CubeOps already treats it that way
(`strings.EqualFold`), so a spec-compliant `authorization: bearer <token>` was silently rejected with 401
by CubeAPI only.

## What this changes

`CubeAPI/src/middleware/auth.rs` — a small `strip_bearer_prefix` helper splits the header on the first
space and compares the scheme with `eq_ignore_ascii_case`:

```rust
fn strip_bearer_prefix(value: &str) -> Option<&str> {
    let (scheme, rest) = value.split_once(' ')?;
    if scheme.eq_ignore_ascii_case("bearer") {
        Some(rest)
    } else {
        None
    }
}
```

The existing `.trim()` and empty-token checks at the call site are unchanged, so a header with extra
whitespace behaves as before, and a non-Bearer scheme still falls through to `X-API-Key`.

`eq_ignore_ascii_case` rather than `to_lowercase` avoids an allocation on every request and is correct
here, since the scheme token is ASCII by definition.

No comment changes.

## Testing

Probed the real binary with `CUBE_API_KEY=supersecret` (500 = credential accepted and the request reached
the CubeMaster call; 401 = rejected at auth):

| header | master | this branch |
|---|---|---|
| `Authorization: Bearer supersecret` | 500 | 500 |
| `Authorization: bearer supersecret` | **401** | **500** |
| `Authorization: BEARER supersecret` | **401** | **500** |
| `Authorization: BeArEr supersecret` | — | 500 |
| `Authorization: Bearer wrongkey` | 401 | 401 |
| `Authorization: Basic supersecret` | 401 | 401 |
| `X-API-Key: supersecret` | 500 | 500 |
| no credential | 401 | 401 |

The last four matter as much as the first three: the change must not start accepting a wrong key, a
different scheme, or a missing credential.

CubeAPI's own suite:

```
$ cargo test
test result: ok. 109 passed; 0 failed; 0 ignored
```

CI gates checked locally:

- `cargo fmt --check` — clean (`fmt-check`).
- `cargo build` — clean.

## Relationship to the rate-limiter branch

The report also flagged that the API key is compared with `!=`, which short-circuits and leaks the key by
timing. That fix lives on the **CubeAPI rate limiter** branch, because keying the limiter on the validated
identity meant touching the same block anyway. I deliberately left it out here so the two branches do not
conflict — this PR is only the scheme-casing fix. If the rate-limiter branch is not taken, the constant-time
comparison should be lifted out of it into its own change.

## Risk / rollout

Low, and strictly widening: requests that previously failed now succeed, and nothing that previously
succeeded changes. No configuration or deployment impact.
