### PR TITLE
fix(cubenet): scan-driven direct on-link neighbor resolution

### DIFF
--- a/CubeNet/cubevs/cubevs.go
+++ b/CubeNet/cubevs/cubevs.go
@@ -224,6 +224,7 @@ const (
 	MapNameDNSAllow      = "dns_allow"    // legacy 8-byte DNS value
 	MapNameDNSAllowV2    = "dns_allow_v2" // current 40-byte DNS value
 	MapNameDNSQueryTrack = "dns_query_track"
+	MapNameDirectNeigh   = "direct_neigh" // direct-mode on-link neighbor trigger/cache
 	// constants referenced by BPF programs.
 	globalNameMVMInnerIP           = "mvm_inner_ip"
 	globalNameMVMMacaddrP1         = "mvm_macaddr_p1"

--- a/CubeNet/cubevs/direct_neigh_scanner.go
+++ b/CubeNet/cubevs/direct_neigh_scanner.go
@@ -1,0 +1,236 @@
+package cubevs
+
+// direct_neigh_scanner.go — userspace driver for direct-mode on-link neighbor
+// resolution.
+//
+// The datapath (mvmtap prepare_egress_l2) only reports state into direct_neigh
+// (fib result + last-activity) and always forwards (gateway MAC fallback when a
+// destination is unresolved). This scanner owns all scheduling: it walks the
+// map on a fixed interval and, per entry, garbage-collects idle destinations,
+// fires learning triggers with exponential backoff for destinations whose last
+// fib lookup failed, and fires keepalive triggers for learned destinations so
+// the kernel neighbor entry is periodically re-validated. The MAC itself is
+// never stored or managed here — it always comes from bpf_fib_lookup.
+//
+// Field ownership in the shared map entry (see cubevs.h struct direct_neighbor):
+// the datapath writes addr/fib_ok/valid_until_ns/last_used_ns; this scanner
+// writes step/next_attempt_ns/next_refresh_ns. A lost read-modify-write race on
+// either side only delays a trigger or an activity timestamp by one scan cycle;
+// it can never produce a wrong MAC, so it is benign and self-healing.
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/cilium/ebpf"
+)
+
+// directNeighbor mirrors struct direct_neighbor in cubevs.h.
+type directNeighbor struct {
+	Addr          [6]uint8
+	FibOk         uint8
+	Step          uint8
+	Flags         uint16
+	_             [2]uint8
+	Reserved      uint32
+	ValidUntilNs  uint64
+	LastUsedNs    uint64
+	NextAttemptNs uint64
+	NextRefreshNs uint64
+}
+
+func (n *directNeighbor) macZero() bool {
+	return n.Addr == ([6]uint8{})
+}
+
+// Scanner tuning. All durations are in nanoseconds to match the datapath's
+// CLOCK_MONOTONIC (bpf_ktime_get_ns) timestamps.
+const (
+	directNeighScanInterval  = 300 * time.Millisecond
+	directNeighGCAfterNs     = uint64(5 * 60 * 1e9) // 5 min idle -> GC
+	directNeighRefreshNs     = uint64(16 * 1e9)     // keepalive period (drives NUD re-validation)
+	directNeighBackoffBaseNs = uint64(1 * 1e9)      // learning backoff starts at 1s
+	directNeighBackoffMaxNs  = uint64(16 * 1e9)     // and caps at 16s
+	directNeighTriggerBurst  = 100                  // token bucket capacity
+	directNeighTriggerPerSec = 100.0                // token bucket refill rate
+	// directNeighTriggerPort is an arbitrary high UDP port; the learning event
+	// is the kernel's ARP resolution for the target, independent of L4.
+	directNeighTriggerPort = 65534
+)
+
+// directNeighStore abstracts the direct_neigh map so the scan logic can be
+// unit-tested against an in-memory fake.
+type directNeighStore interface {
+	forEach(fn func(key uint32, val directNeighbor) (cont bool))
+	update(key uint32, val directNeighbor) error
+	delete(key uint32) error
+}
+
+type directNeighScanner struct {
+	store   directNeighStore
+	trigger func(targetIP uint32) error
+	now     func() uint64 // monotonic ns
+
+	mu     sync.Mutex
+	tokens float64
+	lastNS uint64
+}
+
+func newDirectNeighScanner(store directNeighStore, trigger func(uint32) error, now func() uint64) *directNeighScanner {
+	return &directNeighScanner{
+		store:   store,
+		trigger: trigger,
+		now:     now,
+		tokens:  directNeighTriggerBurst,
+	}
+}
+
+// allowTrigger implements the global token bucket that bounds trigger sends.
+func (s *directNeighScanner) allowTrigger(nowNs uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lastNS != 0 {
+		elapsed := float64(nowNs-s.lastNS) / 1e9
+		s.tokens += elapsed * directNeighTriggerPerSec
+		if s.tokens > directNeighTriggerBurst {
+			s.tokens = directNeighTriggerBurst
+		}
+	}
+	s.lastNS = nowNs
+	if s.tokens < 1 {
+		return false
+	}
+	s.tokens--
+	return true
+}
+
+func (s *directNeighScanner) fireTrigger(key uint32, nowNs uint64) {
+	// Best effort: a failed send just means the kernel did not ARP this round;
+	// the next scan retries. No logging facility exists in this package.
+	_ = s.trigger(key)
+}
+
+// scanOnce runs one pass over the map.
+func (s *directNeighScanner) scanOnce() {
+	nowNs := s.now()
+	s.store.forEach(func(key uint32, val directNeighbor) bool {
+		// GC: idle destination, stop all triggering.
+		if nowNs > val.LastUsedNs+directNeighGCAfterNs {
+			s.store.delete(key)
+			return true
+		}
+
+		if val.FibOk == 0 {
+			// Not yet learned: exponential backoff learning trigger. The backoff
+			// for the CURRENT level (1s, 2s, 4s, ... capped at 16s) is scheduled,
+			// then the level advances.
+			if nowNs >= val.NextAttemptNs && s.allowTrigger(nowNs) {
+				s.fireTrigger(key, nowNs)
+				backoff := directNeighBackoffBaseNs << val.Step
+				if backoff > directNeighBackoffMaxNs || backoff == 0 {
+					backoff = directNeighBackoffMaxNs
+				}
+				val.NextAttemptNs = nowNs + backoff
+				val.Step++
+				s.store.update(key, val)
+			}
+			return true
+		}
+
+		// Learned: keepalive trigger on a fixed period.
+		if val.Step != 0 {
+			val.Step = 0
+			s.store.update(key, val)
+		}
+		if nowNs >= val.NextRefreshNs && s.allowTrigger(nowNs) {
+			s.fireTrigger(key, nowNs)
+			val.NextRefreshNs = nowNs + directNeighRefreshNs
+			s.store.update(key, val)
+		}
+		return true
+	})
+}
+
+// run drives scanOnce on a fixed interval until stop is closed.
+func (s *directNeighScanner) run(stop <-chan struct{}) {
+	ticker := time.NewTicker(directNeighScanInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			s.scanOnce()
+		}
+	}
+}
+
+// ebpfDirectNeighStore adapts the pinned direct_neigh map to directNeighStore.
+type ebpfDirectNeighStore struct {
+	m *ebpf.Map
+}
+
+func (s *ebpfDirectNeighStore) forEach(fn func(uint32, directNeighbor) bool) {
+	var key uint32
+	var val directNeighbor
+	iter := s.m.Iterate()
+	for iter.Next(&key, &val) {
+		if !fn(key, val) {
+			return
+		}
+	}
+}
+
+func (s *ebpfDirectNeighStore) update(key uint32, val directNeighbor) error {
+	return s.m.Update(&key, &val, ebpf.UpdateAny)
+}
+
+func (s *ebpfDirectNeighStore) delete(key uint32) error {
+	return s.m.Delete(&key)
+}
+
+// sendUDPTrigger sends a single UDP datagram from the node NIC's source IP to
+// the target. The learning event is the kernel's ARP resolution for the target
+// (and its reply); the L4 payload is irrelevant and no reply is awaited.
+func sendUDPTrigger(nodeIP net.IP) func(uint32) error {
+	return func(targetIP uint32) error {
+		dst := &net.UDPAddr{IP: uint32ToIP(targetIP), Port: directNeighTriggerPort}
+		src := &net.UDPAddr{IP: nodeIP, Port: 0}
+		conn, err := net.DialUDP("udp4", src, dst)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+		_, err = conn.Write([]byte{0})
+		return err
+	}
+}
+
+// StartDirectNeighScanner starts the periodic scanner for direct-mode on-link
+// neighbor resolution. nodeIP is the node NIC IPv4 used as the trigger source.
+// Like StartSessionReaper it owns its own lifecycle and runs for the process
+// lifetime. It is a best-effort driver of kernel neighbor learning; if it is
+// absent the datapath degrades to fib-only resolution plus the gateway
+// fallback, never to a frozen stale MAC.
+func StartDirectNeighScanner(nodeIP net.IP) error {
+	m, err := loadPinnedMap(MapNameDirectNeigh)
+	if err != nil {
+		return fmt.Errorf("loadPinnedMap %s: %w", MapNameDirectNeigh, err)
+	}
+	scanner := newDirectNeighScanner(&ebpfDirectNeighStore{m: m}, sendUDPTrigger(nodeIP), mustCurrentNS)
+	go scanner.run(make(chan struct{})) // never closed: runs for the process lifetime
+	return nil
+}
+
+// mustCurrentNS returns the current CLOCK_MONOTONIC time in ns; on error it
+// falls back to time.Now-based monotonic time. Scan scheduling tolerates the
+// fallback because all comparisons are relative.
+func mustCurrentNS() uint64 {
+	ns, err := currentNS()
+	if err != nil {
+		return uint64(time.Now().UnixNano())
+	}
+	return ns
+}

