### PR TITLE
ci: validate release tags before writing them to $GITHUB_ENV

### DIFF
--- a/scripts/read-kernel-metadata.sh
+++ b/scripts/read-kernel-metadata.sh
@@ -50,6 +50,7 @@ fi
 PARSED="$(
   python3 - "${META_FILE}" <<'PY'
 import json
+import re
 import shlex
 import sys
 
@@ -69,6 +70,14 @@ if not bm_tag:
     raise SystemExit(f"{path}: missing bm.source_tag")
 if not pvm_tag:
     raise SystemExit(f"{path}: missing pvm.source_tag")
+
+_SAFE_TAG = re.compile(r"\A[A-Za-z0-9._+-]+\Z")
+for name, value in (("bm.source_tag", bm_tag), ("pvm.source_tag", pvm_tag)):
+    if not _SAFE_TAG.match(value):
+        raise SystemExit(
+            f"{path}: {name} must match [A-Za-z0-9._+-]+ (got {value!r}); "
+            "release tags are written verbatim into $GITHUB_ENV and $GITHUB_OUTPUT"
+        )
 
 print(f"KERNEL_BM_SOURCE_TAG={shlex.quote(bm_tag)}")
 print(f"KERNEL_PVM_SOURCE_TAG={shlex.quote(pvm_tag)}")

--- a/scripts/read-release-assets.sh
+++ b/scripts/read-release-assets.sh
@@ -22,6 +22,7 @@ fi
 
 PINS="$(
   python3 - "${PIN_FILE}" <<'PY'
+import re
 import shlex
 import sys
 
@@ -59,6 +60,14 @@ for key in required:
 unknown = sorted(set(data) - set(required))
 if unknown:
     raise SystemExit(f"unknown keys in {path}: {', '.join(unknown)}")
+
+_SAFE_TAG = re.compile(r"\A[A-Za-z0-9._+-]+\Z")
+for key, value in pins.items():
+    if not _SAFE_TAG.match(value):
+        raise SystemExit(
+            f"{key} in {path} must match [A-Za-z0-9._+-]+ (got {value!r}); "
+            "release tags are written verbatim into $GITHUB_ENV and $GITHUB_OUTPUT"
+        )
 
 for key in ("kernel_bm_amd64", "kernel_bm_arm64", "kernel_pvm"):
     if not pins[key].startswith("kernel-release-"):


### PR DESCRIPTION
Closes #1442.

## Motivation

Both release scripts echo parsed tags verbatim into `$GITHUB_ENV` and `$GITHUB_OUTPUT`. A value containing a
newline writes extra lines, which the runner parses as further `KEY=VALUE` pairs — so whoever controls the
pin file can set arbitrary environment variables (`LD_PRELOAD`, `NODE_OPTIONS`, `PATH`, …) for every
subsequent step in the job.

`read-kernel-metadata.sh` applied no format validation at all; `read-release-assets.sh` checked only a prefix,
leaving the rest of the value unconstrained.

## What this changes

Validation is added in the Python half of each script, before anything is printed — so the check covers both
the `eval` path and the `--export` path, and a bad value fails the script instead of being sanitised into
something surprising.

**`scripts/read-kernel-metadata.sh`** — `bm.source_tag` and `pvm.source_tag` must match
`[A-Za-z0-9._+-]+`.

**`scripts/read-release-assets.sh`** — the same charset check is applied to **all four** pins, in addition to
the existing `kernel-release-` / `guest-image-` prefix checks (which are kept).

The error names the offending key and quotes the value, and says why the constraint exists.

`[A-Za-z0-9._+-]` is the character set git tags and release names actually use; it excludes newline, CR, `=`
and shell metacharacters by construction, so there is no separate newline check to get wrong.

No comment changes.

## Testing

Crafted inputs are rejected and **nothing** is written:

```
kernel-metadata, bm.source_tag = "kernel-release-1.0\nLD_PRELOAD=/tmp/pwn.so"
  exit=1
  .../evil.json: bm.source_tag must match [A-Za-z0-9._+-]+ (got 'kernel-release-1.0\nLD_PRELOAD=/tmp/pwn.so');
  release tags are written verbatim into $GITHUB_ENV and $GITHUB_OUTPUT
  GITHUB_ENV lines: 0

release-assets, kernel_bm_amd64 = "kernel-release-1.0\nEVIL=1"
  exit=1
  kernel_bm_amd64 in .../evil.yaml must match [A-Za-z0-9._+-]+ (got 'kernel-release-1.0\nEVIL=1'); ...
  GITHUB_ENV lines: 0
```

Valid inputs still work:

```
kernel-metadata:                      release-assets:
  1 KERNEL_BM_SOURCE_TAG=...            1 KERNEL_BM_AMD64_RELEASE_TAG=...
  2 KERNEL_PVM_SOURCE_TAG=...           2 KERNEL_BM_ARM64_RELEASE_TAG=...
  exit=0                                3 KERNEL_PVM_RELEASE_TAG=...
                                        4 GUEST_IMAGE_RELEASE_TAG=...
                                        exit=0
```

And the **real committed pin file** passes, which is the check that matters for not breaking the release
workflows:

```
$ GITHUB_ENV=/tmp/env bash scripts/read-release-assets.sh --export
bm_amd64=kernel-release-v1.0.0 bm_arm64=kernel-release-v1.0.0 pvm=kernel-release-v1.0.0 guest_image=guest-image-v1.0.0
exit=0
```

There is no committed `kernel-metadata.json` in the tree (it is produced by the kernel release workflow), so
that script was exercised with a synthesised valid file.

CI gates: these scripts are not covered by `fmt-check` or `unit-test-check`. They are consumed by
`release-one-click.yml` and `release-docker-images.yml`, whose inputs are the files verified above.

## Risk / rollout

A release would now **fail** rather than silently proceed if a pin file contained an unexpected character.
That is the intent, and the current pins pass. If any real tag ever needs a character outside
`[A-Za-z0-9._+-]`, the regex is the single place to widen it.
