### PR TITLE
fix(sdk): do not send a non-positive Connect-Timeout-Ms for a command

### DIFF
--- a/sdk/node/src/commands.ts
+++ b/sdk/node/src/commands.ts
@@ -238,7 +238,15 @@ export class Commands {
       ...this.sandbox.trafficTokenHeaders(),
       ...userHeaders(user),
     };
-    if (idleMs !== undefined) {
+    // Only a positive deadline is sent. envd reads Connect-Timeout-Ms as a hard
+    // wall-clock deadline, so a zero or negative one has already passed and the
+    // request never gets an answer — it hangs until the HTTP client gives up on
+    // headers, and reports a transport error that says nothing about the cause.
+    //
+    // Both non-positive values arrive in ordinary use: `0` is how the e2b SDK
+    // spells "no deadline", and NEVER_TIMEOUT is how this one does. `pty.ts`
+    // and the Go SDK already guard this way.
+    if (idleMs !== undefined && idleMs > 0) {
       headers["Connect-Timeout-Ms"] = String(Math.trunc(idleMs));
     }
     const accessToken = this.sandbox.envdAccessToken;

--- a/sdk/node/test/commands.test.ts
+++ b/sdk/node/test/commands.test.ts
@@ -7,7 +7,7 @@ import type { AddressInfo } from "node:net";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { Config } from "../src/config.js";
-import { Sandbox } from "../src/index.js";
+import { NEVER_TIMEOUT, Sandbox } from "../src/index.js";
 
 const SANDBOX_ID = "sb-test-001";
 const DOMAIN = "cube.app";
@@ -141,6 +141,49 @@ describe("Commands.run", () => {
     const result = await sb.commands.run("echo hello", { cwd: "/work", envs: { A: "B" } });
     expect(result.stdout).toBe("hello\nworld\n");
     expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    sb.close();
+  });
+
+  // envd reads Connect-Timeout-Ms as a hard wall-clock deadline, so a
+  // non-positive one has already passed and the request is never answered.
+  // Both values below arrive in ordinary use: 0 is how the e2b SDK spells "no
+  // deadline", and NEVER_TIMEOUT is how this one does.
+  it.each([
+    ["zero", 0],
+    ["NEVER_TIMEOUT", NEVER_TIMEOUT],
+  ])("sends no Connect-Timeout-Ms for a %s timeout", async (_label, timeoutMs) => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.headers["connect-timeout-ms"]).toBeUndefined();
+      return {
+        status: 200,
+        buffer: Buffer.concat([
+          connectFrame(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+          connectFrame(0x02, "{}"),
+        ]),
+      };
+    };
+
+    const result = await sb.commands.run("echo hi", { timeoutMs });
+    expect(result.exitCode).toBe(0);
+    sb.close();
+  });
+
+  it("still sends Connect-Timeout-Ms for a positive timeout", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.headers["connect-timeout-ms"]).toBe("30000");
+      return {
+        status: 200,
+        buffer: Buffer.concat([
+          connectFrame(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+          connectFrame(0x02, "{}"),
+        ]),
+      };
+    };
+
+    const result = await sb.commands.run("echo hi", { timeoutMs: 30_000 });
     expect(result.exitCode).toBe(0);
     sb.close();
   });

--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -146,8 +146,27 @@ class Commands:
             "Connect-Protocol-Version": CONNECT_PROTOCOL_VERSION,
             "Connect-Content-Encoding": "identity",
         }
-        if timeout is not None:
-            headers["Connect-Timeout-Ms"] = str(int(timeout * 1000))
+        # The timeout has two readers that spell "no deadline" differently, so
+        # it is normalised once here.
+        #
+        # envd reads Connect-Timeout-Ms as a hard wall-clock deadline, so a zero
+        # or negative one has already passed and the request never gets an
+        # answer -- it hangs until the HTTP client gives up on headers, and
+        # reports a transport error that says nothing about the cause. The
+        # header is therefore omitted rather than sent as zero.
+        #
+        # httpx reads the same number as a client-side deadline, where only None
+        # means "no deadline": 0 makes every socket operation time out at once,
+        # and -1 is rejected outright. Forwarding the raw value would trade the
+        # hang for an immediate failure, which is not what either value asks
+        # for.
+        #
+        # Both non-positive values arrive in ordinary use: 0 is how the e2b SDK
+        # spells "no deadline", and NEVER_TIMEOUT is how this one does. _pty.py
+        # and the Go SDK already guard this way.
+        effective_timeout = timeout if timeout is not None and timeout > 0 else None
+        if effective_timeout is not None:
+            headers["Connect-Timeout-Ms"] = str(int(effective_timeout * 1000))
         access_token = self._sandbox._data.get("envdAccessToken")
         if access_token:
             headers["X-Access-Token"] = access_token
@@ -159,7 +178,7 @@ class Commands:
             url,
             content=_encode_connect_envelope(json.dumps(payload).encode("utf-8")),
             headers=headers,
-            timeout=timeout,
+            timeout=effective_timeout,
         ) as resp:
             if resp.status_code >= 400:
                 detail = _http_error_detail(resp)

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from cubesandbox import CommandResult, Template
+from cubesandbox import NEVER_TIMEOUT, CommandResult, Template
 from cubesandbox._template import TemplateInfo
 from cubesandbox._commands import Commands, _collect_process_events
 from cubesandbox._config import Config
@@ -77,6 +77,23 @@ def mock_response(body=None, status: int = 200):
 def make_sandbox(**data_overrides) -> Sandbox:
     d = {**SANDBOX_DATA, **data_overrides}
     return Sandbox(d, config=make_config())
