### PR TITLE
test(cubemaster): add race and docker-backed test gates, de-flake unit tests

### DIFF
--- a/.github/workflows/unit-test-check.yml
+++ b/.github/workflows/unit-test-check.yml
@@ -307,20 +307,37 @@ jobs:
                     else error("unsupported component: " + .)
                     end
                   ),
-                  requires_builder: (. != "CubeProxy" and . != "cubelog" and . != "cubedb" and . != "proto")
+                  requires_builder: (. != "CubeProxy" and . != "cubelog" and . != "cubedb" and . != "proto"),
+                  run_mode: "root_make"
                 })
-              | map(
-                  . as $c
-                  | ["amd64", "arm64"]
-                  | map(
-                      $c + {
-                        arch: .,
-                        runner: (if . == "amd64" then "ubuntu-latest" else "ubuntu-24.04-arm" end),
-                        display_name: ($c.display_name + " (" + . + ")")
+              | [
+                  .[] as $component
+                  | if $component.component == "CubeMaster" then
+                      $component,
+                        ($component + {
+                          display_name: "CubeMaster Race",
+                          make_target: "test-race",
+                          run_mode: "cubemaster_builder"
+                        }),
+                        ($component + {
+                          display_name: "CubeMaster Docker",
+                          make_target: "test-docker",
+                          requires_builder: false,
+                          run_mode: "cubemaster_host"
+                        })
+                    else
+                      $component
+                    end
+                ]
+              | [
+                  .[] as $component
+                  | ["amd64", "arm64"][] as $arch
+                  | $component + {
+                        arch: $arch,
+                        runner: (if $arch == "amd64" then "ubuntu-latest" else "ubuntu-24.04-arm" end),
+                        display_name: ($component.display_name + " (" + $arch + ")")
                       }
-                    )
-                )
-              | add
+                ]
             '
           )"
 
@@ -343,6 +360,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Set up Go
+        if: matrix.run_mode == 'cubemaster_host'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: CubeMaster/go.mod
+          cache-dependency-path: CubeMaster/go.sum
 
       - name: Detect builder changes
         id: builder_changes
@@ -431,13 +455,31 @@ jobs:
           MAKE_TARGET: ${{ matrix.make_target }}
           REQUIRES_BUILDER: ${{ matrix.requires_builder }}
           BUILDER_IMAGE: ${{ steps.builder_image.outputs.image }}
+          RUN_MODE: ${{ matrix.run_mode }}
         run: |
           set -euo pipefail
 
           echo "Component: ${{ matrix.component }}"
-          if [[ "${REQUIRES_BUILDER}" == "true" ]]; then
-            echo "Builder image: ${BUILDER_IMAGE}"
-            make "${MAKE_TARGET}" BUILDER_IMAGE="${BUILDER_IMAGE}"
-          else
-            make "${MAKE_TARGET}"
-          fi
+          case "${RUN_MODE}" in
+            root_make)
+              if [[ "${REQUIRES_BUILDER}" == "true" ]]; then
+                echo "Builder image: ${BUILDER_IMAGE}"
+                make "${MAKE_TARGET}" BUILDER_IMAGE="${BUILDER_IMAGE}"
+              else
+                make "${MAKE_TARGET}"
+              fi
+              ;;
+            cubemaster_builder)
+              echo "Builder image: ${BUILDER_IMAGE}"
+              make builder-run \
+                BUILDER_IMAGE="${BUILDER_IMAGE}" \
+                BUILDER_CMD="cd /workspace/CubeMaster && go mod download && make ${MAKE_TARGET}"
+              ;;
+            cubemaster_host)
+              make -C CubeMaster "${MAKE_TARGET}"
+              ;;
+            *)
+              echo "::error::unsupported run mode: ${RUN_MODE}"
+              exit 1
+              ;;
+          esac

--- a/CubeMaster/Makefile
+++ b/CubeMaster/Makefile
@@ -125,6 +125,26 @@ test:
 			$$pkg || exit 1 ;\
 	done )
 
+.PHONY: test-race
+test-race:
+	$(call msg,Run race-enabled unit tests)
+	$(Q)go clean -testcache
+	@( for pkg in ${COVERAGE_PACKAGES}; do \
+		CI=true CGO_ENABLED=1 go test -short -v -race -count=1 \
+			-gcflags=all=-l -timeout=20m $$pkg || exit 1 ;\
+	done )
+
+DOCKER_TEST_PATTERN=^(TestAliasStoreMySQL|TestAliasStorePostgreSQL|TestUpsertReplicaPostgreSQLUpdatePath|TestTrySessionLockPostgreSQL|TestArtifactGCSessionLockMySQL|TestInitReturnsDaoDefaultOnPostgreSQL)$$
+
+.PHONY: test-docker
+test-docker:
+	$(call msg,Run Docker-backed database tests)
+	@command -v docker >/dev/null 2>&1 || { echo "error: docker is not installed"; exit 1; }
+	@docker info >/dev/null 2>&1 || { echo "error: docker daemon is not reachable"; exit 1; }
+	$(Q)CI=true CUBEMASTER_REQUIRE_DOCKER_TESTS=1 go test -v -count=1 \
+		-gcflags=all=-l -timeout=20m -run '$(DOCKER_TEST_PATTERN)' \
+		./pkg/base/db ./pkg/templatecenter
+
 .PHONY: coverage
 coverage:
 	$(Q)echo 'mode: set' > ./coverage/cubemaster.cov

