### PR TITLE
sdk/python: use typing.List in classes that define a `list` method

### DIFF
--- a/sdk/python/cubesandbox/_filesystem.py
+++ b/sdk/python/cubesandbox/_filesystem.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import struct
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import Any, Iterator, List, TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ class Filesystem:
 
     def write_files(
         self,
-        files: list[tuple[str, str | bytes]],
+        files: List[tuple[str, str | bytes]],
         *,
         user: str | None = None,
     ) -> int:
@@ -140,7 +140,7 @@ class Filesystem:
                 ) from e
         return len(files)
 
-    def list(self, path: str) -> list[dict[str, Any]]:
+    def list(self, path: str) -> List[dict[str, Any]]:
         """List entries in a directory."""
         result = self._filesystem_rpc("ListDir", {"path": path})
         return result.get("entries", [])

--- a/sdk/python/cubesandbox/_template.py
+++ b/sdk/python/cubesandbox/_template.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import requests
 
@@ -41,7 +41,7 @@ class TemplateBuild:
     message: str = ""
     created_at: str = ""
     finished_at: str = ""
-    logs: list[str] = field(default_factory=list)
+    logs: List[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict) -> "TemplateBuild":
@@ -80,11 +80,11 @@ class TemplateInfo:
     public: bool = False
     cpu_count: int = 0
     memory_mb: int = 0
-    replicas: list[dict] = field(default_factory=list)
+    replicas: List[dict] = field(default_factory=list)
     create_request: dict | None = None
     network_type: str | None = None
     allow_internet_access: bool | None = None
-    builds: list[TemplateBuild] = field(default_factory=list)
+    builds: List[TemplateBuild] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict) -> "TemplateInfo":
@@ -146,7 +146,7 @@ class Template:
 
 
     @classmethod
-    def list(cls, *, config: Config | None = None) -> list[TemplateInfo]:
+    def list(cls, *, config: Config | None = None) -> List[TemplateInfo]:
         """GET /templates — List all templates.
 
         Args:
@@ -217,7 +217,7 @@ class Template:
         start_cmd: str | None = None,
         instance_type: str | None = None,
         writable_layer_size: str | None = None,
-        exposed_ports: list[int] | None = None,
+        exposed_ports: List[int] | None = None,
         probe_port: int | None = None,
         probe_path: str | None = None,
         cpu_count: int | None = None,
@@ -225,14 +225,14 @@ class Template:
         envs: Dict[str, str] | None = None,
         allow_internet_access: bool | None = None,
         network_type: str | None = None,
-        nodes: list[str] | None = None,
+        nodes: List[str] | None = None,
         registry_username: str | None = None,
         registry_password: str | None = None,
-        command: list[str] | None = None,
-        args: list[str] | None = None,
-        dns: list[str] | None = None,
-        allow_out: list[str] | None = None,
-        deny_out: list[str] | None = None,
+        command: List[str] | None = None,
+        args: List[str] | None = None,
+        dns: List[str] | None = None,
+        allow_out: List[str] | None = None,
+        deny_out: List[str] | None = None,
         enable_ivshmem: bool | None = None,
         config: Config | None = None,
         **kwargs: Any,

--- a/sdk/python/cubesandbox/_volume.py
+++ b/sdk/python/cubesandbox/_volume.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import re
 import threading
 from dataclasses import dataclass
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 import requests
 
@@ -198,9 +198,9 @@ def _validate_mount_path(path: str) -> str:
     return path
 
 
-def _serialize_volume_mounts(mounts: VolumeMountsArg) -> list[dict[str, object]]:
+def _serialize_volume_mounts(mounts: VolumeMountsArg) -> List[dict[str, object]]:
     """Serialize the e2b-style ``{path: volume}`` mapping into the wire format."""
-    serialized: list[dict[str, object]] = []
+    serialized: List[dict[str, object]] = []
     for path, value in mounts.items():
         if isinstance(value, VolumeMount):
             volume = value.volume
@@ -244,7 +244,7 @@ class Volume:
             sb.files.write("/workspace/note.txt", "persisted!")
 
         # List / get_info / connect / destroy
-        for v in Volume.list():           # list[VolumeInfo]
+        for v in Volume.list():           # List[VolumeInfo]
             print(v.volume_id, v.name)
         Volume.get_info(vol.volume_id)    # VolumeInfo
         vol = Volume.connect("my-data")   # Volume instance (== e2b)
@@ -376,7 +376,7 @@ class Volume:
         return cls._from_info(VolumeInfo.from_dict(resp.json()), cfg)
 
     @classmethod
-    def list(cls, *, config: Config | None = None) -> list[VolumeInfo]:
+    def list(cls, *, config: Config | None = None) -> List[VolumeInfo]:
         """GET /volumes — List all volumes.
 
         The returned entries never carry a ``token`` (it is only surfaced on

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import threading
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List
 
 import httpx
 import requests
@@ -190,7 +190,7 @@ class Sandbox:
         env_vars: Dict[str, str] | None = None,
         envs: Dict[str, str] | None = None,
         metadata: Dict[str, str] | None = None,
-        distribution_scope: list[str] | None = None,
+        distribution_scope: List[str] | None = None,
         allow_internet_access: bool = True,
         network: Dict[str, Any] | None = None,
         lifecycle: Dict[str, Any] | None = None,
@@ -354,7 +354,7 @@ class Sandbox:
 
 
     @classmethod
-    def list(cls, config: Config | None = None) -> list[dict]:
+    def list(cls, config: Config | None = None) -> List[dict]:
         """GET /sandboxes - List all running sandboxes (v1).
 
         Args:
@@ -371,7 +371,7 @@ class Sandbox:
         return resp.json()
 
     @classmethod
-    def list_v2(cls, config: Config | None = None) -> list[dict]:
+    def list_v2(cls, config: Config | None = None) -> List[dict]:
         """GET /v2/sandboxes - List all running sandboxes (v2).
 
         Supports state / metadata filtering on the server side.
@@ -644,7 +644,7 @@ class Sandbox:
         limit: int | None = None,
         next_token: str | None = None,
         config: Config | None = None,
-    ) -> tuple[list[SnapshotInfo], str | None]:
+    ) -> tuple[List[SnapshotInfo], str | None]:
         """GET /snapshots — List snapshots (1.2).
 
         Args:
@@ -758,7 +758,7 @@ class Sandbox:
             pass
         self._session = self._build_session()
 
-    def clone(self, n: int = 1, *, concurrency: int = 1) -> list["Sandbox"]:
+    def clone(self, n: int = 1, *, concurrency: int = 1) -> List["Sandbox"]:
         """Clone this sandbox *n* times (1.6).
 
         Internally this executes three steps:
