### PR TITLE
cubelog: add Criticalf/Critical as the honest name for the FATAL level

### DIFF
--- a/cubelog/critical_alias_test.go
+++ b/cubelog/critical_alias_test.go
@@ -1,0 +1,48 @@
+package CubeLog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCriticalfMatchesFatalf(t *testing.T) {
+	var fatalBuf, criticalBuf bytes.Buffer
+
+	l1 := GetLogger("alias-a")
+	l1.SetOutput(&fatalBuf)
+	l1.Fatalf("boom %d", 7)
+
+	l2 := GetLogger("alias-b")
+	l2.SetOutput(&criticalBuf)
+	l2.Criticalf("boom %d", 7)
+
+	if fatalBuf.Len() == 0 || criticalBuf.Len() == 0 {
+		t.Fatalf("expected both to emit output, got fatal=%d critical=%d", fatalBuf.Len(), criticalBuf.Len())
+	}
+	if !strings.Contains(fatalBuf.String(), "boom 7") {
+		t.Fatalf("Fatalf output missing message: %s", fatalBuf.String())
+	}
+	if !strings.Contains(criticalBuf.String(), "boom 7") {
+		t.Fatalf("Criticalf output missing message: %s", criticalBuf.String())
+	}
+	if !strings.Contains(criticalBuf.String(), "FATAL") {
+		t.Fatalf("Criticalf did not log at FATAL level: %s", criticalBuf.String())
+	}
+}
+
+func TestCriticalfDoesNotExit(t *testing.T) {
+	var buf bytes.Buffer
+	l := GetLogger("alias-noexit")
+	l.SetOutput(&buf)
+
+	l.Criticalf("still running %s", "after")
+	l.Criticalf("second call")
+
+	if strings.Count(buf.String(), "still running after") != 1 {
+		t.Fatalf("first message missing: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "second call") {
+		t.Fatal("execution did not continue past the first Criticalf")
+	}
+}

--- a/cubelog/entry.go
+++ b/cubelog/entry.go
@@ -354,6 +354,14 @@ func (entry *Entry) Fatalf(format string, v ...interface{}) {
 	entry.writef(entry.ctx, FATAL, format, v)
 }
 
+func (entry *Entry) Criticalf(format string, v ...interface{}) {
+	entry.writef(entry.ctx, FATAL, format, v)
+}
+
+func (entry *Entry) Critical(v ...interface{}) {
+	entry.writef(entry.ctx, FATAL, "", v)
+}
+
 func (entry *Entry) GetFields() Fields {
 	return entry.data
 }

--- a/cubelog/exported.go
+++ b/cubelog/exported.go
@@ -112,3 +112,11 @@ func Errorf(format string, args ...interface{}) {
 func Fatalf(format string, args ...interface{}) {
 	std.Fatalf(format, args...)
 }
+
+func Criticalf(format string, args ...interface{}) {
+	std.Criticalf(format, args...)
+}
+
+func Critical(args ...interface{}) {
+	std.Critical(args...)
+}

--- a/cubelog/logger.go
+++ b/cubelog/logger.go
@@ -307,6 +307,14 @@ func (logger *Logger) Fatalf(format string, v ...interface{}) {
 	logger.writef(context.TODO(), FATAL, format, v)
 }
 
+func (logger *Logger) Criticalf(format string, v ...interface{}) {
+	logger.writef(context.TODO(), FATAL, format, v)
+}
+
+func (logger *Logger) Critical(v ...interface{}) {
+	logger.writef(context.TODO(), FATAL, "", v)
+}
+
 func getPackageName(f string) string {
 	for {
 		lastPeriod := strings.LastIndex(f, ".")


### PR DESCRIPTION
Closes #1452.

## Motivation

`cubelog.Fatalf` writes at `FATAL` level and returns — it does not exit. Every mainstream Go logger
(`log`, `logrus`, `zap`) terminates on `Fatal`, so the name misleads, and the codebase depends on the
non-terminating behaviour: `Fatalf` is called from inside panic-recovery handlers
(`Cubelet/services/images/volumelifetime.go:655`, `CubeMaster/pkg/scheduler/schedule.go:28`) where exiting
would be exactly wrong.

Making `Fatalf` exit is therefore not an option. The fix is to provide a name that says what actually
happens.

## What this changes

Adds `Criticalf` and `Critical` alongside the existing `Fatalf` / `Fatal`, at all three levels of the API,
each writing at the same `FATAL` level:

- `cubelog/logger.go` — `(*Logger).Criticalf`, `(*Logger).Critical`
- `cubelog/entry.go` — `(*Entry).Criticalf`, `(*Entry).Critical`
- `cubelog/exported.go` — package-level `Criticalf`, `Critical`

`Fatalf` / `Fatal` are unchanged and still work, so this breaks nothing. New code — and, over time, the
call sites inside recovery handlers — can use the name that matches the behaviour.

No comment changes, so the rename is carried by the identifier rather than by documentation.

## Why not migrate the call sites in this PR

The misleading call sites live in **other modules** (`Cubelet`, `CubeMaster`) that consume `cubelog` through
`go.mod`. They cannot call `Criticalf` until a `cubelog` version containing it is published and those
modules bump their dependency. That sequencing makes migration a separate change; this PR is the
prerequisite.

## Testing

New: `cubelog/critical_alias_test.go`

- `TestCriticalfMatchesFatalf` — both emit output, both contain the formatted message, and `Criticalf`
  logs at `FATAL` level. This pins the alias to the same level rather than assuming it.
- `TestCriticalfDoesNotExit` — two consecutive `Criticalf` calls, asserting the second is reached. This is
  the property the name is meant to convey, and it is the one that would break if someone later "fixed"
  `Criticalf` to exit.

```
$ cd cubelog && go test -count=1 -run TestCritical -v ./
--- PASS: TestCriticalfMatchesFatalf (0.00s)
--- PASS: TestCriticalfDoesNotExit (0.00s)

$ go test -count=1 ./
ok  github.com/tencentcloud/CubeSandbox/cubelog  0.769s
```

CI gates checked locally:

- `gofmt -l .` — clean (`fmt-check`).
- `go build ./...` — clean.
- `go test ./` — clean (`cubelog-test` is `go test -short ./...`).

Note the package directory is `cubelog/` but the Go package is `CubeLog`; the new test file matches.
