### PR TITLE
ci: carry the gh.sh digest in a step output so Write cannot forge it

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -51,14 +51,15 @@ jobs:
           permission-pull-requests: write
 
       - name: Prefetch PR review inputs
+        id: prefetch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          # Snapshot the trusted publisher script hash outside the workspace so
-          # a later Write cannot replace the expected digest.
-          sha256sum scripts/gh.sh > "${RUNNER_TEMP}/gh.sh.sha256"
+          # Snapshot the trusted publisher script hash into a step output, which
+          # is captured now and cannot be replaced by a later Write.
+          echo "gh_sh_sha256=$(sha256sum scripts/gh.sh | cut -d" " -f1)" >> "${GITHUB_OUTPUT}"
           mkdir -p review-input
           gh pr view "$PR_NUMBER" \
             --json title,body,author,baseRefName,headRefName,headRefOid,files,additions,deletions \
@@ -123,6 +124,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_GH_SH_SHA256: ${{ steps.prefetch.outputs.gh_sh_sha256 }}
         run: |
           set -euo pipefail
           if [ ! -f review-input/summary.md ]; then
@@ -135,8 +137,15 @@ jobs:
             exit 1
           fi
           # Refuse to run a publisher script that Write may have overwritten.
-          if ! sha256sum -c "${RUNNER_TEMP}/gh.sh.sha256"; then
+          if [ -z "${EXPECTED_GH_SH_SHA256}" ]; then
+            echo "ERROR: no scripts/gh.sh digest was recorded by the prefetch step; refusing to publish."
+            exit 1
+          fi
+          ACTUAL_GH_SH_SHA256="$(sha256sum scripts/gh.sh | cut -d" " -f1)"
+          if [ "${ACTUAL_GH_SH_SHA256}" != "${EXPECTED_GH_SH_SHA256}" ]; then
             echo "ERROR: scripts/gh.sh integrity check failed; refusing to publish."
+            echo "  expected ${EXPECTED_GH_SH_SHA256}"
+            echo "  actual   ${ACTUAL_GH_SH_SHA256}"
             exit 1
           fi
           ./scripts/gh.sh pr review-comment "$PR_NUMBER" --body-file - < review-input/summary.md


### PR DESCRIPTION
Closes #1444.

## Motivation

`code-review.yml` guards `scripts/gh.sh` with a digest snapshot so the review model cannot swap out the
script that later runs with `GH_TOKEN`. The snapshot lives at `${RUNNER_TEMP}/gh.sh.sha256` — outside the
workspace, but not outside `Write`'s reach. `Write` is in `--allowedTools`, takes absolute paths, and
`RUNNER_TEMP` is right there in the environment, so writing two files instead of one defeats the check.

## What this changes

The digest moves from a file on disk to a **step output**.

**Prefetch step** gains `id: prefetch` and records the digest with
`echo "gh_sh_sha256=$(sha256sum scripts/gh.sh | cut -d" " -f1)" >> "${GITHUB_OUTPUT}"`.

**Publish step** receives it via `env: EXPECTED_GH_SH_SHA256: ${{ steps.prefetch.outputs.gh_sh_sha256 }}`,
recomputes the digest, and compares.

This works because Actions captures a step's outputs when that step ends and stores them in the workflow
context. By the time the model runs, the value is no longer read from disk — appending to `GITHUB_OUTPUT`
during a later step affects only that step's own outputs, which nothing consumes. There is no longer any
file whose contents the check depends on.

Two smaller changes in the same block:

- An empty `EXPECTED_GH_SH_SHA256` is now an explicit failure rather than a comparison against `""`, so a
  future refactor that drops the `id:` or renames the output fails closed instead of silently.
- The mismatch branch prints expected and actual, which `sha256sum -c` did not.

The value is passed through `env:` rather than interpolated into the script body. It is a hex digest from a
trusted checkout so injection was never the concern, but `env:` is the right habit in a
`pull_request_target` workflow.

The comment on the snapshot line was rewritten because the old wording ("outside the workspace") describes a
mechanism this PR removes. It is the same two lines; no new commentary.

## Testing

The workflow's own two `run:` blocks were extracted from the YAML with `yaml.safe_load` and executed
verbatim against a simulated runner: real `RUNNER_TEMP` and `GITHUB_OUTPUT`, a stub `gh` on `PATH`, a real
`scripts/gh.sh` that prints `PUBLISHED`, and a tamper step between them standing in for the model's `Write`
tool. Step-output capture is modelled faithfully — outputs are read when the prefetch step ends, and the
tamper attempts to append to `GITHUB_OUTPUT` afterwards, exactly as the attacker would.

```
=== MASTER ===
  no tampering                                    exit=0  PUBLISHED by the real scripts/gh.sh
  Write overwrites scripts/gh.sh only             exit=1  sha256sum: WARNING: 1 computed checksum did NOT match
  Write overwrites gh.sh AND the digest snapshot  exit=0  *** PWNED: attacker-controlled script ran with GH_TOKEN ***

=== THIS BRANCH ===
  no tampering                                    exit=0  PUBLISHED by the real scripts/gh.sh
  Write overwrites scripts/gh.sh only             exit=1    actual   cbe5346a4d50a152c...
  Write overwrites gh.sh AND the digest snapshot  exit=1    actual   cbe5346a4d50a152c...
```

Row 1 is the regression guard — the normal path still publishes. Row 2 shows the existing control still
works. Row 3 is the fix.

`yaml.safe_load` on the workflow parses clean, and no `RUNNER_TEMP` reference remains in the file.

CI gates: `.github/workflows/` is not covered by `fmt-check` or `unit-test-check`, and the repo has no
`actionlint` or `yamllint` step, so there is no gate to satisfy beyond the file being valid YAML. This
workflow only runs on `pull_request_target`, so it cannot be exercised until the PR exists.

## Not fixed here

The stronger fix the issue mentions — dropping `Write` entirely and having the model return the review body
as a step output — depends on what `anthropics/claude-code-action@v1` supports for structured output. That
is worth pursuing, and it would let both the digest check and the `review-input/summary.md` marker checks go
away, but it is a redesign of the publish path rather than a fix to a broken control.

Also unchanged: `Write` is still unconfined, so it can still reach absolute paths under `RUNNER_TEMP` and
elsewhere on the runner. This PR removes the one place where that mattered. If the action ever grows a
workspace-confinement option for `Write`, that is the real boundary and should be turned on.

## Risk / rollout

Low. Same check, same failure message, one fewer file. The only behavioural difference on the happy path is
that the publish step prints two extra lines when the digest does not match.
