### PR TITLE
fix(cubemaster): evict node cache only after sustained empty syncs

### DIFF
--- a/CubeMaster/pkg/localcache/db_cache.go
+++ b/CubeMaster/pkg/localcache/db_cache.go
@@ -18,6 +18,10 @@ import (
 	"gorm.io/gorm"
 )
 
+// Evict the cache only after this many consecutive empty responses,
+// absorbing transient jitter.
+const emptySyncEvictThreshold = 15
+
 func (l *local) DB() *gorm.DB {
 	if l.db.Error == nil || errors.Is(l.db.Error, gorm.ErrRecordNotFound) {
 		return l.db
@@ -47,6 +51,9 @@ func (l *local) syncAllFromDB(ctx context.Context, update bool) error {
 		nodes, err := externalNodeLoader(ctx)
 		if err != nil {
 			retCode = 500
+			// A load failure is not a valid empty view; it must not count
+			// toward the empty-response streak or clear the cache.
+			l.emptySyncStreak.Store(0)
 			return err
 		}
 
@@ -72,9 +79,27 @@ func (l *local) syncAllFromDB(ctx context.Context, update bool) error {
 		}
 		if update {
 			if len(allFromDb) == 0 {
-				log.G(ctx).Warnf("syncAllFromDB: CubeOps returned 0 nodes, cache will be cleared")
+				cur := l.emptySyncStreak.Add(1)
+				if cur < emptySyncEvictThreshold {
+					// Not yet actionable; DEBUG avoids spam on a transient or empty cluster.
+					log.G(ctx).Debugf("syncAllFromDB: CubeOps returned 0 nodes (streak=%d/%d), skip eviction",
+						cur, emptySyncEvictThreshold)
+					return nil
+				}
+				l.emptySyncStreak.Store(0)
+				if len(l.cache.Items()) > 0 {
+					// Expected eviction (threshold reached); WARN for visibility without alerting.
+					log.G(ctx).Warnf("syncAllFromDB: CubeOps returned 0 nodes for %d consecutive syncs, evicting cache",
+						cur)
+				} else {
+					log.G(ctx).Infof("syncAllFromDB: CubeOps returned 0 nodes for %d consecutive syncs, cache already empty",
+						cur)
+				}
+			} else {
+				l.emptySyncStreak.Store(0)
 			}
-			l.checkDirty(ctx, allFromDb)
+			// quiet when the DB view is empty (expected wipe); else keep per-node ERRORs.
+			l.checkDirty(ctx, allFromDb, len(allFromDb) == 0)
 		}
 		return nil
 	}
@@ -139,7 +164,7 @@ func (l *local) syncAllFromDB(ctx context.Context, update bool) error {
 	}
 
 	if update {
-		l.checkDirty(ctx, allFromDb)
+		l.checkDirty(ctx, allFromDb, false)
 	}
 	return nil
 }

--- a/CubeMaster/pkg/localcache/db_cache_test.go
+++ b/CubeMaster/pkg/localcache/db_cache_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package localcache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet/grpcconn"
+)
+
+// newTestLocal returns a local with empty caches, no DB, for testing
+// syncAllFromDB's empty-streak logic.
+func newTestLocal() *local {
+	return &local{
+		cache:                 cache.New(0, 0),
+		imageCache:            cache.New(0, 0),
+		templateNodeCache:     cache.New(0, 0),
+		sortedNodesByClusters: make(map[string]node.NodeList),
+	}
+}
+
+// withExternalNodeLoader swaps the package-level loader, restoring it on cleanup.
+func withExternalNodeLoader(t *testing.T, loader func(context.Context) ([]*node.Node, error)) {
+	t.Helper()
+	orig := externalNodeLoader
+	externalNodeLoader = loader
+	t.Cleanup(func() { externalNodeLoader = orig })
+}
+
+func emptyLoader() func(context.Context) ([]*node.Node, error) {
+	return func(context.Context) ([]*node.Node, error) { return nil, nil }
+}
+
+func TestSyncAllFromDB_EmptyStreakSkipsEviction(t *testing.T) {
+	l := newTestLocal()
+	// Seed nodes so we can prove the skip-eviction branch protects existing
+	// cache contents, not just that the counter accumulates.
+	l.cache.SetDefault("node-1", &node.Node{InsID: "node-1"})
+	l.cache.SetDefault("node-2", &node.Node{InsID: "node-2"})
+
+	withExternalNodeLoader(t, emptyLoader())
+	ctx := context.Background()
+
+	for i := 0; i < emptySyncEvictThreshold-1; i++ {
+		if err := l.syncAllFromDB(ctx, true); err != nil {
+			t.Fatalf("syncAllFromDB: %v", err)
+		}
+	}
+	assert.Equal(t, int32(emptySyncEvictThreshold-1), l.emptySyncStreak.Load(),
+		"streak accumulates below threshold and eviction is skipped")
+	assert.Equal(t, 2, len(l.cache.Items()),
+		"nodes seeded before sustained empty syncs must survive the skip-eviction branch")
+}
+
+func TestSyncAllFromDB_EmptyStreakEvictsAfterThreshold(t *testing.T) {
+	l := newTestLocal()
+	// Seed nodes so eviction is observable, not just a counter reset.
+	l.cache.SetDefault("node-1", &node.Node{InsID: "node-1"})
+	l.cache.SetDefault("node-2", &node.Node{InsID: "node-2"})
+	assert.Equal(t, 2, len(l.cache.Items()), "precondition: cache seeded")
+
+	// Stub delNodeCache side-effects so eviction runs without external deps.
+	patches := gomonkey.NewPatches()
+	patches.ApplyFunc(SyncNodeTemplates, func(context.Context, string, []string) {})
+	patches.ApplyFunc(grpcconn.CloseWorkerConn, func(string) {})
+	defer patches.Reset()
+
+	withExternalNodeLoader(t, emptyLoader())
+	ctx := context.Background()
+
+	for i := 0; i < emptySyncEvictThreshold; i++ {
+		if err := l.syncAllFromDB(ctx, true); err != nil {
+			t.Fatalf("syncAllFromDB: %v", err)
+		}
+	}
+	assert.Equal(t, int32(0), l.emptySyncStreak.Load(),
+		"streak resets to 0 after eviction at threshold")
+	assert.Equal(t, 0, len(l.cache.Items()),
+		"eviction should remove cached nodes at threshold")
+}
+
+func TestSyncAllFromDB_EmptyStreakEvictsEmptyCache(t *testing.T) {
+	l := newTestLocal()
+	// scale-to-zero: cache is already empty, so eviction is a no-op. The
+	// eviction path must still complete cleanly (streak reset, no panic).
+	withExternalNodeLoader(t, emptyLoader())
+	ctx := context.Background()
+
+	for i := 0; i < emptySyncEvictThreshold; i++ {
+		if err := l.syncAllFromDB(ctx, true); err != nil {
+			t.Fatalf("syncAllFromDB: %v", err)
+		}
+	}
+	assert.Equal(t, int32(0), l.emptySyncStreak.Load(),
+		"streak resets after eviction")
+	assert.Equal(t, 0, len(l.cache.Items()),
+		"empty cache stays empty after eviction")
+}
+
+func TestSyncAllFromDB_NonEmptyResetsStreak(t *testing.T) {
+	l := newTestLocal()
+	calls := 0
+	withExternalNodeLoader(t, func(context.Context) ([]*node.Node, error) {
+		calls++
+		if calls == 3 {
+			return []*node.Node{{InsID: "node-1"}}, nil // non-empty resets streak
+		}
+		return nil, nil
+	})
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		if err := l.syncAllFromDB(ctx, true); err != nil {
+			t.Fatalf("syncAllFromDB: %v", err)
+		}
+	}
+	// streak: 1, 2, 0 (non-empty), 1, 2
+	assert.Equal(t, int32(2), l.emptySyncStreak.Load(), "streak resets on non-empty then accumulates")
+}
+
+func TestSyncAllFromDB_LoadErrorResetsStreak(t *testing.T) {
+	l := newTestLocal()
+	// Seed a non-zero streak, then fail; a load error must reset it to 0.
+	loadErr := errors.New("cubeops unreachable")
+	calls := 0
+	withExternalNodeLoader(t, func(context.Context) ([]*node.Node, error) {
+		calls++
+		if calls >= 4 { // 3 empty syncs build streak=3, the 4th call fails
+			return nil, loadErr
+		}
+		return nil, nil
+	})
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if err := l.syncAllFromDB(ctx, true); err != nil {
+			t.Fatalf("seed sync %d: %v", i, err)
+		}
+	}
+	assert.Equal(t, int32(3), l.emptySyncStreak.Load(), "streak should accumulate from empty syncs before error")
+
+	if err := l.syncAllFromDB(ctx, true); err == nil {
+		t.Fatal("expected error from loader")
+	}
+	assert.Zero(t, l.emptySyncStreak.Load(), "load error must reset streak to 0")
+}

