### PR TITLE
sdk: make render() previews match the data plane's single substitution

### DIFF
--- a/sdk/go/policy.go
+++ b/sdk/go/policy.go
@@ -38,7 +38,7 @@ func (i Inject) Render() string {
 	if format == "" {
 		format = "${SECRET}"
 	}
-	return strings.ReplaceAll(format, "${SECRET}", i.Secret)
+	return strings.Replace(format, "${SECRET}", i.Secret, 1)
 }
 
 // Action is a rule action. Allow passes the request through (optionally

--- a/sdk/go/policy_render_test.go
+++ b/sdk/go/policy_render_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubesandbox
+
+import "testing"
+
+func TestInjectRenderMatchesServerSubstitution(t *testing.T) {
+	cases := []struct {
+		name   string
+		format string
+		secret string
+		want   string
+	}{
+		{"default format", "", "tok", "tok"},
+		{"single placeholder", "Bearer ${SECRET}", "tok", "Bearer tok"},
+		{"repeated placeholder", "Basic ${SECRET}:${SECRET}", "tok", "Basic tok:${SECRET}"},
+		{"three placeholders", "${SECRET}-${SECRET}-${SECRET}", "tok", "tok-${SECRET}-${SECRET}"},
+		{"percent in secret", "Bearer ${SECRET}", "a%2Fb", "Bearer a%2Fb"},
+		{"no placeholder", "Bearer static", "tok", "Bearer static"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Inject{Header: "H", Secret: tc.secret, Format: tc.format}.Render()
+			if got != tc.want {
+				t.Fatalf("Render() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/sdk/python/cubesandbox/_policy.py
+++ b/sdk/python/cubesandbox/_policy.py
@@ -68,7 +68,7 @@ class Inject:
     def render(self) -> str:
         """Render the final injected header value (preview helper)."""
         fmt = self.format or "${SECRET}"
-        return fmt.replace("${SECRET}", self.secret)
+        return fmt.replace("${SECRET}", self.secret, 1)
 
     def to_wire(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {"header": self.header, "secret": self.secret}

--- a/sdk/python/tests/test_policy_render.py
+++ b/sdk/python/tests/test_policy_render.py
@@ -1,0 +1,16 @@
+from cubesandbox._policy import Inject
+
+CASES = [
+    ("", "tok", "tok"),
+    ("Bearer ${SECRET}", "tok", "Bearer tok"),
+    ("Basic ${SECRET}:${SECRET}", "tok", "Basic tok:${SECRET}"),
+    ("${SECRET}-${SECRET}-${SECRET}", "tok", "tok-${SECRET}-${SECRET}"),
+    ("Bearer ${SECRET}", "a%2Fb", "Bearer a%2Fb"),
+    ("Bearer static", "tok", "Bearer static"),
+]
+
+
+def test_render_matches_server_substitution():
+    for fmt, secret, want in CASES:
+        got = Inject(header="H", secret=secret, format=(fmt or None)).render()
+        assert got == want, f"format={fmt!r} secret={secret!r}: got {got!r}, want {want!r}"


### PR DESCRIPTION


Closes #1466.

## Motivation

`Inject.render()` exists to show the operator the header value that will actually be sent. The Go and
Python implementations substituted **every** `${SECRET}` occurrence, but CubeEgress substitutes only the
**first** (`access_phase.lua:171` passes `1` as `gsub`'s count limit). For a format like
`Basic ${SECRET}:${SECRET}` the preview said `Basic tok:tok` while the upstream received
`Basic tok:${SECRET}`.

## What this changes

Aligns the two outliers with the server:

- `sdk/go/policy.go` — `strings.ReplaceAll(...)` → `strings.Replace(..., 1)`
- `sdk/python/cubesandbox/_policy.py` — `fmt.replace(...)` → `fmt.replace(..., 1)`

The Node SDK already matches (JS `String.replace` with a string pattern replaces only the first), and the
server is unchanged.

No comment changes.

## Why change the SDKs rather than the server

Two of the four implementations already do single substitution, and the server's explicit `1` limit plus
its "format has no ${SECRET} placeholder" warning read as a deliberate single-substitution contract.
More importantly, changing the server would alter the header value emitted for any existing policy that
repeats the placeholder — a live data-plane change. Changing a preview helper cannot break traffic.

If the maintainers would rather the contract be "replace all", the change is dropping the `1` in
`access_phase.lua:171` and reverting these two lines; the tests here document the contract either way so
the decision is visible.

## Testing

New:

- `sdk/go/policy_render_test.go` — `TestInjectRenderMatchesServerSubstitution`, table-driven over the six
  cases from the issue including the default (empty) format, a `%`-containing secret, and a format with
  no placeholder.
- `sdk/python/tests/test_policy_render.py` — the same table.

Red/green, per SDK:

```
Go, with policy.go reverted:
  --- FAIL: TestInjectRenderMatchesServerSubstitution
      policy_render_test.go:27: Render() = "Basic tok:tok", want "Basic tok:${SECRET}"
      policy_render_test.go:27: Render() = "tok-tok-tok", want "tok-${SECRET}-${SECRET}"
Go, with the fix:
  ok  github.com/tencentcloud/CubeSandbox/sdk/go  0.820s

Python, with _policy.py reverted:
  FAILED tests/test_policy_render.py::test_render_matches_server_substitution
Python, with the fix:
  1 passed in 0.03s
```

CI gates checked locally:

- `gofmt -l .` in `sdk/go` — clean (`fmt-check`).
- `go build ./...` in `sdk/go` — clean.
- `sdk-test-check` covers the SDK suites; both new tests sit in the existing test locations.

## Risk / rollout

None to the data plane. The only behaviour change is that `render()` now returns the same string the
server produces. Anyone who was relying on `render()` to expand a repeated placeholder was getting a
value the server never emitted.
