### PR TITLE
feat(pause): clone live memory on resume so the pause package can be deleted

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/list.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/list.go
@@ -14,7 +14,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -186,9 +185,7 @@ var ListCommand = cli.Command{
 		if c.Bool("wide") {
 			tabHeader += "\ttemplate_id\tnamespace\thost_ip\tlabels"
 		}
-		sort.Slice(rsp.Data, func(i, j int) bool {
-			return rsp.Data[i].CreateAt < rsp.Data[j].CreateAt
-		})
+		types.SortSandboxList(rsp.Data)
 		fmt.Fprintln(w, tabHeader)
 		for _, sandbox := range rsp.Data {
 			row := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s", sandbox.SandboxID,
@@ -252,8 +249,9 @@ func runListQueryAllPages(c *cli.Context, host string, req *types.ListCubeSandbo
 		aggregated.Total = rsp.Total
 		aggregated.EndIdx = rsp.EndIdx
 		aggregated.Size += rsp.Size
-		// Paused sandboxes come from Master's pause table, so every page
-		// carries them regardless of which nodes it scanned.
+		// Shimless paused rows are appended only on the last node page.
+		// Dedup still matters: a tombstone the origin node reported on an
+		// earlier page would otherwise reappear when the last page invents it.
 		for _, item := range rsp.Data {
 			if item == nil || seen[item.SandboxID] {
 				continue

--- a/CubeMaster/pkg/nodemeta/hostfacts_query_test.go
+++ b/CubeMaster/pkg/nodemeta/hostfacts_query_test.go
@@ -41,6 +41,28 @@ func TestFilterHostFactCandidates(t *testing.T) {
 			wantIDs:   []string{"node-a"},
 		},
 		{
+			name: "same kernel different cpuid_hash is rejected",
+			nodes: node.NodeList{
+				nodeA,
+				&node.Node{InsID: "node-other-cpu", IP: "10.0.0.7", Healthy: true, HostFacts: &node.HostFacts{CPUIDHash: "hash-other", HostKernelRelease: "5.15.0"}},
+			},
+			cpuidHash: "hash-x",
+			kernelRel: "5.15.0",
+			matchAll:  false,
+			wantIDs:   []string{"node-a"},
+		},
+		{
+			name: "same cpuid_hash different kernel is rejected",
+			nodes: node.NodeList{
+				nodeA,
+				&node.Node{InsID: "node-other-kernel", IP: "10.0.0.8", Healthy: true, HostFacts: &node.HostFacts{CPUIDHash: "hash-x", HostKernelRelease: "6.1.0"}},
+			},
+			cpuidHash: "hash-x",
+			kernelRel: "5.15.0",
+			matchAll:  false,
+			wantIDs:   []string{"node-a"},
+		},
+		{
 			name:      "ARM node filtered by its own CPUIDHash",
 			nodes:     node.NodeList{nodeA, armNode},
 			cpuidHash: "sha256:arm-a78",

--- a/CubeMaster/pkg/pausesnap/delete_paused.go
+++ b/CubeMaster/pkg/pausesnap/delete_paused.go
@@ -91,23 +91,37 @@ func isShimGonePauseSnapshot(status string) bool {
 	return strings.EqualFold(status, statusReady) || strings.EqualFold(status, statusDeleteFailed)
 }
 
-// DropOriginTombstone removes the PAUSED CubeBox row Pause left on originIP
-// after the sandbox came back up on a different node. Same-node Resume has
-// no use for this: there, target Create replaces the row in place.
-//
-// Only the row goes. The pause package and its cubecow objects stay, exactly
-// as they do after a same-node Resume.
+// DropOriginTombstone removes origin leftovers after a cross-node Resume:
+// the PAUSED CubeBox row, then the pause package. Same-node Resume must not
+// call this — Create already replaced the tombstone; it uses
+// CleanupPauseSnapshot instead.
 //
 // This talks to Cubelet directly rather than going through Master's
 // DestroySandbox, which would publish a lifecycle delete event and make the
 // CLM stop managing a sandbox that is very much alive on the target node.
-func DropOriginTombstone(ctx context.Context, requestID, sandboxID, originIP string) error {
+func DropOriginTombstone(ctx context.Context, requestID, sandboxID, originIP, snapshotID, backend string) error {
 	sandboxID = strings.TrimSpace(sandboxID)
 	originIP = strings.TrimSpace(originIP)
 	if sandboxID == "" || originIP == "" {
 		return nil
 	}
-	return destroyPausedTombstone(ctx, cubeletAddr(originIP), requestID, sandboxID, originIP)
+	addr := cubeletAddr(originIP)
+	tombErr := destroyPausedTombstone(ctx, addr, requestID, sandboxID, originIP)
+	packErr := CleanupPauseSnapshot(ctx, requestID, originIP, snapshotID, backend)
+	return errors.Join(tombErr, packErr)
+}
+
+// CleanupPauseSnapshot removes a pause package from nodeIP. Resume calls this
+// after the sandbox has its own disks: same-node on the resume host, cross-node
+// on origin (via DropOriginTombstone). Missing objects are Cubelet's problem
+// to treat as cleaned.
+func CleanupPauseSnapshot(ctx context.Context, requestID, nodeIP, snapshotID, backend string) error {
+	nodeIP = strings.TrimSpace(nodeIP)
+	snapshotID = strings.TrimSpace(snapshotID)
+	if nodeIP == "" || snapshotID == "" {
+		return nil
+	}
+	return cleanupPauseSnapshotOnCubelet(ctx, cubeletAddr(nodeIP), requestID, snapshotID, backend)
 }
 
 func destroyPausedTombstone(ctx context.Context, addr, requestID, sandboxID, hostIP string) error {

--- a/CubeMaster/pkg/pausesnap/delete_paused_test.go
+++ b/CubeMaster/pkg/pausesnap/delete_paused_test.go
@@ -306,3 +306,62 @@ func TestCheckDestroyRet(t *testing.T) {
 		Ret: &cubeleterrorcode.Ret{RetCode: cubeleterrorcode.ErrorCode_Unknown, RetMsg: "disk full"},
 	}, "sb", "destroy"))
 }
+
+func TestDropOriginTombstoneCleansPausePackage(t *testing.T) {
+	setupPauseDeleteTest(t)
+	destroys, cleans := mockCubeletOK(t)
+
+	err := DropOriginTombstone(context.Background(), "req-x", "sb-x", "10.0.0.8",
+		"snap-x000000000000000000000001", constants.SnapshotBackendS3)
+	require.NoError(t, err)
+	require.Len(t, *destroys, 1)
+	require.Equal(t, "10.0.0.8:50051", (*destroys)[0].addr)
+	require.Equal(t, "true", (*destroys)[0].req.Annotations[constants.CubeAnnotationPauseDeleteTombstone])
+	require.Len(t, *cleans, 1)
+	require.Equal(t, "10.0.0.8:50051", (*cleans)[0].addr)
+	require.Equal(t, "snap-x000000000000000000000001", (*cleans)[0].req.TemplateID)
+	require.Equal(t, constants.SnapshotBackendS3, (*cleans)[0].req.Backend)
+}
+
+func TestCleanupPauseSnapshot(t *testing.T) {
+	setupPauseDeleteTest(t)
+	destroys, cleans := mockCubeletOK(t)
+
+	require.NoError(t, CleanupPauseSnapshot(context.Background(), "req-s", "10.0.0.8",
+		"snap-s000000000000000000000001", constants.SnapshotBackendXFS))
+	require.Empty(t, *destroys)
+	require.Len(t, *cleans, 1)
+	require.Equal(t, "10.0.0.8:50051", (*cleans)[0].addr)
+	require.Equal(t, "snap-s000000000000000000000001", (*cleans)[0].req.TemplateID)
+	require.Equal(t, constants.SnapshotBackendXFS, (*cleans)[0].req.Backend)
+
+	require.NoError(t, CleanupPauseSnapshot(context.Background(), "req-s", "10.0.0.8", "", constants.SnapshotBackendXFS))
+	require.NoError(t, CleanupPauseSnapshot(context.Background(), "req-s", "", "snap-s000000000000000000000001", constants.SnapshotBackendXFS))
+	require.Len(t, *cleans, 1)
+}
+
+func TestDropOriginTombstoneSkipsCleanupWithoutSnapshotID(t *testing.T) {
+	setupPauseDeleteTest(t)
+	destroys, cleans := mockCubeletOK(t)
+
+	err := DropOriginTombstone(context.Background(), "req-x", "sb-x", "10.0.0.8", "", "")
+	require.NoError(t, err)
+	require.Len(t, *destroys, 1)
+	require.Empty(t, *cleans)
+}
+
+func TestDropOriginTombstoneJoinsTombstoneAndCleanupErrors(t *testing.T) {
+	setupPauseDeleteTest(t)
+	destroyOnCubelet = func(_ context.Context, _ string, _ *cubebox.DestroyCubeSandboxRequest) (*cubebox.DestroyCubeSandboxResponse, error) {
+		return nil, errors.New("tombstone rpc failed")
+	}
+	cleanupTemplateOnCubelet = func(_ context.Context, _ string, _ *cubebox.CleanupTemplateRequest) (*cubebox.CleanupTemplateResponse, error) {
+		return nil, errors.New("cleanup rpc failed")
+	}
+
+	err := DropOriginTombstone(context.Background(), "req-x", "sb-x", "10.0.0.8",
+		"snap-x000000000000000000000001", constants.SnapshotBackendS3)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tombstone rpc failed")
+	require.Contains(t, err.Error(), "cleanup rpc failed")
+}

--- a/CubeMaster/pkg/remotestatus/reconciler_test.go
+++ b/CubeMaster/pkg/remotestatus/reconciler_test.go
@@ -176,6 +176,9 @@ func TestTerminalRemoteStatusRunningStaysOpen(t *testing.T) {
 	if next, ok := terminalRemoteStatus(constants.RemoteStatusPending, false); ok {
 		t.Fatalf("pending must not be terminal, got %q", next)
 	}
+	if next, ok := terminalRemoteStatus("", false); ok {
+		t.Fatalf("empty state must not be terminal, got %q", next)
+	}
 	next, ok := terminalRemoteStatus(constants.RemoteStatusReady, true)
 	if !ok || next != constants.RemoteStatusReady {
 		t.Fatalf("ready terminal=%v %q", ok, next)

--- a/CubeMaster/pkg/restoreplace/placement_test.go
+++ b/CubeMaster/pkg/restoreplace/placement_test.go
@@ -24,11 +24,34 @@ func resetPlacementSeams(t *testing.T) {
 	origLookup := lookupNodeFn
 	origSelect := selectNodeFn
 	origList := listCompatibleFn
+	origQuery := queryHostFactCandidatesFn
 	t.Cleanup(func() {
 		lookupNodeFn = origLookup
 		selectNodeFn = origSelect
 		listCompatibleFn = origList
+		queryHostFactCandidatesFn = origQuery
 	})
+}
+
+func isolatedOrigin(id, ip string) *node.Node {
+	n := &node.Node{InsID: id, IP: ip, Healthy: true}
+	n.SetSchedulingDisabled(true)
+	return n
+}
+
+func hostFacts(cpuid, kernel string) *nodemeta.HostFacts {
+	return &nodemeta.HostFacts{CPUIDHash: cpuid, HostKernelRelease: kernel}
+}
+
+func s3ReadyInput(originID string) Input {
+	return Input{
+		SnapshotID:          "snap-1",
+		Backend:             constants.SnapshotBackendS3,
+		RemoteStatus:        constants.RemoteStatusReady,
+		OriginNodeID:        originID,
+		OriginHostFactsJSON: originFactsJSON(),
+		InstanceType:        "cubebox",
+	}
 }
 
 func TestCanCrossNode(t *testing.T) {
@@ -137,6 +160,27 @@ func TestDecideS3PendingDoesNotCross(t *testing.T) {
 	}
 }
 
+func TestDecideS3InprogressDoesNotCross(t *testing.T) {
+	resetPlacementSeams(t)
+	origin := isolatedOrigin("node-a", "10.0.0.1")
+	lookupNodeFn = func(nodeID, nodeIP string) *node.Node { return origin }
+	listCompatibleFn = func(ctx context.Context, origin *nodemeta.HostFacts) ([]compatibleCandidate, error) {
+		t.Fatal("inprogress remote must not query peers")
+		return nil, nil
+	}
+
+	_, err := Decide(context.Background(), Input{
+		SnapshotID:          "snap-1",
+		Backend:             constants.SnapshotBackendS3,
+		RemoteStatus:        constants.RemoteStatusInProgress,
+		OriginNodeID:        "node-a",
+		OriginHostFactsJSON: originFactsJSON(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot restore cross-node") {
+		t.Fatalf("want origin-only failure for inprogress sync, got %v", err)
+	}
+}
+
 func TestDecideCrossNodeWhenOriginCannotSchedule(t *testing.T) {
 	resetPlacementSeams(t)
 	origin := &node.Node{InsID: "node-a", IP: "10.0.0.1", Healthy: false}
@@ -241,5 +285,162 @@ func TestDecideCrossNodeNoCompatiblePeer(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "no compatible node") {
 		t.Fatalf("want no-compatible-node error, got %v", err)
+	}
+}
+
+// Isolate leaves HEALTHY=true and only flips scheduling-disabled. Origin
+// must still be treated as "cannot stay" and fall through to cross-node.
+// Origin is HEALTHY and scheduling-allowed, but origin-scoped Select
+// returns nothing (no capacity / CPU / mem). Stay-local fails, then
+// cross-node Select on the kernel+cpuid peer list must run.
+func TestDecideCrossNodeWhenOriginSelectFails(t *testing.T) {
+	resetPlacementSeams(t)
+	origin := &node.Node{InsID: "node-a", IP: "10.0.0.1", Healthy: true}
+	peer := &node.Node{InsID: "node-b", IP: "10.0.0.2", Healthy: true}
+	lookupNodeFn = func(nodeID, nodeIP string) *node.Node { return origin }
+	selectNodeFn = func(ctx context.Context, instanceType string, reqRes *selctx.RequestResource, scope []string) (*node.Node, error) {
+		for _, s := range scope {
+			if s == "node-a" || s == "10.0.0.1" {
+				return nil, nil
+			}
+		}
+		return peer, nil
+	}
+	listCompatibleFn = func(ctx context.Context, origin *nodemeta.HostFacts) ([]compatibleCandidate, error) {
+		return []compatibleCandidate{{NodeID: "node-b", NodeIP: "10.0.0.2"}}, nil
+	}
+
+	got, err := Decide(context.Background(), s3ReadyInput("node-a"))
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if !got.CrossNode || got.NodeID != "node-b" {
+		t.Fatalf("want cross-node node-b after origin Select miss, got %+v", got)
+	}
+}
+
+func TestDecideCrossNodeWhenOriginIsolated(t *testing.T) {
+	resetPlacementSeams(t)
+	origin := isolatedOrigin("node-a", "10.0.0.1")
+	peer := &node.Node{InsID: "node-b", IP: "10.0.0.2", Healthy: true}
+	lookupNodeFn = func(nodeID, nodeIP string) *node.Node { return origin }
+	selectNodeFn = func(ctx context.Context, instanceType string, reqRes *selctx.RequestResource, scope []string) (*node.Node, error) {
+		if len(scope) == 1 && (scope[0] == "node-a" || scope[0] == "10.0.0.1") {
+			return nil, nil
+		}
+		for _, s := range scope {
+			if s == "node-a" {
+				t.Fatal("isolated origin must be excluded from cross-node scope")
+			}
+		}
+		return peer, nil
+	}
+	listCompatibleFn = func(ctx context.Context, origin *nodemeta.HostFacts) ([]compatibleCandidate, error) {
+		return []compatibleCandidate{{NodeID: "node-b", NodeIP: "10.0.0.2"}}, nil
+	}
+
+	got, err := Decide(context.Background(), s3ReadyInput("node-a"))
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if !got.CrossNode || got.NodeID != "node-b" {
+		t.Fatalf("want cross-node node-b after isolate, got %+v", got)
+	}
+}
+
+func TestDecideIsolatedOriginDoesNotCrossUnlessS3Ready(t *testing.T) {
+	resetPlacementSeams(t)
+	origin := isolatedOrigin("node-a", "10.0.0.1")
+	lookupNodeFn = func(nodeID, nodeIP string) *node.Node { return origin }
+	selectNodeFn = func(ctx context.Context, instanceType string, reqRes *selctx.RequestResource, scope []string) (*node.Node, error) {
+		return nil, nil
+	}
+	listCompatibleFn = func(ctx context.Context, origin *nodemeta.HostFacts) ([]compatibleCandidate, error) {
+		t.Fatal("pending remote must not query peers")
+		return nil, nil
+	}
+
+	_, err := Decide(context.Background(), Input{
+		SnapshotID:          "snap-1",
+		Backend:             constants.SnapshotBackendS3,
+		RemoteStatus:        constants.RemoteStatusPending,
+		OriginNodeID:        "node-a",
+		OriginHostFactsJSON: originFactsJSON(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot restore cross-node") {
+		t.Fatalf("want origin-only failure, got %v", err)
+	}
+}
+
+// queryHostFactCandidatesFn is the DB seam: SQL already equality-filters
+// cpuid_hash + host_kernel_release. Decide's cross-node scope is exactly
+// those rows, minus origin.
+func TestDecideCrossNodeScopeFollowsHostFactQuery(t *testing.T) {
+	resetPlacementSeams(t)
+	origin := isolatedOrigin("node-a", "10.0.0.1")
+	peer := &node.Node{InsID: "node-b", IP: "10.0.0.2", Healthy: true}
+	lookupNodeFn = func(nodeID, nodeIP string) *node.Node { return origin }
+	listCompatibleFn = defaultListCompatible
+	queryHostFactCandidatesFn = func(ctx context.Context, cpuid, kernel string, matchAll bool) ([]*nodemeta.CandidateNode, error) {
+		if matchAll {
+			t.Fatal("restore placement must not drop the required-key SQL predicate")
+		}
+		if cpuid != "sha256:cpu" || kernel != "5.15.0" {
+			t.Fatalf("query must use origin cpuid/kernel, got %s %s", cpuid, kernel)
+		}
+		same := hostFacts(cpuid, kernel)
+		return []*nodemeta.CandidateNode{
+			{NodeID: "node-a", HostIP: "10.0.0.1", HostFacts: same},
+			{NodeID: "node-b", HostIP: "10.0.0.2", HostFacts: same},
+		}, nil
+	}
+	selectNodeFn = func(ctx context.Context, instanceType string, reqRes *selctx.RequestResource, scope []string) (*node.Node, error) {
+		want := map[string]bool{"node-b": false, "10.0.0.2": false}
+		for _, s := range scope {
+			if s == "node-a" || s == "10.0.0.1" {
+				t.Fatalf("origin leaked into cross-node scope: %v", scope)
+			}
+			if _, ok := want[s]; ok {
+				want[s] = true
+			} else {
+				t.Fatalf("unexpected scope entry %q in %v", s, scope)
+			}
+		}
+		for k, seen := range want {
+			if !seen {
+				t.Fatalf("missing %s in scope %v", k, scope)
+			}
+		}
+		return peer, nil
+	}
+
+	got, err := Decide(context.Background(), s3ReadyInput("node-a"))
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if !got.CrossNode || got.NodeID != "node-b" {
+		t.Fatalf("want node-b, got %+v", got)
+	}
+}
+
+func TestDecideCrossNodeFailsWhenQueryHasNoMatchingPeer(t *testing.T) {
+	resetPlacementSeams(t)
+	origin := isolatedOrigin("node-a", "10.0.0.1")
+	lookupNodeFn = func(nodeID, nodeIP string) *node.Node { return origin }
+	selectNodeFn = func(ctx context.Context, instanceType string, reqRes *selctx.RequestResource, scope []string) (*node.Node, error) {
+		t.Fatal("must not Select when query returned no peer")
+		return nil, nil
+	}
+	listCompatibleFn = defaultListCompatible
+	queryHostFactCandidatesFn = func(ctx context.Context, cpuid, kernel string, matchAll bool) ([]*nodemeta.CandidateNode, error) {
+		// DB equality filter: cpuid/kernel mismatch never comes back.
+		return []*nodemeta.CandidateNode{
+			{NodeID: "node-a", HostIP: "10.0.0.1", HostFacts: hostFacts(cpuid, kernel)},
+		}, nil
+	}
+
+	_, err := Decide(context.Background(), s3ReadyInput("node-a"))
+	if err == nil || !strings.Contains(err.Error(), "no compatible node") {
+		t.Fatalf("want no-compatible-node, got %v", err)
 	}
 }

--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"runtime/debug"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -96,60 +95,48 @@ func listSandbox(ctx context.Context, req *types.ListCubeSandboxReq, failOnCubel
 		nodeList, rsp.EndIdx = localcache.RangeDBHost(req.StartIdx, req.Size, req.InstanceType)
 	}
 
-	if len(nodeList) == 0 {
-		return
-	}
-
 	rsp.Size = len(nodeList)
+	if len(nodeList) > 0 {
+		var resChan = make(chan *types.SandboxBriefData, 1000*len(nodeList))
+		done := make(chan struct{})
+		var listFailed atomic.Bool
 
-	var resChan = make(chan *types.SandboxBriefData, 1000*len(nodeList))
-	done := make(chan struct{})
-	var listFailed atomic.Bool
+		dealRspData(ctx, done, resChan, rsp)
 
-	dealRspData(ctx, done, resChan, rsp)
-
-	var wg sync.WaitGroup
-
-	for _, tmpNode := range nodeList {
-		tmpNode := tmpNode
-		recov.GoWithWaitGroup(&wg, func() {
-			doOneList(ctx, req, tmpNode, resChan, &listFailed)
-		}, func(panicError interface{}) {
-			log.G(ctx).Fatalf("panic:%v", string(debug.Stack()))
-		})
-	}
-	wg.Wait()
-	close(resChan)
-	<-done
-
-	if failOnCubeletError && listFailed.Load() {
-		rsp.Ret.RetCode = int(errorcode.ErrorCode_ReqCubeAPIFailed)
-		rsp.Ret.RetMsg = "list sandbox failed: cubelet unreachable"
-	}
-
-	// Results arrive over resChan in goroutine-completion order, which varies
-	// between calls and across nodes, so rsp.Data would otherwise be reshuffled
-	// on every list request. Sort by creation time descending (newest first),
-	// falling back to SandboxID for a deterministic, stable order.
-	sort.Slice(rsp.Data, func(i, j int) bool {
-		if rsp.Data[i].CreateAt != rsp.Data[j].CreateAt {
-			return rsp.Data[i].CreateAt > rsp.Data[j].CreateAt
+		var wg sync.WaitGroup
+		for _, tmpNode := range nodeList {
+			tmpNode := tmpNode
+			recov.GoWithWaitGroup(&wg, func() {
+				doOneList(ctx, req, tmpNode, resChan, &listFailed)
+			}, func(panicError interface{}) {
+				log.G(ctx).Fatalf("panic:%v", string(debug.Stack()))
+			})
 		}
-		return rsp.Data[i].SandboxID < rsp.Data[j].SandboxID
-	})
+		wg.Wait()
+		close(resChan)
+		<-done
+
+		if failOnCubeletError && listFailed.Load() {
+			rsp.Ret.RetCode = int(errorcode.ErrorCode_ReqCubeAPIFailed)
+			rsp.Ret.RetMsg = "list sandbox failed: cubelet unreachable"
+		}
+	}
+
 	enrichSandboxListBackends(ctx, rsp.Data)
 	mergePauseBindings(ctx, req, rsp)
+	types.SortSandboxList(rsp.Data)
 	return
 }
 
 // mergePauseBindings adds Master's pause state to the node-scan result.
 //
 // A paused sandbox has no shim, so the node scan cannot be trusted to report
-// it, and t_cube_pause_snapshot is the source of truth. Bindings are therefore
-// read in full rather than per scanned node: the (StartIdx, Size) window only
-// paginates node scanning. An explicit --hostid is still honoured, because it
-// selects one node on purpose and `list --hostid X --quiet --delete` must not
-// reach a sandbox parked on another node.
+// it, and t_cube_pause_snapshot is the source of truth. Scanned rows are
+// always enriched with pause_snap／remote. Shimless READY／DELETE_FAILED
+// rows that the scan missed are appended only on the last node page (or
+// when --hostid selects one node), so they sit after running sandboxes
+// instead of repeating on every page. Label-filtered lists still do not
+// invent rows (labels only exist on the node).
 func mergePauseBindings(ctx context.Context, req *types.ListCubeSandboxReq, rsp *types.ListCubeSandboxRes) {
 	records, err := pausesnap.List(ctx, pausesnap.ListOptions{
 		HostID:       req.HostID,
@@ -161,11 +148,28 @@ func mergePauseBindings(ctx context.Context, req *types.ListCubeSandboxReq, rsp 
 		}
 		return
 	}
-	rsp.Data = applyPauseBindings(rsp.Data, records, req.Filter != nil && len(req.Filter.LabelSelector) > 0)
+	labelFiltered := req.Filter != nil && len(req.Filter.LabelSelector) > 0
+	rsp.Data = applyPauseBindings(rsp.Data, records, labelFiltered, shouldAppendShimlessPauseRows(req, rsp))
+}
+
+// shouldAppendShimlessPauseRows is true for a single-host list and for the
+// last node-window page. Intermediate pages only decorate rows the scan
+// already returned.
+func shouldAppendShimlessPauseRows(req *types.ListCubeSandboxReq, rsp *types.ListCubeSandboxRes) bool {
+	if req != nil && strings.TrimSpace(req.HostID) != "" {
+		return true
+	}
+	if rsp == nil {
+		return false
+	}
+	if rsp.Total <= 0 || rsp.Size == 0 {
+		return true
+	}
+	return rsp.EndIdx >= rsp.Total
 }
 
 func applyPauseBindings(items []*types.SandboxBriefData, records []*pausesnap.Record,
-	labelFiltered bool) []*types.SandboxBriefData {
+	labelFiltered, appendMissing bool) []*types.SandboxBriefData {
 	known := make(map[string]*types.SandboxBriefData, len(items))
 	for _, item := range items {
 		if item != nil && item.SandboxID != "" {
@@ -189,7 +193,7 @@ func applyPauseBindings(items []*types.SandboxBriefData, records []*pausesnap.Re
 		}
 		// Labels only exist on the node, so a label-filtered list cannot tell
 		// whether this binding would have matched.
-		if labelFiltered {
+		if labelFiltered || !appendMissing {
 			continue
 		}
 		item := pauseBindingRow(rec)

--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -153,8 +153,9 @@ func mergePauseBindings(ctx context.Context, req *types.ListCubeSandboxReq, rsp 
 }
 
 // shouldAppendShimlessPauseRows is true for a single-host list and for the
-// last node-window page. Intermediate pages only decorate rows the scan
-// already returned.
+// last node-window page (EndIdx >= Total, or no healthy nodes). Intermediate
+// pages — including an empty window past the last node — only decorate rows
+// the scan already returned.
 func shouldAppendShimlessPauseRows(req *types.ListCubeSandboxReq, rsp *types.ListCubeSandboxRes) bool {
 	if req != nil && strings.TrimSpace(req.HostID) != "" {
 		return true
@@ -162,7 +163,7 @@ func shouldAppendShimlessPauseRows(req *types.ListCubeSandboxReq, rsp *types.Lis
 	if rsp == nil {
 		return false
 	}
-	if rsp.Total <= 0 || rsp.Size == 0 {
+	if rsp.Total <= 0 {
 		return true
 	}
 	return rsp.EndIdx >= rsp.Total

--- a/CubeMaster/pkg/service/sandbox/sandbox_list_pause_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list_pause_test.go
@@ -29,7 +29,7 @@ func TestApplyPauseBindingsEnrichesScannedRow(t *testing.T) {
 		Backend:      constants.SnapshotBackendS3,
 		RemoteStatus: constants.RemoteStatusReady,
 		UpdatedAt:    pausedAt,
-	}}, false)
+	}}, false, true)
 
 	require.Len(t, got, 1)
 	require.Equal(t, "snap-1", got[0].PauseSnapshotID)
@@ -50,7 +50,7 @@ func TestApplyPauseBindingsAppendsRowMissingFromNodeScan(t *testing.T) {
 		Backend:      constants.SnapshotBackendS3,
 		RemoteStatus: constants.RemoteStatusInProgress,
 		UpdatedAt:    pausedAt,
-	}}, false)
+	}}, false, true)
 
 	require.Len(t, got, 1)
 	require.Equal(t, "sb-2", got[0].SandboxID)
@@ -66,7 +66,7 @@ func TestApplyPauseBindingsSkipsUnfinishedPause(t *testing.T) {
 	got := applyPauseBindings(nil, []*pausesnap.Record{
 		{SandboxID: "sb-3", SnapshotID: "snap-3", Status: "CREATING"},
 		{SandboxID: "sb-4", SnapshotID: "snap-4", Status: pausesnap.StatusFailed},
-	}, false)
+	}, false, true)
 
 	require.Empty(t, got)
 }
@@ -79,7 +79,7 @@ func TestApplyPauseBindingsSurfacesDeleteFailedLeftover(t *testing.T) {
 		Status:       pausesnap.StatusDeleteFailed,
 		Backend:      constants.SnapshotBackendS3,
 		RemoteStatus: constants.RemoteStatusReady,
-	}}, false)
+	}}, false, true)
 
 	require.Len(t, got, 1, "a pause package the node could not sweep must stay visible")
 	require.Equal(t, "sb-stuck", got[0].SandboxID)
@@ -94,11 +94,79 @@ func TestApplyPauseBindingsSkipsAppendWhenLabelFiltered(t *testing.T) {
 		RemoteStatus: constants.RemoteStatusReady,
 	}}
 
-	require.Empty(t, applyPauseBindings(nil, records, true))
+	require.Empty(t, applyPauseBindings(nil, records, true, true))
 
 	// A row the node did report still gets its pause state, filter or not.
 	items := []*types.SandboxBriefData{{SandboxID: "sb-5", Status: 5}}
-	got := applyPauseBindings(items, records, true)
+	got := applyPauseBindings(items, records, true, true)
 	require.Len(t, got, 1)
 	require.Equal(t, constants.RemoteStatusReady, got[0].RemoteStatus)
+}
+
+func TestApplyPauseBindingsDoesNotAppendOnIntermediatePage(t *testing.T) {
+	scanned := []*types.SandboxBriefData{{SandboxID: "sb-run", Status: 1, CreateAt: 99}}
+	records := []*pausesnap.Record{
+		{
+			SandboxID:    "sb-run",
+			SnapshotID:   "snap-run",
+			Status:       pausesnap.StatusReady,
+			RemoteStatus: constants.RemoteStatusReady,
+		},
+		{
+			SandboxID:    "sb-paused",
+			SnapshotID:   "snap-paused",
+			Status:       pausesnap.StatusReady,
+			RemoteStatus: constants.RemoteStatusReady,
+		},
+	}
+
+	got := applyPauseBindings(scanned, records, false, false)
+	require.Len(t, got, 1)
+	require.Equal(t, "sb-run", got[0].SandboxID)
+	require.Equal(t, "snap-run", got[0].PauseSnapshotID)
+}
+
+func TestShouldAppendShimlessPauseRows(t *testing.T) {
+	cases := []struct {
+		name string
+		req  *types.ListCubeSandboxReq
+		rsp  *types.ListCubeSandboxRes
+		want bool
+	}{
+		{
+			name: "hostid always appends",
+			req:  &types.ListCubeSandboxReq{HostID: "node-a"},
+			rsp:  &types.ListCubeSandboxRes{Total: 4, Size: 1, EndIdx: 1},
+			want: true,
+		},
+		{
+			name: "last page",
+			req:  &types.ListCubeSandboxReq{},
+			rsp:  &types.ListCubeSandboxRes{Total: 4, Size: 2, EndIdx: 4},
+			want: true,
+		},
+		{
+			name: "mid page",
+			req:  &types.ListCubeSandboxReq{},
+			rsp:  &types.ListCubeSandboxRes{Total: 4, Size: 2, EndIdx: 2},
+			want: false,
+		},
+		{
+			name: "empty window",
+			req:  &types.ListCubeSandboxReq{},
+			rsp:  &types.ListCubeSandboxRes{Total: 2, Size: 0},
+			want: true,
+		},
+		{
+			name: "no healthy nodes",
+			req:  &types.ListCubeSandboxReq{},
+			rsp:  &types.ListCubeSandboxRes{Total: 0, Size: 0},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldAppendShimlessPauseRows(tc.req, tc.rsp))
+		})
+	}
 }

