### PR TITLE
guest-init: pass argv[0] when exec'ing cube-agent

### DIFF
--- a/guest-init/src/main.rs
+++ b/guest-init/src/main.rs
@@ -62,16 +62,27 @@ fn mount_pmem() -> Result<()> {
     Ok(())
 }
 
+fn agent_argv() -> [CString; 1] {
+    [CString::new(CUBE_AGENT).expect("new cmd failed")]
+}
+
 fn start_agent() -> ! {
-    let args: Vec<CString> = Vec::new();
-    let cmd = CString::new(CUBE_AGENT).expect("new cmd failed");
-    let err = unistd::execvp(cmd.as_c_str(), &args).unwrap_err();
+    let args = agent_argv();
+    let err = unistd::execvp(args[0].as_c_str(), &args).unwrap_err();
     panic!("exec agent failed:{}", err);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn agent_argv_carries_program_name() {
+        let argv = agent_argv();
+        assert_eq!(argv.len(), 1);
+        assert_eq!(argv[0].to_str().unwrap(), CUBE_AGENT);
+        assert!(!argv[0].as_bytes().is_empty());
+    }
 
     #[test]
     fn agent_exec_path_constant() {


### PR DESCRIPTION

Closes #1450.

## Motivation

`start_agent` called `execvp` with an empty `Vec<CString>`, so `nix` built `argv = [NULL]` and
`cube-agent` started with `argc == 0`. POSIX expects `argv[0]` to be the program name, and without it
`/proc/1/cmdline` inside the guest is empty — so nothing in the guest can identify PID 1 by name.

## What this changes

`guest-init/src/main.rs`:

- `agent_argv()` builds the one-element argument vector, and `start_agent` passes it to `execvp`,
  using `args[0]` as the program path so the path and `argv[0]` cannot drift apart.

```rust
fn agent_argv() -> [CString; 1] {
    [CString::new(CUBE_AGENT).expect("new cmd failed")]
}

fn start_agent() -> ! {
    let args = agent_argv();
    let err = unistd::execvp(args[0].as_c_str(), &args).unwrap_err();
    panic!("exec agent failed:{}", err);
}
```

Extracting `agent_argv` is what makes the behaviour testable — `start_agent` itself cannot be unit
tested because a successful `execvp` replaces the process.

No comment changes.

## Testing

New test `agent_argv_carries_program_name` in the existing `mod tests`: asserts the vector has exactly
one element, that it equals `CUBE_AGENT`, and that it is non-empty (the last one is the actual
regression guard — an empty vector was the bug).

```
$ docker run --rm ... -w /w/guest-init rust:1.90 cargo test --all
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

(9 before this change, 10 after.)

CI gates checked locally:

- `cargo fmt --check` — clean (`fmt-check` runs `make fmt` per component).
- `cargo clippy --all-targets` — no new warnings.
- `cargo test --all` — 10 passed.

## What this does not verify

The test covers argv construction, not the exec itself — asserting on `/proc/1/cmdline` would need a
booted guest, which is e2e territory. The mechanism between the two is `nix::unistd::execvp`, which
passes the slice through verbatim.

## Risk / rollout

Very low. The agent does not read `argv` for configuration (it uses `/proc/cmdline`), so nothing changes
functionally — only that PID 1 now has a name.