--- a/CubeMaster/pkg/base/queueworker/queue_test.go
+++ b/CubeMaster/pkg/base/queueworker/queue_test.go
@@ -61,19 +61,24 @@ func TestQueue(t *testing.T) {
 func TestQueueBlock(t *testing.T) {
 	q := NewQueue(5)
 
-	got := false
+	popped := make(chan struct{})
 	go func() {
 		q.BPop()
-		got = true
+		close(popped)
 	}()
 
-	if got {
+	select {
+	case <-popped:
 		t.Error("BPop should block when queue is empty")
+	case <-time.After(50 * time.Millisecond):
 	}
-	q.Push(1)
-	time.Sleep(time.Second)
-	if !got {
-		t.Error("BPop should got value when queue is not empty")
+	if err := q.Push(1); err != nil {
+		t.Fatalf("Push error: %v", err)
+	}
+	select {
+	case <-popped:
+	case <-time.After(time.Second):
+		t.Fatal("BPop should get a value when queue is not empty")
 	}
 }
 

--- a/CubeMaster/pkg/base/recov/runtime_test.go
+++ b/CubeMaster/pkg/base/recov/runtime_test.go
@@ -123,28 +123,41 @@ func TestGoWithRecoverWithoutCrash(t *testing.T) {
 
 func TestGoWithRetryWithoutCrash(t *testing.T) {
 	var panicTime int32 = 0
+	done := make(chan struct{})
 	GoWithRetry(func() {
 		fmt.Println("no panic")
+		close(done)
 	}, 3, func(panicError interface{}) {
 		atomic.AddInt32(&panicTime, 1)
 	})
-	time.Sleep(2 * time.Second)
-	if panicTime != 0 {
-		t.Errorf("should be %d, actual %d", 0, 1)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not complete")
+	}
+	if got := atomic.LoadInt32(&panicTime); got != 0 {
+		t.Errorf("should be %d, actual %d", 0, got)
 	}
 }
 
 func TestGoWithRetryWithCrash(t *testing.T) {
-	retryTime := 3
+	const retryTime int32 = 3
 	var panicTime int32 = 0
+	done := make(chan struct{})
 	GoWithRetry(func() {
 		fmt.Println("panic")
 		panic(any(errors.New("RetryPanic")))
-	}, retryTime, func(panicError interface{}) {
-		atomic.AddInt32(&panicTime, 1)
+	}, int(retryTime), func(panicError interface{}) {
+		if atomic.AddInt32(&panicTime, 1) == retryTime {
+			close(done)
+		}
 	})
-	time.Sleep(2 * time.Second)
-	if int(panicTime) != retryTime {
-		t.Errorf("should be %d, actual %d", 0, 1)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry handler did not complete")
+	}
+	if got := atomic.LoadInt32(&panicTime); got != retryTime {
+		t.Errorf("should be %d, actual %d", retryTime, got)
 	}
 }

--- a/tests/unittest/run.sh
+++ b/tests/unittest/run.sh
@@ -125,6 +125,15 @@ WITH_TESTS=(
 )
 
 GATED_TESTS=(
+	# The race profile is intentionally separate from the fast default gate: it
+	# recompiles every CubeMaster unit package with the race detector and runs
+	# substantially longer than the regular -short suite.
+	"cubemaster-race|Go+race|0|race-enabled CubeMaster sweep is an extended check|make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go mod download && make test-race'"
+	# Docker-backed CubeMaster tests run on the host so dockertest can reach the
+	# daemon and its published 127.0.0.1 ports without nested-container socket or
+	# network plumbing. The component target fails instead of skipping when the
+	# daemon is unavailable.
+	"cubemaster-docker|Go+Docker|0|database tests need a reachable Docker daemon|make -C CubeMaster test-docker"
 	# hypervisor-kvm exercises the tests that need a real /dev/kvm at runtime:
 	# the `vmm` and `hypervisor` crate unit tests call hypervisor::new() /
 	# create_vm(), which fail without KVM (verified: 4/4 vmm cpu:: tests fail with


### PR DESCRIPTION
## Summary

Add race and Docker-backed test gates for CubeMaster unit tests, and replace `time.Sleep` polling with channel-based synchronization to remove flakiness.

- **CI**: extend the CubeMaster test matrix with Race and Docker jobs, introducing three run modes: `root_make`, `cubemaster_builder`, and `cubemaster_host`
- **Makefile**: add `test-race` and `test-docker` targets; `test-docker` fails fast when the Docker daemon is unreachable instead of skipping
- **queueworker / recov tests**: replace `time.Sleep` polling with channel-based synchronization to avoid intermittent failures
- **tests/unittest**: gate the full race sweep and the Docker-backed database tests

## Testing

- The race gate covers all CubeMaster unit-test packages (`-race -count=1`)
- The Docker gate covers MySQL/PostgreSQL-related DAO and template-center tests, run on the host against the Docker daemon
- The regular `-short` suite is unaffected
