### PR TITLE
sdk/node: reject arrays for transform and transform.headers

### DIFF
--- a/sdk/node/src/policy.ts
+++ b/sdk/node/src/policy.ts
@@ -126,14 +126,14 @@ function isE2BPerHostRules(rules: NetworkRules): rules is E2BPerHostRules {
 function convertE2BTransformToInject(transform: {
   headers?: Record<string, string>;
 }): Inject[] {
-  if (typeof transform !== "object" || transform === null) {
+  if (typeof transform !== "object" || transform === null || Array.isArray(transform)) {
     throw new Error("network.rules transform must be an object");
   }
   const headers = transform.headers;
   if (headers === undefined) {
     throw new Error("network.rules transform requires a 'headers' field");
   }
-  if (typeof headers !== "object" || headers === null) {
+  if (typeof headers !== "object" || headers === null || Array.isArray(headers)) {
     throw new Error("network.rules transform.headers must be an object");
   }
   const unknown = Object.keys(transform).filter((k) => k !== "headers");

--- a/sdk/node/test/policy-e2b-shapes.test.ts
+++ b/sdk/node/test/policy-e2b-shapes.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { convertE2BPerHostRules } from "../src/policy";
+
+const perHost = (headers: unknown) => ({
+  "api.example.com": [{ transform: { headers } }],
+});
+
+describe("convertE2BPerHostRules transform.headers validation", () => {
+  it("rejects an array of header values", () => {
+    expect(() => convertE2BPerHostRules(perHost(["sk-secret-1", "sk-secret-2"]) as never)).toThrow(
+      /transform.headers must be an object/,
+    );
+  });
+
+  it("rejects a string", () => {
+    expect(() => convertE2BPerHostRules(perHost("sk-secret") as never)).toThrow(
+      /transform.headers must be an object/,
+    );
+  });
+
+  it("rejects a number", () => {
+    expect(() => convertE2BPerHostRules(perHost(42) as never)).toThrow(
+      /transform.headers must be an object/,
+    );
+  });
+
+  it("rejects an array transform", () => {
+    expect(() =>
+      convertE2BPerHostRules({ "api.example.com": [["headers"]] } as never),
+    ).toThrow(/transform/);
+  });
+
+  it("accepts a plain header map", () => {
+    const rules = convertE2BPerHostRules(perHost({ Authorization: "sk-ok" }) as never);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].action.inject).toEqual([{ header: "Authorization", secret: "sk-ok" }]);
+  });
+
+  it("accepts multiple headers in one transform", () => {
+    const rules = convertE2BPerHostRules(
+      perHost({ Authorization: "sk-a", "X-Api-Key": "sk-b" }) as never,
+    );
+    expect(rules[0].action.inject).toEqual([
+      { header: "Authorization", secret: "sk-a" },
+      { header: "X-Api-Key", secret: "sk-b" },
+    ]);
+  });
+});


### PR DESCRIPTION

Closes #1468.

## Motivation

`convertE2BTransformToInject` validated with `typeof headers !== "object"`. In JavaScript
`typeof [] === "object"`, so an array passed the guard, and `Object.entries(["a","b"])` produced
`[["0","a"],["1","b"]]` — injects whose header names are the array indices `"0"` and `"1"`, carrying real
credentials.

The Python SDK rejects the same input via `isinstance(headers, dict)`, so this was also a cross-SDK
divergence. And the server does not catch it: `validate_policy` requires only a non-empty string header
name, and `"0"` satisfies that, so the malformed policy is accepted end to end.

## What this changes

`sdk/node/src/policy.ts` — two guards gain an `Array.isArray` check:

```ts
if (typeof transform !== "object" || transform === null || Array.isArray(transform)) { ... }
if (typeof headers !== "object" || headers === null || Array.isArray(headers)) { ... }
```

Error messages are unchanged, so callers matching on them are unaffected. Strings and numbers were
already rejected; this closes the array case, and does the same for the outer `transform` for
consistency.

No comment changes.

## Testing

New: `sdk/node/test/policy-e2b-shapes.test.ts`

- rejects an array of header values (the reported case)
- rejects a string, rejects a number (regression guards for the paths that already worked)
- rejects an array `transform`
- accepts a plain header map, and accepts multiple headers in one transform with order preserved

Red/green — with `policy.ts` reverted:

```
× convertE2BPerHostRules transform.headers validation > rejects an array of header values
  Tests  1 failed | 5 passed (6)
```

with the fix, and the whole SDK suite:

```
$ npx vitest run
Test Files  16 passed | 1 skipped (17)
     Tests  192 passed | 1 skipped (193)
```

CI gates checked locally:

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 192 passed (`sdk-test-check`).