--- a/CubeNet/cubevs/direct_neigh_scanner.go
+++ b/CubeNet/cubevs/direct_neigh_scanner.go
@@ -15,8 +15,13 @@ package cubevs
 // Field ownership in the shared map entry (see cubevs.h struct direct_neighbor):
 // the datapath writes addr/fib_ok/valid_until_ns/last_used_ns; this scanner
 // writes step/next_attempt_ns/next_refresh_ns. A lost read-modify-write race on
-// either side only delays a trigger or an activity timestamp by one scan cycle;
-// it can never produce a wrong MAC, so it is benign and self-healing.
+// either side is bounded and self-healing: it can delay a trigger or an
+// activity timestamp by a scan cycle, and — because this scanner writes back
+// the whole value — it can transiently resurrect a MAC the datapath had just
+// invalidated (for at most the leftover valid_until, ≤ CACHE_TTL), before the
+// next datapath fib refresh corrects it. That stays within the documented
+// "cache staleness ≤ CACHE_TTL" failure model, so it is accepted, but it is not
+// strictly "never a wrong MAC".
 
 import (
 	"fmt"
@@ -39,10 +44,6 @@ type directNeighbor struct {
 	LastUsedNs    uint64
 	NextAttemptNs uint64
 	NextRefreshNs uint64
-}
-
-func (n *directNeighbor) macZero() bool {
-	return n.Addr == ([6]uint8{})
 }
 
 // Scanner tuning. All durations are in nanoseconds to match the datapath's
@@ -191,21 +192,21 @@ func (s *ebpfDirectNeighStore) delete(key uint32) error {
 	return s.m.Delete(&key)
 }
 
-// sendUDPTrigger sends a single UDP datagram from the node NIC's source IP to
-// the target. The learning event is the kernel's ARP resolution for the target
-// (and its reply); the L4 payload is irrelevant and no reply is awaited.
-func sendUDPTrigger(nodeIP net.IP) func(uint32) error {
+// sendUDPTrigger returns a trigger sender that shares one long-lived UDP socket
+// bound to the node NIC's source IP, using WriteToUDP per target. This avoids a
+// DialUDP+Close cycle per trigger at the token-bucket ceiling. The learning
+// event is the kernel's ARP resolution for the target (and its reply); the L4
+// payload is irrelevant and no reply is awaited.
+func sendUDPTrigger(nodeIP net.IP) (func(uint32) error, error) {
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: nodeIP, Port: 0})
+	if err != nil {
+		return nil, err
+	}
 	return func(targetIP uint32) error {
 		dst := &net.UDPAddr{IP: uint32ToIP(targetIP), Port: directNeighTriggerPort}
-		src := &net.UDPAddr{IP: nodeIP, Port: 0}
-		conn, err := net.DialUDP("udp4", src, dst)
-		if err != nil {
-			return err
-		}
-		defer conn.Close()
-		_, err = conn.Write([]byte{0})
+		_, err := conn.WriteToUDP([]byte{0}, dst)
 		return err
-	}
+	}, nil
 }
 
 // StartDirectNeighScanner starts the periodic scanner for direct-mode on-link
@@ -219,7 +220,11 @@ func StartDirectNeighScanner(nodeIP net.IP) error {
 	if err != nil {
 		return fmt.Errorf("loadPinnedMap %s: %w", MapNameDirectNeigh, err)
 	}
-	scanner := newDirectNeighScanner(&ebpfDirectNeighStore{m: m}, sendUDPTrigger(nodeIP), mustCurrentNS)
+	trigger, err := sendUDPTrigger(nodeIP)
+	if err != nil {
+		return fmt.Errorf("sendUDPTrigger: %w", err)
+	}
+	scanner := newDirectNeighScanner(&ebpfDirectNeighStore{m: m}, trigger, mustCurrentNS)
 	go scanner.run(make(chan struct{})) // never closed: runs for the process lifetime
 	return nil
 }

