### PR TITLE
cubemaster: clamp the gRPC pool refcount in the stored value, not a local copy

### DIFF
--- a/CubeMaster/pkg/base/grpc-middleware/pool/pool.go
+++ b/CubeMaster/pkg/base/grpc-middleware/pool/pool.go
@@ -111,11 +111,15 @@ func New(ua, address string, option Options) (Pool, error) {
 }
 
 func (p *pool) incrRef() int32 {
-	newRef := atomic.AddInt32(&p.ref, 1)
-	if newRef >= math.MaxInt32 {
-		newRef = math.MaxInt32
+	for {
+		cur := atomic.LoadInt32(&p.ref)
+		if cur == math.MaxInt32 {
+			return cur
+		}
+		if atomic.CompareAndSwapInt32(&p.ref, cur, cur+1) {
+			return cur + 1
+		}
 	}
-	return newRef
 }
 
 func (p *pool) decrRef() {
@@ -123,9 +127,16 @@ func (p *pool) decrRef() {
 		return
 	}
 
-	newRef := atomic.AddInt32(&p.ref, -1)
-	if newRef < 0 {
-		newRef = 0
+	var newRef int32
+	for {
+		cur := atomic.LoadInt32(&p.ref)
+		if cur <= 0 {
+			break
+		}
+		if atomic.CompareAndSwapInt32(&p.ref, cur, cur-1) {
+			newRef = cur - 1
+			break
+		}
 	}
 
 	if newRef == 0 && atomic.LoadInt32(&p.current) > int32(p.opt.MaxIdle) {

--- a/CubeMaster/pkg/base/grpc-middleware/pool/pool_refcount_test.go
+++ b/CubeMaster/pkg/base/grpc-middleware/pool/pool_refcount_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package pool
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func newRefProbe(ref int32) *pool {
+	return &pool{ref: ref, opt: Options{MaxIdle: 1}}
+}
+
+func TestIncrRefDoesNotOverflowPastMaxInt32(t *testing.T) {
+	p := newRefProbe(math.MaxInt32)
+
+	if got := p.incrRef(); got != math.MaxInt32 {
+		t.Fatalf("incrRef returned %d, want math.MaxInt32", got)
+	}
+	if stored := atomic.LoadInt32(&p.ref); stored != math.MaxInt32 {
+		t.Fatalf("stored ref = %d, want math.MaxInt32 (it must not wrap negative)", stored)
+	}
+}
+
+func TestIncrRefIncrementsNormally(t *testing.T) {
+	p := newRefProbe(0)
+
+	if got := p.incrRef(); got != 1 {
+		t.Fatalf("incrRef returned %d, want 1", got)
+	}
+	if got := p.incrRef(); got != 2 {
+		t.Fatalf("incrRef returned %d, want 2", got)
+	}
+	if stored := atomic.LoadInt32(&p.ref); stored != 2 {
+		t.Fatalf("stored ref = %d, want 2", stored)
+	}
+}
+
+func TestDecrRefDoesNotGoNegative(t *testing.T) {
+	p := newRefProbe(0)
+
+	p.decrRef()
+	if stored := atomic.LoadInt32(&p.ref); stored != 0 {
+		t.Fatalf("stored ref = %d after an unbalanced decrRef, want 0", stored)
+	}
+
+	p.decrRef()
+	p.decrRef()
+	if stored := atomic.LoadInt32(&p.ref); stored != 0 {
+		t.Fatalf("stored ref = %d after repeated unbalanced decrRef, want 0", stored)
+	}
+}
+
+func TestDecrRefDecrementsNormally(t *testing.T) {
+	p := newRefProbe(3)
+
+	p.decrRef()
+	if stored := atomic.LoadInt32(&p.ref); stored != 2 {
+		t.Fatalf("stored ref = %d, want 2", stored)
+	}
+}
+
+func TestRefCountIsBalancedUnderConcurrency(t *testing.T) {
+	p := newRefProbe(0)
+
+	const workers = 64
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				p.incrRef()
+				p.decrRef()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if stored := atomic.LoadInt32(&p.ref); stored != 0 {
+		t.Fatalf("stored ref = %d after balanced concurrent use, want 0", stored)
+	}
+}


### PR DESCRIPTION

Closes #1474.

## Motivation

Both `incrRef` and `decrRef` clamped a **local** `int32` after the atomic add, so neither clamp had
any effect on `p.ref`:

```go
newRef := atomic.AddInt32(&p.ref, 1)
if newRef >= math.MaxInt32 { newRef = math.MaxInt32 }   // local only
```

`staticcheck` flags the increment side as `SA4003`. The consequential half is the decrement: a single
unbalanced `decrRef` drives the stored counter to `-1`, and from then on the
`atomic.LoadInt32(&p.ref) == 0` guard inside `decrRef` never holds again — so `deleteFrom(MaxIdle)` is
never reached and idle connections above `MaxIdle` are never reclaimed. A silent connection leak.

## What this changes

`CubeMaster/pkg/base/grpc-middleware/pool/pool.go` — both operations become compare-and-swap loops so
the bound is enforced on the stored value:

- `incrRef` saturates at `math.MaxInt32` instead of wrapping negative.
- `decrRef` stops at `0` instead of going negative, which keeps the idle-trim branch reachable.

`decrRef`'s existing idle-trim block is unchanged; it now sees a counter that can actually reach `0`.

No comment changes.

## Testing

New: `CubeMaster/pkg/base/grpc-middleware/pool/pool_refcount_test.go`

- `TestIncrRefDoesNotOverflowPastMaxInt32` — asserts the **stored** value saturates.
- `TestIncrRefIncrementsNormally` — normal path unchanged.
- `TestDecrRefDoesNotGoNegative` — repeated unbalanced releases leave the stored value at `0`.
- `TestDecrRefDecrementsNormally` — normal path unchanged.
- `TestRefCountIsBalancedUnderConcurrency` — 64 goroutines × 500 balanced incr/decr pairs end at `0`,
  which exercises the CAS retry loops.

Red/green verified — with `pool.go` reverted to master:

```
--- FAIL: TestIncrRefDoesNotOverflowPastMaxInt32
--- FAIL: TestDecrRefDoesNotGoNegative
FAIL
```

and with the fix:

```
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/grpc-middleware/pool  0.283s
```

Also clean under the race detector:

```
$ go test -race -count=1 ./pkg/base/grpc-middleware/pool/
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/grpc-middleware/pool  1.740s
```

CI gates checked locally:

- `gofmt -l` on the package — clean (`fmt-check`).
- `GOOS=linux go build` on the package — clean.
- `staticcheck -checks 'SA*'` — the `SA4003` finding is gone; the remaining `SA1019` hits are
  pre-existing `grpc.DialContext` / `WithInsecure` / `WithBlock` deprecations in `options.go`, not
  touched here.

