### PR TITLE
s3lvol: add rcow_get_lvol RPC and document environment requirements

### DIFF
--- a/CubeS3lvol/README.md
+++ b/CubeS3lvol/README.md
@@ -242,3 +242,98 @@ request header and the canonical string of the SigV4 signature.
 
 `[ERROR] ... response status=404` is **normal**: s3lvol uses a GET's 404 to
 determine whether an object exists.
+
+## Environment Requirements
+
+### NVMe kernel driver / NVMe-oF support
+
+s3lvol exposes volumes over NVMe-oF (nvmf-tcp): the SPDK-backed `s3lvol_tgt`
+is the user-space *target*, but the *host* side that attaches the volumes needs
+the kernel NVMe fabric support:
+
+- the `nvme-fabrics` and `nvme-tcp` kernel modules must be loadable/loaded
+  (`modprobe nvme-tcp`), so that `nvme connect` produces a block device under
+  `/dev/nvme*n*`;
+- the kernel must be built with `CONFIG_NVME_TCP` / `CONFIG_NVME_FABRICS`
+  (a 5.x+ distro kernel normally is);
+- the target itself does **not** need the in-kernel `nvmet`: SPDK's user-space
+  nvmf target provides it.
+
+The dataplane regression suite (`make check`) actually attaches loopback
+NVMe-oF devices, so it only runs on a host with this support (and it needs
+`root`).
+
+### nvme-cli
+
+The `nvme` command-line tool (package `nvme-cli`) is a hard dependency of the
+test scripts: `nvme connect/disconnect/list` are used to attach and detach
+volumes. Install it with:
+
+```sh
+# Debian/Ubuntu
+apt-get install nvme-cli
+# RHEL/CentOS
+yum install nvme-cli
+```
+
+### Preflight: is the NVMe fabric stack loaded?
+
+Before running the suite (or attaching any volume), confirm the host side of
+the fabric is actually available:
+
+```sh
+# 1. kernel NVMe-over-TCP driver (produces /dev/nvme*n* block devices)
+modprobe nvme-tcp                 # idempotent; fails if the module is missing
+lsmod | grep nvme                 # should list nvme_tcp / nvme_fabrics
+
+# 2. nvme-cli (used by the test scripts / attach tooling)
+which nvme                        # must resolve, e.g. /usr/sbin/nvme
+```
+
+If `modprobe nvme-tcp` fails, the kernel was built without NVMe-over-TCP
+(`CONFIG_NVME_TCP` missing), the host cannot attach any volume, and the
+dataplane regression suite cannot run here — check the kernel config before
+proceeding.
+
+### Object store
+
+A COS- or MinIO-compatible bucket is required at runtime; the credentials,
+endpoint and bucket are read from the COS config file (see the config section).
+For a local MinIO the config must also set `path_style = "true"` and
+`no_tls = "true"` so the S3 client talks plain HTTP with path-style URLs.
+
+### Busy-polling threads and CPU affinity
+
+`s3lvol_tgt` runs SPDK reactor threads in busy-poll mode: they spin at 100% of
+the cores they are pinned to and never sleep. The current deployment starts
+with **2 reactors on 2 dedicated cores** (e.g. `-m 0x3` pins them to CPU 0 and
+CPU 1). Those two cores are fully consumed by the target, so **other
+(application/business) processes must be kept off them** — pin them elsewhere
+with `taskset`/`numactl` (or a cpuset/cgroup) so the target's request latency
+is not disturbed by scheduler contention.
+
+## LIMITATIONS and TODOs
+
+### Deleting snapshots / lvols
+
+- A snapshot that is **behind an export** cannot be deleted while the export is
+  alive: `s3lvol_lvol_destroy` refuses with *"the snapshot behind export
+  \<uuid\>, which another node may be reading through. Release that export, or
+  wait for it to expire, before deleting this."* — call `rcow_release_export`
+  first (or wait for the export TTL to lapse).
+- An **active** (attached) lvol cannot be deleted; deactivate it first
+  (`rcow_deactive_bdev`).
+- The delete-time cluster-count log line needs the blob to still be open: if
+  the lvol was deactivated before deletion the blob is closed and the *"Deleted
+  lvol ..."* log line simply omits the counts (they are not recoverable once
+  the blob is gone).
+
+### Snapshotting / cloning an imported lvol
+
+- An lvol that was **imported from an export** cannot be snapshotted or cloned
+  while it is still queued for decoupling: `derive_check` refuses with *"is
+  queued to be decoupled; a snapshot or clone would take its external snapshot
+  while the decouple still reads through it"*. Wait for the decouple to finish
+  (`rcow_get_decouple` status -- its list emptying is the signal) before taking
+  the snapshot or clone.
+

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
@@ -2595,6 +2595,13 @@ struct lvol_destroy_ctx {
 	char                     name[SPDK_LVOL_NAME_MAX];
 	char                     esnap_uuid[SPDK_UUID_STRING_LEN];
 
+	/* Cluster counts read before the destroy: the blob must still be open
+	 * to read them, and is gone by the time the success callback runs, so
+	 * the reclaimed counts can only be reported from there. */
+	uint64_t                 allocated_clusters;
+	uint64_t                 total_clusters;
+	bool                     have_cluster_counts;
+
 	spdk_lvol_op_complete    cb_fn;
 	void                    *cb_arg;
 };
