### PR TITLE
cubelog: emit the Region/Cluster defaults that Trace already computes

### DIFF
--- a/cubelog/metric.go
+++ b/cubelog/metric.go
@@ -197,14 +197,16 @@ func Trace(trace *RequestTrace) {
 	if tmcluster == "" {
 		tmcluster = cluster
 	}
-	version := trace.Version
-	if version == "" {
-		version = moduleVersion
-	}
 
 	if enableLogMetric {
 		fields := makeLogFieldsFromTrace(trace)
 		fields["CostTime"] = cost
+		if region != "" {
+			fields["Region"] = region
+		}
+		if tmcluster != "" {
+			fields["Cluster"] = tmcluster
+		}
 
 		if traceStd.writer != nil {
 			traceStd.WithFields(fields).Errorf("")

--- a/cubelog/metric_trace_test.go
+++ b/cubelog/metric_trace_test.go
@@ -1,0 +1,77 @@
+package CubeLog
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func captureTrace(t *testing.T, rt *RequestTrace) map[string]interface{} {
+	t.Helper()
+
+	var buf bytes.Buffer
+	prevWriter := traceStd.writer
+	SetTraceOutput(&buf)
+	EnableLogMetric()
+	defer func() {
+		DisableLogMetric()
+		traceStd.writer = prevWriter
+	}()
+
+	Trace(rt)
+
+	if buf.Len() == 0 {
+		t.Fatal("Trace produced no output")
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("trace line is not JSON: %v\n%s", err, buf.String())
+	}
+	return got
+}
+
+func TestTraceEmitsConfiguredRegionAndClusterDefaults(t *testing.T) {
+	prevRegion, prevCluster := defaultRegion, cluster
+	SetRegion(Region("ap-guangzhou"))
+	SetCluster("cluster-a")
+	defer func() {
+		defaultRegion, cluster = prevRegion, prevCluster
+	}()
+
+	got := captureTrace(t, &RequestTrace{
+		Action: "VolumeGC",
+		Caller: "cubelet",
+		Cost:   time.Millisecond,
+	})
+
+	if got["Region"] != "ap-guangzhou" {
+		t.Errorf("Region = %v, want ap-guangzhou (the configured default)", got["Region"])
+	}
+	if got["Cluster"] != "cluster-a" {
+		t.Errorf("Cluster = %v, want cluster-a (the configured default)", got["Cluster"])
+	}
+}
+
+func TestTracePrefersExplicitRegionAndCluster(t *testing.T) {
+	prevRegion, prevCluster := defaultRegion, cluster
+	SetRegion(Region("ap-guangzhou"))
+	SetCluster("cluster-a")
+	defer func() {
+		defaultRegion, cluster = prevRegion, prevCluster
+	}()
+
+	got := captureTrace(t, &RequestTrace{
+		Action:  "VolumeGC",
+		Region:  "ap-shanghai",
+		Cluster: "cluster-b",
+		Cost:    time.Millisecond,
+	})
+
+	if got["Region"] != "ap-shanghai" {
+		t.Errorf("Region = %v, want the explicit ap-shanghai", got["Region"])
+	}
+	if got["Cluster"] != "cluster-b" {
+		t.Errorf("Cluster = %v, want the explicit cluster-b", got["Cluster"])
+	}
+}


### PR DESCRIPTION


Closes #1472.

## Motivation

`Trace()` computed `region`, `tmcluster` and `version` fallbacks from the configured globals and then
never used them — `staticcheck` reports all three as `SA4006`. Because
`makeLogFieldsFromTrace` only sets `Region`/`Cluster` when the *trace struct* carries them, any caller
that omits them produced a trace line with no Region and no Cluster, even when the logger had defaults
configured.

`Version` was already defaulted inside `makeLogFieldsFromTrace` (`entry.go:213-217`), so the `version`
local was pure duplication.

## What this changes

`cubelog/metric.go` in `Trace()`:

- The computed `region` / `tmcluster` are now applied to the emitted fields.
- They are applied **only when non-empty**, which preserves the existing omit-when-empty contract —
  see below.
- The redundant `version` local is removed, since `makeLogFieldsFromTrace` already defaults it.

No comment changes.

## The omit-when-empty detail

My first attempt set the fields unconditionally, which broke `TestTraceEnds`
(`logger_test.go:92-93`). That test asserts that when neither the trace nor the globals carry a
cluster, the output must **not** contain `Cluster` — an unconditional assignment made the key present
with an empty value.

The guarded version keeps that contract: absent stays absent, configured defaults now come through.
Both halves of `TestTraceEnds` pass.

## Testing

New: `cubelog/metric_trace_test.go`

- `TestTraceEmitsConfiguredRegionAndClusterDefaults` — with globals configured and the trace fields
  empty, the emitted JSON carries the defaults.
- `TestTracePrefersExplicitRegionAndCluster` — an explicit value on the trace still wins over the
  global.

Both capture the real trace line via `SetTraceOutput` + `EnableLogMetric` and parse it as JSON, and both
restore the globals and the writer afterwards so they do not leak into other tests in the package.

Red/green verified — with `metric.go` reverted to master:

```
--- FAIL: TestTraceEmitsConfiguredRegionAndClusterDefaults
    metric_trace_test.go:49: Region = <nil>, want ap-guangzhou (the configured default)
    metric_trace_test.go:52: Cluster = <nil>, want cluster-a (the configured default)
```

and with the fix:

```
$ cd cubelog && go test -count=1 ./
ok  github.com/tencentcloud/CubeSandbox/cubelog  0.625s

$ go test -count=1 -run TestTrace ./          # the ordering that exposed the omit-when-empty issue
ok  github.com/tencentcloud/CubeSandbox/cubelog  0.164s
```

CI gates checked locally:

- `gofmt -l .` — clean (`fmt-check`).
- `go build ./...` — clean.
- `staticcheck -checks 'SA4006' ./` — the three `metric.go` findings are gone.

Note the package directory is `cubelog/` but the Go package is `CubeLog`; the new test file matches.

## Risk / rollout

Trace lines from callers that omit Region/Cluster will start carrying the configured values. Anything
that parses those lines and currently treats the fields as absent will now see them populated — which
is the intended behaviour, but it is a visible change in log output.

## Related, not fixed here

`cubelog/metric.go:77-180` — the `requestTrace` / `indexKey` / `realKey` / `slice2Str` block is
unreachable (never instantiated). It looks like the other half of a partially-removed metric
aggregation path, and `Trace()` computing inputs for it is probably why these locals existed. Tracked
separately.