--- a/CubeMaster/pkg/localcache/node_cache.go
+++ b/CubeMaster/pkg/localcache/node_cache.go
@@ -38,6 +38,9 @@ type local struct {
 
 	sortedNodesByClusters map[string]node.NodeList
 	totalSelfNodes        int64
+
+	// emptySyncStreak counts consecutive empty CubeOps responses before eviction.
+	emptySyncStreak atomic.Int32
 }
 
 // The node/image stores exist from package load so nodemeta query APIs
@@ -175,13 +178,17 @@ func (l *local) dealEvent(ctx context.Context) {
 	}
 }
 
-func (l *local) checkDirty(ctx context.Context, allFromDb map[string]struct{}) {
+// checkDirty removes cached nodes absent from allFromDb. quiet skips the
+// per-node "is dirty" ERROR for expected bulk evictions.
+func (l *local) checkDirty(ctx context.Context, allFromDb map[string]struct{}, quiet bool) {
 	elems := l.cache.Items()
 	for _, v := range elems {
 		h, ok := v.Object.(*node.Node)
 		if ok {
 			if _, ok := allFromDb[h.InsID]; !ok {
-				CubeLog.WithContext(context.Background()).Errorf("node %s is dirty", h.InsID)
+				if !quiet {
+					CubeLog.WithContext(context.Background()).Errorf("node %s is dirty", h.InsID)
+				}
 				l.delNodeCache(ctx, h)
 			}
 		}

--- a/CubeOps/internal/nodemanagement/service/snapshot.go
+++ b/CubeOps/internal/nodemanagement/service/snapshot.go
@@ -260,6 +260,8 @@ func ToSchedulerNode(snap *model.NodeSnapshot) *model.SchedulerNode {
 		CreateConcurrentNum:   snap.CreateConcurrentNum,
 		MaxMvmLimit:           snap.MaxMvmNum,
 		MetaDataUpdateAt:      snap.HeartbeatTime,
+		QuotaCpu:              quotaCPU,
+		QuotaMem:              quotaMem,
 		MetricUpdate:          snap.MetricUpdate,
 		MetricLocalUpdateAt:   snap.MetricLocalUpdateAt,
 		QuotaCpuUsage:         snap.QuotaCpuUsage,

--- a/CubeOps/internal/nodemanagement/service/snapshot_test.go
+++ b/CubeOps/internal/nodemanagement/service/snapshot_test.go
@@ -249,6 +249,26 @@ func TestToSchedulerNode_PreservesSchedulingFields(t *testing.T) {
 	if n.SystemDiskSize != 100 || n.DataDiskSize != 200 {
 		t.Errorf("disk sizes = %d/%d, want 100/200", n.SystemDiskSize, n.DataDiskSize)
 	}
+	// QuotaCpu/QuotaMem must be propagated so CubeMaster can schedule
+	// sandboxes. Without them the scheduler sees 0 quota -> "no more resource".
+	if n.QuotaCpu != 4000 {
+		t.Errorf("QuotaCpu = %d, want 4000 (fallback to Allocatable.MilliCPU)", n.QuotaCpu)
+	}
+	if n.QuotaMem != 8192 {
+		t.Errorf("QuotaMem = %d, want 8192 (fallback to Allocatable.MemoryMB)", n.QuotaMem)
+	}
+}
+
+func TestToSchedulerNode_QuotaFromSnapshot(t *testing.T) {
+	snap := &model.NodeSnapshot{
+		NodeID:     "node-1",
+		QuotaCPU:   6000,
+		QuotaMemMB: 12288,
+	}
+	n := ToSchedulerNode(snap)
+	if n.QuotaCpu != 6000 || n.QuotaMem != 12288 {
+		t.Errorf("quota = %d/%d, want 6000/12288 (from snap.QuotaCPU/QuotaMemMB)", n.QuotaCpu, n.QuotaMem)
+	}
 }
 
 func TestApplyHostMetaToSnapshot(t *testing.T) {


### PR DESCRIPTION
Clear the local node cache only after emptySyncEvictThreshold consecutive empty CubeOps responses , absorbing transient jitter instead of wiping the scheduler view on a single empty response. Load errors reset the streak and never evict.