@@ -2613,10 +2620,20 @@ s3lvol_lvol_destroyed(void *cb_arg, int lvolerrno)
 		 * that follow are fire-and-forget and log only their failures, and the
 		 * RPC answer travels to the caller, not the log. So "did the delete
 		 * actually go through" was previously answerable only by asking again
-		 * or counting objects; a production post-mortem needs better. */
-		SPDK_NOTICELOG("Deleted lvol '%s/%s'\n",
-			       ctx->owner ? s3lvol_lvstore_get_name(ctx->owner) : "(null)",
-			       ctx->name);
+		 * or counting objects; a production post-mortem needs better. The
+		 * reclaimed cluster counts are printed here, not before the delete,
+		 * so the claim only ever accompanies an actual success. */
+		if (ctx->have_cluster_counts) {
+			SPDK_NOTICELOG("Deleted lvol '%s/%s', reclaimed %" PRIu64
+				       " of %" PRIu64 " clusters\n",
+				       ctx->owner ? s3lvol_lvstore_get_name(ctx->owner) : "(null)",
+				       ctx->name,
+				       ctx->allocated_clusters, ctx->total_clusters);
+		} else {
+			SPDK_NOTICELOG("Deleted lvol '%s/%s'\n",
+				       ctx->owner ? s3lvol_lvstore_get_name(ctx->owner) : "(null)",
+				       ctx->name);
+		}
 
 		if (ctx->esnap_uuid[0] != '\0') {
 			s3lvol_imports_recheck(ctx->owner, ctx->esnap_uuid);
@@ -2842,6 +2859,18 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 			memcpy(ctx->esnap_uuid, esnap_id, id_len);
 			ctx->esnap_uuid[id_len] = '\0';
 		}