@@ -807,7 +807,7 @@ class Sandbox:
         def _create_one() -> Sandbox:
             return Sandbox.create(template=snap_id, config=cfg)
 
-        sandboxes: list[Sandbox] = []
+        sandboxes: List[Sandbox] = []
         first_error: BaseException | None = None
         if concurrency <= 1 or n <= 1:
             # Sequential: short-circuit on first failure to preserve the


### PR DESCRIPTION

Closes #1476.

## Motivation

`Template`, `Sandbox`, `Volume` and `Filesystem` each define a method named `list`. Inside a class body the
name `list` binds to that method, so an annotation written `list[TemplateInfo]` in the same class refers to
the method, not the builtin. mypy reports `Function "...list" is not valid as a type` and, more importantly,
**stops type-checking those parameters** — 10 annotations across two files were effectively `Any`.

## What this changes

Replaces `list[...]` with `typing.List[...]` in the four affected modules and adds `List` to each
`from typing import ...` line:

| file | annotations rewritten |
|---|---|
| `cubesandbox/_template.py` | 11 |
| `cubesandbox/sandbox.py` | 6 |
| `cubesandbox/_volume.py` | 4 |
| `cubesandbox/_filesystem.py` | 2 |

`typing.List` is not shadowed by anything, so the annotations resolve for static analysers as well as at
runtime. The public API — including the `list` method names — is unchanged.

I fixed all four rather than only the two mypy currently flags: `_volume.py` and `_filesystem.py` have the
same construct and would start producing the same errors as soon as anything about their annotations
changed.

No comment changes.

## Correcting the original report

The issue I filed first claimed this broke `typing.get_type_hints` at runtime. **That was wrong**, and I
verified it rather than leaving it in:

```
MASTER get_type_hints(Template.build) -> OK
MASTER get_type_hints(Template.list)  -> OK
MASTER get_type_hints(Sandbox.list)   -> OK
```

All four modules use `from __future__ import annotations`, and `get_type_hints` evaluates against **module**
globals rather than the class namespace, so `list` resolves to the builtin at runtime. The defect is
static-analysis only, and the issue text has been corrected to say so. That also lowers the severity from
what I first suggested.

## Testing

The evidence is the mypy count, since the defect is a type-resolution one:

```
MASTER 'not valid as a type' count: 10
BRANCH 'not valid as a type' count:  0
```

No behavioural change, so no new tests. Existing suite and lint are unaffected:

```
$ python3 -m pytest tests -q
225 passed in 0.38s

$ ruff check --select F,E9 cubesandbox
Found 2 errors.        # both pre-existing F401 on master, identical count
```

CI gates checked locally:

- `pytest` — 225 passed (`sdk-test-check`).
- `ruff` — no new findings (the two `F401` unused-import errors are present on master too and are not
  touched here).