--- a/CubeMaster/pkg/service/sandbox/sandbox_list_pause_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list_pause_test.go
@@ -152,10 +152,10 @@ func TestShouldAppendShimlessPauseRows(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "empty window",
+			name: "empty window is not last page",
 			req:  &types.ListCubeSandboxReq{},
-			rsp:  &types.ListCubeSandboxRes{Total: 2, Size: 0},
-			want: true,
+			rsp:  &types.ListCubeSandboxRes{Total: 2, Size: 0, EndIdx: -1},
+			want: false,
 		},
 		{
 			name: "no healthy nodes",

--- a/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
@@ -447,14 +447,15 @@ func resumeFromPauseSnapshot(ctx context.Context, req *types.UpdateRequest, host
 	purgeErr := cubeproxy.InvalidateBackendCache(ctx, req.SandboxID, targetIP)
 
 	// After Create the sandbox runs on private disks. Drop the pause package
-	// on the node that still holds it: origin when this was cross-node
-	// (also the PAUSED tombstone), otherwise this node.
-	if placement != nil && placement.CrossNode {
-		if origin := strings.TrimSpace(rec.NodeIP); origin != "" && origin != targetIP {
-			if err := pausesnap.DropOriginTombstone(ctx, req.RequestID, req.SandboxID, origin, rec.SnapshotID, rec.Backend); err != nil {
-				log.G(ctx).Errorf("resume: sandbox %s runs on %s but origin %s still has pause leftovers: %v",
-					req.SandboxID, targetIP, origin, err)
-			}
+	// on the node that still holds it: origin when that IP is known and not
+	// the target (also the PAUSED tombstone), otherwise this node. Do not
+	// key this off CrossNode — a cross-node placement with a blank origin
+	// would otherwise skip both cleanup paths and leak the package.
+	origin := strings.TrimSpace(rec.NodeIP)
+	if origin != "" && origin != targetIP {
+		if err := pausesnap.DropOriginTombstone(ctx, req.RequestID, req.SandboxID, origin, rec.SnapshotID, rec.Backend); err != nil {
+			log.G(ctx).Errorf("resume: sandbox %s runs on %s but origin %s still has pause leftovers: %v",
+				req.SandboxID, targetIP, origin, err)
 		}
 	} else if err := pausesnap.CleanupPauseSnapshot(ctx, req.RequestID, targetIP, rec.SnapshotID, rec.Backend); err != nil {
 		log.G(ctx).Errorf("resume: sandbox %s is running but pause package %s on %s was not deleted: %v",

--- a/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
@@ -446,24 +446,22 @@ func resumeFromPauseSnapshot(ctx context.Context, req *types.UpdateRequest, host
 	// describes a sandbox that is by now running whatever the proxy thinks.
 	purgeErr := cubeproxy.InvalidateBackendCache(ctx, req.SandboxID, targetIP)
 
-	// The sandbox now lives on the target, but the origin still holds the
-	// PAUSED CubeBox row Pause left behind. Same-node Resume replaces that
-	// row as part of Create; cross-node has to say so explicitly, or the
-	// origin keeps reporting a paused sandbox that no longer exists there —
-	// which shows up as a duplicate row in List and, worse, lets ID
-	// resolution send a later Destroy to the origin and leak the live one.
+	// After Create the sandbox runs on private disks. Drop the pause package
+	// on the node that still holds it: origin when this was cross-node
+	// (also the PAUSED tombstone), otherwise this node.
 	if placement != nil && placement.CrossNode {
 		if origin := strings.TrimSpace(rec.NodeIP); origin != "" && origin != targetIP {
-			if err := pausesnap.DropOriginTombstone(ctx, req.RequestID, req.SandboxID, origin); err != nil {
-				log.G(ctx).Errorf("resume: sandbox %s runs on %s but origin %s still reports it paused: %v",
+			if err := pausesnap.DropOriginTombstone(ctx, req.RequestID, req.SandboxID, origin, rec.SnapshotID, rec.Backend); err != nil {
+				log.G(ctx).Errorf("resume: sandbox %s runs on %s but origin %s still has pause leftovers: %v",
 					req.SandboxID, targetIP, origin, err)
 			}
 		}
+	} else if err := pausesnap.CleanupPauseSnapshot(ctx, req.RequestID, targetIP, rec.SnapshotID, rec.Backend); err != nil {
+		log.G(ctx).Errorf("resume: sandbox %s is running but pause package %s on %s was not deleted: %v",
+			req.SandboxID, rec.SnapshotID, targetIP, err)
 	}
 
-	// Pause snap stays on disk for Resume. Cubelet drops the previous live
-	// pause snap after the next Pause succeeds. Master only deletes the
-	// pause-snap binding so the next Pause can allocate a new id.
+	// Binding must go so the next Pause can allocate a new id.
 	if err := pausesnap.Delete(ctx, snapID); err != nil {
 		log.G(ctx).Warnf("resume: delete pause snap meta %s: %v", snapID, err)
 	}

--- a/CubeMaster/pkg/service/sandbox/types/sandbox_list_sort.go
+++ b/CubeMaster/pkg/service/sandbox/types/sandbox_list_sort.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package types
+
+import (
+	"sort"
+
+	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+)
+
+// IsPausedBrief reports whether the list row is a paused sandbox (no live
+// shim). Pause bindings are listed after running／exited rows.
+func IsPausedBrief(item *SandboxBriefData) bool {
+	return item != nil && item.Status == int32(cubeboxv1.ContainerState_CONTAINER_PAUSED)
+}
+
+// SortSandboxList puts non-paused rows first (newest CreateAt first), then
+// paused rows. SandboxID breaks ties so the order is stable.
+func SortSandboxList(items []*SandboxBriefData) {
+	sort.SliceStable(items, func(i, j int) bool {
+		pi, pj := IsPausedBrief(items[i]), IsPausedBrief(items[j])
+		if pi != pj {
+			return !pi && pj
+		}
+		if items[i].CreateAt != items[j].CreateAt {
+			return items[i].CreateAt > items[j].CreateAt
+		}
+		return items[i].SandboxID < items[j].SandboxID
+	})
+}

--- a/CubeMaster/pkg/service/sandbox/types/sandbox_list_sort_test.go
+++ b/CubeMaster/pkg/service/sandbox/types/sandbox_list_sort_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+)
+
+func TestSortSandboxListPutsPausedLast(t *testing.T) {
+	paused := int32(cubeboxv1.ContainerState_CONTAINER_PAUSED)
+	running := int32(cubeboxv1.ContainerState_CONTAINER_RUNNING)
+	items := []*SandboxBriefData{
+		{SandboxID: "paused-old", Status: paused, CreateAt: 0, PauseAt: 10},
+		{SandboxID: "run-old", Status: running, CreateAt: 1},
+		{SandboxID: "run-new", Status: running, CreateAt: 3},
+		{SandboxID: "paused-new", Status: paused, CreateAt: 2},
+		{SandboxID: "exited", Status: int32(cubeboxv1.ContainerState_CONTAINER_EXITED), CreateAt: 2},
+	}
+
+	SortSandboxList(items)
+
+	require.Equal(t, []string{"run-new", "exited", "run-old", "paused-new", "paused-old"}, ids(items))
+}
+
+func ids(items []*SandboxBriefData) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.SandboxID)
+	}
+	return out
+}

--- a/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
@@ -197,14 +197,32 @@ func (e *cubeboxInstancePlugin) CreateSandbox(ctx context.Context, flowOpts *wor
 			}
 			backend := pauseResumeCatalogBackend(flowOpts)
 			if flowOpts.IsPauseResume() {
-				// Resume: clone sealed metadata snap → RW volume, then mount
-				// (MountS3MetadataAt never activates the package snap for IO).
+				// Same-node S3: clone package metadata onto s3-meta-<sandbox>
+				// under the sandbox home so CleanupTemplate can drop the pause
+				// package. XFS still reads the package directory in place;
+				// Master deletes that package after Create returns.
+				childID := strings.TrimSpace(flowOpts.GetSandboxID())
+				if childID == "" && flowOpts.ReqInfo != nil {
+					childID = strings.TrimSpace(flowOpts.ReqInfo.GetAnnotations()[constants.MasterAnnotationDesiredSandboxID])
+				}
+				if childID == "" {
+					return nil, ret.Err(errorcode.ErrorCode_AppSnapshotNotExist, "pause resume requires sandbox id to clone metadata off the package")
+				}
 				metaMount := filepath.Join(paths.Base, storage.SnapshotMetadataDir)
+				if isS3CatalogCreateBackend(backend) {
+					sandboxHome := storage.SnapshotHome(backend, storage.SnapshotKindNormal, childID)
+					metaMount = filepath.Join(sandboxHome, storage.SnapshotMetadataDir)
+				}
 				mounted, err := mountRestoreMetadata(ctx, flowOpts, backend, templateID, metaMount)
 				if err != nil {
 					return nil, ret.Err(errorcode.ErrorCode_AppSnapshotNotExist, err.Error())
 				}
 				snapBasePath, snapSpecPath = restorePathsFromMetadataMount(mounted, paths)
+				if isS3CatalogCreateBackend(backend) && snapBasePath != paths.Base {
+					if err := storage.EnsureShimSpecDirLink(snapBasePath, paths.ResDir); err != nil {
+						return nil, ret.Err(errorcode.ErrorCode_AppSnapshotNotExist, err.Error())
+					}
+				}
 			} else {
 				// Create from template／snapshot: private metadata volume
 				// mounted under the sandbox-owned package path — never on
@@ -598,15 +616,6 @@ func isS3CatalogCreateBackend(backend string) bool {
 	return err == nil && normalized == cow.BackendS3
 }
 
-// mountRestoreMetadata puts the metadata disk this sandbox reads its
-// description from in place, and reports where it landed.
-//
-// Cross-node it is the sandbox's own imported copy, mounted under the sandbox
-// home by whichever step first knew the sandbox id — the Create entry for a
-// Resume, this call for a create from a template or snapshot. Same-node a
-// Resume mounts the pause package's sealed disk, and a create clones the
-// parent's into a private volume so a child never writes on a parent's
-// metadata.
 // restorePathsFromMetadataMount turns the directory mountRestoreMetadata
 // returned (the metadata mount) into the snapshot home + spec paths the
 // hypervisor annotations use. Cross-node that directory is the sandbox's
@@ -630,18 +639,31 @@ func restorePathsFromMetadataMount(mounted string, paths *snapshotPaths) (base, 
 	return base, spec
 }
 
+// mountRestoreMetadata puts the metadata disk this sandbox reads its
+// description from in place, and reports where it landed.
+//
+// Cross-node it is the sandbox's own imported copy, mounted under the sandbox
+// home by whichever step first knew the sandbox id — the Create entry for a
+// Resume, this call for a create from a template or snapshot. Same-node
+// Resume and create-from-snapshot both clone the parent into a private
+// volume so the pause／template package can be dropped afterwards.
 func mountRestoreMetadata(ctx context.Context, flowOpts *workflow.CreateContext,
 	backend, packageID, mountPath string) (string, error) {
 	if imp := storage.CrossNodeSandboxImport(flowOpts.ReqInfo.GetAnnotations()); imp != nil {
 		return imp.EnsureMetadata(ctx)
 	}
-	if flowOpts.IsPauseResume() {
-		return mountPath, storage.MountS3MetadataAt(ctx, backend, packageID, mountPath)
-	}
 	sandboxID := strings.TrimSpace(flowOpts.GetSandboxID())
+	if sandboxID == "" && flowOpts.ReqInfo != nil {
+		sandboxID = strings.TrimSpace(flowOpts.ReqInfo.GetAnnotations()[constants.MasterAnnotationDesiredSandboxID])
+	}
 	if sandboxID == "" {
+		if flowOpts.IsPauseResume() {
+			return "", fmt.Errorf("pause resume requires sandbox id to clone metadata off the package")
+		}
 		sandboxID = packageID
 	}
+	// Pause resume and create-from-snapshot both clone into a sandbox-owned
+	// volume. XFS CloneS3MetadataFromParent is a no-op (plain package dir).
 	return mountPath, storage.CloneS3MetadataFromParent(ctx, backend, packageID, sandboxID, mountPath)
 }
 

--- a/Cubelet/services/snapshot/service.go
+++ b/Cubelet/services/snapshot/service.go
@@ -72,13 +72,9 @@ func (s *service) BatchStatus(ctx context.Context, req *api.BatchStatusRequest) 
 func (s *service) statusOne(ctx context.Context, requestID, snapshotID, rawBackend string) *api.StatusResponse {
 	backend, err := normalizeStatusBackend(rawBackend)
 	if err != nil {
-		return &api.StatusResponse{
-			RequestId:  requestID,
-			SnapshotId: snapshotID,
-			Backend:    strings.TrimSpace(rawBackend),
-			State:      cow.RemoteStateFailed,
-			Message:    err.Error(),
-		}
+		// Unknown backend is not an s3lvol export failure; leave State unset
+		// so Master keeps remote_status=inprogress.
+		return unsetStatus(requestID, snapshotID, strings.TrimSpace(rawBackend), err.Error())
 	}
 	rsp := &api.StatusResponse{
 		RequestId:  requestID,
@@ -93,13 +89,12 @@ func (s *service) statusOne(ctx context.Context, requestID, snapshotID, rawBacke
 
 	st, err := storage.SnapshotUploadStatus(ctx, backend, snapshotID)
 	if err != nil {
-		rsp.State = cow.RemoteStateFailed
-		rsp.Message = err.Error()
-		return rsp
+		// Store-not-ready / lookup errors are transient. Empty State means
+		// the remotestatus poller must not stamp failed.
+		return unsetStatus(requestID, snapshotID, backend, err.Error())
 	}
 	if st == nil {
-		rsp.Message = "empty upload status"
-		return rsp
+		return unsetStatus(requestID, snapshotID, backend, "empty upload status")
 	}
 	rsp.State = strings.TrimSpace(st.State)
 	if rsp.State == "" {
@@ -118,6 +113,15 @@ func (s *service) statusOne(ctx context.Context, requestID, snapshotID, rawBacke
 		}
 	}
 	return rsp
+}
+
+func unsetStatus(requestID, snapshotID, backend, message string) *api.StatusResponse {
+	return &api.StatusResponse{
+		RequestId:  requestID,
+		SnapshotId: snapshotID,
+		Backend:    backend,
+		Message:    message,
+	}
 }
 
 func normalizeStatusBackend(raw string) (string, error) {

--- a/Cubelet/services/snapshot/service_test.go
+++ b/Cubelet/services/snapshot/service_test.go
@@ -59,7 +59,7 @@ func TestBatchStatusPreservesOrderAndSkipsNil(t *testing.T) {
 	}
 }
 
-func TestStatusS3WithoutStoreReportsFailedOrPending(t *testing.T) {
+func TestStatusS3WithoutStoreLeavesStateUnset(t *testing.T) {
 	t.Parallel()
 	s := &service{}
 	rsp, err := s.Status(context.Background(), &api.StatusRequest{
@@ -73,11 +73,32 @@ func TestStatusS3WithoutStoreReportsFailedOrPending(t *testing.T) {
 	if rsp.GetBackend() != cow.BackendS3 {
 		t.Fatalf("backend=%q", rsp.GetBackend())
 	}
-	// Without an initialized S3 store the query fails closed.
 	if rsp.GetRemoteReady() {
 		t.Fatal("s3 without store must not be remote_ready")
 	}
-	if rsp.GetState() != cow.RemoteStateFailed && rsp.GetState() != cow.RemoteStatePending {
-		t.Fatalf("state=%q", rsp.GetState())
+	if rsp.GetState() != "" {
+		t.Fatalf("store error must leave state unset, got %q", rsp.GetState())
+	}
+	if rsp.GetMessage() == "" {
+		t.Fatal("expected an error message")
+	}
+}
+
+func TestStatusUnsupportedBackendLeavesStateUnset(t *testing.T) {
+	t.Parallel()
+	s := &service{}
+	rsp, err := s.Status(context.Background(), &api.StatusRequest{
+		RequestId:  "r1",
+		SnapshotId: "snap-1",
+		Backend:    "bogus",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rsp.GetState() != "" {
+		t.Fatalf("unsupported backend must leave state unset, got %q", rsp.GetState())
+	}
+	if rsp.GetRemoteReady() {
+		t.Fatal("unsupported backend must not be remote_ready")
 	}
 }

--- a/Cubelet/storage/cow/remote.go
+++ b/Cubelet/storage/cow/remote.go
@@ -23,7 +23,22 @@ const (
 	ExportStatusNone       = "NONE"
 	ExportStatusInProgress = "INPROGRESS"
 	ExportStatusDone       = "DONE"
+	// s3lvol may report these when an export has actually failed.
+	ExportStatusFailed = "FAILED"
+	ExportStatusError  = "ERROR"
 )
+
+// ExportStatusIsFailed reports whether cubecow/s3lvol marked the export as
+// a terminal failure. Anything else (empty, NONE, INPROGRESS, lookup errors)
+// is not a failure.
+func ExportStatusIsFailed(status string) bool {
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case ExportStatusFailed, ExportStatusError, "FAIL":
+		return true
+	default:
+		return false
+	}
+}
 
 // RemoteUUIDs is the JSON blob Master stores so another node can Fetch.
 // One cubecow uuid per disk that exists today: rootfs / memory / metadata.

--- a/Cubelet/storage/cow/remote_test.go
+++ b/Cubelet/storage/cow/remote_test.go
@@ -22,3 +22,17 @@ func TestRemoteUUIDsJSONRoundTrip(t *testing.T) {
 		t.Fatal("empty json must parse as nil")
 	}
 }
+
+func TestExportStatusIsFailed(t *testing.T) {
+	t.Parallel()
+	for _, status := range []string{"FAILED", "failed", "ERROR", "FAIL"} {
+		if !ExportStatusIsFailed(status) {
+			t.Fatalf("%q should be a confirmed s3lvol failure", status)
+		}
+	}
+	for _, status := range []string{"", ExportStatusNone, ExportStatusInProgress, ExportStatusDone, "WAT"} {
+		if ExportStatusIsFailed(status) {
+			t.Fatalf("%q must not be treated as s3lvol failure", status)
+		}
+	}
+}

--- a/Cubelet/storage/cow/store.go
+++ b/Cubelet/storage/cow/store.go
@@ -55,6 +55,9 @@ type Store interface {
 	CommitTemplateRootfs(ctx context.Context, sourceName, templateID string) (*Object, error)
 	CreateMemoryVolume(ctx context.Context, templateID string, sizeBytes uint64) (*Object, error)
 	CommitTemplateMemory(ctx context.Context, sourceName, templateID string, sizeBytes uint64) (*Object, error)
+	// CloneSandboxMemory copies package memory into sb-<id>-memory
+	// so Resume can drop the pause package afterwards.
+	CloneSandboxMemory(ctx context.Context, sandboxID, sourceName string) (*Object, error)
 	DeleteByKind(ctx context.Context, name, kind string) error
 	DeactivateByKind(ctx context.Context, name, kind string) error
 	ResolveDevPath(ctx context.Context, name, kind string) (string, error)

--- a/Cubelet/storage/cow_store_ops.go
+++ b/Cubelet/storage/cow_store_ops.go
@@ -378,6 +378,11 @@ func CleanupObjectsFor(ctx context.Context, backend string, refs []CowObjectRef)
 			}
 			continue
 		}
+		if isXFSCleanupBackend(backend) {
+			if err := removeLegacyXfsCowObjectIfGone(ctx, name); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cleanup legacy cubecow object %q: %w", name, err))
+			}
+		}
 	}
 	return cleanupErr
 }
@@ -621,10 +626,6 @@ func ReleaseRollbackReplacedVolumes(ctx context.Context, backend, sandboxID stri
 }
 
 func releaseImportedMemoryAfterRollback(ctx context.Context, backend, sandboxID string) error {
-	// Only a cross-node S3 restore imports a memory disk of its own.
-	if !isS3CatalogBackend(backend) {
-		return nil
-	}
 	if localStorage == nil || localStorage.db == nil {
 		return nil
 	}

--- a/Cubelet/storage/cubecow_volume_manager.go
+++ b/Cubelet/storage/cubecow_volume_manager.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/cubecow"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/storage/cow"
@@ -261,6 +262,47 @@ func (m *XfsCow) CommitTemplateMemory(ctx context.Context, sourceName, templateI
 		devPath = resolvedPath
 	}
 	return newCowVolume(snapshotName, cowKindSnapshot, 0, devPath), nil
+}
+
+func (m *XfsCow) CloneSandboxMemory(ctx context.Context, sandboxID, sourceName string) (*cowVolume, error) {
+	return cloneSandboxMemory(ctx, m, sandboxID, sourceName)
+}
+
+type sandboxMemoryCloner interface {
+	createOrResolveVolumeFromSnapshot(ctx context.Context, sourceSnapshot, volumeName string) (string, error)
+	ResolveDevPath(ctx context.Context, name, kind string) (string, error)
+}
+
+func cloneSandboxMemory(ctx context.Context, m sandboxMemoryCloner, sandboxID, sourceName string) (*cowVolume, error) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	sourceName = strings.TrimSpace(sourceName)
+	if sandboxID == "" || sourceName == "" {
+		return nil, fmt.Errorf("sandbox id and source memory name are required")
+	}
+	volumeName := SandboxMemoryName(sandboxID)
+	devPath, err := m.createOrResolveVolumeFromSnapshot(ctx, sourceName, volumeName)
+	if err != nil {
+		return nil, err
+	}
+	if resolved, err := m.ResolveDevPath(ctx, volumeName, cowKindVolume); err == nil && resolved != "" {
+		devPath = resolved
+	}
+	return newCowVolume(volumeName, cowKindVolume, 0, devPath), nil
+}
+
+func (m *XfsCow) createOrResolveVolumeFromSnapshot(ctx context.Context, sourceSnapshot, volumeName string) (string, error) {
+	devPath, err := m.engine.CreateVolumeFromSnapshot(sourceSnapshot, volumeName)
+	if err != nil {
+		if !isCowSemantic(err, cubecow.SemAlreadyExists) {
+			return "", err
+		}
+		devPath, err = m.ResolveDevPath(ctx, volumeName, cowKindVolume)
+		if err != nil {
+			return "", err
+		}
+		return devPath, nil
+	}
+	return devPath, nil
 }
 
 func (m *XfsCow) createInitializedTemplateVolume(ctx context.Context, name string, sizeBytes uint64) (*cowVolume, error) {

--- a/Cubelet/storage/cubecow_volume_manager_test.go
+++ b/Cubelet/storage/cubecow_volume_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/cubecow"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/storage/cow"
 )
 
 type fakeCowEngine struct {
@@ -414,6 +415,63 @@ func TestCreateMemoryVolumeUsesVolumeKind(t *testing.T) {
 	assert.Equal(t, "tpl-snap-memory", volume.VolumeName)
 	assert.Equal(t, cowKindVolume, volume.Kind)
 	assert.Equal(t, "/dev/mapper/tpl-snap-memory", volume.FilePath)
+}
+
+func TestCloneSandboxMemory(t *testing.T) {
+	source := "tpl-snap-pause-memory-snap"
+	dest := SandboxMemoryName("sb1")
+	stores := []struct {
+		name string
+		new  func(*fakeCowEngine) cow.Store
+	}{
+		{"xfs", func(e *fakeCowEngine) cow.Store { return &XfsCow{engine: e} }},
+		{"s3", func(e *fakeCowEngine) cow.Store { return &S3Cow{engine: e} }},
+	}
+	for _, tc := range stores {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := &fakeCowEngine{}
+			store := tc.new(engine)
+			volume, err := store.CloneSandboxMemory(context.Background(), "sb1", source)
+			require.NoError(t, err)
+			require.NotNil(t, volume)
+			assert.Equal(t, dest, volume.VolumeName)
+			assert.Equal(t, cowKindVolume, volume.Kind)
+			assert.Equal(t, [][2]string{{source, dest}}, engine.createVolumeFromSnapshots)
+			assert.NotEmpty(t, volume.FilePath)
+		})
+		t.Run(tc.name+"/already exists", func(t *testing.T) {
+			engine := &fakeCowEngine{
+				createVolumeFromSnapshotErr: &cubecow.CowError{Code: cubecow.SemAlreadyExists, RawRC: int32(cubecow.SemAlreadyExists)},
+				volumeInfos:                 map[string]*cubecow.Volume{dest: {}},
+				activatePaths:               map[string]string{dest: "/dev/mapper/" + dest},
+			}
+			store := tc.new(engine)
+			volume, err := store.CloneSandboxMemory(context.Background(), "sb1", source)
+			require.NoError(t, err)
+			require.Equal(t, dest, volume.VolumeName)
+			assert.Equal(t, cowKindVolume, volume.Kind)
+			assert.Equal(t, "/dev/mapper/"+dest, volume.FilePath)
+		})
+		t.Run(tc.name+"/empty ids", func(t *testing.T) {
+			store := tc.new(&fakeCowEngine{})
+			_, err := store.CloneSandboxMemory(context.Background(), "", source)
+			require.Error(t, err)
+			_, err = store.CloneSandboxMemory(context.Background(), "sb1", "")
+			require.Error(t, err)
+		})
+		t.Run(tc.name+"/volume source", func(t *testing.T) {
+			volSrc := "tpl-snap-pause-memory"
+			engine := &fakeCowEngine{}
+			store := tc.new(engine)
+			volume, err := store.CloneSandboxMemory(context.Background(), "sb1", volSrc)
+			require.NoError(t, err)
+			require.Equal(t, dest, volume.VolumeName)
+			assert.Equal(t, cowKindVolume, volume.Kind)
+			assert.Equal(t, [][2]string{{volSrc, dest}}, engine.createVolumeFromSnapshots)
+			assert.Empty(t, engine.createSnapshots)
+			assert.Empty(t, engine.deletedSnapshots)
+		})
+	}
 }
 
 func TestTemplateArtifactsRejectAlreadyExists(t *testing.T) {

--- a/Cubelet/storage/legacy_reflink_cleanup.go
+++ b/Cubelet/storage/legacy_reflink_cleanup.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/storage/cow"
+)
+
+func isXFSCleanupBackend(backend string) bool {
+	normalized, err := cow.NormalizeBackend(backend)
+	if err != nil {
+		return false
+	}
+	return normalized == cow.BackendXFS
+}
+
+// removeLegacyXfsCowObjectIfGone deletes a cubecow volume directory or
+// snapshot file from the pre-refactor <work>/cubecow-reflink pool when the
+// same name is already gone from <work>/xfs/objects. Template / snapshot
+// cleanup used to miss those leftovers because cubecow's reflink root_dir
+// now points at xfs/objects and treats old objects as NotFound.
+func removeLegacyXfsCowObjectIfGone(ctx context.Context, name string) error {
+	name = strings.TrimSpace(name)
+	if err := pathutil.ValidateSafeID(name); err != nil {
+		return nil
+	}
+	currentRoot, legacyRoot, ok := reflinkCleanupRoots()
+	if !ok {
+		return nil
+	}
+	if _, found, err := locateReflinkObject(currentRoot, name); err != nil {
+		return err
+	} else if found {
+		return nil
+	}
+	path, found, err := locateReflinkObject(legacyRoot, name)
+	if err != nil || !found {
+		return err
+	}
+	if err := removeReflinkPath(legacyRoot, path); err != nil {
+		return err
+	}
+	log.G(ctx).Infof("removed leftover xfs cubecow object %s from legacy reflink path %s", name, path)
+	return nil
+}
+
+func reflinkCleanupRoots() (currentRoot, legacyRoot string, ok bool) {
+	if localStorage == nil || localStorage.config == nil {
+		return "", "", false
+	}
+	dataPath := strings.TrimSpace(localStorage.config.DataPath)
+	if dataPath == "" {
+		return "", "", false
+	}
+	work := stripStoragePluginDataDir(filepath.Clean(dataPath))
+	if work == "" || work == "." {
+		return "", "", false
+	}
+	return filepath.Join(work, cow.BackendXFS, SnapshotObjectsDir),
+		filepath.Join(work, legacyReflinkDirName),
+		true
+}
+
+func locateReflinkObject(root, name string) (string, bool, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "", false, nil
+	}
+	volumes := filepath.Join(root, reflinkVolumesDirName)
+	st, err := os.Lstat(volumes)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if !st.IsDir() || st.Mode()&os.ModeSymlink != 0 {
+		return "", false, nil
+	}
+
+	volDir := filepath.Join(volumes, name)
+	resolved, err := pathutil.ValidatePathUnderBase(volumes, volDir)
+	if err != nil {
+		return "", false, nil
+	}
+	if info, err := os.Lstat(resolved); err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+		return resolved, true, nil
+	}
+
+	entries, err := os.ReadDir(volumes)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == name {
+			continue
+		}
+		if err := pathutil.ValidateSafeID(entry.Name()); err != nil {
+			continue
+		}
+		candidate := filepath.Join(volumes, entry.Name(), name)
+		resolved, err := pathutil.ValidatePathUnderBase(volumes, candidate)
+		if err != nil {
+			continue
+		}
+		info, err := os.Lstat(resolved)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			continue
+		}
+		return resolved, true, nil
+	}
+	return "", false, nil
+}
+
+func removeReflinkPath(root, target string) error {
+	volumes := filepath.Join(root, reflinkVolumesDirName)
+	resolved, err := pathutil.ValidatePathUnderBase(volumes, target)
+	if err != nil {
+		return fmt.Errorf("refusing unsafe legacy reflink path %q: %w", target, err)
+	}
+	info, err := os.Lstat(resolved)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to remove symlink leftover %q", resolved)
+	}
+	if info.IsDir() {
+		return os.RemoveAll(resolved)
+	}
+	return os.Remove(resolved)
+}

--- a/Cubelet/storage/legacy_reflink_cleanup_test.go
+++ b/Cubelet/storage/legacy_reflink_cleanup_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/storage/cow"
+)
+
+func writeLegacyVolume(t *testing.T, root, name string) string {
+	t.Helper()
+	dir := filepath.Join(root, reflinkVolumesDirName, name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("vol"), 0o644))
+	return dir
+}
+
+func writeLegacySnapshot(t *testing.T, root, origin, name string) string {
+	t.Helper()
+	dir := filepath.Join(root, reflinkVolumesDirName, origin)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, origin), []byte("origin"), 0o644))
+	snap := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(snap, []byte("snap"), 0o644))
+	return snap
+}
+
+func TestCleanupObjectsRemovesLegacyXfsVolumeWhenMissingFromNewPath(t *testing.T) {
+	work := t.TempDir()
+	legacy := filepath.Join(work, legacyReflinkDirName)
+	current := filepath.Join(work, cow.BackendXFS, SnapshotObjectsDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(current, reflinkVolumesDirName), 0o755))
+	volDir := writeLegacyVolume(t, legacy, "tpl-old-rootfs")
+
+	engine := &fakeCowEngine{}
+	useTestCowStorage(t, engine)
+	localStorage.config.DataPath = work
+
+	err := CleanupObjectsFor(context.Background(), cow.BackendXFS, []CowObjectRef{
+		{Name: "tpl-old-rootfs", Kind: CowKindSnapshot, Role: "rootfs"},
+	})
+	require.NoError(t, err)
+	_, statErr := os.Stat(volDir)
+	require.Error(t, statErr)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestCleanupObjectsRemovesLegacyXfsSnapshotFileWhenMissingFromNewPath(t *testing.T) {
+	work := t.TempDir()
+	legacy := filepath.Join(work, legacyReflinkDirName)
+	current := filepath.Join(work, cow.BackendXFS, SnapshotObjectsDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(current, reflinkVolumesDirName), 0o755))
+	originDir := filepath.Join(legacy, reflinkVolumesDirName, "tpl-old-memory")
+	snap := writeLegacySnapshot(t, legacy, "tpl-old-memory", "tpl-old-memory-snap")
+
+	engine := &fakeCowEngine{}
+	useTestCowStorage(t, engine)
+	localStorage.config.DataPath = work
+
+	err := CleanupObjectsFor(context.Background(), cow.BackendXFS, []CowObjectRef{
+		{Name: "tpl-old-memory-snap", Kind: CowKindSnapshot, Role: "memory"},
+	})
+	require.NoError(t, err)
+	_, statErr := os.Stat(snap)
+	require.True(t, os.IsNotExist(statErr))
+	_, originErr := os.Stat(filepath.Join(originDir, "tpl-old-memory"))
+	require.NoError(t, originErr, "origin volume must stay when only the snap is deleted")
+}
+
+func TestCleanupObjectsLeavesLegacyWhenPresentOnNewPath(t *testing.T) {
+	work := t.TempDir()
+	legacy := filepath.Join(work, legacyReflinkDirName)
+	current := filepath.Join(work, cow.BackendXFS, SnapshotObjectsDir)
+	legacyDir := writeLegacyVolume(t, legacy, "tpl-both-rootfs")
+	currentDir := writeLegacyVolume(t, current, "tpl-both-rootfs")
+
+	engine := &fakeCowEngine{}
+	useTestCowStorage(t, engine)
+	localStorage.config.DataPath = work
+
+	err := CleanupObjectsFor(context.Background(), cow.BackendXFS, []CowObjectRef{
+		{Name: "tpl-both-rootfs", Kind: CowKindSnapshot, Role: "rootfs"},
+	})
+	require.NoError(t, err)
+	_, err = os.Stat(legacyDir)
+	require.NoError(t, err, "legacy copy must stay while the new-path object still exists")
+	_, err = os.Stat(currentDir)
+	require.NoError(t, err)
+}
+
+func TestCleanupObjectsS3DoesNotTouchLegacyXfsPool(t *testing.T) {
+	work := t.TempDir()
+	legacy := filepath.Join(work, legacyReflinkDirName)
+	volDir := writeLegacyVolume(t, legacy, "tpl-s3-rootfs")
+
+	engine := &fakeCowEngine{}
+	useTestCowStorage(t, engine)
+	localStorage.config.DataPath = work
+
+	err := CleanupObjectsFor(context.Background(), cow.BackendS3, []CowObjectRef{
+		{Name: "tpl-s3-rootfs", Kind: CowKindSnapshot, Role: "rootfs"},
+	})
+	require.NoError(t, err)
+	_, err = os.Stat(volDir)
+	require.NoError(t, err)
+}
+
+func TestRemoveLegacyXfsCowObjectRejectsTraversalName(t *testing.T) {
+	work := t.TempDir()
+	engine := &fakeCowEngine{}
+	useTestCowStorage(t, engine)
+	localStorage.config.DataPath = work
+	require.NoError(t, removeLegacyXfsCowObjectIfGone(context.Background(), "../etc"))
+}

