### PR TITLE
cubemaster: log score-plugin failures instead of silently skipping them

### DIFF
--- a/CubeMaster/pkg/scheduler/schedule.go
+++ b/CubeMaster/pkg/scheduler/schedule.go
@@ -188,6 +188,7 @@ func runScoreFilter(selCtx *selctx.SelectorCtx, scores []score.Selector) error {
 			continue
 		}
 		if tmpResult, err := f.Select(selCtx); err != nil {
+			log.G(selCtx.Ctx).Warnf("runScoreFilter_skipped, selector: %s, err: %v", f.ID(), err)
 			continue
 		} else {
 			if len(tmpResult) > 0 {


### PR DESCRIPTION

Closes #1456.

## Motivation

`runScoreFilter` swallowed score-plugin errors with a bare `continue`. A plugin failing on every call
looked exactly like a disabled one, and because `totalPluginWeight` only accumulates for plugins that
returned results, a persistently failing plugin silently drops out of the weighted average and skews
placement — with nothing in the log to explain it.

The filter stage already reports its failures (`schedule.go:127`), so this was an inconsistency
between the two stages.

## What this changes

`CubeMaster/pkg/scheduler/schedule.go` — one line added to the existing error branch:

```go
if tmpResult, err := f.Select(selCtx); err != nil {
    log.G(selCtx.Ctx).Warnf("runScoreFilter_skipped, selector: %s, err: %v", f.ID(), err)
    continue
} else {
```

`f.ID()` is part of the `score.Selector` interface (`pkg/selector/score/init.go:21`), so the plugin is
named in the log. The message shape follows the existing `runFilter_failed` convention. Warn level
matches `runFilter`.

Scoring behaviour is unchanged — this is observability only.

No comment changes.

## Testing

No new test: the change adds a log line inside an existing branch and alters no logic, so there is no
new behaviour to pin. Existing coverage for the scoring path continues to pass.

```
$ docker run --rm ... -w /w/CubeMaster golang:1.26 go test -short ./pkg/scheduler/... ./pkg/selector/...
ok  .../pkg/scheduler          ok  .../pkg/scheduler/selctx
ok  .../pkg/selector/filter    ok  .../pkg/selector/score
```

CI gates checked locally:

- `gofmt -l ./pkg/scheduler` — clean (`fmt-check`).
- `GOOS=linux go build ./pkg/scheduler/` — clean.

## Related, not fixed here

`parallelRunFilters` discards the context returned by `errgroup.WithContext`
(`schedule.go:139`), so filter goroutines never observe cancellation when a sibling fails. Left out to
keep this PR to one concern; tracked with the scheduler filter-intersection issue.

