### PR TITLE
fix(cubenet): reset stale TCP sessions on sandbox rollback

### DIFF
--- a/CubeNet/cubevs/reaper.go
+++ b/CubeNet/cubevs/reaper.go
@@ -168,7 +168,8 @@ type natSession struct {
 	PacketClass   uint8
 	L7Scheme      uint8
 	PolicyVersion uint32
-	Reserved      [28]uint8
+	Gen           uint32
+	Reserved      [24]uint8
 }
 
 // timeout returns the timeout for the session in nanoseconds.

--- a/CubeNet/cubevs/tap.go
+++ b/CubeNet/cubevs/tap.go
@@ -158,6 +158,23 @@ func BumpMvmVersion(ifindex uint32) error {
 	return bumpMvmVersion(m, ifindex)
 }
 
+// LookupIfindexByIP resolves a sandbox's TAP ifindex from its IP via the
+// mvmip_to_ifindex map. O(1), unlike listing and scanning every TAP device.
+func LookupIfindexByIP(ip net.IP) (uint32, error) {
+	m, err := loadPinnedMap(MapNameMVMIPToIfindex)
+	if err != nil {
+		return 0, err
+	}
+	defer m.Close()
+
+	key := ipToUint32(ip)
+	var ifindex uint32
+	if err := m.Lookup(&key, &ifindex); err != nil {
+		return 0, fmt.Errorf("map.Lookup failed: %w, name: %s", err, MapNameMVMIPToIfindex)
+	}
+	return ifindex, nil
+}
+
 // mvmVersionMapOps is the subset of the metadata map used to bump the version;
 // it is an interface so the read-modify-write can be unit-tested against a fake.
 type mvmVersionMapOps interface {

--- a/CubeNet/cubevs/tap.go
+++ b/CubeNet/cubevs/tap.go
@@ -140,6 +140,45 @@ func UpsertTAPDeviceMetadata(ifindex uint32, ip net.IP, id string, version uint3
 	return nil
 }
 
+// BumpMvmVersion increments the sandbox's rollback generation
+// (ifindex_to_mvmmeta[ifindex].version) via a read-modify-write of the map
+// value, preserving IP/UUID/DNSPolicyFlags/Reserved. A sandbox rollback calls
+// this after the guest has been restored and resumed; the dataplane then treats
+// a session whose stamped gen differs from the current version as stale and
+// resets it. This is a map RMW (not the process-local registration counter) so
+// it stays monotonic per ifindex even across a Cubelet restart that reset that
+// counter — otherwise a bump could write a value equal to the registration
+// version and make the rollback invisible.
+func BumpMvmVersion(ifindex uint32) error {
+	m, err := loadPinnedMap(MapNameIfindexToMVMMetadata)
+	if err != nil {
+		return err
+	}
+	defer m.Close()
+	return bumpMvmVersion(m, ifindex)
+}
+
+// mvmVersionMapOps is the subset of the metadata map used to bump the version;
+// it is an interface so the read-modify-write can be unit-tested against a fake.
+type mvmVersionMapOps interface {
+	Lookup(key, valueOut interface{}) error
+	Update(key, value any, flags ebpf.MapUpdateFlags) error
+}
+
+// bumpMvmVersion does the read-modify-write on the metadata map value. It
+// preserves IP/UUID/DNSPolicyFlags/Reserved and only increments Version.
+func bumpMvmVersion(m mvmVersionMapOps, ifindex uint32) error {
+	var meta mvmMetadata
+	if err := m.Lookup(&ifindex, &meta); err != nil {
+		return fmt.Errorf("map.Lookup failed: %w, name: %s", err, MapNameIfindexToMVMMetadata)
+	}
+	meta.Version++
+	if err := m.Update(&ifindex, &meta, ebpf.UpdateAny); err != nil {
+		return fmt.Errorf("map.Update failed: %w, name: %s", err, MapNameIfindexToMVMMetadata)
+	}
+	return nil
+}
+
 // UpsertTAPDevice registers a TAP device and replaces its desired policy state.
 func UpsertTAPDevice(ifindex uint32, ip net.IP, id string, version uint32, opts MVMOptions) error {
 	if err := UpsertTAPDeviceMetadata(ifindex, ip, id, version); err != nil {

--- a/CubeNet/cubevs/tap_test.go
+++ b/CubeNet/cubevs/tap_test.go
@@ -109,3 +109,53 @@ func TestDeleteTAPDeviceMetadataEntriesLookupErrorDoesNotPartiallyDelete(t *test
 		t.Fatal("ifindex metadata was deleted after reverse lookup failed")
 	}
 }
+
+// fakeMvmMetadataMap is an in-memory mvmVersionMapOps for bumpMvmVersion tests.
+type fakeMvmMetadataMap struct {
+	entries map[uint32]mvmMetadata
+}
+
+func (m *fakeMvmMetadataMap) Lookup(key, valueOut interface{}) error {
+	v, ok := m.entries[*key.(*uint32)]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	*valueOut.(*mvmMetadata) = v
+	return nil
+}
+
+func (m *fakeMvmMetadataMap) Update(key, value any, _ ebpf.MapUpdateFlags) error {
+	m.entries[*key.(*uint32)] = *value.(*mvmMetadata)
+	return nil
+}
+
+func TestBumpMvmVersionIncrementsAndPreservesFields(t *testing.T) {
+	const ifindex = uint32(42)
+	orig := mvmMetadata{
+		Version:        5,
+		IP:             0x0a000002,
+		DNSPolicyFlags: 3,
+	}
+	orig.UUID[0] = 'a'
+	orig.Reserved[0] = 0x7f
+	m := &fakeMvmMetadataMap{entries: map[uint32]mvmMetadata{ifindex: orig}}
+
+	if err := bumpMvmVersion(m, ifindex); err != nil {
+		t.Fatal(err)
+	}
+	got := m.entries[ifindex]
+	if got.Version != 6 {
+		t.Fatalf("version = %d, want 6 (map RMW +1, immune to a reset counter)", got.Version)
+	}
+	if got.IP != orig.IP || got.DNSPolicyFlags != orig.DNSPolicyFlags ||
+		got.UUID != orig.UUID || got.Reserved != orig.Reserved {
+		t.Fatal("bump must preserve IP/UUID/DNSPolicyFlags/Reserved")
+	}
+}
+
+func TestBumpMvmVersionMissingEntry(t *testing.T) {
+	m := &fakeMvmMetadataMap{entries: map[uint32]mvmMetadata{}}
+	if err := bumpMvmVersion(m, 99); !errors.Is(err, ebpf.ErrKeyNotExist) {
+		t.Fatalf("err = %v, want ErrKeyNotExist", err)
+	}
+}

--- a/CubeNet/src/cubevs.h
+++ b/CubeNet/src/cubevs.h
@@ -370,7 +370,9 @@ struct nat_session {
 	__u8 packet_class;	/* SNAT_PACKET or L7PROXY_PACKET */
 	__u8 l7_scheme;		/* L7_SCHEME_*; NONE for non-L7 sessions */
 	__u32 policy_version;	/* mvm_meta.policy_version at create / last re-check */
-	__u8 reserved[28];
+	__u32 gen;		/* mvm_meta->version at creation; a sandbox rollback
+				 * bumps it, so a gen != current session is stale */
+	__u8 reserved[24];
 };
 
 struct ingress_session {

--- a/CubeNet/src/localgw.bpf.c
+++ b/CubeNet/src/localgw.bpf.c
@@ -52,7 +52,7 @@ static __always_inline int update_l7_session_from_cubedev(struct __sk_buff *skb)
 
 	if (session_is_stale(sess)) {
 		delete_session_pair(&key, sess);
-		return tcp_reflect_reset(skb, skb->ingress_ifindex);
+		return tcp_send_reset(skb, skb->ingress_ifindex, l3->saddr);
 	}
 
 	now = bpf_ktime_get_ns();

--- a/CubeNet/src/localgw.bpf.c
+++ b/CubeNet/src/localgw.bpf.c
@@ -11,12 +11,22 @@
 #include "nat.h"
 #include "skb.h"
 #include "tcp.h"
+#include "tcp_reset.h"
 
 /* Update a CubeEgress TCP session from the original reply tuple before DNAT
  * rewrites the sandbox-assigned destination address to mvm_inner_ip. A missing
  * or non-L7 session is intentionally non-blocking.
  */
-static __always_inline void update_l7_session_from_cubedev(struct __sk_buff *skb)
+/* Update a CubeEgress TCP session from the original reply tuple before DNAT
+ * rewrites the sandbox-assigned destination address to mvm_inner_ip.
+ *
+ * Returns the reset-redirect action when the reply belongs to a stale
+ * (pre-rollback) L7 session — a RST is reflected to the proxy and the session
+ * pair removed so the proxied connection is torn down instead of desyncing —
+ * or 0 to continue normal delivery. A missing or non-L7 session is
+ * intentionally non-blocking (returns 0).
+ */
+static __always_inline int update_l7_session_from_cubedev(struct __sk_buff *skb)
 {
 	struct session_key key = {};
 	struct nat_session *sess;
@@ -26,9 +36,9 @@ static __always_inline void update_l7_session_from_cubedev(struct __sk_buff *skb
 	__u64 now;
 
 	if (!__pull_headers(skb, &l2, &l3, &l4))
-		return;
+		return 0;
 	if (l3->protocol != IPPROTO_TCP)
-		return;
+		return 0;
 
 	key.src_ip = l3->saddr;
 	key.dst_ip = l3->daddr;
@@ -38,11 +48,17 @@ static __always_inline void update_l7_session_from_cubedev(struct __sk_buff *skb
 	key.protocol = IPPROTO_TCP;
 	sess = lookup_session(&key);
 	if (!sess || sess->packet_class != L7PROXY_PACKET)
-		return;
+		return 0;
+
+	if (session_is_stale(sess)) {
+		delete_session_pair(&key, sess);
+		return tcp_reflect_reset(skb, skb->ingress_ifindex);
+	}
 
 	now = bpf_ktime_get_ns();
 	update_session(IP_CT_DIR_REPLY, sess, now, l4->syn, l4->ack,
 		       l4->fin, l4->rst);
+	return 0;
 }
 
 /* This filter will be attached to the egress path of cube-dev device.
@@ -60,7 +76,11 @@ int from_envoy(struct __sk_buff *skb)
 	if (skb->protocol != bpf_htons(ETH_P_IP))
 		return TC_ACT_OK;
 
-	update_l7_session_from_cubedev(skb);
+	/* A stale (pre-rollback) L7 session gets its RST reflected to the proxy;
+	 * stop before delivering the reply to the guest. */
+	ret = update_l7_session_from_cubedev(skb);
+	if (ret)
+		return ret;
 
 	ret = pull_headers(skb, &l2, &l3);
 	if (ret != TC_ACT_OK)

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -244,121 +244,6 @@ enum tcp_nat_result {
 #define TCP_NAT_STATUS(ret)	((enum tcp_nat_result)((__u32)(ret)))
 #define TCP_NAT_IFINDEX(ret)	((__u32)((__u64)(ret) >> 32))
 
-
-static __always_inline int tcp_reply_reset(struct __sk_buff *skb, __u32 ifindex)
-{
-	struct tcphdr new_tcp = {};
-	struct ethhdr *l2;
-	struct iphdr *l3;
-	struct tcphdr *l4;
-	__be32 old_saddr, old_daddr, new_saddr, new_daddr;
-	__be16 old_tot_len, new_tot_len;
-	__u32 seq, ack_seq, new_skb_len;
-	__u32 seg_len, tcp_off, tcp_csum_off;
-	__u16 ip_hlen, new_ip_len;
-	long err;
-
-	/* bpf_skb_change_tail() may fail on GSO skbs or leave segmentation
-	 * state inconsistent. Fall back to drop instead of sending RST.
-	 */
-	if (skb->gso_segs)
-		return TC_ACT_SHOT;
-
-	if (!__pull_headers(skb, &l2, &l3, &l4))
-		return TC_ACT_SHOT;
-
-	if ((l3->frag_off & IP_FLAG_MF) || (l3->frag_off & IP_FRAG_OFF_MASK))
-		return TC_ACT_SHOT;
-
-	/* Never send a reset in response to a reset. */
-	if (l4->rst)
-		return TC_ACT_SHOT;
-
-	ip_hlen = BPF_CORE_READ_BITFIELD(l3, ihl);
-	ip_hlen <<= 2;
-	seq = l4->seq;
-	ack_seq = l4->ack_seq;
-	if (!tcp_segment_len(l3, l4, &seg_len))
-		return TC_ACT_SHOT;
-
-	new_saddr = l3->daddr;
-	new_daddr = mvm_inner_ip;
-	new_tcp.source = l4->dest;
-	new_tcp.dest = l4->source;
-	new_tcp.doff = sizeof(new_tcp) >> 2;
-	new_tcp.rst = 1;
-	if (l4->ack) {
-		new_tcp.seq = ack_seq;
-	} else {
-		new_tcp.ack_seq = bpf_htonl(bpf_ntohl(seq) + seg_len);
-		new_tcp.ack = 1;
-	}
-	/* Build the new TCP header with check = 0; tcp_ipv4_set_checksum()
-	 * folds the pseudo-header and TCP header words into the checksum
-	 * incrementally via bpf_l4_csum_replace.
-	 */
-
-	new_ip_len = ip_hlen + sizeof(new_tcp);
-	new_skb_len = sizeof(struct ethhdr) + new_ip_len;
-	if (bpf_skb_change_tail(skb, new_skb_len, 0))
-		return TC_ACT_SHOT;
-
-	/* bpf_skb_change_tail invalidates all packet pointers. */
-	if (!__pull_headers(skb, &l2, &l3, &l4))
-		return TC_ACT_SHOT;
-
-	/* Snapshot old IP header fields and rewrite the L2 MAC pair before
-	 * touching the packet via BPF helpers — bpf_skb_store_bytes() and
-	 * bpf_l{3,4}_csum_replace() invalidate l2/l3/l4 pointers.
-	 */
-	old_saddr = l3->saddr;
-	old_daddr = l3->daddr;
-	old_tot_len = l3->tot_len;
-	new_tot_len = bpf_htons(new_ip_len);
-	tcp_off = sizeof(struct ethhdr) + ip_hlen;
-	tcp_csum_off = TCP_CSUM_OFF(ip_hlen);
-	set_mac_pair(l2, cubegw0_macaddr_p1, cubegw0_macaddr_p2,
-		     mvm_macaddr_p1, mvm_macaddr_p2);
-
-	/* Write the new TCP header (with check = 0). */
-	err = bpf_skb_store_bytes(skb, tcp_off, &new_tcp, sizeof(new_tcp), 0);
-	if (err)
-		return TC_ACT_SHOT;
-
-	/* Update IP tot_len + IP csum. */
-	err = rewrite_l3_tot_len(skb, old_tot_len, new_tot_len);
-	if (err)
-		return TC_ACT_SHOT;
-
-	/* Update IP saddr + IP csum. */
-	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_saddr, new_saddr,
-				  sizeof(new_saddr));
-	if (err)
-		return TC_ACT_SHOT;
-	err = bpf_skb_store_bytes(skb, IP_SADDR_OFF, &new_saddr,
-				  sizeof(new_saddr), 0);
-	if (err)
-		return TC_ACT_SHOT;
-
-	/* Update IP daddr + IP csum. */
-	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_daddr, new_daddr,
-				  sizeof(new_daddr));
-	if (err)
-		return TC_ACT_SHOT;
-	err = bpf_skb_store_bytes(skb, IP_DADDR_OFF, &new_daddr,
-				  sizeof(new_daddr), 0);
-	if (err)
-		return TC_ACT_SHOT;
-
-	/* Compute the TCP checksum into the (currently zero) check field. */
-	err = tcp_ipv4_set_checksum(skb, tcp_csum_off, new_saddr, new_daddr,
-				    &new_tcp);
-	if (err)
-		return TC_ACT_SHOT;
-
-	return bpf_redirect(ifindex, 0);
-}
-
 static __always_inline struct snat_ip *pick_snat_ip_port(__u32 mvm_ip, const struct session_key *ekey,
 							 __u16 *selected_port)
 {
@@ -1137,7 +1022,7 @@ int from_cube(struct __sk_buff *skb)
 			sess = bpf_map_lookup_elem(&egress_sessions, &pmkey);
 			if (sess && session_is_stale(sess)) {
 				bpf_map_delete_elem(&egress_sessions, &pmkey);
-				return tcp_reply_reset(skb, ifindex);
+				return tcp_send_reset(skb, skb->ingress_ifindex, mvm_inner_ip);
 			}
 
 			err = snat_tcp(skb, ifindex, l2, l3, l4, l4->source, *host_port);
@@ -1165,7 +1050,7 @@ int from_cube(struct __sk_buff *skb)
 		switch (classify_egress_flow(ifindex, daddr, 0)) {
 		case FLOW_REJECT:
 			if (proto == IPPROTO_TCP)
-				return tcp_reply_reset(skb, ifindex);
+				return tcp_send_reset(skb, skb->ingress_ifindex, mvm_inner_ip);
 			return TC_ACT_SHOT;
 		default:
 			return bpf_redirect(cubegw0_ifindex, BPF_F_INGRESS);
@@ -1179,7 +1064,7 @@ int from_cube(struct __sk_buff *skb)
 		if (TCP_NAT_STATUS(tcp_ret) == TCP_L7PROXY_OK)
 			return bpf_redirect(TCP_NAT_IFINDEX(tcp_ret), BPF_F_INGRESS);
 		if (TCP_NAT_STATUS(tcp_ret) == TCP_NAT_RESET)
-			return tcp_reply_reset(skb, ifindex);
+			return tcp_send_reset(skb, skb->ingress_ifindex, mvm_inner_ip);
 		return TC_ACT_SHOT;
 	}
 

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -14,6 +14,7 @@
 #include "map.h"
 #include "skb.h"
 #include "tcp.h"
+#include "tcp_reset.h"
 #include "udp.h"
 #include "dns_query.h"
 
@@ -243,101 +244,6 @@ enum tcp_nat_result {
 #define TCP_NAT_STATUS(ret)	((enum tcp_nat_result)((__u32)(ret)))
 #define TCP_NAT_IFINDEX(ret)	((__u32)((__u64)(ret) >> 32))
 
-static __always_inline bool tcp_segment_len(const struct iphdr *l3, const struct tcphdr *l4,
-					    __u32 *seg_len)
-{
-	__u16 ip_hlen, tcp_hlen, total_len;
-
-	ip_hlen = BPF_CORE_READ_BITFIELD(l3, ihl);
-	ip_hlen <<= 2;
-	tcp_hlen = BPF_CORE_READ_BITFIELD(l4, doff);
-	tcp_hlen <<= 2;
-	total_len = bpf_ntohs(l3->tot_len);
-	if (ip_hlen < sizeof(struct iphdr) || tcp_hlen < sizeof(struct tcphdr) ||
-	    total_len < ip_hlen + tcp_hlen)
-		return false;
-
-	*seg_len = total_len - ip_hlen - tcp_hlen;
-	if (l4->syn)
-		(*seg_len)++;
-	if (l4->fin)
-		(*seg_len)++;
-
-	return true;
-}
-
-/* Update the IP tot_len field together with the IP header checksum.
- * Uses bpf_l3_csum_replace for the incremental csum update and
- * bpf_skb_store_bytes to write the new value, instead of touching the
- * packet pointer directly.
- */
-static __always_inline int rewrite_l3_tot_len(struct __sk_buff *skb,
-					      __be16 old_tot_len, __be16 new_tot_len)
-{
-	long err;
-
-	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_tot_len, new_tot_len,
-				  sizeof(new_tot_len));
-	if (err)
-		return err;
-
-	return bpf_skb_store_bytes(skb, IP_TOT_LEN_OFF, &new_tot_len,
-				   sizeof(new_tot_len), 0);
-}
-
-/* Set the TCP checksum field of a freshly written TCP header.
- *
- * Pre-condition: the TCP header at @tcp_csum_off..+sizeof(*tcp) is already
- * present in skb with the check field cleared to 0. This helper folds the
- * IPv4 pseudo-header (saddr, daddr, proto, length) and the on-wire TCP
- * header bytes into the checksum via bpf_l4_csum_replace.
- *
- * Per the bpf-helpers(7) man page, calling bpf_l4_csum_replace with
- * from = 0 makes the helper recompute the csum against `to` only — i.e.
- * accumulates `to` into the existing in-place checksum. We start from a
- * zeroed check field and add each 32-bit word in turn.
- */
-static __always_inline int tcp_ipv4_set_checksum(struct __sk_buff *skb,
-						 __u32 tcp_csum_off,
-						 __be32 saddr, __be32 daddr,
-						 const struct tcphdr *tcp)
-{
-	const __u32 *words = (const __u32 *)tcp;
-	/* zero | proto | length, in network byte order */
-	__be32 proto_len = bpf_htonl(((__u32)IPPROTO_TCP << 16) | sizeof(*tcp));
-	__u64 ph_flags = BPF_F_PSEUDO_HDR | sizeof(__u32);
-	__u64 hdr_flags = sizeof(__u32);
-	long err;
-
-	/* Pseudo-header words */
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, saddr, ph_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, daddr, ph_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, proto_len, ph_flags);
-	if (err)
-		return err;
-
-	/* TCP header words: source|dest, seq, ack_seq, doff/flags/window,
-	 * check|urg_ptr. The check word currently contains 0 (caller wrote
-	 * a zeroed check field), so adding it is a no-op for the csum.
-	 */
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[0], hdr_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[1], hdr_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[2], hdr_flags);
-	if (err)
-		return err;
-	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[3], hdr_flags);
-	if (err)
-		return err;
-	return bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[4], hdr_flags);
-}
 
 static __always_inline int tcp_reply_reset(struct __sk_buff *skb, __u32 ifindex)
 {
@@ -1144,6 +1050,8 @@ int from_cube(struct __sk_buff *skb)
 	__u32 daddr, ifindex, dst_ifindex;
 	__u64 tcp_ret;
 	struct mvm_port mvm_port = {};
+	struct nat_session *sess;
+	struct session_key pmkey = {};
 	struct mvm_meta *mvm_meta;
 	struct ethhdr *l2;
 	struct iphdr *l3;
@@ -1219,6 +1127,18 @@ int from_cube(struct __sk_buff *skb)
 		if (host_port) {
 			if (l4->syn && !l4->ack)
 				return TC_ACT_SHOT;
+
+			/* A port_mapping session whose gen differs from the VM's current
+			 * mvm_meta->version is stale (the sandbox was rolled back); reset
+			 * the guest side so the application unblocks. A miss forwards
+			 * statelessly (today's behaviour). port_mapping sessions have no
+			 * ingress entry. */
+			port_mapping_key(&pmkey, l3->daddr, l4->dest, l4->source);
+			sess = bpf_map_lookup_elem(&egress_sessions, &pmkey);
+			if (sess && session_is_stale(sess)) {
+				bpf_map_delete_elem(&egress_sessions, &pmkey);
+				return tcp_reply_reset(skb, ifindex);
+			}
 
 			err = snat_tcp(skb, ifindex, l2, l3, l4, l4->source, *host_port);
 			if (err)

--- a/CubeNet/src/nodenic.bpf.c
+++ b/CubeNet/src/nodenic.bpf.c
@@ -73,7 +73,7 @@ static int tcp_nat_proxy(struct __sk_buff *skb, struct ethhdr *l2, struct iphdr 
 		 * entry so a reconnect starts clean. port_mapping sessions have no
 		 * ingress entry. */
 		bpf_map_delete_elem(&egress_sessions, &pkey);
-		return tcp_reflect_reset(skb, skb->ingress_ifindex);
+		return tcp_send_reset(skb, skb->ingress_ifindex, l3->saddr);
 	}
 	if (!sess) {
 		/* New connection (SYN) or a rebuilt aged one (non-SYN). */
@@ -174,7 +174,7 @@ static int tcp_nat_session(struct __sk_buff *skb, struct ethhdr *l2, struct iphd
 	if (isess->version != current_gen_by_ip(isess->vm_ip)) {
 		bpf_map_delete_elem(&egress_sessions, &ekey);
 		bpf_map_delete_elem(&ingress_sessions, &key);
-		return tcp_reflect_reset(skb, skb->ingress_ifindex);
+		return tcp_send_reset(skb, skb->ingress_ifindex, l3->saddr);
 	}
 
 	sess = bpf_map_lookup_elem(&egress_sessions, &ekey);

--- a/CubeNet/src/nodenic.bpf.c
+++ b/CubeNet/src/nodenic.bpf.c
@@ -13,18 +13,81 @@
 #include "map.h"
 #include "skb.h"
 #include "tcp.h"
+#include "tcp_reset.h"
 #include "udp.h"
 #include "dns_query.h"
 #include "dns_response.h"
+
+/* create_port_mapping_session installs an egress_sessions entry for a
+ * port_mapping connection. Called on the inbound path (SYN for a new
+ * connection, or a non-SYN packet whose session was reaped and is being
+ * rebuilt). */
+static __always_inline void create_port_mapping_session(__be32 peer_ip, __be16 peer_port,
+							struct mvm_port *mvm_port,
+							__be32 node_ip, __be16 host_port,
+							__u32 node_ifindex, __u64 now_ns,
+							__u8 initial_state)
+{
+	struct nat_session sess = {};
+	struct session_key pkey = {};
+
+	port_mapping_key(&pkey, peer_ip, peer_port, mvm_port->listen_port);
+
+	sess.access_time = now_ns;
+	sess.node_ifindex = node_ifindex;
+	sess.node_ip = node_ip;
+	sess.node_port = host_port;
+	sess.vm_ifindex = mvm_port->ifindex;
+	sess.vm_ip = mvm_inner_ip;
+	sess.vm_port = mvm_port->listen_port;
+	sess.state = initial_state;
+	sess.packet_class = PORT_MAPPING_PACKET;
+	{
+		struct mvm_meta *meta = bpf_map_lookup_elem(&ifindex_to_mvmmeta, &mvm_port->ifindex);
+
+		if (meta)
+			sess.gen = meta->version;
+	}
+	bpf_map_update_elem(&egress_sessions, &pkey, &sess, BPF_ANY);
+}
 
 static int tcp_nat_proxy(struct __sk_buff *skb, struct ethhdr *l2, struct iphdr *l3, struct tcphdr *l4,
 			 struct mvm_port *mvm_port)
 {
 	__u32 old_daddr, new_daddr, tcp_csum_off;
+	struct nat_session *sess;
+	struct session_key pkey = {};
 	__u16 old_dport, new_dport;
 	__u16 ip_hlen;
+	__u64 now;
 	__u64 flags;
 	long err;
+
+	/* Track the port_mapping connection's generation so a rollback can reset
+	 * it while an aged (reaped) one is rebuilt. */
+	now = bpf_ktime_get_ns();
+	port_mapping_key(&pkey, l3->saddr, l4->source, mvm_port->listen_port);
+	sess = bpf_map_lookup_elem(&egress_sessions, &pkey);
+	if (sess && sess->gen != current_gen(sess->vm_ifindex)) {
+		/* Stale: the sandbox was rolled back. Reset the peer and drop the
+		 * entry so a reconnect starts clean. port_mapping sessions have no
+		 * ingress entry. */
+		bpf_map_delete_elem(&egress_sessions, &pkey);
+		return tcp_reflect_reset(skb, skb->ingress_ifindex);
+	}
+	if (!sess) {
+		/* New connection (SYN) or a rebuilt aged one (non-SYN). */
+		if (l4->syn && !l4->ack)
+			create_port_mapping_session(l3->saddr, l4->source, mvm_port,
+						    l3->daddr, l4->dest, skb->ingress_ifindex,
+						    now, TCP_CONNTRACK_SYN_RECV);
+		else
+			create_port_mapping_session(l3->saddr, l4->source, mvm_port,
+						    l3->daddr, l4->dest, skb->ingress_ifindex,
+						    now, TCP_CONNTRACK_ESTABLISHED);
+	} else {
+		sess->access_time = now;
+	}
 
 	old_daddr = l3->daddr;
 	new_daddr = mvm_inner_ip;
@@ -71,9 +134,11 @@ static int tcp_nat_proxy(struct __sk_buff *skb, struct ethhdr *l2, struct iphdr 
 static int tcp_nat_session(struct __sk_buff *skb, struct ethhdr *l2, struct iphdr *l3, struct tcphdr *l4)
 {
 	__u32 old_daddr, new_daddr, tcp_csum_off;
-	__u16 old_dport, new_dport;
-	struct session_key key = {};
+	struct ingress_session *isess;
 	struct nat_session *sess;
+	struct session_key key = {};
+	struct session_key ekey = {};
+	__u16 old_dport, new_dport;
 	bool syn, ack, fin, rst;
 	__u16 ip_hlen;
 	__u64 flags;
@@ -86,7 +151,33 @@ static int tcp_nat_session(struct __sk_buff *skb, struct ethhdr *l2, struct iphd
 	key.dst_port = l4->dest;
 	key.version = 0;
 	key.protocol = l3->protocol;
-	sess = lookup_session(&key);
+
+	/* The ingress key version is always 0, so a tracked sandbox connection's
+	 * ingress entry is found regardless of rollback. Its presence marks this
+	 * packet as sandbox traffic; host-bound traffic (e.g. external SSH to the
+	 * node) has no ingress entry and must never be reset here. */
+	isess = bpf_map_lookup_elem(&ingress_sessions, &key);
+	if (!isess)
+		return TC_ACT_OK;
+
+	/* Sandbox traffic. The ingress value records the creation generation in
+	 * its version field; a mismatch against the VM's current mvm_meta->version
+	 * means the connection is stale after a rollback. Build the egress key
+	 * (the ingress value carries the VM tuple and the recorded generation),
+	 * drop the pair, and reset the peer. */
+	ekey.src_ip = isess->vm_ip;
+	ekey.dst_ip = key.src_ip;
+	ekey.src_port = isess->vm_port;
+	ekey.dst_port = key.src_port;
+	ekey.version = isess->version;
+	ekey.protocol = key.protocol;
+	if (isess->version != current_gen_by_ip(isess->vm_ip)) {
+		bpf_map_delete_elem(&egress_sessions, &ekey);
+		bpf_map_delete_elem(&ingress_sessions, &key);
+		return tcp_reflect_reset(skb, skb->ingress_ifindex);
+	}
+
+	sess = bpf_map_lookup_elem(&egress_sessions, &ekey);
 	if (!sess)
 		return TC_ACT_OK;
 

--- a/CubeNet/src/session.h
+++ b/CubeNet/src/session.h
@@ -10,6 +10,12 @@
 enum packet_class {
 	SNAT_PACKET = 0,
 	L7PROXY_PACKET,
+	/* PORT_MAPPING_PACKET marks sessions for statically port-mapped (inbound)
+	 * connections. They have no ingress_sessions entry and their key version is
+	 * fixed at 0; the rollback generation is carried in nat_session.gen so an
+	 * aged (reaped) connection misses and is rebuilt while a stale (rolled-back)
+	 * one is found and reset. */
+	PORT_MAPPING_PACKET,
 };
 
 /* Lazy refresh threshold: 1 second in nanoseconds */
@@ -68,6 +74,67 @@ static __always_inline struct nat_session *lookup_session(const struct session_k
 	ekey.protocol = ikey->protocol;
 
 	return bpf_map_lookup_elem(&egress_sessions, &ekey);
+}
+
+/* current_gen returns the VM's current rollback generation (mvm_meta->version),
+ * or 0 when the metadata is missing. */
+static __always_inline __u32 current_gen(__u32 vm_ifindex)
+{
+	struct mvm_meta *meta = bpf_map_lookup_elem(&ifindex_to_mvmmeta, &vm_ifindex);
+
+	return meta ? meta->version : 0;
+}
+
+/* current_gen_by_ip returns the current rollback generation for the sandbox
+ * owning vm_ip, resolved via mvmip_to_ifindex. Used when only the VM's IP is
+ * available (e.g. an ingress_session value, which has no ifindex). */
+static __always_inline __u32 current_gen_by_ip(__be32 vm_ip)
+{
+	__u32 *ifindex = bpf_map_lookup_elem(&mvmip_to_ifindex, &vm_ip);
+
+	return ifindex ? current_gen(*ifindex) : 0;
+}
+
+/* session_is_stale reports whether the session was created in a previous
+ * rollback generation: its stamped gen differs from the VM's current version.
+ * A sandbox rollback bumps mvm_meta->version, orphaning older sessions. */
+static __always_inline bool session_is_stale(const struct nat_session *sess)
+{
+	return sess->gen != current_gen(sess->vm_ifindex);
+}
+
+/* port_mapping_key builds the egress_sessions key for a port_mapping
+ * connection. The guest is the server, so the key is the guest-side tuple
+ * (mvm_inner_ip:listen_port -> peer:peer_port) with a fixed key version of 0;
+ * the rollback generation is carried in the session value's gen field. */
+static __always_inline void port_mapping_key(struct session_key *key, __be32 peer_ip,
+					     __be16 peer_port, __be16 listen_port)
+{
+	key->src_ip = mvm_inner_ip;
+	key->src_port = listen_port;
+	key->dst_ip = peer_ip;
+	key->dst_port = peer_port;
+	key->version = 0;
+	key->protocol = IPPROTO_TCP;
+}
+
+/* delete_session_pair removes a stale session's egress entry and its ingress
+ * entry (ingress keys use version 0) so the tuple is freed for an immediate
+ * reconnect. Only used for SNAT/L7 sessions, which have an ingress entry. */
+static __always_inline void delete_session_pair(struct session_key *ikey,
+						struct nat_session *sess)
+{
+	struct session_key ekey = {};
+
+	ekey.src_ip = sess->vm_ip;
+	ekey.dst_ip = ikey->src_ip;
+	ekey.src_port = sess->vm_port;
+	ekey.dst_port = ikey->src_port;
+	ekey.version = sess->gen;
+	ekey.protocol = ikey->protocol;
+
+	bpf_map_delete_elem(&egress_sessions, &ekey);
+	bpf_map_delete_elem(&ingress_sessions, ikey);
 }
 
 /* Unified egress policy verdict for a candidate flow.
@@ -309,6 +376,17 @@ static __always_inline bool create_nat_session(struct __sk_buff *skb,
 	 * mvm_meta is what schedules this flow's next re-check.
 	 */
 	sess.policy_version = policy_version;
+
+	/* Stamp the creation generation (the VM's current mvm_meta->version) so a
+	 * reverse-path reader can tell a stale (pre-rollback) session from a
+	 * merely reaped one. For SNAT/L7 this equals ekey->version; for
+	 * port_mapping the key version is fixed at 0 while gen tracks rollback. */
+	{
+		struct mvm_meta *meta = bpf_map_lookup_elem(&ifindex_to_mvmmeta, &vm_ifindex);
+
+		if (meta)
+			sess.gen = meta->version;
+	}
 	err = bpf_map_update_elem(&egress_sessions, ekey, &sess, BPF_NOEXIST);
 	if (err) {
 		/* on failure, clean up the ingress slot we reserved earlier */

--- a/CubeNet/src/tcp_reset.h
+++ b/CubeNet/src/tcp_reset.h
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright (c) 2026 Cube Authors */
+#ifndef __TCP_RESET_H
+#define __TCP_RESET_H
+
+#include "cubevs.h"
+#include "l2l3.h"
+#include "skb.h"
+
+/* Shared helpers for building a TCP RST from a triggering packet. These were
+ * moved out of mvmtap.bpf.c so the reverse (peer/proxy-facing) programs can
+ * reflect a reset, not just the guest-facing one. */
+
+static __always_inline bool tcp_segment_len(const struct iphdr *l3, const struct tcphdr *l4,
+					    __u32 *seg_len)
+{
+	__u16 ip_hlen, tcp_hlen, total_len;
+
+	ip_hlen = BPF_CORE_READ_BITFIELD(l3, ihl);
+	ip_hlen <<= 2;
+	tcp_hlen = BPF_CORE_READ_BITFIELD(l4, doff);
+	tcp_hlen <<= 2;
+	total_len = bpf_ntohs(l3->tot_len);
+	if (ip_hlen < sizeof(struct iphdr) || tcp_hlen < sizeof(struct tcphdr) ||
+	    total_len < ip_hlen + tcp_hlen)
+		return false;
+
+	*seg_len = total_len - ip_hlen - tcp_hlen;
+	if (l4->syn)
+		(*seg_len)++;
+	if (l4->fin)
+		(*seg_len)++;
+
+	return true;
+}
+
+/* tcp_ipv4_set_checksum computes the TCP checksum (pseudo-header + TCP header)
+ * into the check field, which the caller must have written as zero.
+ */
+static __always_inline int tcp_ipv4_set_checksum(struct __sk_buff *skb,
+						 __u32 tcp_csum_off,
+						 __be32 saddr, __be32 daddr,
+						 const struct tcphdr *tcp)
+{
+	const __u32 *words = (const __u32 *)tcp;
+	/* zero | proto | length, in network byte order */
+	__be32 proto_len = bpf_htonl(((__u32)IPPROTO_TCP << 16) | sizeof(*tcp));
+	__u64 ph_flags = BPF_F_PSEUDO_HDR | sizeof(__u32);
+	__u64 hdr_flags = sizeof(__u32);
+	long err;
+
+	/* Pseudo-header words */
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, saddr, ph_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, daddr, ph_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, proto_len, ph_flags);
+	if (err)
+		return err;
+
+	/* TCP header words: source|dest, seq, ack_seq, doff/flags/window,
+	 * check|urg_ptr. The check word currently contains 0 (caller wrote
+	 * a zeroed check field), so adding it is a no-op for the csum.
+	 */
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[0], hdr_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[1], hdr_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[2], hdr_flags);
+	if (err)
+		return err;
+	err = bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[3], hdr_flags);
+	if (err)
+		return err;
+	return bpf_l4_csum_replace(skb, tcp_csum_off, 0, words[4], hdr_flags);
+}
+
+static __always_inline int rewrite_l3_tot_len(struct __sk_buff *skb,
+					      __be16 old_tot_len, __be16 new_tot_len)
+{
+	long err;
+
+	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_tot_len, new_tot_len,
+				  sizeof(new_tot_len));
+	if (err)
+		return err;
+
+	return bpf_skb_store_bytes(skb, IP_TOT_LEN_OFF, &new_tot_len,
+				   sizeof(new_tot_len), 0);
+}
+
+/* tcp_reflect_reset reflects a TCP RST back toward the sender of the
+ * triggering packet, redirected out the interface it arrived on.
+ *
+ * The reply is a pure mirror of the trigger: source/destination IP, ports, and
+ * MACs are swapped, so it works unchanged for guest-facing (mvmtap) and
+ * peer/proxy-facing (nodenic/localgw) callers. Sequence numbers follow
+ * RFC 793/5961: if the trigger had ACK set, the RST's seq is that ack value
+ * (which the sender accepts as within its window); otherwise the RST carries
+ * ACK = trigger.seq + seg_len. Returns the bpf_redirect action, or TC_ACT_SHOT
+ * when the packet can't be safely rewritten (GSO, fragmented, or a RST).
+ */
+static __always_inline int tcp_reflect_reset(struct __sk_buff *skb, __u32 out_ifindex)
+{
+	struct tcphdr new_tcp = {};
+	union macaddr old_smac, old_dmac;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+	__be32 old_saddr, old_daddr, new_saddr, new_daddr;
+	__be16 old_tot_len, new_tot_len;
+	__u32 seq, ack_seq, new_skb_len;
+	__u32 seg_len, tcp_off, tcp_csum_off;
+	__u16 ip_hlen, new_ip_len;
+	long err;
+
+	/* bpf_skb_change_tail() may fail on GSO skbs or leave segmentation
+	 * state inconsistent. Fall back to drop instead of sending RST. */
+	if (skb->gso_segs)
+		return TC_ACT_SHOT;
+
+	if (!__pull_headers(skb, &l2, &l3, &l4))
+		return TC_ACT_SHOT;
+
+	if ((l3->frag_off & IP_FLAG_MF) || (l3->frag_off & IP_FRAG_OFF_MASK))
+		return TC_ACT_SHOT;
+
+	/* Never send a reset in response to a reset. */
+	if (l4->rst)
+		return TC_ACT_SHOT;
+
+	ip_hlen = BPF_CORE_READ_BITFIELD(l3, ihl);
+	ip_hlen <<= 2;
+	seq = l4->seq;
+	ack_seq = l4->ack_seq;
+	if (!tcp_segment_len(l3, l4, &seg_len))
+		return TC_ACT_SHOT;
+
+	/* Mirror: the reply comes from the address the sender talked to, back
+	 * to the sender. */
+	new_saddr = l3->daddr;
+	new_daddr = l3->saddr;
+	new_tcp.source = l4->dest;
+	new_tcp.dest = l4->source;
+	new_tcp.doff = sizeof(new_tcp) >> 2;
+	new_tcp.rst = 1;
+	if (l4->ack) {
+		new_tcp.seq = ack_seq;
+	} else {
+		new_tcp.ack_seq = bpf_htonl(bpf_ntohl(seq) + seg_len);
+		new_tcp.ack = 1;
+	}
+
+	new_ip_len = ip_hlen + sizeof(new_tcp);
+	new_skb_len = sizeof(struct ethhdr) + new_ip_len;
+	if (bpf_skb_change_tail(skb, new_skb_len, 0))
+		return TC_ACT_SHOT;
+
+	/* bpf_skb_change_tail invalidates all packet pointers. */
+	if (!__pull_headers(skb, &l2, &l3, &l4))
+		return TC_ACT_SHOT;
+
+	/* Snapshot fields and swap MACs before helper calls invalidate the
+	 * packet pointers: the reply leaves with src = our interface MAC and
+	 * dst = the last-hop sender's MAC. */
+	old_saddr = l3->saddr;
+	old_daddr = l3->daddr;
+	old_tot_len = l3->tot_len;
+	old_smac = *(union macaddr *)l2->h_source;
+	old_dmac = *(union macaddr *)l2->h_dest;
+	new_tot_len = bpf_htons(new_ip_len);
+	tcp_off = sizeof(struct ethhdr) + ip_hlen;
+	tcp_csum_off = TCP_CSUM_OFF(ip_hlen);
+	set_mac_pair(l2, old_dmac.p1, old_dmac.p2, old_smac.p1, old_smac.p2);
+
+	/* Write the new TCP header (with check = 0). */
+	err = bpf_skb_store_bytes(skb, tcp_off, &new_tcp, sizeof(new_tcp), 0);
+	if (err)
+		return TC_ACT_SHOT;
+	err = rewrite_l3_tot_len(skb, old_tot_len, new_tot_len);
+	if (err)
+		return TC_ACT_SHOT;
+	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_saddr, new_saddr,
+				  sizeof(new_saddr));
+	if (err)
+		return TC_ACT_SHOT;
+	err = bpf_skb_store_bytes(skb, IP_SADDR_OFF, &new_saddr,
+				  sizeof(new_saddr), 0);
+	if (err)
+		return TC_ACT_SHOT;
+	err = bpf_l3_csum_replace(skb, IP_CSUM_OFF, old_daddr, new_daddr,
+				  sizeof(new_daddr));
+	if (err)
+		return TC_ACT_SHOT;
+	err = bpf_skb_store_bytes(skb, IP_DADDR_OFF, &new_daddr,
+				  sizeof(new_daddr), 0);
+	if (err)
+		return TC_ACT_SHOT;
+	err = tcp_ipv4_set_checksum(skb, tcp_csum_off, new_saddr, new_daddr,
+				    &new_tcp);
+	if (err)
+		return TC_ACT_SHOT;
+
+	return bpf_redirect(out_ifindex, 0);
+}
+
+#endif /* __TCP_RESET_H */

--- a/CubeNet/src/tcp_reset.h
+++ b/CubeNet/src/tcp_reset.h
@@ -93,25 +93,32 @@ static __always_inline int rewrite_l3_tot_len(struct __sk_buff *skb,
 				   sizeof(new_tot_len), 0);
 }
 
-/* tcp_reflect_reset reflects a TCP RST back toward the sender of the
- * triggering packet, redirected out the interface it arrived on.
+/* tcp_send_reset builds a TCP RST from the triggering packet and redirects it
+ * out out_ifindex.
  *
- * The reply is a pure mirror of the trigger: source/destination IP, ports, and
- * MACs are swapped, so it works unchanged for guest-facing (mvmtap) and
- * peer/proxy-facing (nodenic/localgw) callers. Sequence numbers follow
+ * The reply mirrors the trigger except for its destination: new_saddr is the
+ * address the sender talked to (the trigger's destination), ports and MACs are
+ * swapped, and new_daddr is supplied by the caller. Sequence numbers follow
  * RFC 793/5961: if the trigger had ACK set, the RST's seq is that ack value
  * (which the sender accepts as within its window); otherwise the RST carries
  * ACK = trigger.seq + seg_len. Returns the bpf_redirect action, or TC_ACT_SHOT
  * when the packet can't be safely rewritten (GSO, fragmented, or a RST).
+ *
+ * Callers pick new_daddr per direction: peer/proxy-facing paths (nodenic /
+ * localgw) pass the trigger's source (l3->saddr, i.e. back to the sender);
+ * guest-facing paths (mvmtap) pass mvm_inner_ip, because from_cube rewrites the
+ * source to the sandbox's real IP before the reset, so the trigger's source is
+ * no longer the guest's TAP-side address.
  */
-static __always_inline int tcp_reflect_reset(struct __sk_buff *skb, __u32 out_ifindex)
+static __always_inline int tcp_send_reset(struct __sk_buff *skb, __u32 out_ifindex,
+					  __be32 new_daddr)
 {
 	struct tcphdr new_tcp = {};
 	union macaddr old_smac, old_dmac;
 	struct ethhdr *l2;
 	struct iphdr *l3;
 	struct tcphdr *l4;
-	__be32 old_saddr, old_daddr, new_saddr, new_daddr;
+	__be32 old_saddr, old_daddr, new_saddr;
 	__be16 old_tot_len, new_tot_len;
 	__u32 seq, ack_seq, new_skb_len;
 	__u32 seg_len, tcp_off, tcp_csum_off;
@@ -140,10 +147,9 @@ static __always_inline int tcp_reflect_reset(struct __sk_buff *skb, __u32 out_if
 	if (!tcp_segment_len(l3, l4, &seg_len))
 		return TC_ACT_SHOT;
 
-	/* Mirror: the reply comes from the address the sender talked to, back
-	 * to the sender. */
+	/* The reply comes from the address the sender talked to; new_daddr is the
+	 * caller-chosen destination. */
 	new_saddr = l3->daddr;
-	new_daddr = l3->saddr;
 	new_tcp.source = l4->dest;
 	new_tcp.dest = l4->source;
 	new_tcp.doff = sizeof(new_tcp) >> 2;

--- a/Cubelet/services/cubebox/rollback.go
+++ b/Cubelet/services/cubebox/rollback.go
@@ -21,6 +21,8 @@ import (
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
+
+	"github.com/tencentcloud/CubeSandbox/CubeNet/cubevs"
 )
 
 const (
@@ -229,6 +231,14 @@ func (s *service) RollbackSandbox(ctx context.Context, req *cubebox.RollbackSand
 	// Pid/StartedAt against the live shim once RollingBack clears.
 	resetSandboxStatusAfterRollback(cb)
 
+	// The rollback restored and resumed the guest. Bump its network generation
+	// so the dataplane resets now-stale TCP sessions instead of letting them
+	// hang. Warn-only: the guest is already running, so failing the RPC over a
+	// dataplane bump would diverge master/cubelet state for a non-fatal issue.
+	if err := bumpRollbackNetworkGeneration(req.GetSandboxID()); err != nil {
+		stepLog.Warnf("rollback succeeded but failed to bump network generation for sandbox %s: %v", req.GetSandboxID(), err)
+	}
+
 	newRootfs.MountName = currentRootfs.MountName
 	if err := storage.PersistSandboxRootfs(ctx, req.GetSandboxID(), newRootfs); err != nil {
 		rsp.Ret.RetCode = errorcode.ErrorCode_Unknown
@@ -333,6 +343,22 @@ func resolveRollbackTargets(ctx context.Context, backend string, req *cubebox.Ro
 		return "", "", "", "", fmt.Errorf("rollback: local snapshot catalog lookup for %s failed: %w", req.GetSnapshotID(), err)
 	}
 	return entry.RootfsVol, entry.MemoryVol, entry.MemoryKind, entry.MetaDir, nil
+}
+
+// bumpRollbackNetworkGeneration bumps the sandbox's network generation so the
+// dataplane resets now-stale TCP sessions after a rollback. Best effort; the
+// caller logs a warning on failure.
+func bumpRollbackNetworkGeneration(sandboxID string) error {
+	taps, err := cubevs.ListTAPDevices()
+	if err != nil {
+		return err
+	}
+	for _, tap := range taps {
+		if tap.ID == sandboxID {
+			return cubevs.BumpMvmVersion(uint32(tap.Ifindex))
+		}
+	}
+	return fmt.Errorf("no TAP device found for sandbox %s", sandboxID)
 }
 
 func (s *service) buildRollbackRestoreConfig(ctx context.Context, sandboxID, metaDir string, currentRootfs, newRootfs, memory *storage.CowSnapshotObject) (string, error) {

--- a/Cubelet/services/cubebox/rollback.go
+++ b/Cubelet/services/cubebox/rollback.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"path/filepath"
 	"strings"
 	"time"
@@ -235,7 +236,7 @@ func (s *service) RollbackSandbox(ctx context.Context, req *cubebox.RollbackSand
 	// so the dataplane resets now-stale TCP sessions instead of letting them
 	// hang. Warn-only: the guest is already running, so failing the RPC over a
 	// dataplane bump would diverge master/cubelet state for a non-fatal issue.
-	if err := bumpRollbackNetworkGeneration(req.GetSandboxID()); err != nil {
+	if err := bumpRollbackNetworkGeneration(cb.IP); err != nil {
 		stepLog.Warnf("rollback succeeded but failed to bump network generation for sandbox %s: %v", req.GetSandboxID(), err)
 	}
 
@@ -347,18 +348,19 @@ func resolveRollbackTargets(ctx context.Context, backend string, req *cubebox.Ro
 
 // bumpRollbackNetworkGeneration bumps the sandbox's network generation so the
 // dataplane resets now-stale TCP sessions after a rollback. Best effort; the
-// caller logs a warning on failure.
-func bumpRollbackNetworkGeneration(sandboxID string) error {
-	taps, err := cubevs.ListTAPDevices()
+// caller logs a warning on failure. It resolves the TAP ifindex from the
+// sandbox IP in O(1) via the mvmip_to_ifindex map rather than scanning every
+// TAP device.
+func bumpRollbackNetworkGeneration(sandboxIP string) error {
+	ip := net.ParseIP(sandboxIP).To4()
+	if ip == nil {
+		return fmt.Errorf("invalid sandbox IP %q", sandboxIP)
+	}
+	ifindex, err := cubevs.LookupIfindexByIP(ip)
 	if err != nil {
 		return err
 	}
-	for _, tap := range taps {
-		if tap.ID == sandboxID {
-			return cubevs.BumpMvmVersion(uint32(tap.Ifindex))
-		}
-	}
-	return fmt.Errorf("no TAP device found for sandbox %s", sandboxID)
+	return cubevs.BumpMvmVersion(ifindex)
 }
 
 func (s *service) buildRollbackRestoreConfig(ctx context.Context, sandboxID, metaDir string, currentRootfs, newRootfs, memory *storage.CowSnapshotObject) (string, error) {


### PR DESCRIPTION
 ---
  Problem

  A sandbox rollback (restore snapshot + resume guest) rewinds the guest's TCP state, but the dataplane conntrack/NAT session table and the peer's TCP state do not rewind. In-flight connections then desync and hang: the guest waits for retransmits the peer already ACKed (recv
  hang), or keeps retransmitting data the peer already confirmed (send hang). Clearing the session table alone is not enough — the guest's stack won't error out on silent packet loss.

  Approach

  Detect stale (pre-rollback) sessions by generation and reset them so both endpoints get a clean ECONNRESET and reconnect promptly.

  - Generation = mvm_meta.version, carried in a new nat_session.gen field (stamped at creation) and in the session key for SNAT/L7. RollbackSandbox bumps it via a map read-modify-write +1 after the guest is restored and resumed.
  - RollbackSandbox bump is O(1): the TAP ifindex is resolved from the sandbox IP via the mvmip_to_ifindex map (LookupIfindexByIP) instead of scanning every TAP device.

  Per-connection-type behavior

  - SNAT: forward misses reuse the existing miss-reset; reverse (nodenic) resets the peer when the ingress entry (key version always 0, so it is found across a rollback) records a generation that differs from the current one. Host-bound traffic has no ingress entry and is passed 
  through, never reset (e.g. external SSH to the node).
  - L7 (localgw from_envoy): a stale L7 reply reflects a reset to the proxy and drops the session pair; a miss is non-blocking as before.
  - port_mapping: the inbound path tracks the connection in an egress session (fixed key, gen in value). A stale connection resets the peer; a reaped one is rebuilt (not reset); the guest side is reset via the mvmtap reply path.

  Unified RST builder

  A single tcp_send_reset(skb, out_ifindex, new_daddr) in tcp_reset.h serves both directions (removes the duplicated tcp_reply_reset):
  - peer/proxy-facing (nodenic / localgw) passes the trigger's source;
  - guest-facing (mvmtap) passes mvm_inner_ip, because from_cube rewrites the source to the sandbox's real IP before the reset decision.

  Verification

  - mvmtap / nodenic / localgw compile for amd64 + arm64 and pass the kernel verifier (bpftool prog loadall).
  - cubevs Go tests (incl. BumpMvmVersion RMW + field preservation) and Cubelet services/cubebox + network suites pass.
  - e2e (real snapshot/rollback with a long-lived connection observing ECONNRESET) should be run on a target cluster before merge.

  Assisted-by: zhouxianping999@qq.com