### PR TITLE
cubemaster: stop shadowing err when parsing container resource quantities

### DIFF
--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -163,14 +163,14 @@ func getReqResource(req *types.CreateCubeSandboxReq) (cpu, mem resource.Quantity
 			err = ret.Err(errorcode.ErrorCode_MasterParamsError, "request Resources nil")
 			break
 		}
-		ctncpuQuantity, err := resource.ParseQuantity(ctr.Resources.Cpu)
-		if err != nil {
-			err = fmt.Errorf("parse container %q cpu limit: %w", ctr.Name, err)
+		ctncpuQuantity, cpuErr := resource.ParseQuantity(ctr.Resources.Cpu)
+		if cpuErr != nil {
+			err = fmt.Errorf("parse container %q cpu limit: %w", ctr.Name, cpuErr)
 			break
 		}
-		ctnmemQuantity, err := resource.ParseQuantity(ctr.Resources.Mem)
-		if err != nil {
-			err = fmt.Errorf("parse container %q mem limit: %w", ctr.Name, err)
+		ctnmemQuantity, memErr := resource.ParseQuantity(ctr.Resources.Mem)
+		if memErr != nil {
+			err = fmt.Errorf("parse container %q mem limit: %w", ctr.Name, memErr)
 			break
 		}
 		cpu.Add(ctncpuQuantity)

--- a/CubeMaster/pkg/service/sandbox/util_resource_parse_test.go
+++ b/CubeMaster/pkg/service/sandbox/util_resource_parse_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestGetReqResourceRejectsUnparseableQuantities(t *testing.T) {
+	cases := []struct {
+		name    string
+		cpu     string
+		mem     string
+		wantSub string
+	}{
+		{"unparseable cpu", "not-a-quantity", "512Mi", "cpu limit"},
+		{"unparseable mem", "500m", "10 GB", "mem limit"},
+		{"both unparseable", "abc", "def", "cpu limit"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &types.CreateCubeSandboxReq{
+				Containers: []*types.Container{{
+					Name:      "c1",
+					Resources: &types.Resource{Cpu: tc.cpu, Mem: tc.mem},
+				}},
+			}
+
+			_, _, err := getReqResource(req)
+			if err == nil {
+				t.Fatalf("getReqResource(cpu=%q, mem=%q) returned no error", tc.cpu, tc.mem)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("err = %v, want it to mention %q", err, tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), "c1") {
+				t.Fatalf("err = %v, want it to name the offending container", err)
+			}
+		})
+	}
+}
+
+func TestGetReqResourceSumsValidQuantities(t *testing.T) {
+	req := &types.CreateCubeSandboxReq{
+		Containers: []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "500m", Mem: "256Mi"}},
+			{Name: "c2", Resources: &types.Resource{Cpu: "250m", Mem: "256Mi"}},
+		},
+	}
+
+	cpu, mem, err := getReqResource(req)
+	if err != nil {
+		t.Fatalf("getReqResource: %v", err)
+	}
+	if cpu.String() != "750m" {
+		t.Fatalf("cpu = %s, want 750m", cpu.String())
+	}
+	if mem.String() != "512Mi" {
+		t.Fatalf("mem = %s, want 512Mi", mem.String())
+	}
+}


### PR DESCRIPTION
Closes #1462.

## Motivation

`getReqResource` has a named return `err`, but the loop body used `:=` when calling
`resource.ParseQuantity`, which declares a *new* `err` scoped to the loop body. The
`err = fmt.Errorf(...)` assignments therefore wrote to that shadow and were discarded at `break`,
leaving the named return `nil`.

Consequence: a `CreateCubeSandbox` request with an unparseable `cpu` or `mem` string was admitted as
consuming `cpu=0, mem=0`. Those values flow through `checkAndGetReqResource` into
`selctx.RequestResource`, which is what the scheduler filters on — so the sandbox passed every
resource filter and could land on any node regardless of its real footprint.

The `ctr.Resources == nil` branch a few lines above uses plain `=` on the named return and worked
correctly, which is what made the bug easy to miss.

## What this changes

`CubeMaster/pkg/service/sandbox/util.go` — the two `ParseQuantity` calls now use distinct error
variables (`cpuErr`, `memErr`) so the `fmt.Errorf` assignments land on the named return:

```go
ctncpuQuantity, cpuErr := resource.ParseQuantity(ctr.Resources.Cpu)
if cpuErr != nil {
    err = fmt.Errorf("parse container %q cpu limit: %w", ctr.Name, cpuErr)
    break
}
```

Three lines, no behaviour change on the success path, no comment changes.

## Testing

New: `CubeMaster/pkg/service/sandbox/util_resource_parse_test.go`

- `TestGetReqResourceRejectsUnparseableQuantities` — three sub-cases (bad cpu, bad mem, both); each
  asserts a non-nil error that names both the offending field and the container.
- `TestGetReqResourceSumsValidQuantities` — regression guard that valid multi-container quantities
  still sum correctly (`750m` / `512Mi`).

```
$ docker run --rm ... -w /w/CubeMaster golang:1.26 go test -short -v -run TestGetReqResource ./pkg/service/sandbox/
--- PASS: TestGetReqResourceRejectsUnparseableQuantities
--- PASS: TestGetReqResourceSumsValidQuantities
--- PASS: TestGetReqResourceRejectsCPUOverflowWhenMemIsValid        (pre-existing)
--- PASS: TestGetReqResourceRejectsCPUOverflowBeforeMemOverflow     (pre-existing)
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox
```

CI gates checked locally:

- `gofmt -l ./pkg` — clean (`fmt-check`).
- `GOOS=linux go build ./...` — clean.
- `staticcheck -checks 'SA*' ./pkg/service/sandbox/` — the `SA4006` / `SA4017` findings on
  `util.go:168` and `:173` are gone.

## Pre-existing failure, unrelated to this change

Running the whole `pkg/service/sandbox` package in Linux (as `make test` does) shows one failure:

```
--- FAIL: TestValidatePauseResumeVolumesPresent
```

I confirmed this is **pre-existing on master**, not introduced here:

- passes in isolation (`-run TestValidatePauseResumeVolumesPresent`) on both master and this branch;
- fails when the full package runs, on **master** as well as this branch.

It looks like cross-test state pollution within the package. Not fixed here to keep this PR
single-purpose; worth its own issue.

(On macOS the package additionally cannot run at all — `gomonkey` cannot patch binaries on darwin —
so Linux is the only meaningful local target, matching CI.)
