### PR TITLE
hotswap: compare config bytes exactly and check the marshal error

### DIFF
--- a/CubeMaster/pkg/base/hotswap/file.go
+++ b/CubeMaster/pkg/base/hotswap/file.go
@@ -91,7 +91,10 @@ func (o *FileOperator) reload(path string) bool {
 		return false
 	}
 	new, err := yaml.Marshal(config)
-	if len(o.backupOldCfg) == len(new) && bytes.EqualFold(o.backupOldCfg, new) {
+	if err != nil {
+		return false
+	}
+	if bytes.Equal(o.backupOldCfg, new) {
 		return false
 	}
 	o.backupOldCfg = new

--- a/CubeMaster/pkg/base/hotswap/file_reload_test.go
+++ b/CubeMaster/pkg/base/hotswap/file_reload_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package hotswap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type reloadProbeCfg struct {
+	Level string `yaml:"level"`
+	Host  string `yaml:"host"`
+}
+
+func newReloadProbe(t *testing.T, body string) (*FileOperator, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "conf.yaml")
+	write(t, path, body)
+
+	op, err := NewWatcher(path, 0, &reloadProbeCfg{})
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	if !op.reload(path) {
+		t.Fatalf("first reload did not establish a baseline")
+	}
+	return op, path
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestReloadDetectsCaseOnlyKeyValueChange(t *testing.T) {
+	op, path := newReloadProbe(t, "level: INFO\nhost: foo.internal\n")
+
+	write(t, path, "level: info\nhost: foo.internal\n")
+	if !op.reload(path) {
+		t.Fatal("reload reported no change for a case-only edit (INFO -> info)")
+	}
+}
+
+func TestReloadDetectsCaseOnlyHostChange(t *testing.T) {
+	op, path := newReloadProbe(t, "level: info\nhost: Foo.internal\n")
+
+	write(t, path, "level: info\nhost: foo.internal\n")
+	if !op.reload(path) {
+		t.Fatal("reload reported no change for a case-only host edit (Foo -> foo)")
+	}
+}
+
+func TestReloadReportsNoChangeForIdenticalConfig(t *testing.T) {
+	op, path := newReloadProbe(t, "level: info\nhost: foo.internal\n")
+
+	if op.reload(path) {
+		t.Fatal("reload reported a change for an identical config")
+	}
+}
+
+func TestReloadDetectsOrdinaryChange(t *testing.T) {
+	op, path := newReloadProbe(t, "level: info\nhost: foo.internal\n")
+
+	write(t, path, "level: debug\nhost: foo.internal\n")
+	if !op.reload(path) {
+		t.Fatal("reload reported no change for a genuine edit")
+	}
+}

--- a/Cubelet/pkg/hotswap/file.go
+++ b/Cubelet/pkg/hotswap/file.go
@@ -91,7 +91,10 @@ func (o *FileOperator) reload(path string) bool {
 		return false
 	}
 	new, err := yaml.Marshal(config)
-	if len(o.backupOldCfg) == len(new) && bytes.EqualFold(o.backupOldCfg, new) {
+	if err != nil {
+		return false
+	}
+	if bytes.Equal(o.backupOldCfg, new) {
 		return false
 	}
 	o.backupOldCfg = new

--- a/Cubelet/pkg/hotswap/file_reload_test.go
+++ b/Cubelet/pkg/hotswap/file_reload_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package hotswap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type reloadProbeCfg struct {
+	Level string `yaml:"level"`
+	Host  string `yaml:"host"`
+}
+
+func newReloadProbe(t *testing.T, body string) (*FileOperator, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "conf.yaml")
+	write(t, path, body)
+
+	op, err := NewWatcher(path, 0, &reloadProbeCfg{})
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	if !op.reload(path) {
+		t.Fatalf("first reload did not establish a baseline")
+	}
+	return op, path
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestReloadDetectsCaseOnlyKeyValueChange(t *testing.T) {
+	op, path := newReloadProbe(t, "level: INFO\nhost: foo.internal\n")
+
+	write(t, path, "level: info\nhost: foo.internal\n")
+	if !op.reload(path) {
+		t.Fatal("reload reported no change for a case-only edit (INFO -> info)")
+	}
+}
+
+func TestReloadDetectsCaseOnlyHostChange(t *testing.T) {
+	op, path := newReloadProbe(t, "level: info\nhost: Foo.internal\n")
+
+	write(t, path, "level: info\nhost: foo.internal\n")
+	if !op.reload(path) {
+		t.Fatal("reload reported no change for a case-only host edit (Foo -> foo)")
+	}
+}
+
+func TestReloadReportsNoChangeForIdenticalConfig(t *testing.T) {
+	op, path := newReloadProbe(t, "level: info\nhost: foo.internal\n")
+
+	if op.reload(path) {
+		t.Fatal("reload reported a change for an identical config")
+	}
+}
+
+func TestReloadDetectsOrdinaryChange(t *testing.T) {
+	op, path := newReloadProbe(t, "level: info\nhost: foo.internal\n")
+
+	write(t, path, "level: debug\nhost: foo.internal\n")
+	if !op.reload(path) {
+		t.Fatal("reload reported no change for a genuine edit")
+	}
+}


### PR DESCRIPTION


Closes #1470.

## Motivation

`FileOperator.reload` used `bytes.EqualFold` to decide whether the config had changed.
`EqualFold` is a case-*insensitive* comparison, so any edit that only changed ASCII letter case —
`level: INFO` → `level: info`, `host: Foo.internal` → `host: foo.internal`, `driver: MySQL` →
`driver: mysql` — was reported as "no change" and never pushed to listeners.

The `yaml.Marshal` error on the same line was also unchecked. On failure `new` is nil, so the
baseline `backupOldCfg` was wiped to nil and `notify()` still fired with the unmarshalable config.
`Init()` at `:71-74` already checks the same call, so this was an inconsistency within one file.

## What this changes

Both copies of the package — `CubeMaster/pkg/base/hotswap/file.go` and `Cubelet/pkg/hotswap/file.go`
— get the same two-line change:

```go
new, err := yaml.Marshal(config)
if err != nil {
    return false
}
if bytes.Equal(o.backupOldCfg, new) {
    return false
}
```

`bytes.Equal` replaces `EqualFold`, and the `len(...) == len(...)` pre-check goes away because
`bytes.Equal` already compares lengths first. A marshal failure now returns `false` without
corrupting the baseline or notifying listeners.

No comment changes.

Per CONTRIBUTING's "one component per commit", this should land as two commits — one for CubeMaster,
one for Cubelet — since the two packages are separate copies. The diff is identical in both.

## Testing

New: `CubeMaster/pkg/base/hotswap/file_reload_test.go` and `Cubelet/pkg/hotswap/file_reload_test.go`
(identical).

- `TestReloadDetectsCaseOnlyKeyValueChange` — `INFO` → `info` is detected.
- `TestReloadDetectsCaseOnlyHostChange` — `Foo.internal` → `foo.internal` is detected.
- `TestReloadReportsNoChangeForIdenticalConfig` — an unchanged file still reports no change, so the
  fix does not turn every watcher tick into a spurious notify.
- `TestReloadDetectsOrdinaryChange` — regression guard for the normal path.

The tests drive `reload()` directly via `NewWatcher` rather than `Init()`, so no fsnotify goroutine is
started.

Red/green verified — with `file.go` reverted to master:

```
--- FAIL: TestReloadDetectsCaseOnlyKeyValueChange
--- FAIL: TestReloadDetectsCaseOnlyHostChange
FAIL
```

and with the fix applied:

```
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/hotswap  0.363s
ok  github.com/tencentcloud/CubeSandbox/Cubelet/pkg/hotswap          0.512s
```

CI gates checked locally:

- `gofmt -l` on both packages — clean (`fmt-check`).
- `GOOS=linux go build` on both packages — clean.

## Risk / rollout

Low. The change makes reload strictly more sensitive, so the only behavioural difference is that
case-only edits now take effect — which is the intent. Listeners already had to tolerate being
notified on any change.

