### PR TITLE
fix(cubelet): reuse cached envd version for snapshots

### DIFF
--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -263,9 +263,11 @@ func (s *service) CommitSandbox(ctx context.Context, req *cubebox.CommitSandboxR
 	rsp.AgentVersion = versions.Agent
 	rsp.KernelVersion = versions.Kernel
 	rsp.ShimVersion = versions.Shim
-	// The source sandbox stays running through commit, so probe its real envd
-	// version in-guest after the memory snapshot. Best-effort: empty on failure.
-	rsp.EnvdVersion = s.collectEnvdVersion(ctx, rsp.SandboxID)
+	// The template's envd version is propagated on Create and retained in the
+	// CubeBox annotations. Reuse it here instead of synchronously entering the
+	// guest after every snapshot; legacy templates without the annotation keep
+	// the previous best-effort behavior of returning an empty version.
+	rsp.EnvdVersion = envdVersionFromCubeBox(cb)
 	if err := storage.WriteSnapshotCatalogFor(backend, &storage.SnapshotCatalogEntry{
 		SnapshotID:        rsp.TemplateID,
 		InstanceType:      "cubebox",

--- a/Cubelet/services/cubebox/version_binding.go
+++ b/Cubelet/services/cubebox/version_binding.go
@@ -7,6 +7,7 @@ package cubebox
 import (
 	"strings"
 
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/templatetypes"
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 )
@@ -16,6 +17,17 @@ type guestEnvironmentVersions struct {
 	Agent      string
 	Kernel     string
 	Shim       string
+}
+
+// envdVersionFromCubeBox returns the template envd version propagated by
+// CubeMaster when the sandbox was created. CubeBox annotations are persisted
+// with the sandbox, so snapshot commits can reuse the value without a guest
+// Exec on their latency-sensitive success path.
+func envdVersionFromCubeBox(cb *cubeboxstore.CubeBox) string {
+	if cb == nil {
+		return ""
+	}
+	return strings.TrimSpace(cb.Annotations[constants.MasterAnnotationComponentEnvdVersion])
 }
 
 // collectGuestEnvironmentVersions reads the live toolbox once via the same

--- a/Cubelet/services/cubebox/version_binding_test.go
+++ b/Cubelet/services/cubebox/version_binding_test.go
@@ -8,9 +8,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/templatetypes"
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 )
+
+func TestEnvdVersionFromCubeBoxUsesCreateAnnotation(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{Metadata: cubeboxstore.Metadata{Annotations: map[string]string{
+		constants.MasterAnnotationComponentEnvdVersion: " 0.2.0 ",
+	}}}
+	require.Equal(t, "0.2.0", envdVersionFromCubeBox(cb))
+	require.Empty(t, envdVersionFromCubeBox(&cubeboxstore.CubeBox{}))
+	require.Empty(t, envdVersionFromCubeBox(nil))
+}
 
 func TestGuestEnvironmentVersionsFromComponentMapPrefersPinned(t *testing.T) {
 	fallback := guestEnvironmentVersions{


### PR DESCRIPTION
fix #1503

Reuse the envd version propagated from the source template instead of executing envd --version inside the guest for every CommitSandbox call. This removes the synchronous guest exec from the snapshot critical path.


### Snapshot Creation vs. Concurrency

Lower is better. Values are batch wall-clock averages.

| Concurrency | v0.3.0 baseline | Before fix | After fix | Improvement |
|---:|---:|---:|---:|---:|
| 1 | 75.2 ms | 129.0 ms | 82.5 ms | 46.5 ms / 36.0% |
| 5 | 107.1 ms | 167.0 ms | 116.9 ms | 50.1 ms / 30.0% |
| 10 | 151.3 ms | 229.2 ms | 192.8 ms | 36.4 ms / 15.9% |

At concurrency 1 and 5, the fix removes approximately 47-50 ms from the Snapshot path and brings latency to within about 10% of the v0.3.0 baseline. Concurrency 10 also improves, although concurrent-operation contention and run-to-run variance remain visible.

### Snapshot Creation vs. Dirty-Page Size

Lower is better. Values are average Snapshot creation latency.

| Write Size | v0.3.0 baseline | Before fix | After fix | Improvement |
|---:|---:|---:|---:|---:|
| 0 MiB | 74.0 ms | 120.9 ms | 93.1 ms | 27.8 ms / 23.0% |
| 10 MiB | 99.6 ms | 160.7 ms | 104.4 ms | 56.3 ms / 35.0% |
| 50 MiB | 129.1 ms | 173.7 ms | 130.7 ms | 43.0 ms / 24.8% |
| 100 MiB | 150.2 ms | 209.9 ms | 166.6 ms | 43.3 ms / 20.6% |
| 200 MiB | 192.9 ms | 240.7 ms | 190.0 ms | 50.7 ms / 21.1% |
| 500 MiB | 300.0 ms | 335.5 ms | 285.2 ms | 50.3 ms / 15.0% |
| 800 MiB | 401.8 ms | 415.6 ms | 376.8 ms | 38.8 ms / 9.3% |
| 1024 MiB | 471.2 ms | 489.9 ms | 459.8 ms | 30.1 ms / 6.1% |

The corrected results improve by 28-56 ms across all tested dirty-page sizes. Most results return close to, or outperform, the v0.3.0 baseline. The magnitude and shape of the improvement confirm that the synchronous Guest Exec was the fixed overhead responsible for the regression.