+	}
+
+	/* Capture the cluster counts before the destroy: the blob must still be
+	 * open to read them, and is gone by the time s3lvol_lvol_destroyed()
+	 * runs. Printing them from the success callback (rather than here) keeps
+	 * "reclaimed" honest when an asynchronous destroy fails. */
+	if (lvol->blob != NULL) {
+		ctx->allocated_clusters =
+			spdk_blob_get_num_allocated_clusters(lvol->blob);
+		ctx->total_clusters =
+			spdk_blob_get_num_clusters(lvol->blob);
+		ctx->have_cluster_counts = true;
 	}
 
 	if (lvol->bdev) {

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
@@ -1564,6 +1564,94 @@ SPDK_RPC_REGISTER("rcow_get_lvstores", rpc_rcow_get_lvstores,
 		  SPDK_RPC_RUNTIME)
 
 /* ==========================================================================
+ * rcow_get_lvol
+ *
+ * Report an lvol's cluster geometry and how much of it is actually allocated.
+ * The answer is synchronous: the lvol is looked up among the loaded (attached)
+ * lvols, so a name that is not loaded is an error, not an empty reply.
+ *
+ * allocated_clusters is the blob's own allocation bitmap -- for a volume that
+ * reads through an export (esnap clone) it can be 0 until decoupled; the
+ * export/import logs report the reference count instead.
+ * ========================================================================== */
+
+static const struct spdk_json_object_decoder rpc_get_lvol_decoders[] = {
+	/* lvs_name is optional so rpc_lookup_lvol()'s scan-all-lvstores path
+	 * stays reachable; lvol_name is required -- without it the lookup has
+	 * nothing to find, so it fails at decode time. */
+	{"lvs_name",  offsetof(struct rpc_lvol_name, lvs_name),
+	 spdk_json_decode_string, true},
+	{"lvol_name", offsetof(struct rpc_lvol_name, lvol_name),
+	 spdk_json_decode_string, false},
+};
+
+static void
+rpc_rcow_get_lvol(struct spdk_jsonrpc_request *request,
+		  const struct spdk_json_val *params)
+{
+	struct rpc_lvol_name req = {0};
+	struct rpc_json_buf buf;
+	struct spdk_lvol *lvol;
+	struct s3lvol_lvstore *lvs;
+	struct spdk_lvol_store *store;
+	struct spdk_json_write_ctx *w;
+
+	if (spdk_json_decode_object(params, rpc_get_lvol_decoders,
+				    SPDK_COUNTOF(rpc_get_lvol_decoders), &req)) {
+		rpc_lvol_respond_err(request, 0, "Invalid parameters");
+		goto cleanup;
+	}
+
+	lvol = rpc_lookup_lvol(request, &req);
+	if (!lvol) {
+		goto cleanup;
+	}
+
+	/* rpc_lookup_lvol() resolved the lvol through the named lvstore, so the
+	 * wrapper around that store is guaranteed to be loaded; assert rather
+	 * than keep a branch that can never fire. */
+	lvs = s3lvol_lvstore_find_by_lvs(lvol->lvol_store);
+	assert(lvs != NULL);
+
+	store = s3lvol_lvstore_get_lvs(lvs);
+
+	/* Structured answer, serialised into string_value like every other
+	 * external RPC in this file -- see the envelope contract at the top. */
+	w = rpc_json_buf_begin(&buf);
+	if (!w) {
+		rpc_lvol_respond_err(request, -ENOMEM, NULL);
+		goto cleanup;
+	}
+	spdk_json_write_object_begin(w);
+	spdk_json_write_named_string(w, "lvs_name", s3lvol_lvstore_get_name(lvs));
+	spdk_json_write_named_string(w, "name", lvol->name);
+	if (lvol->bdev) {
+		spdk_json_write_named_string(w, "bdev_name", lvol->bdev->name);
+	}
+	spdk_json_write_named_uuid(w, "uuid", &lvol->uuid);
+	spdk_json_write_named_uint64(w, "cluster_size",
+				     spdk_bs_get_cluster_size(store->blobstore));
+	if (lvol->blob != NULL) {
+		spdk_json_write_named_uint64(w, "total_clusters",
+					     spdk_blob_get_num_clusters(lvol->blob));
+		spdk_json_write_named_uint64(w, "allocated_clusters",
+					     spdk_blob_get_num_allocated_clusters(lvol->blob));
+	} else {
+		/* Not open (never attached, or closed by deactivate): the blob's
+		 * allocation bitmap is not readable without reopening it. */
+		spdk_json_write_named_uint64(w, "total_clusters", 0);
+		spdk_json_write_named_uint64(w, "allocated_clusters", 0);
+	}
+	spdk_json_write_object_end(w);
+	rpc_json_buf_respond(request, w, &buf);
+
+cleanup:
+	free(req.lvs_name);
+	free(req.lvol_name);
+}
+SPDK_RPC_REGISTER("rcow_get_lvol", rpc_rcow_get_lvol, SPDK_RPC_RUNTIME)
+
+/* ==========================================================================
  * Cross-node transfer: export / import / release
  *
  * The pause and resume entry points of a sandbox. Naming follows the rest of


### PR DESCRIPTION
Two follow-up commits for the CubeS3lvol (s3lvol) storage target:

1. **s3lvol: add rcow_get_lvol and report cluster counts on delete** — new `rcow_get_lvol` RPC returns the owning lvstore, bdev name, uuid, cluster size, total clusters and allocated clusters for an lvol or snapshot; `s3lvol_lvol_destroy` now logs reclaimed cluster counts (allocated/total) before tearing the blob down. Verified against a production lvstore on a test node.

2. **docs: add environment requirements and limitations sections** — README documents host-side kernel NVMe-oF/nvme-tcp requirements (target is user-space SPDK), nvme-cli as a hard dependency of the test scripts, object-store config notes (path_style/no_tls for MinIO), plus current LIMITATIONS/TODOs around deleting exported/active snapshots and snapshotting imported lvols during decoupling.