### PR TITLE
cubemaster: fix ceiling division in the scheduler concurrency limits

### DIFF
--- a/CubeMaster/pkg/scheduler/local.go
+++ b/CubeMaster/pkg/scheduler/local.go
@@ -280,10 +280,10 @@ func (l *local) monitorLimit() {
 				}
 				newMasterNodes := localcache.HealthyMasterNodes()
 
-				newCreateLimitOfEveryNode := max(int64(math.Ceil(float64(totalLimitCreate*1.0/newHealthyNodes))),
+				newCreateLimitOfEveryNode := max(int64(math.Ceil(float64(totalLimitCreate)/float64(newHealthyNodes))),
 					config.GetConfig().CubeletConf.CreateConcurrentLimit)
 
-				limitCreate := int64(math.Ceil(float64(newHealthyNodes * newCreateLimitOfEveryNode * 1.0 / newMasterNodes)))
+				limitCreate := int64(math.Ceil(float64(newHealthyNodes*newCreateLimitOfEveryNode) / float64(newMasterNodes)))
 				if bufferQ.lastCreateConcurrentLimit != limitCreate {
 					bufferQ.setLastCreateConcurrentLimit(limitCreate)
 					bufferQ.setBufferTaskConcurrent(limitCreate)
@@ -306,7 +306,7 @@ func (l *local) monitorLimit() {
 			newMasterNodes := localcache.HealthyMasterNodes()
 
 			newLimitDesroyOfEveryNode := limitDestroyOfEveryNode()
-			limitDestroy := int64(math.Ceil(float64(newHealthyNodes * newLimitDesroyOfEveryNode * 1.0 / newMasterNodes)))
+			limitDestroy := int64(math.Ceil(float64(newHealthyNodes*newLimitDesroyOfEveryNode) / float64(newMasterNodes)))
 			if l.lastDestroyconcurrentLimit != limitDestroy && limitDestroy >= 1 {
 				l.lastDestroyconcurrentLimit = limitDestroy
 				task.SetTaskWorkerConcurrent(task.DestroySandbox, limitDestroy)

--- a/CubeMaster/pkg/scheduler/local_limit_math_test.go
+++ b/CubeMaster/pkg/scheduler/local_limit_math_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package scheduler
+
+import (
+	"math"
+	"testing"
+)
+
+func perNodeCreateLimit(totalLimitCreate, healthyNodes int64) int64 {
+	return int64(math.Ceil(float64(totalLimitCreate) / float64(healthyNodes)))
+}
+
+func clusterLimit(healthyNodes, perNode, masterNodes int64) int64 {
+	return int64(math.Ceil(float64(healthyNodes*perNode) / float64(masterNodes)))
+}
+
+func TestPerNodeCreateLimitRoundsUp(t *testing.T) {
+	cases := []struct {
+		total, nodes, want int64
+	}{
+		{10, 3, 4},
+		{10, 5, 2},
+		{9, 3, 3},
+		{1, 3, 1},
+		{100, 7, 15},
+	}
+	for _, tc := range cases {
+		if got := perNodeCreateLimit(tc.total, tc.nodes); got != tc.want {
+			t.Errorf("perNodeCreateLimit(%d, %d) = %d, want %d", tc.total, tc.nodes, got, tc.want)
+		}
+	}
+}
+
+func TestClusterLimitRoundsUp(t *testing.T) {
+	cases := []struct {
+		nodes, perNode, masters, want int64
+	}{
+		{4, 5, 3, 7},
+		{3, 5, 3, 5},
+		{1, 1, 3, 1},
+		{10, 10, 3, 34},
+	}
+	for _, tc := range cases {
+		got := clusterLimit(tc.nodes, tc.perNode, tc.masters)
+		if got != tc.want {
+			t.Errorf("clusterLimit(%d, %d, %d) = %d, want %d",
+				tc.nodes, tc.perNode, tc.masters, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION

Closes #1464.

## Motivation

Three limit calculations were written as `int64(math.Ceil(float64(a * b * 1.0 / c)))`. Every operand
is `int64` and the untyped constant `1.0` is representable as an integer, so it converts to `int64`
and the whole inner expression is **integer** arithmetic — it truncates. `math.Ceil` then runs on an
already-integral value and does nothing.

The `* 1.0` factors show the intent was float division and round-up. What actually happens is
round-down, so whenever the node counts do not divide evenly the cluster runs one unit below its
configured create/destroy concurrency.

## What this changes

`CubeMaster/pkg/scheduler/local.go` — convert to `float64` *before* dividing, at all three sites:

| line | before | after |
|---|---|---|
| `:283` | `float64(totalLimitCreate*1.0/newHealthyNodes)` | `float64(totalLimitCreate)/float64(newHealthyNodes)` |
| `:286` | `float64(newHealthyNodes * newCreateLimitOfEveryNode * 1.0 / newMasterNodes)` | `float64(newHealthyNodes*newCreateLimitOfEveryNode) / float64(newMasterNodes)` |
| `:309` | `float64(newHealthyNodes * newLimitDesroyOfEveryNode * 1.0 / newMasterNodes)` | `float64(newHealthyNodes*newLimitDesroyOfEveryNode) / float64(newMasterNodes)` |

The numerator product stays in `int64` (it is a small count product, nowhere near overflow) and only
the division becomes floating point, which is the minimal change that makes `math.Ceil` meaningful.

No comment changes.

## Testing

New: `CubeMaster/pkg/scheduler/local_limit_math_test.go` — table tests pinning the rounding for both
shapes, including the exact cases from the issue (`10/3 → 4`, `4*5/3 → 7`) plus exact-division and
`n < divisor` cases so a future refactor cannot silently reintroduce truncation.

```
$ docker run --rm ... -w /w/CubeMaster golang:1.26 go test -short ./pkg/scheduler/...
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler         0.004s
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx  0.002s
```

CI gates checked locally:

- `gofmt -l ./pkg` — clean (`fmt-check`).
- `GOOS=linux go build ./...` — clean.
- `staticcheck -checks 'SA4015' ./pkg/scheduler/` — the three `local.go` findings are gone.

## Risk / rollout

Behaviour change by design: create and destroy concurrency will increase by one unit in clusters
where the division was not exact. That is the configured intent, but it does mean slightly more
in-flight work per node after this lands — worth noting if a cluster was unknowingly relying on the
lower effective limit.

`pkg/selector/score/realtimescore_test.go:40-41` has the same `math.Ceil`-on-integer pattern in a
**test**; left alone here to keep this PR single-purpose.