### PR TITLE
tests: fix the data races in queueworker, recov and bufferqueue

### DIFF
--- a/CubeMaster/pkg/base/bufferqueue/bufferqueue_test.go
+++ b/CubeMaster/pkg/base/bufferqueue/bufferqueue_test.go
@@ -128,7 +128,9 @@ func TestQueueCheckTimestampPriority(t *testing.T) {
 	waittime := time.Duration(testnum*10) * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), waittime)
 	defer cancel()
+	watcherDone := make(chan struct{})
 	go func() {
+		defer close(watcherDone)
 		for {
 			select {
 			case <-ctx.Done():
@@ -143,6 +145,7 @@ func TestQueueCheckTimestampPriority(t *testing.T) {
 			}
 		}
 	}()
+	defer func() { <-watcherDone }()
 
 	bw.GraceFullStop(ctx)
 	assert.Equal(t, int32(testnum), worked)

--- a/CubeMaster/pkg/base/queueworker/queue_test.go
+++ b/CubeMaster/pkg/base/queueworker/queue_test.go
@@ -6,6 +6,7 @@ package queueworker
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -61,18 +62,24 @@ func TestQueue(t *testing.T) {
 func TestQueueBlock(t *testing.T) {
 	q := NewQueue(5)
 
-	got := false
+	var got atomic.Bool
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		q.BPop()
-		got = true
+		got.Store(true)
 	}()
 
-	if got {
+	if got.Load() {
 		t.Error("BPop should block when queue is empty")
 	}
 	q.Push(1)
-	time.Sleep(time.Second)
-	if !got {
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("BPop did not return after Push")
+	}
+	if !got.Load() {
 		t.Error("BPop should got value when queue is not empty")
 	}
 }

--- a/CubeMaster/pkg/base/recov/runtime_test.go
+++ b/CubeMaster/pkg/base/recov/runtime_test.go
@@ -144,7 +144,7 @@ func TestGoWithRetryWithCrash(t *testing.T) {
 		atomic.AddInt32(&panicTime, 1)
 	})
 	time.Sleep(2 * time.Second)
-	if int(panicTime) != retryTime {
+	if int(atomic.LoadInt32(&panicTime)) != retryTime {
 		t.Errorf("should be %d, actual %d", 0, 1)
 	}
 }

--- a/Cubelet/pkg/queueworker/queue_test.go
+++ b/Cubelet/pkg/queueworker/queue_test.go
@@ -6,6 +6,7 @@ package queueworker
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -61,18 +62,24 @@ func TestQueue(t *testing.T) {
 func TestQueueBlock(t *testing.T) {
 	q := NewQueue(5)
 
-	got := false
+	var got atomic.Bool
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		q.BPop()
-		got = true
+		got.Store(true)
 	}()
 
-	if got {
+	if got.Load() {
 		t.Error("BPop should block when queue is empty")
 	}
 	q.Push(1)
-	time.Sleep(time.Second)
-	if !got {
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("BPop did not return after Push")
+	}
+	if !got.Load() {
 		t.Error("BPop should got value when queue is not empty")
 	}
 }

--- a/Cubelet/pkg/recov/runtime_test.go
+++ b/Cubelet/pkg/recov/runtime_test.go
@@ -144,7 +144,7 @@ func TestGoWithRetryWithCrash(t *testing.T) {
 		atomic.AddInt32(&panicTime, 1)
 	})
 	time.Sleep(2 * time.Second)
-	if int(panicTime) != retryTime {
+	if int(atomic.LoadInt32(&panicTime)) != retryTime {
 		t.Errorf("should be %d, actual %d", 0, 1)
 	}
 }


### PR DESCRIPTION

Closes #1478.

## Motivation

`go test -race` fails in three packages because tests read state written by a goroutine without
synchronization. The production code is correct in all three cases; the tests are wrong.

These are part of what stands between the repo and a green `-race` gate.

## What this changes

**`queueworker/queue_test.go` — `TestQueueBlock`** (CubeMaster and Cubelet copies)

`got` becomes an `atomic.Bool`, and the test now waits on a `done` channel closed by the goroutine
instead of sleeping for a fixed second:

- removes the race on `got`
- removes the unconditional 1s sleep, so the test finishes as soon as `BPop` returns
- fails with a clear message if `BPop` never returns, instead of reporting a confusing assertion failure

**`recov/runtime_test.go` — `TestGoWithRetryWithCrash`** (CubeMaster and Cubelet copies)

`int(panicTime)` becomes `int(atomic.LoadInt32(&panicTime))`, matching the `atomic.AddInt32` that
production `HandleCrash` uses to write it.

**`bufferqueue/bufferqueue_test.go` — `TestQueueCheckTimestampPriority`** (CubeMaster only)

The watcher goroutine is given a `watcherDone` channel and the test joins it via `defer`, so `t.Logf`
can no longer run after the test function has returned.

No production code changed. No comment changes.

Per CONTRIBUTING's "one component per commit", this should land as two commits — one for CubeMaster, one
for Cubelet.

## Testing

```
CubeMaster:
  ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/queueworker  10.694s
  ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov         5.869s

Cubelet:
  ok  github.com/tencentcloud/CubeSandbox/Cubelet/pkg/queueworker  12.305s
  ok  github.com/tencentcloud/CubeSandbox/Cubelet/pkg/recov         5.478s
```

all under `-race -count=1`, where master reports `--- FAIL` plus a `WARNING: DATA RACE` for
`TestQueueBlock` and `TestGoWithRetryWithCrash`.

Module-wide `go test -race ./...` in CubeMaster:

| | races |
|---|---|
| master | 9 |
| this branch | **7** |

The remaining 7 are the `localcache` production races, which are fixed on their own branch. The two
changes together take CubeMaster to 0.

## On the bufferqueue one

I could not reproduce that race in five isolated runs of the package — it showed up only in a full
`go test -race ./...`. `bw.Workings()` is correctly `atomic.LoadInt32`, so the plausible cause is the
unjoined goroutine touching `t` after the test returned, which is a `testing` misuse regardless of
whether the detector catches it on a given run. I fixed it on those grounds rather than claiming a
verified red/green, since I would rather say so than present an unproven fix as proven.

CI gates checked locally:

- `gofmt -l` on all four packages — clean (`fmt-check`).
- `go test -race` on all four — clean.
