### PR TITLE
tests(sdk_compat): remove the duplicate get_host definitions

### DIFF
--- a/tests/e2e/sdk_compat/adapters/base.py
+++ b/tests/e2e/sdk_compat/adapters/base.py
@@ -63,9 +63,6 @@ class SandboxAdapter(ABC):
     def resume_or_connect(self, *, timeout: int = 60) -> "SandboxAdapter":
         raise UnsupportedCapability(self.backend, "pause_resume")
 
-    def get_host(self, port: int) -> str:
-        raise UnsupportedCapability(self.backend, "network_public_access")
-
     def traffic_access_token(self) -> str | None:
         raise UnsupportedCapability(self.backend, "network_public_access")
 

--- a/tests/e2e/sdk_compat/adapters/tracing_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/tracing_adapter.py
@@ -129,17 +129,6 @@ class TracingSandboxAdapter(SandboxAdapter):
         )
         return wrap_adapter(resumed, self._trace)
 
-    def get_host(self, port: int) -> str:
-        return self._trace.capture(
-            "get_host",
-            {
-                "backend": self.backend,
-                "sandbox_id": self.sandbox_id,
-                "port": port,
-            },
-            lambda: self._wrapped.get_host(port),
-        )
-
     def traffic_access_token(self) -> str | None:
         return self._trace.capture(
             "traffic_access_token",


### PR DESCRIPTION
Closes #1448.

## Motivation

`get_host` was defined twice in two adapter classes. Python keeps the last definition, so in both cases
the *working* implementation was shadowed:

- `adapters/base.py` — the first definition delegates to `self.raw_sandbox.get_host(port)`; the second
  unconditionally raises `UnsupportedCapability(..., "network_public_access")`. The base class therefore
  always reported the capability as unsupported and the delegation was unreachable.
- `adapters/tracing_adapter.py` — the two bodies are identical except that the surviving one drops
  `output=lambda host: {"host": host}`, so the resolved host never made it into the trace.

## What this changes

Deletes the shadowing definition in each file, keeping the functional one:

- `base.py` — removes the `raise UnsupportedCapability(...)` variant, keeping the `raw_sandbox`
  delegation.
- `tracing_adapter.py` — removes the variant without `output=`, keeping the one that records the host.

No other changes; no comment changes.

## Testing

Verified structurally rather than behaviourally, because exercising `get_host` end to end needs a live
sandbox (this is the e2e compat harness):

```
$ ruff check --select F811 tests/e2e/sdk_compat/adapters/
All checks passed!
```

An AST duplicate-method scan over both files reports:

```
tests/e2e/sdk_compat/adapters/base.py::SandboxAdapter: duplicates=none
tests/e2e/sdk_compat/adapters/tracing_adapter.py::TracingSandboxAdapter: duplicates=none
```

I also confirmed the surviving bodies are the intended ones — `base.py:53` still delegates via
`raw_sandbox`, and `tracing_adapter.py:95` still passes `output=lambda host: {"host": host}`.

Collection over the suite still succeeds, so there is no import or signature breakage:

```
$ python3 -m pytest tests/e2e/sdk_compat --collect-only -q
145 tests collected in 0.14s
```

## Recommended follow-up

Adding `F811` to the project's ruff selection would have caught this at lint time, and would catch the
next one. Not done here to keep the change scoped to the defect.

## Risk / rollout

Low, and test-harness only. The behavioural change is that a hypothetical adapter which does **not**
override `get_host` now delegates to the underlying sandbox instead of raising — which is what the
surviving implementation was written to do. Both existing adapters override it, so nothing in the current
suite changes.
