### PR TITLE
ci: run the race detector for the modules that are already race-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,15 +353,15 @@ shim-test: builder-image
 # container is faster.
 .PHONY: cubelog-test
 cubelog-test:
-	cd cubelog && go test -short ./...
+	cd cubelog && go test -short -race ./...
 
 .PHONY: cubedb-test
 cubedb-test:
-	cd CubeDB && go mod download && go test ./...
+	cd CubeDB && go mod download && go test -race ./...
 
 .PHONY: cube-lifecycle-manager-test
 cube-lifecycle-manager-test: builder-image
-	$(MAKE) builder-run BUILDER_CMD='cd /workspace/cube-lifecycle-manager && go mod download && go test ./...'
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace/cube-lifecycle-manager && go mod download && go test -race ./...'
 
 # cubelet-pkg-test bypasses cubelet-test: that target runs `go test
 # -coverprofile`, and the builder's Go toolchain lacks the `covdata` tool, so

--- a/tests/unittest/run_sdk_test.sh
+++ b/tests/unittest/run_sdk_test.sh
@@ -60,7 +60,7 @@ cd "$REPO_ROOT"
 #   invocation reproduces CI. Live/integration suites are excluded by each
 #   tool's own gate:
 #     go     — integration_test.go is `//go:build integration`, so the default
-#              `go test ./...` skips it.
+#              `go test -race ./...` skips it.
 #     node   — the live suite is `describe.skipIf(CUBE_RUN_INTEGRATION!=1)`, so
 #              `npm test` runs only unit tests.
 #     python — pytest collects only tests/test_*.py; the standalone
@@ -69,7 +69,7 @@ cd "$REPO_ROOT"
 #              only one of the two.
 
 SDKS=(
-	"go|Go|cd sdk/go && go test ./..."
+	"go|Go|cd sdk/go && go test -race ./..."
 	"node|Node|cd sdk/node && npm ci && npm test"
 	"python|Python|cd sdk/python && py=\$(command -v python3 || command -v python) && \"\$py\" -m pip install -e '.[dev]' && \"\$py\" -m pytest"
 )


### PR DESCRIPTION
Closes #1460.

## Motivation

Nothing in the repo passes `-race` to `go test`, so concurrency bugs ship undetected. Enabling it surfaces
12 races and 12 failing tests today — five of the races in production code, including a torn `interface{}`
read in `CubeMaster/pkg/base/localcache`.

## What this changes

Adds `-race` to the four modules that are **already clean**, so this can land immediately without waiting on
any fix:

| target | file |
|---|---|
| `cubelog-test` | `Makefile:356` |
| `cubedb-test` | `Makefile:360` |
| `cube-lifecycle-manager-test` | `Makefile:364` |
| Go SDK | `tests/unittest/run_sdk_test.sh:72` |

Nothing else changes — same packages, same flags otherwise.

## Deliberately staged

`cubeops-test`, `cubemaster-test` and `cubelet-pkg-test` are **not** switched on here, because they are red
today and this PR would fail CI on arrival. They should be enabled as a follow-up once the corresponding
fixes land:

| target | blocked on |
|---|---|
| `cubeops-test` | the `cachingFakeFetchOnly` map-read race in `internal/handler/store_test.go` |
| `cubemaster-test` | the five `localcache` production races, plus the `queueworker` / `recov` / `bufferqueue` test races |
| `cubelet-pkg-test` | the `queueworker` / `recov` test races |

Each of those has its own branch. Landing this PR first means the gate exists and every *new* module or
package added to these four targets is race-checked from day one.

## Testing

All four gated modules verified clean under the detector:

```
cubelog                  0  <- races + failures
CubeDB                   0
cube-lifecycle-manager   0
sdk/go                   0
```

(`go test -race -count=1 ./...` per module, counting `WARNING: DATA RACE` and `FAIL` lines.)

## Cost

`-race` typically costs 2-5x runtime and ~5-10x memory. These four are the small, fast modules — the ones
whose runtime is dominated by process startup rather than the tests themselves — so the CI impact is
minimal. The expensive modules (CubeMaster, Cubelet) are the ones deliberately left for the follow-up, which
is a good moment to measure the real cost before committing to it.

`cubelog-test` keeps `-short`, so the long-running cases stay skipped.