--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -973,8 +973,9 @@ func (l *local) cleanupCreateResult(ctx context.Context, result *StorageInfo) er
 }
 
 // prefetchRestoreMemoryVolURL resolves the memory image the shim restores
-// from, and reports the name of the disk when this create imported one of
-// its own (cross-node) rather than pointing at the package's shared image.
+// from, and reports the name of the disk when this create minted one of
+// its own (cross-node import or same-node pause-resume clone) rather than
+// pointing at the package's shared image.
 func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.CreateContext) (string, string, error) {
 	if opts == nil || opts.ReqInfo == nil || opts.IsCreateSnapshot() {
 		return "", "", nil
@@ -991,9 +992,10 @@ func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.
 	// file:///dev/nvmeXn1 from a previous activate on this or another node.
 	// Always resolve the catalog vol name and Activate for the live path.
 	backend := createContextStorageBackend(opts)
-	// Cross-node: the package's memory image is not on this node, so the
-	// sandbox imports its own. Same-node falls through and points at the
-	// package's shared snapshot, which outlives every sandbox using it.
+	// Cross-node imports a sandbox-private memory volume. Same-node pause
+	// resume clones the package memory snap onto sb-<id>-memory so the
+	// pause package can be deleted after Create. Other restores still
+	// attach the package snapshot (templates / customer snaps stay).
 	if imp := CrossNodeSandboxImport(annotations); imp != nil {
 		name, devPath, err := imp.Memory(ctx)
 		if err != nil {
@@ -1003,12 +1005,35 @@ func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.
 			return cowFileURLFromPath(devPath), name, nil
 		}
 	}
+	pauseOwner := ""
+	if opts.IsPauseResume() && CrossNodeSandboxImport(annotations) == nil {
+		pauseOwner = pauseResumeMemoryOwnerID(opts)
+		if pauseOwner == "" {
+			// Attaching the package then letting Master delete it would
+			// pull the disk out from under the restored VM.
+			return "", "", fmt.Errorf("pause resume requires sandbox id to clone memory off the package")
+		}
+	}
 	volumeName, volumeKind, err := l.resolveSnapshotMemoryVolFromCatalog(ctx, backend, annotations)
 	if err != nil {
 		return "", "", err
 	}
 	if volumeName == "" {
 		return "", "", nil
+	}
+	if pauseOwner != "" {
+		store, err := l.storeForBackend(backend)
+		if err != nil {
+			return "", "", err
+		}
+		cloned, err := store.CloneSandboxMemory(ctx, pauseOwner, volumeName)
+		if err != nil {
+			return "", "", fmt.Errorf("clone pause memory %s for sandbox %s: %w", volumeName, pauseOwner, err)
+		}
+		if cloned == nil || strings.TrimSpace(cloned.FilePath) == "" {
+			return "", "", fmt.Errorf("clone pause memory %s for sandbox %s: empty device path", volumeName, pauseOwner)
+		}
+		return cowFileURLFromPath(cloned.FilePath), cloned.VolumeName, nil
 	}
 	normalizedKind, err := normalizeCowKind(volumeKind)
 	if err != nil {
@@ -1025,12 +1050,35 @@ func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.
 	return cowFileURLFromPath(devPath), "", nil
 }
 
-// releaseImportedMemoryVol deletes the memory disk this sandbox imported.
-// Driven by what Create recorded rather than by the naming convention, so a
-// same-node restore — whose memory is the package's snapshot — is untouched.
+// pauseResumeMemoryOwnerID is the sandbox that must own a private copy of the
+// pause package's memory. Empty means this is not a same-node pause resume
+// (cross-node already imported one, or this is a template／FromSnap create).
+// A same-node pause resume that still returns empty is missing its sandbox
+// id; the caller must fail rather than attach the package snapshot.
+func pauseResumeMemoryOwnerID(opts *workflow.CreateContext) string {
+	if opts == nil || !opts.IsPauseResume() {
+		return ""
+	}
+	ann := map[string]string{}
+	if opts.ReqInfo != nil {
+		ann = opts.ReqInfo.GetAnnotations()
+	}
+	if CrossNodeSandboxImport(ann) != nil {
+		return ""
+	}
+	if id := strings.TrimSpace(opts.GetSandboxID()); id != "" {
+		return id
+	}
+	return strings.TrimSpace(ann[constants.MasterAnnotationDesiredSandboxID])
+}
+
+// releaseImportedMemoryVol deletes the memory disk this sandbox cloned or
+// imported. Driven by what Create recorded rather than by the naming
+// convention, so a restore that still reads a package snapshot (empty field)
+// is untouched.
 func (l *local) releaseImportedMemoryVol(ctx context.Context, backend string, info *StorageInfo) {
 	name := strings.TrimSpace(info.ImportedMemoryVol)
-	if name == "" || backend != cow.BackendS3 {
+	if name == "" {
 		return
 	}
 	store, err := l.storeForBackend(backend)
@@ -1038,7 +1086,7 @@ func (l *local) releaseImportedMemoryVol(ctx context.Context, backend string, in
 		return
 	}
 	if err := store.DeactivateByKind(ctx, name, cowKindVolume); err != nil {
-		log.G(ctx).Warnf("destroy sandbox %s: deactivate imported memory %s: %v", info.SandboxID, name, err)
+		log.G(ctx).Warnf("destroy sandbox %s: deactivate sandbox memory %s: %v", info.SandboxID, name, err)
 	}
 	if err := store.DeleteByKind(ctx, name, cowKindVolume); err != nil {
 		warnVolumeDeleteDeferred(ctx, name, cowKindVolume, err)
@@ -1868,11 +1916,9 @@ type StorageInfo struct {
 
 	RestoreMemoryVolURL string `json:"-"`
 
-	// ImportedMemoryVol is the memory disk a cross-node restore imported for
-	// this sandbox, and the only memory disk destroy may delete. Same-node
-	// restores leave it empty: they read the package's own memory snapshot,
-	// which outlives every sandbox started from it. Persisted, so a cubelet
-	// restart does not turn it into a leak.
+	// ImportedMemoryVol is the sandbox-private memory disk Create minted
+	// (cross-node import or same-node pause-resume clone). Destroy deletes
+	// it. Empty means this restore still reads a package memory snapshot.
 	ImportedMemoryVol string `json:"importedMemoryVol,omitempty"`
 
 	// PluginVolumeBackendInfos records the result of every plugin_volume attach.

--- a/Cubelet/storage/local_pause_resume_memory_test.go
+++ b/Cubelet/storage/local_pause_resume_memory_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/workflow"
+)
+
+func pauseResumeCreateContext(sandboxID string, ann map[string]string) *workflow.CreateContext {
+	return &workflow.CreateContext{
+		BaseWorkflowInfo: workflow.BaseWorkflowInfo{SandboxID: sandboxID},
+		ReqInfo: &cubebox.RunCubeSandboxRequest{
+			InstanceType: cubebox.InstanceType_cubebox.String(),
+			Annotations:  ann,
+		},
+	}
+}
+
+func TestPauseResumeMemoryOwnerID(t *testing.T) {
+	t.Parallel()
+
+	pauseAnn := map[string]string{
+		constants.MasterAnnotationPauseSnapshotID:   "snap-pause1",
+		constants.MasterAnnotationRuntimeSnapshotID: "snap-pause1",
+	}
+	require.Equal(t, "sb-1", pauseResumeMemoryOwnerID(pauseResumeCreateContext("sb-1", pauseAnn)))
+	require.Equal(t, "sb-desired", pauseResumeMemoryOwnerID(pauseResumeCreateContext("", map[string]string{
+		constants.MasterAnnotationPauseSnapshotID:   "snap-pause1",
+		constants.MasterAnnotationRuntimeSnapshotID: "snap-pause1",
+		constants.MasterAnnotationDesiredSandboxID:  "sb-desired",
+	})))
+	require.Empty(t, pauseResumeMemoryOwnerID(pauseResumeCreateContext("", pauseAnn)))
+	require.Empty(t, pauseResumeMemoryOwnerID(nil))
+	require.Empty(t, pauseResumeMemoryOwnerID(pauseResumeCreateContext("sb-1", map[string]string{
+		constants.MasterAnnotationRuntimeSnapshotID: "snap-customer",
+	})))
+	cross := crossNodeAnnotations()
+	cross[constants.MasterAnnotationPauseSnapshotID] = "snap-pause1"
+	cross[constants.MasterAnnotationRuntimeSnapshotID] = "snap-pause1"
+	require.Empty(t, pauseResumeMemoryOwnerID(pauseResumeCreateContext("sb-1", cross)))
+}
+
+func TestPrefetchRestoreMemoryVolURLFailsClosedWithoutSandboxID(t *testing.T) {
+	l := &local{config: &Config{StorageBackend: "cubecow"}}
+	_, _, err := l.prefetchRestoreMemoryVolURL(context.Background(), pauseResumeCreateContext("", map[string]string{
+		constants.MasterAnnotationPauseSnapshotID:   "snap-pause1",
+		constants.MasterAnnotationRuntimeSnapshotID: "snap-pause1",
+	}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sandbox id")
+}
+
+func TestPrefetchRestoreMemoryVolURLFromSnapDoesNotClone(t *testing.T) {
+	l := &local{config: &Config{StorageBackend: "cubecow"}}
+	_, imported, err := l.prefetchRestoreMemoryVolURL(context.Background(), pauseResumeCreateContext("sb-1", map[string]string{
+		constants.MasterAnnotationRuntimeSnapshotID: "snap-customer",
+	}))
+	// Catalog miss is expected; the point is FromSnap must not fail closed
+	// as a pause resume, and must not record a cloned memory disk.
+	if err != nil {
+		require.NotContains(t, err.Error(), "sandbox id")
+	}
+	require.Empty(t, imported)
+}

--- a/Cubelet/storage/local_test.go
+++ b/Cubelet/storage/local_test.go
@@ -202,6 +202,11 @@ type fakeCowCommitMemoryCall struct {
 	sizeBytes  uint64
 }
 
+type fakeCowCloneMemoryCall struct {
+	sandboxID  string
+	sourceName string
+}
+
 type fakeCowResolveCall struct {
 	name string
 	kind string
@@ -227,7 +232,9 @@ type fakeCowVolumeManager struct {
 	commitRootfsCalls   []fakeCowCommitTemplateRootfsCall
 	createMemoryCalls   []fakeCowCreateMemoryCall
 	commitMemoryCalls   []fakeCowCommitMemoryCall
+	cloneMemoryCalls    []fakeCowCloneMemoryCall
 	commitMemoryErr     error
+	cloneMemoryErr      error
 	resolveCalls        []fakeCowResolveCall
 	deleteCalls         []fakeCowDeleteCall
 	deactivateCalls     []fakeCowDeleteCall
@@ -339,6 +346,24 @@ func (m *fakeCowVolumeManager) CommitTemplateMemory(ctx context.Context, sourceN
 		}
 	}
 	return &cowVolume{VolumeName: name, Kind: cowKindSnapshot, Gen: 0, FilePath: path}, nil
+}
+
+func (m *fakeCowVolumeManager) CloneSandboxMemory(ctx context.Context, sandboxID, sourceName string) (*cowVolume, error) {
+	_ = ctx
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cloneMemoryCalls = append(m.cloneMemoryCalls, fakeCowCloneMemoryCall{sandboxID: sandboxID, sourceName: sourceName})
+	if m.cloneMemoryErr != nil {
+		return nil, m.cloneMemoryErr
+	}
+	name := SandboxMemoryName(sandboxID)
+	path := fmt.Sprintf("/dev/mapper/%s", name)
+	if m.resolvePaths != nil {
+		if v, ok := m.resolvePaths[name]; ok {
+			path = v
+		}
+	}
+	return &cowVolume{VolumeName: name, Kind: cowKindVolume, Gen: 0, FilePath: path}, nil
 }
 
 func (m *fakeCowVolumeManager) DeleteByKind(ctx context.Context, name, kind string) error {

--- a/Cubelet/storage/s3_metadata.go
+++ b/Cubelet/storage/s3_metadata.go
@@ -319,8 +319,8 @@ func PrepareS3MetadataMount(ctx context.Context, backend, snapshotID, mountPath 
 // CloneS3MetadataFromParent creates the child package／sandbox metadata disk
 // as a snapshot of the parent's metadata volume (template / snapshot /
 // pause). If the parent volume is missing, falls back to cloning the
-// node-local base. Resume should call MountS3MetadataAt on the pause id
-// instead — that disk already exists from Pause.
+// node-local base. Pause resume uses this with childID=sandboxID so the
+// pause package can be deleted afterwards.
 func CloneS3MetadataFromParent(ctx context.Context, backend, parentID, childID, mountPath string) error {
 	if !isS3CatalogBackend(backend) {
 		return nil

--- a/Cubelet/storage/s3_metadata_test.go
+++ b/Cubelet/storage/s3_metadata_test.go
@@ -258,12 +258,9 @@ func TestUploadStatusEmptyExportStatusWithoutUUIDIsRunning(t *testing.T) {
 	require.Equal(t, cow.RemoteStateRunning, st.State)
 }
 
-// s3lvol returns a uuid before it can tell whether the transfer will run,
-// and on failure records nothing under it: every later lookup then says no
-// such export and cubecow leaves the status empty. Reporting that as still
-// uploading leaves the package inprogress forever, because only a fresh
-// export can ever change the answer.
-func TestUploadStatusDeadExportUUIDIsFailed(t *testing.T) {
+// A recorded uuid with empty export_status is not an s3lvol-confirmed
+// failure. Status must stay non-terminal so Master keeps inprogress.
+func TestUploadStatusEmptyExportStatusWithUUIDIsRunning(t *testing.T) {
 	engine := &fakeCowEngine{
 		volumeInfos: map[string]*cubecow.Volume{
 			"tpl-snap-1-rootfs": {
@@ -278,10 +275,30 @@ func TestUploadStatusDeadExportUUIDIsFailed(t *testing.T) {
 
 	st, err := SnapshotUploadStatus(context.Background(), cow.BackendS3, "snap-1")
 	require.NoError(t, err)
+	require.Equal(t, cow.RemoteStateRunning, st.State)
+}
+
+func TestUploadStatusExportStatusFailedIsFailed(t *testing.T) {
+	engine := &fakeCowEngine{
+		volumeInfos: map[string]*cubecow.Volume{
+			"tpl-snap-1-rootfs": {
+				SizeBytes:    1 << 20,
+				ExportUUID:   "uuid-root",
+				ExportStatus: cow.ExportStatusDone,
+			},
+			"tpl-snap-1-memory": {
+				SizeBytes:    64 << 20,
+				ExportUUID:   "uuid-mem",
+				ExportStatus: cow.ExportStatusFailed,
+			},
+		},
+	}
+	useTestCowStorage(t, engine)
+
+	st, err := SnapshotUploadStatus(context.Background(), cow.BackendS3, "snap-1")
+	require.NoError(t, err)
 	require.Equal(t, cow.RemoteStateFailed, st.State)
-	// Name the dead uuid: re-exporting is the only fix, and the operator
-	// needs to know which role to re-export.
-	require.Contains(t, st.Message, "uuid-mem")
+	require.Contains(t, st.Message, "tpl-snap-1-memory")
 }
 
 func TestUploadSkipsMetadataBaseAndUploadsDerived(t *testing.T) {

--- a/Cubelet/storage/s3_sandbox_import.go
+++ b/Cubelet/storage/s3_sandbox_import.go
@@ -92,10 +92,8 @@ func SandboxRootfsName(sandboxID string, gen uint32) string {
 	return fmt.Sprintf("%srootfs-gen%d", SandboxObjectNamePrefix(sandboxID), gen)
 }
 
-// SandboxMemoryName is the private memory image a cross-node restore imports.
-// A same-node restore reads the package's own memory snapshot instead and
-// must never be given one of these: that disk belongs to the template or
-// snapshot and outlives every sandbox started from it.
+// SandboxMemoryName is the private memory image a restore owns: imported
+// cross-node, or cloned from the pause package on a same-node Resume.
 func SandboxMemoryName(sandboxID string) string {
 	return SandboxObjectNamePrefix(sandboxID) + "memory"
 }

--- a/Cubelet/storage/s3_snapshot_layout.go
+++ b/Cubelet/storage/s3_snapshot_layout.go
@@ -28,6 +28,10 @@ const (
 	SnapshotDiskDir = "disk"
 	// SnapshotObjectsDir is the XFS cubecow object pool (files, not metadata).
 	SnapshotObjectsDir = "objects"
+	// legacyReflinkDirName is the pre-refactor cubecow reflink pool
+	// (<work>/cubecow-reflink). Current objects live under xfs/objects.
+	legacyReflinkDirName  = "cubecow-reflink"
+	reflinkVolumesDirName = "volumes"
 
 	// Deprecated aliases kept so existing S3 helpers keep compiling.
 	S3SnapshotRootName    = "s3"

--- a/Cubelet/storage/s3_upload.go
+++ b/Cubelet/storage/s3_upload.go
@@ -263,7 +263,7 @@ func (m *S3Cow) UploadStatus(ctx context.Context, snapshotID string) (*cow.Remot
 		allDone      = true
 		anyProgress  bool
 		anyNone      bool
-		anyDead      bool
+		anyFailed    bool
 		localVolumes []cow.VolumeRemoteInfo
 		messages     []string
 	)
@@ -274,9 +274,9 @@ func (m *S3Cow) UploadStatus(ctx context.Context, snapshotID string) (*cow.Remot
 		info, infoErr := m.GetVolumeInfo(ctx, ref.Name)
 		exists, existsErr := cowObjectPresent(info, infoErr)
 		if existsErr != nil {
-			st.State = cow.RemoteStateFailed
-			st.Message = existsErr.Error()
-			return st, nil
+			// Lookup/RPC errors are not an s3lvol export failure. Bubble
+			// them so Status leaves State unset and Master stays inprogress.
+			return nil, existsErr
 		}
 		vol := cow.VolumeRemoteInfo{Name: ref.Name, Role: ref.Role, Exists: exists}
 		if info != nil {
@@ -324,18 +324,13 @@ func (m *S3Cow) UploadStatus(ctx context.Context, snapshotID string) (*cow.Remot
 		switch {
 		case status == cow.ExportStatusDone:
 			// ok
-		case status == "" && uuid != "":
-			// A recorded uuid that reports no status at all is a dead
-			// export: s3lvol hands the uuid back before the transfer can
-			// fail, then records nothing under it, so every later lookup
-			// says no such export and cubecow leaves the status empty.
-			// Waiting cannot fix it — only exporting again can — so this
-			// is a terminal failure rather than an upload still in flight.
+		case cow.ExportStatusIsFailed(status):
 			allDone = false
-			anyDead = true
-			messages = append(messages, fmt.Sprintf("%s export %s no longer exists", ref.Name, uuid))
+			anyFailed = true
+			messages = append(messages, fmt.Sprintf("%s=%s", ref.Name, status))
 		case status == cow.ExportStatusInProgress, status == "":
-			// Empty without a uuid means cubecow has not reported yet.
+			// Empty status (with or without a uuid) is not a confirmed
+			// s3lvol failure. Keep polling; Master must not stamp failed.
 			allDone = false
 			anyProgress = true
 		case status == cow.ExportStatusNone:
@@ -356,10 +351,7 @@ func (m *S3Cow) UploadStatus(ctx context.Context, snapshotID string) (*cow.Remot
 	}
 
 	switch {
-	case anyDead:
-		// Terminal: report it now so Master stops polling a package that
-		// can never become usable and surfaces it as failed instead of
-		// leaving it inprogress forever.
+	case anyFailed:
 		st.State = cow.RemoteStateFailed
 		st.Message = strings.Join(messages, "; ")
 	case allDone:

--- a/Cubelet/storage/s3_volume_manager.go
+++ b/Cubelet/storage/s3_volume_manager.go
@@ -211,6 +211,10 @@ func (m *S3Cow) CommitTemplateMemory(ctx context.Context, sourceName, templateID
 	return newCowVolume(volumeName, cowKindVolume, 0, devPath), nil
 }
 
+func (m *S3Cow) CloneSandboxMemory(ctx context.Context, sandboxID, sourceName string) (*cowVolume, error) {
+	return cloneSandboxMemory(ctx, m, sandboxID, sourceName)
+}
+
 func (m *S3Cow) createInitializedTemplateVolume(ctx context.Context, name string, sizeBytes uint64) (*cowVolume, error) {
 	devPath, err := m.createTemplateVolumePath(name, sizeBytes)
 	if err != nil {

--- a/cubecow/src/engine/reflink.rs
+++ b/cubecow/src/engine/reflink.rs
@@ -755,9 +755,8 @@ impl Engine for ReflinkEngine {
         // the moment FICLONE returns.
         Self::validate_name(volume_name, "volume")?;
 
-        // Resolve source: must be an existing snapshot. Cloning from
-        // another volume is rejected — callers should snapshot first
-        // and then clone, mirroring the s3 backend contract.
+        // XFS: volume and snapshot are both independent FICLONE files.
+        // Clone from either. (S3 keeps a real snapshot vs volume split.)
         let source_path = {
             let idx = self
                 .name_index
@@ -767,12 +766,7 @@ impl Engine for ReflinkEngine {
                 Some(NameKind::Snapshot { origin_volume }) => {
                     self.snap_file(origin_volume, source_snapshot)
                 }
-                Some(NameKind::Volume) => {
-                    return Err(CubecowError::InvalidArg(format!(
-                        "'{source_snapshot}' is a volume; \
-                         create_volume_from_snapshot requires a snapshot as source"
-                    )));
-                }
+                Some(NameKind::Volume) => self.vol_main_file(source_snapshot),
                 None => {
                     return Err(CubecowError::NotFound(format!(
                         "snapshot '{source_snapshot}'"
@@ -1490,6 +1484,39 @@ mod tests {
             engine.delete_volume("vol"),
             Err(CubecowError::NotFound(_))
         ));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn create_volume_from_volume_source() {
+        let root = unique_root("vol-from-vol");
+        if !fs_supports_ficlone(&root.join("volumes")) {
+            eprintln!("[skip] tmpdir does not support FICLONE");
+            return;
+        }
+        let engine = make_engine(&root);
+
+        engine.create_volume("src-vol", 1024 * 1024).unwrap();
+        let cloned = engine
+            .create_volume_from_snapshot("src-vol", "dst-vol")
+            .unwrap();
+        assert_eq!(cloned.name, "dst-vol");
+        assert!(cloned.device_path.ends_with("/volumes/dst-vol/dst-vol"));
+        assert!(root
+            .join("volumes")
+            .join("dst-vol")
+            .join("dst-vol")
+            .exists());
+
+        engine.delete_volume("src-vol").unwrap();
+        assert!(
+            root.join("volumes")
+                .join("dst-vol")
+                .join("dst-vol")
+                .exists(),
+            "clone is independent of the source volume"
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }


### PR DESCRIPTION
Follow-up to #1489. Resume used to keep the VM on pause-package disks, so the package could not be deleted until the next Pause. This clones live disks onto sandbox-owned volumes first, then drops the package immediately.

## Features

- **Resume clones pause-package memory** onto `sb-<id>-memory` (`CloneSandboxMemory`). Same-node S3 also clones metadata onto `s3-meta-<id>`. Destroy records `ImportedMemoryVol` for both same-node and cross-node.
- **Delete the pause package immediately after a successful Resume.** Same-node: `CleanupPauseSnapshot` on the resume host. Cross-node: `DropOriginTombstone` also removes the origin package (not only the PAUSED CubeBox row).
- **XFS `create_volume_from_snapshot` accepts a volume source.** Pause catalogs XFS memory as `kind=volume`; FICLONE from either volume or snapshot. S3 still requires a real snapshot parent.
- **`cubebox list` sorts paused rows last.** Shimless READY/DELETE_FAILED pause rows are appended only on the last node page (or `--hostid`), so they do not repeat on every page.
- **Legacy XFS reflink pool cleanup** on cubelet storage init.

## Bugfixes

- Same-node pause resume **fails closed** if the sandbox id is missing, instead of attaching the package disk and then deleting it under the VM.
- **`UploadStatus` only stamps `remote_status=failed` when s3lvol reports `FAILED`/`ERROR`.** Lookup/RPC errors and empty export status (with or without a uuid) leave State unset so Master stays `inprogress`.
- Cross-node origin no longer leaves the pause package behind after Resume.

## Test plan

- [ ] Same-node XFS: Pause → Resume → pause package directory gone; live disks `sb-<id>-rootfs-gen*` + `sb-<id>-memory`
- [ ] Same-node S3: same layout plus `s3-meta-<id>`; package directory gone
- [ ] Cross-node S3: Resume on peer; origin tombstone + pause package gone; target live disks only
- [ ] `cubebox list`: running rows first, paused last; paused not duplicated on intermediate pages
- [ ] Cubelet UploadStatus: unknown backend / lookup error does not flip Master to `failed`
- [ ] `go test` for CubeMaster `restoreplace`, `pausesnap`, `sandbox` list/resume; Cubelet storage clone/legacy-cleanup tests

Assisted-by: Cursor:Composer
Signed-off-by: ls-ggg <335814617@qq.com>

Made with [Cursor](https://cursor.com)