### PR TITLE
cubeegress: validate match field types, and make rule_matches fail closed

### DIFF
--- a/CubeEgress/lua/access_phase.lua
+++ b/CubeEgress/lua/access_phase.lua
@@ -136,7 +136,7 @@ local function rule_matches(m, ctx)
         if type(m.method) ~= "table" then return false end
         local hit = false
         for _, mm in ipairs(m.method) do
-            if string.upper(mm) == ctx.method then hit = true; break end
+            if type(mm) == "string" and string.upper(mm) == ctx.method then hit = true; break end
         end
         if not hit then return false end
     end
@@ -144,7 +144,7 @@ local function rule_matches(m, ctx)
         if not path_match(m.path, ctx.path) then return false end
     end
     if m.scheme ~= nil then
-        if string.lower(m.scheme) ~= ctx.scheme then return false end
+        if type(m.scheme) ~= "string" or string.lower(m.scheme) ~= ctx.scheme then return false end
     end
     return true
 end

--- a/CubeEgress/lua/policy.lua
+++ b/CubeEgress/lua/policy.lua
@@ -82,6 +82,23 @@ local function validate_policy(p)
         if type(r.match) ~= "table" then
             return false, "rules[" .. i .. "].match required (object; empty {} allowed)"
         end
+        for _, field in ipairs({"sni", "host", "path", "scheme"}) do
+            if r.match[field] ~= nil and type(r.match[field]) ~= "string" then
+                return false, string.format(
+                    "rules[%d].match.%s must be a string", i, field)
+            end
+        end
+        if r.match.method ~= nil then
+            if type(r.match.method) ~= "table" then
+                return false, string.format("rules[%d].match.method must be an array of strings", i)
+            end
+            for j, mm in ipairs(r.match.method) do
+                if type(mm) ~= "string" then
+                    return false, string.format(
+                        "rules[%d].match.method[%d] must be a string", i, j)
+                end
+            end
+        end
         if type(r.action) ~= "table" then
             return false, "rules[" .. i .. "].action required (object)"
         end


### PR DESCRIPTION

Closes #1458.

## Motivation

`validate_policy` verified that `rule.match` is a table and stopped there. `rule_matches` then called
`string.upper` on each `match.method` entry and `string.lower` on `match.scheme`, so a policy the admin API
had accepted produced an uncaught Lua error inside `access_by_lua_block` — nginx 500 for every request from
that sandbox, with nothing pointing at the policy as the cause.

## What this changes

Two layers, because either alone leaves a gap.

**1. `CubeEgress/lua/policy.lua` — reject malformed policies at install time.** `validate_policy` now
requires `match.sni` / `match.host` / `match.path` / `match.scheme` to be strings when present, and
`match.method` to be an array of strings. Errors name the rule index and the field, matching the existing
message style. An empty `match = {}` is still allowed, as documented.

**2. `CubeEgress/lua/access_phase.lua` — make `rule_matches` fail closed.** A non-string `method` entry is
skipped rather than passed to `string.upper`, and a non-string `scheme` returns no-match rather than being
passed to `string.lower`. This matters because a policy can reach the shared dict without going through
`validate_policy` (bootstrap load, or anything written directly), and the data plane should deny rather than
500 in that case.

No comment changes.

## Testing

**Install-time validation** — all 11 cases behave as intended, where master accepted 8 of them:

```
                                   this branch          master
match.method = [ {} ]              rejected             accepted
match.method = [ 1 ]               rejected             accepted
match.method = "GET"               rejected             accepted
match.scheme = {}                  rejected             accepted
match.scheme = 80                  rejected             accepted
match.host   = {}                  rejected             accepted
match.path   = {}                  rejected             accepted
match.sni    = 12345               rejected             accepted
match.method = {} (empty object)   accepted             accepted
match = {} (empty, allowed)        accepted             accepted
valid full match                   accepted             accepted
```

with messages like `rules[1].match.method[1] must be a string`.

**Request-path hardening** — driving the real `rule_matches` via its exported `_rule_matches` hook:

```
                     master                               this branch
method = [ {} ]      LUA ERROR -> nginx 500               returned false (deny)
scheme = {}          LUA ERROR -> nginx 500               returned false (deny)
method = [ 1 ]       returned false                       returned false
scheme = 80          returned false                       returned false
host/path/sni bad    returned false                       returned false
                     LUA ERRORS: 2                        NO LUA ERRORS
```

**Matching semantics unchanged** — the same harness checks the normal cases, and the credential-injection
harness from the HTTP-inject issue is re-run as a regression check:

```
valid match (should be true)      -> true
non-matching method (false)       -> false
empty match (matches anything)    -> true

1. HTTPS, Host==SNI (legit)              allow=true  injected=sk-live-REAL-OPERATOR-CREDENTIAL
2. HTTPS, Host!=SNI (G4 blocks)          allow=true  injected=<none>
3. HTTP, spoofed Host -> attacker dst_ip allow=true  injected=sk-live-REAL-OPERATOR-CREDENTIAL
```

Case 3 is the separate plaintext-injection issue, tracked on its own branch — unchanged here, and shown so it
is clear this PR did not alter it.

CI gates: the Lua files are not covered by `fmt-check` (no Lua formatter configured) or by
`unit-test-check`. Verification is via LuaJIT against the real modules, as above.

## Risk / rollout

A `PUT` that previously returned `200` for a malformed rule now returns `400`. Any control-plane component
pushing such a rule would start seeing failures — but those rules were producing 500s on the data plane
anyway, so surfacing the error at install time is strictly better.