--- a/CubeNet/cubevs/direct_neigh_scanner_test.go
+++ b/CubeNet/cubevs/direct_neigh_scanner_test.go
@@ -1,0 +1,179 @@
+package cubevs
+
+import (
+	"sort"
+	"testing"
+)
+
+// fakeNeighStore is an in-memory directNeighStore for scanner unit tests.
+type fakeNeighStore struct {
+	entries map[uint32]directNeighbor
+}
+
+func newFakeNeighStore() *fakeNeighStore {
+	return &fakeNeighStore{entries: map[uint32]directNeighbor{}}
+}
+
+func (f *fakeNeighStore) forEach(fn func(uint32, directNeighbor) bool) {
+	keys := make([]uint32, 0, len(f.entries))
+	for k := range f.entries {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	for _, k := range keys {
+		if !fn(k, f.entries[k]) {
+			return
+		}
+	}
+}
+
+func (f *fakeNeighStore) update(key uint32, val directNeighbor) error {
+	f.entries[key] = val
+	return nil
+}
+
+func (f *fakeNeighStore) delete(key uint32) error {
+	delete(f.entries, key)
+	return nil
+}
+
+type scannerFixture struct {
+	store     *fakeNeighStore
+	scanner   *directNeighScanner
+	triggered []uint32
+	nowNs     uint64
+}
+
+func newScannerFixture() *scannerFixture {
+	fx := &scannerFixture{store: newFakeNeighStore()}
+	fx.scanner = newDirectNeighScanner(fx.store, func(ip uint32) error {
+		fx.triggered = append(fx.triggered, ip)
+		return nil
+	}, func() uint64 { return fx.nowNs })
+	return fx
+}
+
+func (fx *scannerFixture) scan() { fx.scanner.scanOnce() }
+
+func (fx *scannerFixture) add(key uint32, val directNeighbor) { fx.store.entries[key] = val }
+
+func TestScannerLearningBackoffSequenceAndCap(t *testing.T) {
+	fx := newScannerFixture()
+	fx.add(0x0a000001, directNeighbor{LastUsedNs: 0, FibOk: 0})
+
+	// t=0: first trigger fires immediately, backoff = 1s.
+	fx.scan()
+	if len(fx.triggered) != 1 {
+		t.Fatalf("first scan must trigger once, got %d", len(fx.triggered))
+	}
+	e := fx.store.entries[0x0a000001]
+	if e.Step != 1 || e.NextAttemptNs != 0+directNeighBackoffBaseNs {
+		t.Fatalf("after first trigger step=%d next=%d, want step=1 next=1s", e.Step, e.NextAttemptNs)
+	}
+
+	// t=0.5s: not yet due.
+	fx.nowNs = directNeighBackoffBaseNs / 2
+	fx.scan()
+	if len(fx.triggered) != 1 {
+		t.Fatalf("early scan must not trigger, got %d", len(fx.triggered))
+	}
+
+	// Walk the backoff: the immediate first trigger scheduled +1s (asserted
+	// above); subsequent intervals are 2s, 4s, 8s, then capped at 16s.
+	wantBackoffs := []uint64{2, 4, 8, 16, 16, 16}
+	prev := fx.store.entries[0x0a000001].NextAttemptNs
+	for i, wantSec := range wantBackoffs {
+		fx.nowNs = prev // exactly when due
+		fx.scan()
+		e = fx.store.entries[0x0a000001]
+		got := (e.NextAttemptNs - prev) / 1e9
+		if got != wantSec {
+			t.Fatalf("step %d: backoff=%ds, want %ds", i, got, wantSec)
+		}
+		prev = e.NextAttemptNs
+	}
+}
+
+func TestScannerLearnedEntrySwitchesToKeepalive(t *testing.T) {
+	fx := newScannerFixture()
+	// A learning entry that just resolved (datapath set fib_ok=1 mid-backoff).
+	fx.add(0x0a000002, directNeighbor{
+		LastUsedNs:    0,
+		FibOk:         1,
+		Step:          3,
+		NextRefreshNs: 0,
+	})
+
+	fx.scan()
+	e := fx.store.entries[0x0a000002]
+	if e.Step != 0 {
+		t.Fatalf("learned entry must reset step, got %d", e.Step)
+	}
+	if len(fx.triggered) != 1 {
+		t.Fatalf("keepalive must fire when next_refresh due, got %d", len(fx.triggered))
+	}
+	if e.NextRefreshNs != fx.nowNs+directNeighRefreshNs {
+		t.Fatalf("next_refresh=%d, want now+16s", e.NextRefreshNs)
+	}
+
+	// Next scan before the refresh period: no new trigger.
+	fx.nowNs = directNeighRefreshNs / 2
+	fx.scan()
+	if len(fx.triggered) != 1 {
+		t.Fatalf("keepalive must not fire before the refresh period, got %d", len(fx.triggered))
+	}
+}
+
+func TestScannerGarbageCollectsIdle(t *testing.T) {
+	fx := newScannerFixture()
+	// Active entry (recently used) must survive; idle entry must be GC'd.
+	fx.nowNs = 100 * 1e9
+	fx.add(0x0a000003, directNeighbor{LastUsedNs: fx.nowNs, FibOk: 1})                  // active
+	fx.add(0x0a000004, directNeighbor{LastUsedNs: fx.nowNs - directNeighGCAfterNs - 1}) // idle
+
+	fx.scan()
+	if _, ok := fx.store.entries[0x0a000003]; !ok {
+		t.Fatal("active entry must not be GC'd")
+	}
+	if _, ok := fx.store.entries[0x0a000004]; ok {
+		t.Fatal("idle entry must be GC'd")
+	}
+	// The GC'd entry gets no trigger.
+	for _, ip := range fx.triggered {
+		if ip == 0x0a000004 {
+			t.Fatal("GC'd entry must not be triggered")
+		}
+	}
+}
+
+func TestScannerTokenBucketLimitsTriggers(t *testing.T) {
+	fx := newScannerFixture()
+	// More unlearned, all-due entries than the token bucket allows in one scan.
+	const n = directNeighTriggerBurst + 50
+	for i := 0; i < n; i++ {
+		fx.add(0x0a000100+uint32(i), directNeighbor{LastUsedNs: 0, FibOk: 0})
+	}
+	fx.scan()
+	if len(fx.triggered) > directNeighTriggerBurst {
+		t.Fatalf("token bucket must cap triggers at %d, got %d",
+			directNeighTriggerBurst, len(fx.triggered))
+	}
+	if len(fx.triggered) == 0 {
+		t.Fatal("at least some triggers must fire")
+	}
+}
+
+func TestScannerSkipsTriggerWhenNotDue(t *testing.T) {
+	fx := newScannerFixture()
+	// Learning entry not yet due for its next attempt.
+	fx.add(0x0a000005, directNeighbor{
+		LastUsedNs:    0,
+		FibOk:         0,
+		NextAttemptNs: 10 * 1e9, // due at t=10s
+	})
+	fx.nowNs = 5 * 1e9
+	fx.scan()
+	if len(fx.triggered) != 0 {
+		t.Fatalf("must not trigger before next_attempt, got %d", len(fx.triggered))
+	}
+}

--- a/CubeNet/cubevs/miscs.go
+++ b/CubeNet/cubevs/miscs.go
@@ -324,6 +324,10 @@ func Init(params Params) (retErr error) {
 	_ = os.Remove(pinPath("tungrp_to_tuns")) // NOCC:Path Traversal()
 	// dns_query_track is runtime pending-query state, not persisted policy.
 	_ = os.Remove(pinPath(MapNameDNSQueryTrack)) // NOCC:Path Traversal()
+	// direct_neigh is runtime neighbor trigger/cache state; its content is
+	// re-learned from the kernel neighbor table via fib, so always start from a
+	// fresh map. This also drops any stale pin with a different value size.
+	_ = os.Remove(pinPath(MapNameDirectNeigh)) // NOCC:Path Traversal()
 
 	err = loadObject(params, loadLocalgw, "loadLocalgw")
 	if err != nil {

--- a/CubeNet/docs/direct-neighbor-resolution.md
+++ b/CubeNet/docs/direct-neighbor-resolution.md
@@ -1,0 +1,101 @@
+# Direct-mode on-link neighbor resolution (scan-driven)
+
+In **direct mode** (no cube-router, `EgressRedirectFlags == 0`), a sandbox may
+egress to a destination that is on the node NIC's own L2 link (on-link). The
+datapath needs the destination's MAC. This document describes how that is
+resolved after the rework that followed PR #1321.
+
+## Design rule
+
+**The kernel neighbor table is the only source of truth for the MAC.** Neither
+the datapath nor userspace fabricates ARP packets, mirrors the neighbor table,
+or subscribes to netlink events. The split of responsibility is:
+
+- **Datapath** (`mvmtap.bpf.c` `prepare_egress_l2`): only *reports* state — it
+  runs `bpf_fib_lookup`, records the result, and *always forwards the packet*.
+- **Userspace scanner** (`cubevs/direct_neigh_scanner.go`): owns all
+  *scheduling* — when to trigger kernel neighbor learning, when to keepalive,
+  when to garbage-collect.
+
+## Datapath behavior (`prepare_egress_l2`)
+
+For an on-link destination, in order:
+
+1. **Positive cache hit** — `direct_neigh[daddr]` has a MAC and `now <
+   valid_until_ns`: use the cached MAC, no fib lookup. `valid_until_ns` is
+   *never* renewed on a hit (iron rule: a cache entry lives at most
+   `CACHE_TTL` before being re-checked against the kernel).
+2. **Negative cache hit** — `valid_until_ns` fresh but MAC is zero (a recent
+   fib failure): skip the fib lookup, use the gateway MAC (fallback).
+3. **Expired / never resolved** — run `bpf_fib_lookup(DIRECT|OUTPUT)`:
+   - success (route out the node NIC): cache `fib.dmac` with
+     `valid_until_ns = now + CACHE_TTL`, set `fib_ok = 1`, use it;
+   - failure: invalidate the cache (MAC = 0, short `NEG_TTL`), set `fib_ok = 0`,
+     use the gateway MAC (**fallback — the packet is never dropped**).
+
+`last_used_ns` is refreshed at 1s granularity to bound map-write pressure on
+high-pps flows.
+
+**Off-link** destinations are untouched: the static gateway MAC pair, as before.
+
+## Userspace scanner
+
+A per-process goroutine (`StartDirectNeighScanner`) walks `direct_neigh` every
+`SCAN_INTERVAL` and per entry:
+
+- **GC**: `now - last_used_ns > GC_AFTER` → delete (traffic stopped; stop all
+  triggering).
+- **`fib_ok == 0`** (not yet learned): if `next_attempt_ns` is due, send a UDP
+  trigger and schedule the next attempt with exponential backoff (1s, 2s, 4s,
+  8s, 16s cap).
+- **`fib_ok == 1`** (learned): reset backoff, and every `REFRESH_INTERVAL` send
+  a keepalive trigger so the kernel re-validates the neighbor (drives NUD).
+
+Trigger sends are rate-limited by a global token bucket
+(`directNeighTriggerPerSec`) so a sandbox scanning a subnet cannot amplify into
+node-level probing.
+
+`send_udp_trigger` sends one UDP datagram from the node NIC's source IP to the
+target. The learning event is the kernel's own ARP request/reply for the target
+— independent of L4 — so no reply is awaited.
+
+## Failure model (correctness depends on the scanner)
+
+The scanner is in the correctness path only for *learning*; it never serves a
+MAC itself.
+
+| Scenario | Behavior |
+|---|---|
+| New on-link dest, hairpin network | Gateway fallback delivers immediately (zero loss); switch to direct MAC once learned. |
+| New on-link dest, non-hairpin | Bounded blackhole (≤ scan interval + ARP RTT), then converges. |
+| Learned dest, MAC changes silently | Keepalive (≤16s) → kernel NUD re-validates → fib serves the new MAC; cache staleness ≤ CACHE_TTL. |
+| Dest dead | fib keeps failing → negative cache (1s) + gateway fallback; scanner backs off to 1 probe/16s. |
+| Scanner process restarts | No persisted state to restore; the map is rebuilt fresh; the datapath keeps serving via fib + fallback. |
+| Scanner down long-term | Data plane re-freshes from fib at least every `CACHE_TTL`; new destinations in a non-hairpin network degrade to the pre-#1321 behaviour (never a frozen stale MAC). |
+| Policy-routed NIC (fib ifindex mismatch) | Treated as unresolvable: gateway fallback, no trigger. |
+
+## Parameters
+
+| Parameter | Value | Notes |
+|---|---|---|
+| `SCAN_INTERVAL` | 200–500 ms | Main term in cold-destination learning latency. |
+| learning backoff | immediate, 1s→16s cap | Dead target steady-state = 1 probe/16s. |
+| `REFRESH_INTERVAL` | 16 s | Drives kernel NUD re-validation. |
+| `CACHE_TTL` | 4 s | fib-result positive-cache lifetime; ≪ keepalive period so the cache is re-validated against the kernel at least once per cycle. |
+| `NEG_TTL` | 1 s | Negative-cache lifetime after a fib failure. |
+| `GC_AFTER` | 5 min | Idle entries are reclaimed. |
+| trigger token bucket | 100/s | Anti-scan-amplification. |
+| map capacity | 8192 LRU | Eviction → untracked (pure gateway fallback), still correct. |
+
+## Migration from PR #1321
+
+- The in-BPF ARP construction (`direct_egress_arp_request` + padding clear) and
+  the `from_world` ARP learning (`learn_direct_neighbor`) are removed.
+- `direct_neigh` changes from `{MAC, next_probe_at_ns}` to the trigger/cache
+  struct above. Its content is disposable (re-learned via fib), so `Init`
+  removes any stale pin before loading (this also drops a stale pin whose value
+  size differs from the new struct).
+- fib-first is retained and is now the only way a MAC is obtained.
+- The gateway fallback is extended from off-link to on-link-unresolved, replacing
+  the previous drop/probe behaviour. **First-packet loss and the 5-minute
+  sacrifice packet are eliminated.**

--- a/CubeNet/docs/direct-neighbor-resolution.md
+++ b/CubeNet/docs/direct-neighbor-resolution.md
@@ -67,7 +67,7 @@ MAC itself.
 | Scenario | Behavior |
 |---|---|
 | New on-link dest, hairpin network | Gateway fallback delivers immediately (zero loss); switch to direct MAC once learned. |
-| New on-link dest, non-hairpin | Bounded blackhole (≤ scan interval + ARP RTT), then converges. |
+| New on-link dest, non-hairpin | Bounded blackhole (≤ scan interval + ARP RTT + NEG_TTL — a fresh negative cache can suppress the fib refresh for up to NEG_TTL after the kernel learns the neighbor), then converges. |
 | Learned dest, MAC changes silently | Keepalive (≤16s) → kernel NUD re-validates → fib serves the new MAC; cache staleness ≤ CACHE_TTL. |
 | Dest dead | fib keeps failing → negative cache (1s) + gateway fallback; scanner backs off to 1 probe/16s. |
 | Scanner process restarts | No persisted state to restore; the map is rebuilt fresh; the datapath keeps serving via fib + fallback. |

--- a/CubeNet/src/cubevs.h
+++ b/CubeNet/src/cubevs.h
@@ -79,8 +79,16 @@ const volatile __u32 cube_l7_mark_mask = 0xFFFF0000u;
 const volatile __u32 cube_l7_mark_http = 0xCE010000u;
 const volatile __u32 cube_l7_mark_https = 0xCE020000u;
 #define DNS_QUERY_TRACK_TTL_NS		(10ULL * NSEC_PER_SEC)
-#define DIRECT_NEIGH_PROBE_INTERVAL_NS		(1ULL * NSEC_PER_SEC)
-#define DIRECT_NEIGH_REVALIDATE_INTERVAL_NS	(5ULL * 60 * NSEC_PER_SEC)
+/* Positive cache lifetime for a fib-learned neighbor MAC. Must be well below
+ * the userspace keepalive period (16s) so the cache is re-validated against the
+ * kernel neighbor table at least once per keepalive cycle. */
+#define DIRECT_NEIGH_CACHE_TTL_NS		(4ULL * NSEC_PER_SEC)
+/* Negative cache lifetime after a fib failure, so a dead destination does not
+ * trigger a fib lookup on every packet. */
+#define DIRECT_NEIGH_NEG_TTL_NS			(1ULL * NSEC_PER_SEC)
+/* Minimum interval between last_used_ns writes, bounding map-write pressure on
+ * high-pps flows. */
+#define DIRECT_NEIGH_TOUCH_THROTTLE_NS		(1ULL * NSEC_PER_SEC)
 
 /* https://en.wikipedia.org/wiki/IPv4#Header
  *
@@ -173,15 +181,24 @@ struct arphdr_eth {
 	__be32 ar_tip;			/* target IP address */
 } __attribute__((packed));
 
-struct arp_packet {
-	struct ethhdr eth;
-	struct arphdr_eth arp;
-} __attribute__((packed));
-
+/* Direct-egress on-link neighbor trigger/cache entry.
+ *
+ * The kernel neighbor table is the only source of truth for the MAC; this entry
+ * is a TTL-bounded cache of the last bpf_fib_lookup() result plus the trigger
+ * state the userspace scanner schedules against. Field ownership:
+ *   BPF datapath writes: addr, fib_ok, valid_until_ns, last_used_ns
+ *   userspace scanner writes: step, next_attempt_ns, next_refresh_ns
+ */
 struct direct_neighbor {
-	unsigned char addr[ETH_ALEN];
-	__u16 reserved;
-	__u64 next_probe_at_ns;
+	unsigned char addr[ETH_ALEN];	/* cached MAC; all-zero = no valid cache */
+	__u8	fib_ok;			/* last fib lookup result (1=learned) */
+	__u8	step;			/* scanner: backoff level */
+	__u16	flags;
+	__u32	reserved;
+	__u64	valid_until_ns;	/* cache expiry; written only on fib success/failure, never renewed on hit */
+	__u64	last_used_ns;		/* last packet time (1s write throttle) */
+	__u64	next_attempt_ns;	/* scanner: next learning-trigger time */
+	__u64	next_refresh_ns;	/* scanner: next keepalive-trigger time */
 };
 
 union macaddr {

--- a/CubeNet/src/map.h
+++ b/CubeNet/src/map.h
@@ -96,11 +96,14 @@ struct {
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } snat_iplist SEC(".maps");
 
-/* Direct-egress on-link neighbor cache.
+/* Direct-egress on-link neighbor trigger/cache.
  *
  * key:   destination IPv4 address in packet-byte layout
- * value: destination MAC plus probe deadline; an all-zero MAC means initial
- *        resolution is pending
+ * value: struct direct_neighbor — a TTL-bounded cache of the last
+ *        bpf_fib_lookup() result (MAC + valid_until + fib_ok + last_used) plus
+ *        the userspace scanner's trigger scheduling fields (step +
+ *        next_attempt/next_refresh). The MAC always comes from fib; this map
+ *        only caches it briefly and drives scanner scheduling.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -120,80 +120,22 @@ static __always_inline bool direct_neighbor_is_zero(const struct direct_neighbor
 	return macaddr->p1 == 0 && macaddr->p2 == 0;
 }
 
-#define DIRECT_ARP_PRESERVED_LEN	96
-#define DIRECT_ARP_HEADROOM	32
-#define DIRECT_ARP_FRAME_LEN		(DIRECT_ARP_PRESERVED_LEN + DIRECT_ARP_HEADROOM)
-#define DIRECT_ARP_ZERO_CHUNK_LEN	32
-
-static __always_inline long direct_egress_clear_arp_padding(struct __sk_buff *skb)
-{
-	unsigned char zeroes[DIRECT_ARP_ZERO_CHUNK_LEN] = {};
-	long err;
-
-	err = bpf_skb_store_bytes(skb, sizeof(struct arp_packet),
-				  zeroes, sizeof(zeroes), 0);
-	if (err)
-		return err;
-	err = bpf_skb_store_bytes(skb,
-				  sizeof(struct arp_packet) + DIRECT_ARP_ZERO_CHUNK_LEN,
-				  zeroes, sizeof(zeroes), 0);
-	if (err)
-		return err;
-	return bpf_skb_store_bytes(skb,
-				   sizeof(struct arp_packet) + 2 * DIRECT_ARP_ZERO_CHUNK_LEN,
-				   zeroes,
-				   DIRECT_ARP_FRAME_LEN - sizeof(struct arp_packet) -
-				   2 * DIRECT_ARP_ZERO_CHUNK_LEN, 0);
-}
-
-static __always_inline long direct_egress_arp_request(struct __sk_buff *skb, __u32 daddr)
-{
-	struct arp_packet packet = {};
-	union macaddr *macaddr;
-	long err;
-
-	__builtin_memset(packet.eth.h_dest, 0xff, ETH_ALEN);
-	macaddr = (union macaddr *)packet.eth.h_source;
-	macaddr->p1 = nodenic_macaddr_p1;
-	macaddr->p2 = nodenic_macaddr_p2;
-	packet.eth.h_proto = bpf_htons(ETH_P_ARP);
-
-	packet.arp.ar_hrd = bpf_htons(ARPHRD_ETHER);
-	packet.arp.ar_pro = bpf_htons(ETH_P_IP);
-	packet.arp.ar_hln = ETH_ALEN;
-	packet.arp.ar_pln = sizeof(__be32);
-	packet.arp.ar_op = bpf_htons(ARPOP_REQUEST);
-	macaddr = (union macaddr *)packet.arp.ar_sha;
-	macaddr->p1 = nodenic_macaddr_p1;
-	macaddr->p2 = nodenic_macaddr_p2;
-	packet.arp.ar_sip = nodenic_ip;
-	packet.arp.ar_tip = daddr;
-
-	/* CHECKSUM_PARTIAL can write L4 csum after we return.
-	 * change_tail will not shrink below that write (min_len).
-	 * change_head(32) moves it past ARP. Then store ARP and zero the rest.
-	 */
-	err = bpf_skb_change_tail(skb, DIRECT_ARP_PRESERVED_LEN, 0);
-	if (err)
-		return TC_ACT_SHOT;
-	err = bpf_skb_change_head(skb, DIRECT_ARP_HEADROOM, 0);
-	if (err)
-		return TC_ACT_SHOT;
-	err = bpf_skb_store_bytes(skb, 0, &packet, sizeof(packet), 0);
-	if (err)
-		return TC_ACT_SHOT;
-	err = direct_egress_clear_arp_padding(skb);
-	if (err)
-		return TC_ACT_SHOT;
-
-	return 0;
-}
-
-#define EGRESS_MAC_DROP		(-1)
 #define EGRESS_MAC_READY	0
-#define EGRESS_MAC_PROBE	1
 
-/* READY: L2 rewritten. PROBE: skb is now an ARP request. DROP: wait. */
+/* Resolve the external L2 addresses for an on-link direct-egress destination.
+ *
+ * The kernel neighbor table is the only source of truth for the MAC:
+ *   - a fresh positive entry in direct_neigh is used as-is (no fib lookup);
+ *   - a fresh negative entry (recent fib failure) skips fib and falls back;
+ *   - otherwise bpf_fib_lookup() refreshes the cache, and on failure the cache
+ *     is invalidated and the gateway MAC is used as a fallback.
+ *
+ * There is no packet drop or packet-into-ARP conversion: an unresolved on-link
+ * destination is forwarded to the gateway (zero loss on hairpin networks; a
+ * bounded blackhole elsewhere until the scanner's trigger makes the kernel ARP
+ * resolve and the next fib refresh caches the MAC). Always returns
+ * EGRESS_MAC_READY.
+ */
 static __always_inline int prepare_egress_l2(struct __sk_buff *skb,
 					     struct ethhdr *l2, __u32 daddr)
 {
@@ -205,9 +147,7 @@ static __always_inline int prepare_egress_l2(struct __sk_buff *skb,
 	};
 	struct direct_neighbor pending = {};
 	struct direct_neighbor *neighbor;
-	union macaddr *neighbor_mac;
-	const union macaddr *dmac;
-	const union macaddr *smac;
+	union macaddr *mac;
 	__u64 now;
 	long err;
 
@@ -217,41 +157,65 @@ static __always_inline int prepare_egress_l2(struct __sk_buff *skb,
 		return EGRESS_MAC_READY;
 	}
 
-	err = bpf_fib_lookup(skb, &fib, sizeof(fib),
-			     BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
-	if (err == BPF_FIB_LKUP_RET_SUCCESS && fib.ifindex == nodenic_ifindex) {
-		smac = (const union macaddr *)fib.smac;
-		dmac = (const union macaddr *)fib.dmac;
-		set_mac_pair(l2, smac->p1, smac->p2, dmac->p1, dmac->p2);
+	now = bpf_ktime_get_ns();
+	neighbor = bpf_map_lookup_elem(&direct_neigh, &daddr);
+	if (!neighbor) {
+		/* Untracked destination: only register for the scanner, never
+		 * disturb its scheduling fields. */
+		bpf_map_update_elem(&direct_neigh, &daddr, &pending, BPF_NOEXIST);
+		neighbor = bpf_map_lookup_elem(&direct_neigh, &daddr);
+	}
+	if (!neighbor) {
+		/* Map full or vanished: untracked, pure gateway fallback. */
+		set_mac_pair(l2, egress_smacaddr_p1, egress_smacaddr_p2,
+			     egress_dmacaddr_p1, egress_dmacaddr_p2);
 		return EGRESS_MAC_READY;
 	}
 
-	now = bpf_ktime_get_ns();
-	neighbor = bpf_map_lookup_elem(&direct_neigh, &daddr);
-	if (neighbor) {
-		if (neighbor->next_probe_at_ns > now) {
-			if (!direct_neighbor_is_zero(neighbor))
-				goto set_neighbor;
-			return EGRESS_MAC_DROP;
+	if (now < neighbor->valid_until_ns) {
+		if (!direct_neighbor_is_zero(neighbor)) {
+			/* Positive cache hit: use the cached MAC, no fib. */
+			mac = (union macaddr *)neighbor->addr;
+			set_mac_pair(l2, nodenic_macaddr_p1, nodenic_macaddr_p2,
+				     mac->p1, mac->p2);
+		} else {
+			/* Negative cache hit (recent fib failure): skip fib. */
+			set_mac_pair(l2, egress_smacaddr_p1, egress_smacaddr_p2,
+				     egress_dmacaddr_p1, egress_dmacaddr_p2);
 		}
-
-		/* A concurrent learn may make this probe redundant, which is harmless. */
-		neighbor->next_probe_at_ns = now + DIRECT_NEIGH_PROBE_INTERVAL_NS;
 	} else {
-		pending.next_probe_at_ns = now + DIRECT_NEIGH_PROBE_INTERVAL_NS;
-		err = bpf_map_update_elem(&direct_neigh, &daddr, &pending, BPF_NOEXIST);
-		if (err)
-			return EGRESS_MAC_DROP;
+		err = bpf_fib_lookup(skb, &fib, sizeof(fib),
+				     BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
+		if (err == BPF_FIB_LKUP_RET_SUCCESS &&
+		    fib.ifindex == nodenic_ifindex) {
+			const union macaddr *dmac = (const union macaddr *)fib.dmac;
+			const union macaddr *smac = (const union macaddr *)fib.smac;
+
+			/* Cache the MAC; valid_until is written ONLY on a fib
+			 * result, never renewed on a cache hit. */
+			mac = (union macaddr *)neighbor->addr;
+			mac->p1 = dmac->p1;
+			mac->p2 = dmac->p2;
+			neighbor->valid_until_ns = now + DIRECT_NEIGH_CACHE_TTL_NS;
+			neighbor->fib_ok = 1;
+			set_mac_pair(l2, smac->p1, smac->p2, dmac->p1, dmac->p2);
+		} else {
+			/* Invalidate the cache and fall back to the gateway. A
+			 * short negative TTL keeps a dead destination from
+			 * triggering a fib lookup on every packet. */
+			mac = (union macaddr *)neighbor->addr;
+			mac->p1 = 0;
+			mac->p2 = 0;
+			neighbor->valid_until_ns = now + DIRECT_NEIGH_NEG_TTL_NS;
+			neighbor->fib_ok = 0;
+			set_mac_pair(l2, egress_smacaddr_p1, egress_smacaddr_p2,
+				     egress_dmacaddr_p1, egress_dmacaddr_p2);
+		}
 	}
 
-	if (direct_egress_arp_request(skb, daddr))
-		return EGRESS_MAC_DROP;
-	return EGRESS_MAC_PROBE;
-
-set_neighbor:
-	neighbor_mac = (union macaddr *)neighbor->addr;
-	set_mac_pair(l2, nodenic_macaddr_p1, nodenic_macaddr_p2,
-		     neighbor_mac->p1, neighbor_mac->p2);
+	/* Throttle last_used writes to 1s granularity; never renew valid_until. */
+	if (now > neighbor->last_used_ns + DIRECT_NEIGH_TOUCH_THROTTLE_NS)
+		neighbor->last_used_ns = now;
 	return EGRESS_MAC_READY;
 }
 
@@ -264,7 +228,6 @@ set_neighbor:
 enum tcp_nat_result {
 	TCP_NAT_DROP = 0,
 	TCP_NAT_OK,
-	TCP_NAT_PROBE,
 	TCP_NAT_RESET,
 	TCP_L7PROXY_OK,
 };
@@ -843,7 +806,6 @@ static __always_inline __u64 do_tcp_nat(struct __sk_buff *skb, struct mvm_meta *
 	__u8 l7_scheme = L7_SCHEME_NONE;
 	__u8 verdict = FLOW_SNAT;
 	bool create_snat = false;
-	int mac_result;
 	long err;
 	bool ok;
 
@@ -972,14 +934,9 @@ do_update:
 
 prepare_snat:
 	/* Resolve external L2 before allocating or mutating TCP session state.
-	 * A cold miss consumes this packet as an ARP probe, so the original TCP
-	 * packet must remain untouched and a new session must not be installed.
-	 */
-	mac_result = prepare_egress_l2(skb, l2, key.dst_ip);
-	if (mac_result == EGRESS_MAC_DROP)
-		return TCP_NAT_DROP;
-	if (mac_result == EGRESS_MAC_PROBE)
-		return TCP_NAT_PACK(nodenic_ifindex, TCP_NAT_PROBE);
+	 * prepare_egress_l2 never drops the packet (unresolved on-link falls back
+	 * to the gateway MAC), so session state can be installed right after. */
+	prepare_egress_l2(skb, l2, key.dst_ip);
 
 	if (create_snat) {
 		snat_ip = pick_snat_ip_port(mvm_meta->ip, &key, &snat_port);
@@ -1173,7 +1130,6 @@ int from_cube(struct __sk_buff *skb)
 	struct iphdr *l3;
 	struct tcphdr *l4;
 	struct udphdr *udp;
-	int mac_result;
 	__u16 *host_port;
 	__u32 dns_off;
 	__u8 proto;
@@ -1281,8 +1237,6 @@ int from_cube(struct __sk_buff *skb)
 		tcp_ret = do_tcp_nat(skb, mvm_meta);
 		if (TCP_NAT_STATUS(tcp_ret) == TCP_NAT_OK)
 			return bpf_redirect(TCP_NAT_IFINDEX(tcp_ret), egress_redirect_flags);
-		if (TCP_NAT_STATUS(tcp_ret) == TCP_NAT_PROBE)
-			return bpf_redirect(TCP_NAT_IFINDEX(tcp_ret), 0);
 		if (TCP_NAT_STATUS(tcp_ret) == TCP_L7PROXY_OK)
 			return bpf_redirect(TCP_NAT_IFINDEX(tcp_ret), BPF_F_INGRESS);
 		if (TCP_NAT_STATUS(tcp_ret) == TCP_NAT_RESET)
@@ -1290,11 +1244,9 @@ int from_cube(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
-	mac_result = prepare_egress_l2(skb, l2, daddr);
-	if (mac_result == EGRESS_MAC_DROP)
-		return TC_ACT_SHOT;
-	if (mac_result == EGRESS_MAC_PROBE)
-		return bpf_redirect(nodenic_ifindex, 0);
+	/* Unresolved on-link destinations fall back to the gateway MAC inside
+	 * prepare_egress_l2 (no drop/probe), so the packet always forwards. */
+	prepare_egress_l2(skb, l2, daddr);
 
 	if (proto == IPPROTO_UDP) {
 		if (!__pull_headers_udp(skb, &l2, &l3, &udp))

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -161,7 +161,11 @@ static __always_inline int prepare_egress_l2(struct __sk_buff *skb,
 	neighbor = bpf_map_lookup_elem(&direct_neigh, &daddr);
 	if (!neighbor) {
 		/* Untracked destination: only register for the scanner, never
-		 * disturb its scheduling fields. */
+		 * disturb its scheduling fields. Seed last_used_ns so the
+		 * scanner's GC (idle > GC_AFTER) never reclaims a freshly
+		 * created entry in the window before the end-of-function
+		 * touch, while the datapath still holds its pointer. */
+		pending.last_used_ns = now;
 		bpf_map_update_elem(&direct_neigh, &daddr, &pending, BPF_NOEXIST);
 		neighbor = bpf_map_lookup_elem(&direct_neigh, &daddr);
 	}

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -120,8 +120,6 @@ static __always_inline bool direct_neighbor_is_zero(const struct direct_neighbor
 	return macaddr->p1 == 0 && macaddr->p2 == 0;
 }
 
-#define EGRESS_MAC_READY	0
-
 /* Resolve the external L2 addresses for an on-link direct-egress destination.
  *
  * The kernel neighbor table is the only source of truth for the MAC:
@@ -133,11 +131,11 @@ static __always_inline bool direct_neighbor_is_zero(const struct direct_neighbor
  * There is no packet drop or packet-into-ARP conversion: an unresolved on-link
  * destination is forwarded to the gateway (zero loss on hairpin networks; a
  * bounded blackhole elsewhere until the scanner's trigger makes the kernel ARP
- * resolve and the next fib refresh caches the MAC). Always returns
- * EGRESS_MAC_READY.
+ * resolve and the next fib refresh caches the MAC). It only rewrites the skb's
+ * L2 addresses; the packet is always forwarded.
  */
-static __always_inline int prepare_egress_l2(struct __sk_buff *skb,
-					     struct ethhdr *l2, __u32 daddr)
+static __always_inline void prepare_egress_l2(struct __sk_buff *skb,
+					      struct ethhdr *l2, __u32 daddr)
 {
 	struct bpf_fib_lookup fib = {
 		.family = AF_INET,
@@ -154,7 +152,7 @@ static __always_inline int prepare_egress_l2(struct __sk_buff *skb,
 	if (!direct_egress_is_onlink(daddr)) {
 		set_mac_pair(l2, egress_smacaddr_p1, egress_smacaddr_p2,
 			     egress_dmacaddr_p1, egress_dmacaddr_p2);
-		return EGRESS_MAC_READY;
+		return;
 	}
 
 	now = bpf_ktime_get_ns();
@@ -173,7 +171,7 @@ static __always_inline int prepare_egress_l2(struct __sk_buff *skb,
 		/* Map full or vanished: untracked, pure gateway fallback. */
 		set_mac_pair(l2, egress_smacaddr_p1, egress_smacaddr_p2,
 			     egress_dmacaddr_p1, egress_dmacaddr_p2);
-		return EGRESS_MAC_READY;
+		return;
 	}
 
 	if (now < neighbor->valid_until_ns) {
@@ -220,7 +218,6 @@ static __always_inline int prepare_egress_l2(struct __sk_buff *skb,
 	/* Throttle last_used writes to 1s granularity; never renew valid_until. */
 	if (now > neighbor->last_used_ns + DIRECT_NEIGH_TOUCH_THROTTLE_NS)
 		neighbor->last_used_ns = now;
-	return EGRESS_MAC_READY;
 }
 
 /* Egress flow classification now lives in classify_egress_flow() (session.h),

--- a/CubeNet/src/nodenic.bpf.c
+++ b/CubeNet/src/nodenic.bpf.c
@@ -17,49 +17,6 @@
 #include "dns_query.h"
 #include "dns_response.h"
 
-/* Learn ARP replies only for IPs already present in the map. */
-static __always_inline void learn_direct_neighbor(struct __sk_buff *skb)
-{
-	struct direct_neighbor neighbor = {};
-	struct arp_packet *packet;
-	union macaddr *eth_src, *arp_src, *mac;
-	void *data, *data_end;
-	__u32 ip;
-
-	if (skb->ifindex != nodenic_ifindex ||
-	    bpf_skb_pull_data(skb, sizeof(struct arp_packet)))
-		return;
-
-	data = (void *)(__u64)skb->data;
-	data_end = (void *)(__u64)skb->data_end;
-	if (data + sizeof(struct arp_packet) > data_end)
-		return;
-
-	packet = data;
-	if (packet->eth.h_proto != bpf_htons(ETH_P_ARP) ||
-	    packet->arp.ar_hrd != bpf_htons(ARPHRD_ETHER) ||
-	    packet->arp.ar_pro != bpf_htons(ETH_P_IP) ||
-	    packet->arp.ar_hln != ETH_ALEN ||
-	    packet->arp.ar_pln != sizeof(__be32) ||
-	    packet->arp.ar_op != bpf_htons(ARPOP_REPLY))
-		return;
-
-	eth_src = (union macaddr *)packet->eth.h_source;
-	arp_src = (union macaddr *)packet->arp.ar_sha;
-	/* Only trust a nonzero unicast sender MAC that matches the Ethernet header. */
-	if (eth_src->p1 != arp_src->p1 || eth_src->p2 != arp_src->p2 ||
-	    (arp_src->addr[0] & 1) || (arp_src->p1 == 0 && arp_src->p2 == 0))
-		return;
-
-	mac = (union macaddr *)neighbor.addr;
-	mac->p1 = arp_src->p1;
-	mac->p2 = arp_src->p2;
-	neighbor.next_probe_at_ns = bpf_ktime_get_ns() +
-				    DIRECT_NEIGH_REVALIDATE_INTERVAL_NS;
-	ip = packet->arp.ar_sip;
-	bpf_map_update_elem(&direct_neigh, &ip, &neighbor, BPF_EXIST);
-}
-
 static int tcp_nat_proxy(struct __sk_buff *skb, struct ethhdr *l2, struct iphdr *l3, struct tcphdr *l4,
 			 struct mvm_port *mvm_port)
 {
@@ -435,10 +392,6 @@ int from_world(struct __sk_buff *skb)
 	struct iphdr *l3;
 	int ret;
 
-	if (skb->protocol == bpf_htons(ETH_P_ARP)) {
-		learn_direct_neighbor(skb);
-		return TC_ACT_OK;
-	}
 	if (skb->protocol != bpf_htons(ETH_P_IP))
 		return TC_ACT_OK;
 

--- a/Cubelet/network/runtime/controller.go
+++ b/Cubelet/network/runtime/controller.go
@@ -308,6 +308,15 @@ func initCubeVS(cfg Config, device *systemnet.HostDevice, cubeDev *systemnet.Cub
 	if err := os.WriteFile("/proc/sys/net/ipv4/ip_local_port_range", []byte("10000\t19999"), 0644); err != nil {
 		return nil, fmt.Errorf("set ip_local_port_range failed: %w", err)
 	}
+	// Direct mode (no cube-router): the datapath resolves on-link neighbors via
+	// fib and reports into direct_neigh; this scanner drives the kernel's
+	// neighbor learning so fib resolves them. Route-aware mode does not attach
+	// the direct on-link path, so there is nothing to scan.
+	if params.EgressRedirectFlags == 0 {
+		if err := cubevs.StartDirectNeighScanner(params.NodeIP); err != nil {
+			return nil, fmt.Errorf("start direct neighbor scanner failed: %w", err)
+		}
+	}
 	return cubeRouter, nil
 }
 


### PR DESCRIPTION
The #1321 direct-mode on-link resolution built ARP requests in BPF and dropped the triggering packet (first-packet loss) plus a periodic sacrifice packet after each 5-minute revalidate. Replace it with a fib-driven + userspace-scanner design that never drops a packet and never fabricates ARP in the datapath.

The datapath (prepare_egress_l2) now only reports state and always forwards: on-link traffic uses a TTL-bounded cache of the last bpf_fib_lookup result (valid_until is written only on a fib success and never renewed on a hit, so a dead neighbour cannot freeze the cache); a fib failure invalidates the cache, uses a short negative TTL, and falls back to the gateway MAC so the packet is always forwarded. The in-BPF ARP construction, the from_world ARP learning, and the probe/DROP branches are removed, along with the now-unused probe/revalidate constants and struct arp_packet.

A userspace scanner (cubevs/direct_neigh_scanner.go) owns all scheduling: it walks direct_neigh on an interval, GCs idle entries, fires learning triggers with exponential backoff for unresolved destinations, and fires 16s keepalive triggers for learned ones (driving kernel NUD re-validation), rate-limited by a global token bucket. Triggers are plain UDP sends from the node NIC source IP; the learning event is the kernel's own ARP exchange. Init drops any stale direct_neigh pin so the resized value reloads cleanly, and the scanner starts only in direct mode.

Assisted-by: zhouxianping999@qq.com