+
+
+def _recording_client(transport: httpx.MockTransport, seen: dict) -> httpx.Client:
+    """An httpx client that records the timeout each request was given.
+
+    MockTransport answers synchronously and enforces no timeouts at all, so the
+    value a caller passes is only observable by recording it here.
+    """
+    client = httpx.Client(transport=transport)
+    stream = client.stream
+
+    def recording_stream(*args, **kwargs):
+        seen["timeout"] = kwargs.get("timeout")
+        return stream(*args, **kwargs)
+
+    client.stream = recording_stream
+    return client
 
 
 def connect_envelope(flags: int, payload: str) -> bytes:
@@ -1396,6 +1413,68 @@ class TestCommands:
         assert seen["payload"]["process"]["cwd"] == "/work"
         assert seen["payload"]["process"]["envs"] == {"A": "B"}
         assert seen["payload"]["process"]["args"] == ["-l", "-c", "echo hello"]
+
+    # envd reads Connect-Timeout-Ms as a hard wall-clock deadline, so a
+    # non-positive one has already passed and the request is never answered.
+    # Both values below arrive in ordinary use: 0 is how the e2b SDK spells
+    # "no deadline", and NEVER_TIMEOUT is how this one does.
+    #
+    # The client-side deadline is asserted as well as the header. httpx reads
+    # the same number, and only None disables it there -- 0 times out every
+    # socket operation at once and -1 is rejected -- so forwarding the raw
+    # value would trade the hang for an immediate failure. MockTransport
+    # enforces no timeouts at all, which is why what was passed is inspected
+    # rather than its effect.
+    @pytest.mark.parametrize("timeout", [0, NEVER_TIMEOUT])
+    def test_run_omits_non_positive_timeout_header(self, timeout):
+        sb = make_sandbox()
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["headers"] = request.headers
+            body = b"".join(
+                [
+                    connect_envelope(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+                    connect_envelope(0x02, "{}"),
+                ]
+            )
+            return httpx.Response(200, stream=httpx.ByteStream(body))
+
+        client = _recording_client(httpx.MockTransport(handler), seen)
+        with (
+            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
+            patch.object(sb, "_build_data_client", return_value=client),
+        ):
+            result = sb.commands.run("echo hi", timeout=timeout)
+
+        assert result.exit_code == 0
+        assert "connect-timeout-ms" not in seen["headers"]
+        assert seen["timeout"] is None
+
+    def test_run_sends_positive_timeout_header(self):
+        sb = make_sandbox()
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["headers"] = request.headers
+            body = b"".join(
+                [
+                    connect_envelope(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+                    connect_envelope(0x02, "{}"),
+                ]
+            )
+            return httpx.Response(200, stream=httpx.ByteStream(body))
+
+        client = _recording_client(httpx.MockTransport(handler), seen)
+        with (
+            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
+            patch.object(sb, "_build_data_client", return_value=client),
+        ):
+            result = sb.commands.run("echo hi", timeout=30)
+
+        assert result.exit_code == 0
+        assert seen["headers"]["connect-timeout-ms"] == "30000"
+        assert seen["timeout"] == 30
 
     def test_run_stderr_event(self):
         sb = make_sandbox()


### PR DESCRIPTION
Fixes #1484.

## What

`commands.run` forwarded `timeoutMs` to envd as `Connect-Timeout-Ms` without checking that it was
positive. envd reads that header as a hard wall-clock deadline, so a zero or negative one has
already passed: the request is never answered, and the caller waits until its HTTP client gives up
on headers and reports a transport error that says nothing about the cause.

Both non-positive values arrive in ordinary use:

- **`0`** is how the `e2b` SDK spells "no deadline", so it comes with exactly the port the README's
  drop-in compatibility invites.
- **`NEVER_TIMEOUT`** is how this SDK spells it, and its value is `-1` — a constant meaning "does
  not time out" whose effect was that nothing ever returned.

## Why this is a slip rather than a design choice

The same guard is already correct everywhere else it appears:

| | `commands` | `pty` |
| --- | --- | --- |
| Node | `if (idleMs !== undefined)` ← fixed here | `if (options.timeoutMs !== undefined && options.timeoutMs > 0)` |
| Python | `if timeout is not None:` ← fixed here | `if timeout is not None and timeout > 0:` |
| Go | `if timeout <= 0 { return }` | same helper |

## What is not changed

`Sandbox.create`'s own `timeout` field. `0` and `NEVER_TIMEOUT` are meaningful to CubeAPI there,
and `test_create_sends_explicit_zero_timeout` / `test_create_sends_never_timeout` still pass
unchanged.

## Tests

Node and Python both gain two cases: no `Connect-Timeout-Ms` header for `0` or `NEVER_TIMEOUT`, and
a header that is still sent for a positive value. Both new cases fail against the previous
behaviour — reverting the one-line guard turns them red and leaves the rest green.

```
node    216 passed | 2 skipped   tsc --noEmit clean
python  257 passed | 4 skipped
```

## Measured

Against a running sandbox, before the fix:

```
timeoutMs: 0              → fetch failed / UND_ERR_HEADERS_TIMEOUT
timeoutMs: NEVER_TIMEOUT  → fetch failed / UND_ERR_HEADERS_TIMEOUT
timeoutMs: 30000          → { stdout: "hi\n", exitCode: 0 }   ~22 ms
omitted                   → { stdout: "hi\n", exitCode: 0 }   ~21 ms
```
