### PR TITLE
cubeegress: generate MITM leaf serials from a CSPRNG and fail closed

### DIFF
--- a/CubeEgress/lua/cert_signer.lua
+++ b/CubeEgress/lua/cert_signer.lua
@@ -22,6 +22,7 @@ local altname_lib = require "resty.openssl.x509.altname"
 local ext_lib     = require "resty.openssl.x509.extension"
 local digest_lib  = require "resty.openssl.digest"
 local bn_lib      = require "resty.openssl.bn"
+local resty_random = require "resty.random"
 
 local _M = {}
 
@@ -93,6 +94,24 @@ function _M.bootstrap(opts)
                       "s cache_ttl=", CACHE_TTL_SEC, "s")
 end
 
+local SERIAL_BYTES = 16
+
+local function random_serial()
+    local raw = resty_random.bytes(SERIAL_BYTES, true)
+    if not raw then
+        raw = resty_random.bytes(SERIAL_BYTES)
+    end
+    if not raw or #raw ~= SERIAL_BYTES then
+        return nil, "no random bytes available"
+    end
+    local first = string.byte(raw, 1) % 128
+    if first == 0 then
+        first = 1
+    end
+    raw = string.char(first) .. string.sub(raw, 2)
+    return bn_lib.from_binary(raw)
+end
+
 -- ---- Internal: sign a fresh leaf for (sni, dst_ip) ----
 local function sign_leaf(sni, dst_ip)
     -- 1. Generate leaf key (ECDSA P-256: fast, small)
@@ -103,9 +122,14 @@ local function sign_leaf(sni, dst_ip)
     local cert = x509_lib.new()
     cert:set_version(3)
 
-    -- Random 64-bit serial; uniqueness is best-effort for short-lived MITM certs.
-    local serial = bn_lib.new(math.floor(ngx.now() * 1000000) + math.random(1, 1e9))
-    if serial then cert:set_serial_number(serial) end
+    local serial, serial_err = random_serial()
+    if not serial then
+        return nil, "generate serial: " .. tostring(serial_err)
+    end
+    local ok_serial, err_serial = cert:set_serial_number(serial)
+    if not ok_serial then
+        return nil, "set serial: " .. tostring(err_serial)
+    end
 
     local now = ngx.time()
     cert:set_not_before(now - 60)              -- 60s clock skew tolerance


### PR DESCRIPTION

Closes #1454.

## Motivation

Leaf certificate serials were `ngx.now()*1e6 + math.random(1, 1e9)`. `math.randomseed` is never called
anywhere in `CubeEgress/lua/`, so every worker produces the same `math.random` sequence after fork, and the
value is dominated by the timestamp — roughly 30 bits of actual randomness, against the ≥64 bits the
CA/Browser Forum baseline expects. A failure to build the serial was also swallowed by `if serial then`,
leaving the certificate signed with the default serial 0.

## What this changes

`CubeEgress/lua/cert_signer.lua`:

1. **`random_serial()`** draws 16 bytes from `resty.random.bytes(16, true)` — the CSPRNG-backed variant —
   falling back to the non-strong variant only if that returns nil, and errors if neither yields bytes.
   The top bit of the first byte is cleared so the DER integer is unambiguously positive, and a zero first
   byte is bumped to 1 to keep the encoding well-formed. That leaves 127 bits of entropy in a 128-bit
   serial, which is the usual practice.
2. **Failure is now fatal.** `sign_leaf` returns an error if the serial cannot be generated or cannot be
   set, so the handshake fails with a logged reason instead of emitting a certificate with serial 0.

`resty.random` and `resty.openssl.bn` are both already available in the OpenResty runtime; no new
dependency.

No comment changes.

## Testing

`resty.openssl.bn` is bundled with the OpenResty image, so the generator was exercised directly:

```
sample serial: 788FAB7B3B2AF0CBE30EA475E8A93FF3
sample serial: 7B27B0FD4264EF576E37E4DFFF8AD12E
sample serial: 3F0D4051BFAF30E779143DCAFFB87C93
20000 serials, collisions=0, shortest hex=32 chars (>=124 bits)
NO COLLISIONS
```

The check also asserts every serial is positive (`to_dec()` never starts with `-`), which is what the
top-bit mask is for.

And the master behaviour it replaces, run twice as two separate processes:

```
worker A serials: 1.7000007943297e+15, 1.7000006989759e+15, ...
worker A serials: 1.7000007943297e+15, 1.7000006989759e+15, ...   <- identical
```

`cert_signer.lua` parses cleanly (`loadfile` → SYNTAX OK).

## What I could not test

`sign_leaf` itself needs `lua-resty-openssl`'s x509 modules plus a real CA keypair inside an OpenResty
worker; `opm get fffonion/lua-resty-openssl` is not reachable from this environment, so the full
sign-a-leaf path was not executed. What is verified is the serial generator (against the real
`resty.openssl.bn`) and that the module still parses. The surrounding `sign_leaf` changes are a guard clause
and an error return, with no new API surface.

CI gates: the Lua files are not covered by `fmt-check` or `unit-test-check`.

## Risk / rollout

Certificates minted after this change carry 128-bit random serials instead of timestamp-derived ones.
Clients do not pin serials, and these are short-lived MITM leaves (`LEAF_TTL_SEC`, default 7 days), so
existing cached certificates are unaffected.