### PR TITLE
cubelet: roll back only the host ports a failed Reserve newly acquired

### DIFF
--- a/Cubelet/network/runtime/resource_allocator.go
+++ b/Cubelet/network/runtime/resource_allocator.go
@@ -296,14 +296,18 @@ func (b *PortBinder) Reserve(owner string, requestedMappings []PortMapping, defa
 			b.releaseOwnedLocked(owner, ownedNow)
 			return nil, fmt.Errorf("host port %d appears more than once in one reservation request", port)
 		}
+		preOwned := false
 		if !automatic {
+			preOwned = b.assigned[port] == owner
 			if err := b.ownLocked(owner, port); err != nil {
 				b.releaseOwnedLocked(owner, ownedNow)
 				return nil, err
 			}
 		}
 		seenHostPorts[port] = struct{}{}
-		ownedNow = append(ownedNow, port)
+		if !preOwned {
+			ownedNow = append(ownedNow, port)
+		}
 		actualMappings = append(actualMappings, PortMapping{
 			Protocol:      nonEmpty(mapping.Protocol, "tcp"),
 			HostIP:        nonEmpty(mapping.HostIP, defaultHostIP),

--- a/Cubelet/network/runtime/resource_allocator_rollback_test.go
+++ b/Cubelet/network/runtime/resource_allocator_rollback_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package runtime
+
+import "testing"
+
+func TestReserveRollbackKeepsPortsFromEarlierReservation(t *testing.T) {
+	b := newTestPortBinder()
+	const owner = "sandbox-A"
+
+	if _, err := b.Reserve(owner, []PortMapping{
+		{ContainerPort: 8080, HostPort: 20500},
+	}, "10.0.0.1"); err != nil {
+		t.Fatalf("first Reserve: %v", err)
+	}
+	if got := b.assigned[20500]; got != owner {
+		t.Fatalf("after first Reserve, assigned[20500] = %q, want %q", got, owner)
+	}
+
+	_, err := b.Reserve(owner, []PortMapping{
+		{ContainerPort: 8080, HostPort: 20500},
+		{ContainerPort: 0, HostPort: 20501},
+	}, "10.0.0.1")
+	if err == nil {
+		t.Fatal("second Reserve was expected to fail on the invalid container port")
+	}
+
+	if got := b.assigned[20500]; got != owner {
+		t.Fatalf("rollback revoked a port from the earlier reservation: assigned[20500] = %q, want %q", got, owner)
+	}
+	if _, ok := b.owners[owner][20500]; !ok {
+		t.Fatal("rollback removed 20500 from the owner set")
+	}
+	if _, leaked := b.assigned[20501]; leaked {
+		t.Fatal("the failed reservation leaked port 20501")
+	}
+}
+
+func TestReserveRollbackReleasesOnlyItsOwnPorts(t *testing.T) {
+	b := newTestPortBinder()
+
+	if _, err := b.Reserve("A", []PortMapping{{ContainerPort: 80, HostPort: 20500}}, "ip"); err != nil {
+		t.Fatalf("Reserve for A: %v", err)
+	}
+
+	if _, err := b.Reserve("B", []PortMapping{
+		{ContainerPort: 81, HostPort: 20501},
+		{ContainerPort: 0, HostPort: 20502},
+	}, "ip"); err == nil {
+		t.Fatal("Reserve for B was expected to fail")
+	}
+
+	if got := b.assigned[20500]; got != "A" {
+		t.Fatalf("A's port was collaterally released: assigned[20500] = %q", got)
+	}
+	if _, leaked := b.assigned[20501]; leaked {
+		t.Fatal("B's partial port leaked")
+	}
+}
+
+func TestReserveRollbackReleasesNewlyAcquiredPorts(t *testing.T) {
+	b := newTestPortBinder()
+	const owner = "sandbox-A"
+
+	_, err := b.Reserve(owner, []PortMapping{
+		{ContainerPort: 80, HostPort: 20600},
+		{ContainerPort: 0, HostPort: 20601},
+	}, "ip")
+	if err == nil {
+		t.Fatal("Reserve was expected to fail")
+	}
+	if _, leaked := b.assigned[20600]; leaked {
+		t.Fatal("a port acquired by the failed call was not released")
+	}
+	if _, present := b.owners[owner]; present {
+		t.Fatal("the owner entry was left behind after a fully-rolled-back reservation")
+	}
+}
+
+func TestReserveAutomaticAllocationStillWorks(t *testing.T) {
+	b := newTestPortBinder()
+
+	got, err := b.Reserve("A", []PortMapping{
+		{ContainerPort: 80},
+		{ContainerPort: 81},
+	}, "10.0.0.1")
+	if err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d mappings, want 2", len(got))
+	}
+	if got[0].HostPort == got[1].HostPort {
+		t.Fatalf("automatic allocation reused the same host port %d", got[0].HostPort)
+	}
+	for _, m := range got {
+		if m.HostPort < int32(portMin) || m.HostPort > int32(portMax) {
+			t.Fatalf("host port %d outside the managed range", m.HostPort)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1440.

## Motivation

`ownLocked` lets an owner re-own a port it already holds, and `Reserve` appended every port it touched to
`ownedNow` regardless. On a partial failure, `releaseOwnedLocked(owner, ownedNow)` therefore released
ports that belonged to an **earlier successful** reservation for the same owner — leaving them
allocatable to another sandbox while still programmed into CubeVS for the first.

Latent today (`Reserve` is called once per sandbox create), but the failure mode is a silent host-port
collision, and it becomes reachable the moment a retry or incremental port-add path is added.

## What this changes

`Cubelet/network/runtime/resource_allocator.go` — `Reserve` records whether each explicit port was
already owned by this owner before claiming it, and only adds newly-acquired ports to the rollback set:

```go
preOwned := false
if !automatic {
    preOwned = b.assigned[port] == owner
    if err := b.ownLocked(owner, port); err != nil {
        b.releaseOwnedLocked(owner, ownedNow)
        return nil, err
    }
}
seenHostPorts[port] = struct{}{}
if !preOwned {
    ownedNow = append(ownedNow, port)
}
```

Automatically-allocated ports always go into the rollback set, since `allocateLocked` only ever picks an
unassigned port.

`releaseOwnedLocked` is unchanged — it now simply receives the right list.

No comment changes.

## Testing

New: `Cubelet/network/runtime/resource_allocator_rollback_test.go` (reuses the existing
`newTestPortBinder` helper rather than declaring another).

- `TestReserveRollbackKeepsPortsFromEarlierReservation` — the issue's exact scenario; asserts both
  `assigned` and the owner set retain the earlier port, and that the failed call's own port did not leak.
- `TestReserveRollbackReleasesOnlyItsOwnPorts` — cross-owner rollback still correct (this already worked;
  guards against over-correcting).
- `TestReserveRollbackReleasesNewlyAcquiredPorts` — a fully-rolled-back call leaves nothing behind,
  including no empty owner entry.
- `TestReserveAutomaticAllocationStillWorks` — automatic allocation returns distinct in-range ports.

Red/green — with `resource_allocator.go` reverted to master:

```
--- FAIL: TestReserveRollbackKeepsPortsFromEarlierReservation
    resource_allocator_rollback_test.go:31: rollback revoked a port from the earlier
    reservation: assigned[20500] = "", want "sandbox-A"
```

and with the fix, the whole package (controller, tap pool, startup recovery, state store — ~9.8k lines
of tests) passes:

```
$ go test -count=1 ./network/runtime/
ok  github.com/tencentcloud/CubeSandbox/Cubelet/network/runtime  1.285s
```

CI gates checked locally:

- `gofmt -l ./network/runtime` — clean (`fmt-check`).
- `GOOS=linux GOARCH=amd64 go vet ./network/runtime/` — clean.

### Note on running these tests locally

`network/runtime` imports `CubeNet/cubevs`, which does not compile from a clean checkout until the
`bpf2go` bindings are generated (they are gitignored). To run the suite I generated them first and then
ran the tests in a `linux/amd64` container:

```
# in CubeNet/cubevs, with clang installed:
GOARCH=amd64 go generate ./...
# then:
docker run --platform linux/amd64 ... -w /w/Cubelet golang:1.26 go test ./network/runtime/
```
