### PR TITLE
cubelog: remove the dead requestTrace aggregation path

### DIFF
--- a/cubelog/metric.go
+++ b/cubelog/metric.go
@@ -5,12 +5,8 @@
 package CubeLog
 
 import (
-	"bytes"
 	"io"
-	"reflect"
-	"strconv"
 	"time"
-	"unsafe"
 )
 
 var (
@@ -72,111 +68,6 @@ func (rt *RequestTrace) DeepCopy() *RequestTrace {
 func (rt *RequestTrace) WithCallee(callee string) *RequestTrace {
 	rt.Callee = callee
 	return rt
-}
-
-type requestTrace struct {
-	Timestamp      int64
-	AppId          int64
-	FunctionId     string
-	Action         string
-	Qualifier      string
-	Region         string
-	Cluster        string
-	Version        string
-	Caller         string
-	Callee         string
-	CallerIP       string
-	CalleeEndpoint string
-	CalleeAction   string
-	ErrorCode      int64
-	CalleeCluster  string
-	FunctionType   string
-	DeployMode     string
-
-	ReqCnt       uint64
-	SuccCnt      uint64
-	FailCnt      uint64
-	ColdStartCnt uint64
-
-	ColdStart          float64
-	ColdStartSum       float64
-	ColdStartMax       float64
-	ColdStartMin       float64
-	ColdStartRange1Cnt uint64
-	ColdStartRange2Cnt uint64
-	ColdStartRange3Cnt uint64
-	ColdStartRange4Cnt uint64
-	ColdStartRange5Cnt uint64
-	ColdStartRange6Cnt uint64
-	ColdStartRange7Cnt uint64
-	ColdStartRange8Cnt uint64
-
-	Cost          float64
-	CostSum       float64
-	CostMax       float64
-	CostMin       float64
-	CostRange1Cnt uint64
-	CostRange2Cnt uint64
-	CostRange3Cnt uint64
-	CostRange4Cnt uint64
-	CostRange5Cnt uint64
-	CostRange6Cnt uint64
-	CostRange7Cnt uint64
-	CostRange8Cnt uint64
-}
-
-func (m *requestTrace) indexKey() []byte {
-	size := 1 +
-		len(m.Region) + len(m.Cluster) + len(m.Callee) +
-		len(m.CalleeAction) + len(m.CalleeEndpoint)
-	b := make([]byte, 0, size)
-	buf := bytes.NewBuffer(b)
-	buf.WriteString(m.Region)
-	buf.WriteString(m.Cluster)
-	buf.WriteString(m.Callee)
-	buf.WriteString(m.CalleeAction)
-	buf.WriteString(m.CalleeEndpoint)
-	return buf.Bytes()
-}
-
-func (m *requestTrace) realKey() string {
-	errorCode := strconv.FormatInt(m.ErrorCode, 10)
-	appId := strconv.FormatInt(m.AppId, 10)
-	size := 1 +
-		len(m.Region) + len(m.Cluster) + len(m.CalleeCluster) + len(m.FunctionType) + len(m.DeployMode) +
-		len(m.Version) + len(m.Caller) + len(m.CallerIP) +
-		len(m.Callee) + len(m.CalleeAction) + len(m.CalleeEndpoint) +
-		len(errorCode) + len(appId) + len(m.FunctionId) +
-		len(m.Action) + len(m.Qualifier)
-	b := make([]byte, 0, size)
-	buf := bytes.NewBuffer(b)
-
-	buf.WriteString(m.Region)
-	buf.WriteString(m.Cluster)
-	buf.WriteString(m.CalleeCluster)
-	buf.WriteString(m.FunctionType)
-	buf.WriteString(m.DeployMode)
-	buf.WriteString(m.Version)
-	buf.WriteString(m.Caller)
-	buf.WriteString(m.CallerIP)
-	buf.WriteString(m.Callee)
-	buf.WriteString(m.CalleeAction)
-	buf.WriteString(m.CalleeEndpoint)
-	buf.WriteString(errorCode)
-	buf.WriteString(appId)
-	buf.WriteString(m.FunctionId)
-	buf.WriteString(m.Action)
-	buf.WriteString(m.Qualifier)
-	return slice2Str(buf.Bytes())
-}
-
-func slice2Str(b []byte) string {
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sh := reflect.StringHeader{
-		Data: bh.Data,
-		Len:  bh.Len,
-	}
-	return *(*string)(unsafe.Pointer(&sh))
 }
 
 func init() {


### PR DESCRIPTION

Closes #1480.

## Motivation

`requestTrace` is never constructed anywhere in the tree, so its methods `indexKey()` and `realKey()`
have no callers, and `slice2Str()` is called only from `realKey()`. The whole block is unreachable.

It is not harmless dead weight: `go vet` reports `possible misuse of reflect.StringHeader` at
`metric.go:179`, inside `slice2Str`. Keeping unreachable unsafe-pointer code around means that warning
sits in the build output forever and any future reader has to work out whether it matters.

## What this changes

`cubelog/metric.go` — deletes 109 lines:

- `type requestTrace struct` (`:77-130`)
- `func (m *requestTrace) indexKey()` (`:128`)
- `func (m *requestTrace) realKey()` (`:142`)
- `func slice2Str(b []byte) string` (`:173`)

and drops the four imports that only that block used: `bytes`, `reflect`, `strconv`, `unsafe`. `io` and
`time` remain.

The exported `RequestTrace` type (different type, capital R) and `Trace()` are untouched — those are
the live API.

Verified nothing outside the deleted block referenced any of these identifiers:

```
$ grep -rn "requestTrace\b|slice2Str|indexKey()" --include='*.go' .   # outside cubelog/: no hits
```

`Cubelet/services/images/volumelifetime.go` has its **own** separate `slice2Str`/`realKey` which are
live and are deliberately left alone here — they belong to the unsafe-header issue.

No comment changes.

## Testing

Deletion only, so no new tests. Existing coverage confirms nothing depended on it:

```
$ cd cubelog && go build ./...
BUILD OK

$ go test -count=1 ./
ok  github.com/tencentcloud/CubeSandbox/cubelog  1.663s

$ go vet ./
(clean — the metric.go:179 reflect.StringHeader warning is gone)
```

CI gates checked locally:

- `gofmt -l .` — clean (`fmt-check`).
- `go build ./...`, `go test ./...`, `go vet ./` — all clean.

`git diff --stat`: `cubelog/metric.go | 109 ------` , 1 file changed, 109 deletions.

## Risk / rollout

Very low — removing code with no callers and no exported surface. If the aggregation was intended to
come back, this PR is the wrong direction and it should be wired up instead; the deleted code is
recoverable from history either way.
