### PR TITLE
docs(integrations): add Google ADK integration guide

### DIFF
--- a/docs/guide/integrations/google-adk.md
+++ b/docs/guide/integrations/google-adk.md
@@ -30,11 +30,11 @@ tool's code execution crosses into CubeSandbox.
 | Google ADK | Python package `google-adk>=2.0.0` |
 | Python | 3.10+ |
 | CubeSandbox | E2B-compatible CubeAPI and a template that supports `run_code` |
-| SDK path | `e2b-code-interpreter` pointed at CubeAPI through `E2B_API_URL` |
+| SDK path | `e2b==2.26.0` and `e2b-code-interpreter==2.8.1`, pointed at CubeAPI through `E2B_API_URL` |
 
-Google ADK is evolving quickly. Pin the resolved `google-adk` and
-`e2b-code-interpreter` versions after validating them against your CubeSandbox
-deployment.
+Google ADK is evolving quickly. The example pins the E2B packages to a pair
+that plain `pip` can install and that is recorded in the repository's SDK
+compatibility notes. Revalidate before changing either package version.
 
 ## Prerequisites
 
@@ -97,14 +97,18 @@ root_agent = Agent(
 The tool itself keeps the Cube-specific logic in one place:
 
 ```python
+import os
+
 from e2b_code_interpreter import Sandbox
 
 def run_python_in_cube(code: str) -> dict:
     template_id = os.environ["CUBE_TEMPLATE_ID"]
     with Sandbox.create(template=template_id, timeout=300) as sandbox:
         execution = sandbox.run_code(code)
+        stdout = "".join(str(item) for item in execution.logs.stdout)
         return {
-            "stdout": execution.text,
+            "stdout": stdout,
+            "text": execution.text,
             "error": str(execution.error) if execution.error else None,
         }
 ```

--- a/docs/guide/integrations/google-adk.md
+++ b/docs/guide/integrations/google-adk.md
@@ -29,7 +29,7 @@ tool's code execution crosses into CubeSandbox.
 | --- | --- |
 | Google ADK | Python package `google-adk>=2.0.0` |
 | Python | 3.10+ |
-| CubeSandbox | E2B-compatible CubeAPI and a template that supports `run_code` |
+| CubeSandbox | E2B-compatible CubeAPI, a reachable CubeProxy data plane, and a template that supports `run_code` |
 | SDK path | `e2b==2.26.0` and `e2b-code-interpreter==2.8.1`, pointed at CubeAPI through `E2B_API_URL` |
 
 Google ADK is evolving quickly. The example pins the E2B packages to a pair
@@ -40,15 +40,23 @@ compatibility notes. Revalidate before changing either package version.
 
 - A running [CubeSandbox deployment](/guide/quickstart) with CubeAPI reachable,
   normally at `http://<cube-host>:3000`.
+- Data-plane reachability for the official E2B SDK. A one-click local
+  deployment includes CoreDNS; production deployments should configure wildcard
+  DNS, and local setups without wildcard DNS can use the
+  [E2B development sidecar](/guide/connect-existing-cluster).
 - A CubeSandbox template ID. Use a template that supports the E2B code
   interpreter `run_code` path.
 - Python 3.10+ on the machine running the ADK agent.
 - A Google API key or another ADK-supported model configuration.
 
 ::: warning Control plane and data plane
-`E2B_API_URL` points the E2B-compatible SDK at CubeAPI. If your deployment uses
-TLS with a self-signed certificate, set `CUBE_SSL_CERT_FILE` so the example can
-export `SSL_CERT_FILE` before opening the sandbox.
+`E2B_API_URL` selects the CubeAPI control-plane endpoint. The official E2B SDK
+also connects to per-sandbox data-plane hostnames when `run_code` executes.
+Configure wildcard DNS for production deployments, or use the
+[E2B development sidecar](/guide/connect-existing-cluster) for local
+development without wildcard DNS. If your deployment uses TLS with a self-signed
+certificate, set `CUBE_SSL_CERT_FILE` so the example can export `SSL_CERT_FILE`
+before opening the sandbox.
 :::
 
 ## Setup
@@ -72,6 +80,7 @@ Configure `.env`:
 | `CUBE_TEMPLATE_ID` | CubeSandbox template ID used for temporary tool sandboxes |
 | `GOOGLE_API_KEY` | Google model API key used by ADK |
 | `GOOGLE_ADK_MODEL` | ADK model name, for example `gemini-2.5-flash` |
+| `CUBE_SANDBOX_TIMEOUT` | Optional sandbox lifetime bound in seconds, passed to `Sandbox.create(timeout=...)`; defaults to `300` |
 | `CUBE_SSL_CERT_FILE` | Optional CubeSandbox CA bundle for self-signed deployments |
 
 ## Integration Snippet
@@ -167,7 +176,8 @@ and deletes the temporary sandbox when the tool call finishes.
   tool call for simplicity. For multi-step notebooks, keep a sandbox handle in a
   session-scoped service and delete it when the ADK session ends.
 - **Timeouts:** set `CUBE_SANDBOX_TIMEOUT` or pass a fixed timeout to
-  `Sandbox.create(...)` for longer analysis tasks.
+  `Sandbox.create(...)` for the sandbox lifetime. This does not set a per-call
+  `run_code` execution timeout.
 - **Network policy:** create sandboxes with Cube-specific egress controls when
   generated code must only reach approved hosts. See
   [network policy](/guide/network-policy).

--- a/docs/guide/integrations/google-adk.md
+++ b/docs/guide/integrations/google-adk.md
@@ -85,6 +85,7 @@ Configure `.env`:
 | `CUBE_SANDBOX_TIMEOUT` | Optional sandbox lifetime bound in seconds, passed to `Sandbox.create(timeout=...)`; defaults to `300` |
 | `CUBE_RUN_CODE_TIMEOUT` | Optional per-call execution timeout in seconds, passed to `sandbox.run_code(timeout=...)`; defaults to `60` |
 | `CUBE_USE_DEV_SIDECAR` | Optional local-development switch. Set to `true` to call the E2B dev-sidecar before sandbox creation |
+| `CUBE_REMOTE_PROXY_BASE` | Required when `CUBE_USE_DEV_SIDECAR=true`; CubeProxy data-plane endpoint for the sidecar, for example `https://127.0.0.1:11443` in dev-env |
 | `CUBE_SSL_CERT_FILE` | Optional CubeSandbox CA bundle for self-signed deployments |
 
 ## Integration Snippet
@@ -133,7 +134,9 @@ The runnable example also supports `CUBE_USE_DEV_SIDECAR=true` for local
 development without wildcard DNS. That mode calls the sidecar setup from
 [`examples/e2b-dev-sidecar`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar)
 before sandbox creation, so configure that example's `CUBE_REMOTE_PROXY_*`
-variables as well.
+variables in this example's `.env` file or export them in the ADK process
+environment. Do not rely on `examples/e2b-dev-sidecar/.env`; this example does
+not load that file.
 
 ### Migrating a local ADK code tool
 

--- a/docs/guide/integrations/google-adk.md
+++ b/docs/guide/integrations/google-adk.md
@@ -56,7 +56,9 @@ Configure wildcard DNS for production deployments, or use the
 [E2B development sidecar](/guide/connect-existing-cluster) for local
 development without wildcard DNS. If your deployment uses TLS with a self-signed
 certificate, set `CUBE_SSL_CERT_FILE` so the example can export `SSL_CERT_FILE`
-before opening the sandbox.
+before opening the sandbox. `SSL_CERT_FILE` is process-global; use a CA bundle
+that also preserves model-provider TLS trust, or leave it unset when CubeAPI is
+served with a public certificate.
 :::
 
 ## Setup
@@ -81,6 +83,8 @@ Configure `.env`:
 | `GOOGLE_API_KEY` | Google model API key used by ADK |
 | `GOOGLE_ADK_MODEL` | ADK model name, for example `gemini-2.5-flash` |
 | `CUBE_SANDBOX_TIMEOUT` | Optional sandbox lifetime bound in seconds, passed to `Sandbox.create(timeout=...)`; defaults to `300` |
+| `CUBE_RUN_CODE_TIMEOUT` | Optional per-call execution timeout in seconds, passed to `sandbox.run_code(timeout=...)`; defaults to `60` |
+| `CUBE_USE_DEV_SIDECAR` | Optional local-development switch. Set to `true` to call the E2B dev-sidecar before sandbox creation |
 | `CUBE_SSL_CERT_FILE` | Optional CubeSandbox CA bundle for self-signed deployments |
 
 ## Integration Snippet
@@ -113,7 +117,7 @@ from e2b_code_interpreter import Sandbox
 def run_python_in_cube(code: str) -> dict:
     template_id = os.environ["CUBE_TEMPLATE_ID"]
     with Sandbox.create(template=template_id, timeout=300) as sandbox:
-        execution = sandbox.run_code(code)
+        execution = sandbox.run_code(code, timeout=60)
         stdout = "".join(str(item) for item in execution.logs.stdout)
         return {
             "stdout": stdout,
@@ -125,6 +129,12 @@ def run_python_in_cube(code: str) -> dict:
 Compared with a host-side Python tool, only the tool body changes. The ADK agent
 still sees a regular function tool with structured inputs and outputs.
 
+The runnable example also supports `CUBE_USE_DEV_SIDECAR=true` for local
+development without wildcard DNS. That mode calls the sidecar setup from
+[`examples/e2b-dev-sidecar`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar)
+before sandbox creation, so configure that example's `CUBE_REMOTE_PROXY_*`
+variables as well.
+
 ### Migrating a local ADK code tool
 
 ```diff
@@ -135,8 +145,10 @@ still sees a regular function tool with structured inputs and outputs.
 +     return run_python_in_cube(code)
 ```
 
-The agent definition and prompts can remain unchanged if they already reference
-the original code execution tool.
+The agent definition can remain unchanged if it already references the original
+code execution tool. Update prompts or result handling if they depend on fields
+that differ from this example's `stdout`, `text`, `error`, and `results_count`
+shape.
 
 ## Runnable Demo
 
@@ -176,8 +188,9 @@ and deletes the temporary sandbox when the tool call finishes.
   tool call for simplicity. For multi-step notebooks, keep a sandbox handle in a
   session-scoped service and delete it when the ADK session ends.
 - **Timeouts:** set `CUBE_SANDBOX_TIMEOUT` or pass a fixed timeout to
-  `Sandbox.create(...)` for the sandbox lifetime. This does not set a per-call
-  `run_code` execution timeout.
+  `Sandbox.create(...)` for the sandbox lifetime. Set `CUBE_RUN_CODE_TIMEOUT`
+  or pass `timeout=...` to `sandbox.run_code(...)` for the per-call execution
+  limit.
 - **Network policy:** create sandboxes with Cube-specific egress controls when
   generated code must only reach approved hosts. See
   [network policy](/guide/network-policy).

--- a/docs/guide/integrations/google-adk.md
+++ b/docs/guide/integrations/google-adk.md
@@ -1,0 +1,195 @@
+---
+title: Google ADK Integration Guide
+author: ztt0216
+date: 2026-08-25
+tags:
+  - integration
+  - google-adk
+  - agent
+lang: en-US
+---
+
+# Google ADK Integration Guide
+
+[中文](../../zh/guide/integrations/google-adk.md)
+
+Use CubeSandbox as the code execution environment for a
+[Google Agent Development Kit](https://github.com/google/adk-python) agent.
+Google ADK supports Python function tools, and CubeSandbox exposes an
+E2B-compatible API, so an ADK agent can call a normal Python tool while the
+generated code runs inside an isolated CubeSandbox MicroVM.
+
+This guide follows the "agent on the host, code in the sandbox" pattern. The
+ADK runtime, model credentials, and local project stay on the host; only the
+tool's code execution crosses into CubeSandbox.
+
+## Integration Target and Version
+
+| Component | Baseline |
+| --- | --- |
+| Google ADK | Python package `google-adk>=2.0.0` |
+| Python | 3.10+ |
+| CubeSandbox | E2B-compatible CubeAPI and a template that supports `run_code` |
+| SDK path | `e2b-code-interpreter` pointed at CubeAPI through `E2B_API_URL` |
+
+Google ADK is evolving quickly. Pin the resolved `google-adk` and
+`e2b-code-interpreter` versions after validating them against your CubeSandbox
+deployment.
+
+## Prerequisites
+
+- A running [CubeSandbox deployment](/guide/quickstart) with CubeAPI reachable,
+  normally at `http://<cube-host>:3000`.
+- A CubeSandbox template ID. Use a template that supports the E2B code
+  interpreter `run_code` path.
+- Python 3.10+ on the machine running the ADK agent.
+- A Google API key or another ADK-supported model configuration.
+
+::: warning Control plane and data plane
+`E2B_API_URL` points the E2B-compatible SDK at CubeAPI. If your deployment uses
+TLS with a self-signed certificate, set `CUBE_SSL_CERT_FILE` so the example can
+export `SSL_CERT_FILE` before opening the sandbox.
+:::
+
+## Setup
+
+Install the example:
+
+```bash
+cd examples/google-adk-integration
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Configure `.env`:
+
+| Variable | Purpose |
+| --- | --- |
+| `E2B_API_URL` | CubeAPI control-plane URL, for example `http://<cube-host>:3000` |
+| `E2B_API_KEY` | E2B-compatible key accepted by your CubeAPI auth callback, or `e2b_000000` when auth is disabled |
+| `CUBE_TEMPLATE_ID` | CubeSandbox template ID used for temporary tool sandboxes |
+| `GOOGLE_API_KEY` | Google model API key used by ADK |
+| `GOOGLE_ADK_MODEL` | ADK model name, for example `gemini-2.5-flash` |
+| `CUBE_SSL_CERT_FILE` | Optional CubeSandbox CA bundle for self-signed deployments |
+
+## Integration Snippet
+
+Expose a CubeSandbox execution function as an ADK tool:
+
+```python
+from google.adk import Agent
+
+from cube_code_tool import run_python_in_cube
+
+root_agent = Agent(
+    name="cube_code_agent",
+    model="gemini-2.5-flash",
+    instruction=(
+        "When Python code needs to run, call run_python_in_cube so execution "
+        "happens inside an isolated CubeSandbox MicroVM."
+    ),
+    tools=[run_python_in_cube],
+)
+```
+
+The tool itself keeps the Cube-specific logic in one place:
+
+```python
+from e2b_code_interpreter import Sandbox
+
+def run_python_in_cube(code: str) -> dict:
+    template_id = os.environ["CUBE_TEMPLATE_ID"]
+    with Sandbox.create(template=template_id, timeout=300) as sandbox:
+        execution = sandbox.run_code(code)
+        return {
+            "stdout": execution.text,
+            "error": str(execution.error) if execution.error else None,
+        }
+```
+
+Compared with a host-side Python tool, only the tool body changes. The ADK agent
+still sees a regular function tool with structured inputs and outputs.
+
+### Migrating a local ADK code tool
+
+```diff
+- def run_python(code: str) -> dict:
+-     completed = subprocess.run(["python3", "-c", code], capture_output=True, text=True)
+-     return {"stdout": completed.stdout, "stderr": completed.stderr}
++ def run_python(code: str) -> dict:
++     return run_python_in_cube(code)
+```
+
+The agent definition and prompts can remain unchanged if they already reference
+the original code execution tool.
+
+## Runnable Demo
+
+Run the offline wiring check first:
+
+```bash
+cd examples/google-adk-integration
+python smoke_test.py
+```
+
+Expected output:
+
+```text
+GOOGLE_ADK_CUBE_SMOKE_OK
+```
+
+Then run the ADK agent from the parent directory:
+
+```bash
+cd examples
+adk run google-adk-integration
+```
+
+Ask:
+
+```text
+Run Python in the sandbox to calculate the first 10 Fibonacci numbers.
+```
+
+The agent calls `run_python_in_cube`, creates a temporary CubeSandbox from
+`CUBE_TEMPLATE_ID`, executes the generated Python code, returns the tool output,
+and deletes the temporary sandbox when the tool call finishes.
+
+## Going Further
+
+- **Reuse a sandbox per session:** the example creates one temporary sandbox per
+  tool call for simplicity. For multi-step notebooks, keep a sandbox handle in a
+  session-scoped service and delete it when the ADK session ends.
+- **Timeouts:** set `CUBE_SANDBOX_TIMEOUT` or pass a fixed timeout to
+  `Sandbox.create(...)` for longer analysis tasks.
+- **Network policy:** create sandboxes with Cube-specific egress controls when
+  generated code must only reach approved hosts. See
+  [network policy](/guide/network-policy).
+- **Credential handling:** keep model provider keys on the host. If sandboxed
+  code must call an external API, prefer Cube's security proxy and credential
+  injection flow instead of placing raw secrets in the VM.
+- **Templates:** preinstall heavy dependencies in the template image so each ADK
+  tool call starts quickly from a ready snapshot.
+
+## Caveats
+
+- The example validates imports and wiring offline. A full live run requires a
+  reachable CubeSandbox deployment and a `run_code`-capable template.
+- Google ADK's native Agent Runtime Code Execution tool targets Google Cloud
+  Agent Runtime. This guide uses a custom ADK function tool so CubeSandbox can
+  provide the execution backend.
+- The default example creates and deletes a sandbox for each tool call. That is
+  easiest to review, but not the lowest-latency shape for long multi-step tasks.
+
+## References
+
+- Runnable example:
+  [`examples/google-adk-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/google-adk-integration)
+- Google ADK Python:
+  <https://github.com/google/adk-python>
+- ADK custom tools:
+  <https://adk.dev/tools-custom/>
+- ADK Agent Runtime Code Execution:
+  <https://adk.dev/integrations/code-exec-agent-runtime/>

--- a/docs/guide/integrations/google-adk.md
+++ b/docs/guide/integrations/google-adk.md
@@ -27,14 +27,17 @@ tool's code execution crosses into CubeSandbox.
 
 | Component | Baseline |
 | --- | --- |
-| Google ADK | Python package `google-adk>=2.0.0` |
+| Google ADK | Python package `google-adk==2.7.1` |
 | Python | 3.10+ |
 | CubeSandbox | E2B-compatible CubeAPI, a reachable CubeProxy data plane, and a template that supports `run_code` |
 | SDK path | `e2b==2.26.0` and `e2b-code-interpreter==2.8.1`, pointed at CubeAPI through `E2B_API_URL` |
 
-Google ADK is evolving quickly. The example pins the E2B packages to a pair
-that plain `pip` can install and that is recorded in the repository's SDK
-compatibility notes. Revalidate before changing either package version.
+Google ADK is evolving quickly, so the runnable example pins the ADK package.
+The E2B packages are pinned to a pair that plain `pip` can install and that is
+recorded in the repository's SDK compatibility notes. This PR does not include
+a live `run_code` validation against that exact pair and a real CubeSandbox
+deployment, so revalidate the live path before changing package versions or
+using this example as a production baseline.
 
 ## Prerequisites
 
@@ -108,7 +111,9 @@ root_agent = Agent(
 )
 ```
 
-The tool itself keeps the Cube-specific logic in one place:
+The simplified tool shape keeps the Cube-specific logic in one place. The
+runnable example includes additional environment loading, stderr handling,
+sidecar setup, and cross-version output normalization:
 
 ```python
 import os
@@ -120,8 +125,10 @@ def run_python_in_cube(code: str) -> dict:
     with Sandbox.create(template=template_id, timeout=300) as sandbox:
         execution = sandbox.run_code(code, timeout=60)
         stdout = "".join(str(item) for item in execution.logs.stdout)
+        stderr = "".join(str(item) for item in execution.logs.stderr)
         return {
             "stdout": stdout,
+            "stderr": stderr,
             "text": execution.text,
             "error": str(execution.error) if execution.error else None,
         }
@@ -151,7 +158,8 @@ not load that file.
 The agent definition can remain unchanged if it already references the original
 code execution tool. Update prompts or result handling if they depend on fields
 that differ from this example's `stdout`, `text`, `error`, and `results_count`
-shape.
+shape. The runnable example also returns `stderr` so the agent can inspect
+tracebacks and diagnostic output from failed runs.
 
 ## Runnable Demo
 
@@ -207,6 +215,9 @@ and deletes the temporary sandbox when the tool call finishes.
 
 - The example validates imports and wiring offline. A full live run requires a
   reachable CubeSandbox deployment and a `run_code`-capable template.
+- The E2B package pair is selected for plain-pip install compatibility recorded
+  in the repository. This PR does not verify `run_code` against a live
+  CubeSandbox deployment for that exact pair.
 - Google ADK's native Agent Runtime Code Execution tool targets Google Cloud
   Agent Runtime. This guide uses a custom ADK function tool so CubeSandbox can
   provide the execution backend.

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -51,3 +51,4 @@ lang: en-US
 | [Claude Code Integration Guide](./claude-code.md) | shsaihdsaiudh | 2026-07-06 | integration, claude-code, coding-agent |
 | [LangChain Integration Guide](./langchain.md) | peerless-hero | 2026-07-07 | integration, langchain, agent |
 | [OpenAI Agents SDK Integration Guide](./openai-agents-sdk.md) | ZedingZhang | 2026-08-19 | integration, openai-agents-sdk, agent |
+| [Google ADK Integration Guide](./google-adk.md) | ztt0216 | 2026-08-25 | integration, google-adk, agent |

--- a/docs/zh/guide/integrations/google-adk.md
+++ b/docs/zh/guide/integrations/google-adk.md
@@ -22,12 +22,14 @@ lang: zh-CN
 
 | 组件 | 基线 |
 | --- | --- |
-| Google ADK | Python package `google-adk>=2.0.0` |
+| Google ADK | Python package `google-adk==2.7.1` |
 | Python | 3.10+ |
 | CubeSandbox | E2B-compatible CubeAPI、可访问的 CubeProxy 数据面，以及支持 `run_code` 的模板 |
 | SDK 路径 | 通过 `E2B_API_URL` 指向 CubeAPI 的 `e2b==2.26.0` 和 `e2b-code-interpreter==2.8.1` |
 
-Google ADK 仍在快速演进。示例把 E2B 相关包固定到一个 plain `pip` 可直接安装、且已记录在仓库 SDK compatibility notes 中的组合。修改任一版本前请重新验证。
+Google ADK 仍在快速演进，因此可运行示例固定了 ADK 包版本。E2B 相关包固定到一个 plain `pip`
+可直接安装、且已记录在仓库 SDK compatibility notes 中的组合。本 PR 没有把这个精确组合连接真实
+CubeSandbox 部署做 live `run_code` 验证；修改版本或把该示例作为生产基线前，请重新验证 live 路径。
 
 ## 前置条件
 
@@ -94,7 +96,8 @@ root_agent = Agent(
 )
 ```
 
-工具函数把 Cube 相关逻辑集中在一处：
+这个简化工具形态把 Cube 相关逻辑集中在一处。可运行示例还包含环境加载、stderr 处理、sidecar setup
+和跨版本输出归一化：
 
 ```python
 import os
@@ -106,8 +109,10 @@ def run_python_in_cube(code: str) -> dict:
     with Sandbox.create(template=template_id, timeout=300) as sandbox:
         execution = sandbox.run_code(code, timeout=60)
         stdout = "".join(str(item) for item in execution.logs.stdout)
+        stderr = "".join(str(item) for item in execution.logs.stderr)
         return {
             "stdout": stdout,
+            "stderr": stderr,
             "text": execution.text,
             "error": str(execution.error) if execution.error else None,
         }
@@ -131,7 +136,7 @@ ADK 进程环境中。不要只修改 `examples/e2b-dev-sidecar/.env`；本示�
 ```
 
 如果原 agent 已经引用这个代码执行工具，agent 定义可以保持不变。若原 prompt 或结果处理依赖特定字段，
-请按本示例返回的 `stdout`、`text`、`error`、`results_count` 结构调整。
+请按本示例返回的 `stdout`、`stderr`、`text`、`error`、`results_count` 结构调整。
 
 ## 可运行 Demo
 
@@ -175,6 +180,8 @@ agent 会调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建临时 Cu
 ## 注意事项
 
 - 示例离线验证导入和接线。完整 live run 需要可访问的 CubeSandbox 部署和支持 `run_code` 的模板。
+- E2B 包组合是基于仓库记录的 plain-pip 安装兼容性选择。本 PR 没有针对这个精确组合连接真实
+  CubeSandbox 部署验证 `run_code`。
 - Google ADK 原生 Agent Runtime Code Execution tool 面向 Google Cloud Agent Runtime。本文使用自定义 ADK 函数工具，让 CubeSandbox 提供执行后端。
 - 默认示例每次工具调用创建并删除一个沙箱，便于 review，但不是长多步任务的最低延迟形态。
 

--- a/docs/zh/guide/integrations/google-adk.md
+++ b/docs/zh/guide/integrations/google-adk.md
@@ -1,0 +1,168 @@
+---
+title: Google ADK 集成指南
+author: ztt0216
+date: 2026-08-25
+tags:
+  - integration
+  - google-adk
+  - agent
+lang: zh-CN
+---
+
+# Google ADK 集成指南
+
+[English](../../../guide/integrations/google-adk.md)
+
+本文介绍如何把 CubeSandbox 用作
+[Google Agent Development Kit](https://github.com/google/adk-python) agent 的代码执行环境。Google ADK 支持 Python 函数工具，CubeSandbox 提供 E2B-compatible API，因此 ADK agent 可以像调用普通 Python 工具一样调用 CubeSandbox，而实际生成代码会在隔离的 CubeSandbox MicroVM 中运行。
+
+这个方案采用“agent 在宿主机运行，代码进沙箱执行”的模式。ADK runtime、模型凭证和本地项目保留在宿主机上；只有工具中的代码执行进入 CubeSandbox。
+
+## 集成对象与版本
+
+| 组件 | 基线 |
+| --- | --- |
+| Google ADK | Python package `google-adk>=2.0.0` |
+| Python | 3.10+ |
+| CubeSandbox | E2B-compatible CubeAPI，以及支持 `run_code` 的模板 |
+| SDK 路径 | 通过 `E2B_API_URL` 指向 CubeAPI 的 `e2b-code-interpreter` |
+
+Google ADK 仍在快速演进。生产使用前，应在你的 CubeSandbox 部署上验证并固定 `google-adk` 与 `e2b-code-interpreter` 的具体版本。
+
+## 前置条件
+
+- 一个可用的 [CubeSandbox 部署](/zh/guide/quickstart)，CubeAPI 通常位于 `http://<cube-host>:3000`。
+- 一个 CubeSandbox 模板 ID。请使用支持 E2B code interpreter `run_code` 路径的模板。
+- 运行 ADK agent 的机器上有 Python 3.10+。
+- Google API key，或其他 ADK 支持的模型配置。
+
+::: warning 控制面与数据面
+`E2B_API_URL` 会把 E2B-compatible SDK 指向 CubeAPI。如果你的部署使用自签 TLS 证书，请设置 `CUBE_SSL_CERT_FILE`，示例会在打开沙箱前导出 `SSL_CERT_FILE`。
+:::
+
+## 配置步骤
+
+安装示例依赖：
+
+```bash
+cd examples/google-adk-integration
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+配置 `.env`：
+
+| 变量 | 用途 |
+| --- | --- |
+| `E2B_API_URL` | CubeAPI 控制面地址，例如 `http://<cube-host>:3000` |
+| `E2B_API_KEY` | CubeAPI auth callback 接受的 E2B-compatible key；未启用认证时可用 `e2b_000000` |
+| `CUBE_TEMPLATE_ID` | 工具调用创建临时沙箱时使用的 CubeSandbox 模板 ID |
+| `GOOGLE_API_KEY` | ADK 使用的 Google 模型 API key |
+| `GOOGLE_ADK_MODEL` | ADK 模型名，例如 `gemini-2.5-flash` |
+| `CUBE_SSL_CERT_FILE` | 自签部署可选的 CubeSandbox CA bundle |
+
+## 集成代码片段
+
+把 CubeSandbox 执行函数暴露为 ADK 工具：
+
+```python
+from google.adk import Agent
+
+from cube_code_tool import run_python_in_cube
+
+root_agent = Agent(
+    name="cube_code_agent",
+    model="gemini-2.5-flash",
+    instruction=(
+        "When Python code needs to run, call run_python_in_cube so execution "
+        "happens inside an isolated CubeSandbox MicroVM."
+    ),
+    tools=[run_python_in_cube],
+)
+```
+
+工具函数把 Cube 相关逻辑集中在一处：
+
+```python
+from e2b_code_interpreter import Sandbox
+
+def run_python_in_cube(code: str) -> dict:
+    template_id = os.environ["CUBE_TEMPLATE_ID"]
+    with Sandbox.create(template=template_id, timeout=300) as sandbox:
+        execution = sandbox.run_code(code)
+        return {
+            "stdout": execution.text,
+            "error": str(execution.error) if execution.error else None,
+        }
+```
+
+与宿主机本地 Python 工具相比，只有工具函数内部实现发生变化。ADK agent 看到的仍是一个普通的结构化函数工具。
+
+### 迁移已有本地代码执行工具
+
+```diff
+- def run_python(code: str) -> dict:
+-     completed = subprocess.run(["python3", "-c", code], capture_output=True, text=True)
+-     return {"stdout": completed.stdout, "stderr": completed.stderr}
++ def run_python(code: str) -> dict:
++     return run_python_in_cube(code)
+```
+
+如果原 agent 已经引用这个代码执行工具，agent 定义和 prompt 可以保持不变。
+
+## 可运行 Demo
+
+先运行离线接线检查：
+
+```bash
+cd examples/google-adk-integration
+python smoke_test.py
+```
+
+期望输出：
+
+```text
+GOOGLE_ADK_CUBE_SMOKE_OK
+```
+
+然后从父目录运行 ADK agent：
+
+```bash
+cd examples
+adk run google-adk-integration
+```
+
+向 agent 提问：
+
+```text
+Run Python in the sandbox to calculate the first 10 Fibonacci numbers.
+```
+
+agent 会调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建临时 CubeSandbox，执行生成的 Python 代码，返回工具输出，并在工具调用结束后删除临时沙箱。
+
+## 进一步配置
+
+- **按会话复用沙箱：** 示例为了便于 review，每次工具调用创建一个临时沙箱。多轮 notebook 类任务可以把 sandbox handle 放入会话级服务，并在 ADK session 结束时删除。
+- **超时：** 长分析任务可设置 `CUBE_SANDBOX_TIMEOUT`，或在 `Sandbox.create(...)` 中传入固定 timeout。
+- **网络策略：** 如果生成代码只能访问指定主机，请在创建沙箱时配置 Cube 的出站控制。参见[网络策略](/zh/guide/network-policy)。
+- **凭证处理：** 模型提供商 key 应保留在宿主机。如果沙箱内代码必须调用外部 API，优先使用 Cube 的 security proxy 和凭证注入流程，不要把原始密钥写入 VM。
+- **模板：** 把重依赖预装进模板镜像，让每次 ADK 工具调用都能从 ready snapshot 快速启动。
+
+## 注意事项
+
+- 示例离线验证导入和接线。完整 live run 需要可访问的 CubeSandbox 部署和支持 `run_code` 的模板。
+- Google ADK 原生 Agent Runtime Code Execution tool 面向 Google Cloud Agent Runtime。本文使用自定义 ADK 函数工具，让 CubeSandbox 提供执行后端。
+- 默认示例每次工具调用创建并删除一个沙箱，便于 review，但不是长多步任务的最低延迟形态。
+
+## 参考
+
+- 可运行示例：
+  [`examples/google-adk-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/google-adk-integration)
+- Google ADK Python：
+  <https://github.com/google/adk-python>
+- ADK custom tools：
+  <https://adk.dev/tools-custom/>
+- ADK Agent Runtime Code Execution：
+  <https://adk.dev/integrations/code-exec-agent-runtime/>

--- a/docs/zh/guide/integrations/google-adk.md
+++ b/docs/zh/guide/integrations/google-adk.md
@@ -43,7 +43,8 @@ Google ADK 仍在快速演进。示例把 E2B 相关包固定到一个 plain `pi
 `E2B_API_URL` 用于选择 CubeAPI 控制平面端点。官方 E2B SDK 在执行 `run_code` 时还会访问每个沙箱的数据面域名。
 生产环境应配置泛域名 DNS；本地开发若没有泛域名 DNS，可以使用
 [E2B 开发 sidecar](/zh/guide/connect-existing-cluster)。如果你的部署使用自签 TLS 证书，请设置
-`CUBE_SSL_CERT_FILE`，示例会在打开沙箱前导出 `SSL_CERT_FILE`。
+`CUBE_SSL_CERT_FILE`，示例会在打开沙箱前导出 `SSL_CERT_FILE`。`SSL_CERT_FILE` 是进程级全局设置；
+请使用同时保留模型提供商 TLS 信任的 CA bundle，或在 CubeAPI 使用公开证书时不要设置它。
 :::
 
 ## 配置步骤
@@ -68,6 +69,8 @@ cp .env.example .env
 | `GOOGLE_API_KEY` | ADK 使用的 Google 模型 API key |
 | `GOOGLE_ADK_MODEL` | ADK 模型名，例如 `gemini-2.5-flash` |
 | `CUBE_SANDBOX_TIMEOUT` | 可选的沙箱生命周期上限，单位秒，会传给 `Sandbox.create(timeout=...)`；默认值为 `300` |
+| `CUBE_RUN_CODE_TIMEOUT` | 可选的单次代码执行超时，单位秒，会传给 `sandbox.run_code(timeout=...)`；默认值为 `60` |
+| `CUBE_USE_DEV_SIDECAR` | 可选的本地开发开关。设为 `true` 时，会在创建沙箱前调用 E2B dev-sidecar |
 | `CUBE_SSL_CERT_FILE` | 自签部署可选的 CubeSandbox CA bundle |
 
 ## 集成代码片段
@@ -100,7 +103,7 @@ from e2b_code_interpreter import Sandbox
 def run_python_in_cube(code: str) -> dict:
     template_id = os.environ["CUBE_TEMPLATE_ID"]
     with Sandbox.create(template=template_id, timeout=300) as sandbox:
-        execution = sandbox.run_code(code)
+        execution = sandbox.run_code(code, timeout=60)
         stdout = "".join(str(item) for item in execution.logs.stdout)
         return {
             "stdout": stdout,
@@ -110,6 +113,10 @@ def run_python_in_cube(code: str) -> dict:
 ```
 
 与宿主机本地 Python 工具相比，只有工具函数内部实现发生变化。ADK agent 看到的仍是一个普通的结构化函数工具。
+
+可运行示例也支持 `CUBE_USE_DEV_SIDECAR=true`，用于没有泛域名 DNS 的本地开发环境。该模式会在创建沙箱前调用
+[`examples/e2b-dev-sidecar`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar)
+中的 sidecar setup，因此也需要配置该示例使用的 `CUBE_REMOTE_PROXY_*` 变量。
 
 ### 迁移已有本地代码执行工具
 
@@ -121,7 +128,8 @@ def run_python_in_cube(code: str) -> dict:
 +     return run_python_in_cube(code)
 ```
 
-如果原 agent 已经引用这个代码执行工具，agent 定义和 prompt 可以保持不变。
+如果原 agent 已经引用这个代码执行工具，agent 定义可以保持不变。若原 prompt 或结果处理依赖特定字段，
+请按本示例返回的 `stdout`、`text`、`error`、`results_count` 结构调整。
 
 ## 可运行 Demo
 
@@ -157,7 +165,7 @@ agent 会调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建临时 Cu
 
 - **按会话复用沙箱：** 示例为了便于 review，每次工具调用创建一个临时沙箱。多轮 notebook 类任务可以把 sandbox handle 放入会话级服务，并在 ADK session 结束时删除。
 - **超时：** 可设置 `CUBE_SANDBOX_TIMEOUT`，或在 `Sandbox.create(...)` 中传入固定 timeout，控制沙箱生命周期。
-  这个值不是单次 `run_code` 调用的执行超时。
+  可设置 `CUBE_RUN_CODE_TIMEOUT`，或给 `sandbox.run_code(...)` 传入 `timeout=...`，控制单次执行上限。
 - **网络策略：** 如果生成代码只能访问指定主机，请在创建沙箱时配置 Cube 的出站控制。参见[网络策略](/zh/guide/network-policy)。
 - **凭证处理：** 模型提供商 key 应保留在宿主机。如果沙箱内代码必须调用外部 API，优先使用 Cube 的 security proxy 和凭证注入流程，不要把原始密钥写入 VM。
 - **模板：** 把重依赖预装进模板镜像，让每次 ADK 工具调用都能从 ready snapshot 快速启动。

--- a/docs/zh/guide/integrations/google-adk.md
+++ b/docs/zh/guide/integrations/google-adk.md
@@ -24,7 +24,7 @@ lang: zh-CN
 | --- | --- |
 | Google ADK | Python package `google-adk>=2.0.0` |
 | Python | 3.10+ |
-| CubeSandbox | E2B-compatible CubeAPI，以及支持 `run_code` 的模板 |
+| CubeSandbox | E2B-compatible CubeAPI、可访问的 CubeProxy 数据面，以及支持 `run_code` 的模板 |
 | SDK 路径 | 通过 `E2B_API_URL` 指向 CubeAPI 的 `e2b==2.26.0` 和 `e2b-code-interpreter==2.8.1` |
 
 Google ADK 仍在快速演进。示例把 E2B 相关包固定到一个 plain `pip` 可直接安装、且已记录在仓库 SDK compatibility notes 中的组合。修改任一版本前请重新验证。
@@ -32,12 +32,18 @@ Google ADK 仍在快速演进。示例把 E2B 相关包固定到一个 plain `pi
 ## 前置条件
 
 - 一个可用的 [CubeSandbox 部署](/zh/guide/quickstart)，CubeAPI 通常位于 `http://<cube-host>:3000`。
+- 官方 E2B SDK 需要可访问的数据面。一键本地部署自带 CoreDNS；生产环境应配置泛域名 DNS；
+  本地无法配置泛域名 DNS 时，可以使用
+  [E2B 开发 sidecar](/zh/guide/connect-existing-cluster)。
 - 一个 CubeSandbox 模板 ID。请使用支持 E2B code interpreter `run_code` 路径的模板。
 - 运行 ADK agent 的机器上有 Python 3.10+。
 - Google API key，或其他 ADK 支持的模型配置。
 
 ::: warning 控制面与数据面
-`E2B_API_URL` 会把 E2B-compatible SDK 指向 CubeAPI。如果你的部署使用自签 TLS 证书，请设置 `CUBE_SSL_CERT_FILE`，示例会在打开沙箱前导出 `SSL_CERT_FILE`。
+`E2B_API_URL` 用于选择 CubeAPI 控制平面端点。官方 E2B SDK 在执行 `run_code` 时还会访问每个沙箱的数据面域名。
+生产环境应配置泛域名 DNS；本地开发若没有泛域名 DNS，可以使用
+[E2B 开发 sidecar](/zh/guide/connect-existing-cluster)。如果你的部署使用自签 TLS 证书，请设置
+`CUBE_SSL_CERT_FILE`，示例会在打开沙箱前导出 `SSL_CERT_FILE`。
 :::
 
 ## 配置步骤
@@ -61,6 +67,7 @@ cp .env.example .env
 | `CUBE_TEMPLATE_ID` | 工具调用创建临时沙箱时使用的 CubeSandbox 模板 ID |
 | `GOOGLE_API_KEY` | ADK 使用的 Google 模型 API key |
 | `GOOGLE_ADK_MODEL` | ADK 模型名，例如 `gemini-2.5-flash` |
+| `CUBE_SANDBOX_TIMEOUT` | 可选的沙箱生命周期上限，单位秒，会传给 `Sandbox.create(timeout=...)`；默认值为 `300` |
 | `CUBE_SSL_CERT_FILE` | 自签部署可选的 CubeSandbox CA bundle |
 
 ## 集成代码片段
@@ -149,7 +156,8 @@ agent 会调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建临时 Cu
 ## 进一步配置
 
 - **按会话复用沙箱：** 示例为了便于 review，每次工具调用创建一个临时沙箱。多轮 notebook 类任务可以把 sandbox handle 放入会话级服务，并在 ADK session 结束时删除。
-- **超时：** 长分析任务可设置 `CUBE_SANDBOX_TIMEOUT`，或在 `Sandbox.create(...)` 中传入固定 timeout。
+- **超时：** 可设置 `CUBE_SANDBOX_TIMEOUT`，或在 `Sandbox.create(...)` 中传入固定 timeout，控制沙箱生命周期。
+  这个值不是单次 `run_code` 调用的执行超时。
 - **网络策略：** 如果生成代码只能访问指定主机，请在创建沙箱时配置 Cube 的出站控制。参见[网络策略](/zh/guide/network-policy)。
 - **凭证处理：** 模型提供商 key 应保留在宿主机。如果沙箱内代码必须调用外部 API，优先使用 Cube 的 security proxy 和凭证注入流程，不要把原始密钥写入 VM。
 - **模板：** 把重依赖预装进模板镜像，让每次 ADK 工具调用都能从 ready snapshot 快速启动。

--- a/docs/zh/guide/integrations/google-adk.md
+++ b/docs/zh/guide/integrations/google-adk.md
@@ -25,9 +25,9 @@ lang: zh-CN
 | Google ADK | Python package `google-adk>=2.0.0` |
 | Python | 3.10+ |
 | CubeSandbox | E2B-compatible CubeAPI，以及支持 `run_code` 的模板 |
-| SDK 路径 | 通过 `E2B_API_URL` 指向 CubeAPI 的 `e2b-code-interpreter` |
+| SDK 路径 | 通过 `E2B_API_URL` 指向 CubeAPI 的 `e2b==2.26.0` 和 `e2b-code-interpreter==2.8.1` |
 
-Google ADK 仍在快速演进。生产使用前，应在你的 CubeSandbox 部署上验证并固定 `google-adk` 与 `e2b-code-interpreter` 的具体版本。
+Google ADK 仍在快速演进。示例把 E2B 相关包固定到一个 plain `pip` 可直接安装、且已记录在仓库 SDK compatibility notes 中的组合。修改任一版本前请重新验证。
 
 ## 前置条件
 
@@ -86,14 +86,18 @@ root_agent = Agent(
 工具函数把 Cube 相关逻辑集中在一处：
 
 ```python
+import os
+
 from e2b_code_interpreter import Sandbox
 
 def run_python_in_cube(code: str) -> dict:
     template_id = os.environ["CUBE_TEMPLATE_ID"]
     with Sandbox.create(template=template_id, timeout=300) as sandbox:
         execution = sandbox.run_code(code)
+        stdout = "".join(str(item) for item in execution.logs.stdout)
         return {
-            "stdout": execution.text,
+            "stdout": stdout,
+            "text": execution.text,
             "error": str(execution.error) if execution.error else None,
         }
 ```

--- a/docs/zh/guide/integrations/google-adk.md
+++ b/docs/zh/guide/integrations/google-adk.md
@@ -71,6 +71,7 @@ cp .env.example .env
 | `CUBE_SANDBOX_TIMEOUT` | 可选的沙箱生命周期上限，单位秒，会传给 `Sandbox.create(timeout=...)`；默认值为 `300` |
 | `CUBE_RUN_CODE_TIMEOUT` | 可选的单次代码执行超时，单位秒，会传给 `sandbox.run_code(timeout=...)`；默认值为 `60` |
 | `CUBE_USE_DEV_SIDECAR` | 可选的本地开发开关。设为 `true` 时，会在创建沙箱前调用 E2B dev-sidecar |
+| `CUBE_REMOTE_PROXY_BASE` | `CUBE_USE_DEV_SIDECAR=true` 时必需；sidecar 使用的 CubeProxy 数据面地址，dev-env 中通常是 `https://127.0.0.1:11443` |
 | `CUBE_SSL_CERT_FILE` | 自签部署可选的 CubeSandbox CA bundle |
 
 ## 集成代码片段
@@ -116,7 +117,8 @@ def run_python_in_cube(code: str) -> dict:
 
 可运行示例也支持 `CUBE_USE_DEV_SIDECAR=true`，用于没有泛域名 DNS 的本地开发环境。该模式会在创建沙箱前调用
 [`examples/e2b-dev-sidecar`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar)
-中的 sidecar setup，因此也需要配置该示例使用的 `CUBE_REMOTE_PROXY_*` 变量。
+中的 sidecar setup，因此也需要在本示例的 `.env` 文件中配置 `CUBE_REMOTE_PROXY_*` 变量，或把它们导出到
+ADK 进程环境中。不要只修改 `examples/e2b-dev-sidecar/.env`；本示例不会加载那个文件。
 
 ### 迁移已有本地代码执行工具
 

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -51,3 +51,4 @@ lang: zh-CN
 | [Claude Code 集成指南](./claude-code.md) | shsaihdsaiudh | 2026-07-06 | integration, claude-code, coding-agent |
 | [LangChain 集成指南](./langchain.md) | peerless-hero | 2026-07-07 | integration, langchain, agent |
 | [OpenAI Agents SDK 集成指南](./openai-agents-sdk.md) | ZedingZhang | 2026-08-19 | integration, openai-agents-sdk, agent |
+| [Google ADK 集成指南](./google-adk.md) | ztt0216 | 2026-08-25 | integration, google-adk, agent |

--- a/examples/google-adk-integration/.env.example
+++ b/examples/google-adk-integration/.env.example
@@ -1,5 +1,6 @@
 # CubeSandbox E2B-compatible control plane.
-E2B_API_URL="http://127.0.0.1:3000"
+# For dev-env with host-to-guest port mapping, this is usually http://127.0.0.1:13000.
+E2B_API_URL="http://<cube-api-host>:3000"
 E2B_API_KEY="e2b_000000"
 CUBE_TEMPLATE_ID="<your-template-id>"
 

--- a/examples/google-adk-integration/.env.example
+++ b/examples/google-adk-integration/.env.example
@@ -6,6 +6,14 @@ CUBE_TEMPLATE_ID="<your-template-id>"
 # Optional: sandbox lifetime bound passed to Sandbox.create(timeout=...).
 # CUBE_SANDBOX_TIMEOUT="300"
 
+# Optional: per-call execution timeout passed to sandbox.run_code(timeout=...).
+# CUBE_RUN_CODE_TIMEOUT="60"
+
+# Optional: route official E2B SDK data-plane calls through examples/e2b-dev-sidecar.
+# Set this only for local development without wildcard DNS, and configure the
+# CUBE_REMOTE_PROXY_* sidecar variables documented in examples/e2b-dev-sidecar.
+# CUBE_USE_DEV_SIDECAR="false"
+
 # Google ADK / Gemini model settings.
 GOOGLE_API_KEY="<your-google-api-key>"
 GOOGLE_ADK_MODEL="gemini-2.5-flash"

--- a/examples/google-adk-integration/.env.example
+++ b/examples/google-adk-integration/.env.example
@@ -3,6 +3,9 @@ E2B_API_URL="http://127.0.0.1:3000"
 E2B_API_KEY="e2b_000000"
 CUBE_TEMPLATE_ID="<your-template-id>"
 
+# Optional: sandbox lifetime bound passed to Sandbox.create(timeout=...).
+# CUBE_SANDBOX_TIMEOUT="300"
+
 # Google ADK / Gemini model settings.
 GOOGLE_API_KEY="<your-google-api-key>"
 GOOGLE_ADK_MODEL="gemini-2.5-flash"

--- a/examples/google-adk-integration/.env.example
+++ b/examples/google-adk-integration/.env.example
@@ -10,9 +10,12 @@ CUBE_TEMPLATE_ID="<your-template-id>"
 # CUBE_RUN_CODE_TIMEOUT="60"
 
 # Optional: route official E2B SDK data-plane calls through examples/e2b-dev-sidecar.
-# Set this only for local development without wildcard DNS, and configure the
-# CUBE_REMOTE_PROXY_* sidecar variables documented in examples/e2b-dev-sidecar.
+# Set this only for local development without wildcard DNS. Keep E2B_API_URL on
+# your CubeAPI control-plane endpoint; for dev-env this is usually port 13000.
 # CUBE_USE_DEV_SIDECAR="false"
+# CUBE_REMOTE_PROXY_BASE="https://127.0.0.1:11443"
+# CUBE_REMOTE_SANDBOX_DOMAIN="cube.app"
+# CUBE_REMOTE_PROXY_VERIFY_SSL="false"
 
 # Google ADK / Gemini model settings.
 GOOGLE_API_KEY="<your-google-api-key>"

--- a/examples/google-adk-integration/.env.example
+++ b/examples/google-adk-integration/.env.example
@@ -1,0 +1,11 @@
+# CubeSandbox E2B-compatible control plane.
+E2B_API_URL="http://127.0.0.1:3000"
+E2B_API_KEY="e2b_000000"
+CUBE_TEMPLATE_ID="<your-template-id>"
+
+# Google ADK / Gemini model settings.
+GOOGLE_API_KEY="<your-google-api-key>"
+GOOGLE_ADK_MODEL="gemini-2.5-flash"
+
+# Optional: use a custom CA bundle for self-signed CubeSandbox deployments.
+# CUBE_SSL_CERT_FILE="/path/to/cube-ca.pem"

--- a/examples/google-adk-integration/README.md
+++ b/examples/google-adk-integration/README.md
@@ -65,4 +65,11 @@ temporary sandbox when the tool call finishes.
 - The E2B packages are pinned to a pair that plain `pip` can install and that is
   listed in the repository's SDK compatibility notes. Revalidate before changing
   either package version.
+- `CUBE_SANDBOX_TIMEOUT` controls the temporary sandbox lifetime.
+  `CUBE_RUN_CODE_TIMEOUT` controls each `run_code` execution.
+- For local development without wildcard DNS, set `CUBE_USE_DEV_SIDECAR=true`
+  and configure the `CUBE_REMOTE_PROXY_*` variables documented in
+  `examples/e2b-dev-sidecar`.
 - If your CubeAPI uses a self-signed certificate, set `CUBE_SSL_CERT_FILE`.
+  This exports `SSL_CERT_FILE` process-wide, so use a CA bundle that preserves
+  trust for your model provider as well.

--- a/examples/google-adk-integration/README.md
+++ b/examples/google-adk-integration/README.md
@@ -56,15 +56,17 @@ Run Python in the sandbox to calculate the first 10 Fibonacci numbers.
 ```
 
 The agent should call `run_python_in_cube`, create a CubeSandbox from
-`CUBE_TEMPLATE_ID`, execute the Python code, return stdout, and delete the
-temporary sandbox when the tool call finishes.
+`CUBE_TEMPLATE_ID`, execute the Python code, return stdout and stderr, and
+delete the temporary sandbox when the tool call finishes.
 
 ## Notes
 
 - Use a template that supports the E2B code interpreter `run_code` path.
 - The E2B packages are pinned to a pair that plain `pip` can install and that is
-  listed in the repository's SDK compatibility notes. Revalidate before changing
-  either package version.
+  listed in the repository's SDK compatibility notes. This example's offline
+  smoke test does not validate the live `run_code` path against that exact pair,
+  so revalidate against a real CubeSandbox deployment before changing package
+  versions or using this as a production baseline.
 - `CUBE_SANDBOX_TIMEOUT` controls the temporary sandbox lifetime.
   `CUBE_RUN_CODE_TIMEOUT` controls each `run_code` execution.
 - For local development without wildcard DNS, set `CUBE_USE_DEV_SIDECAR=true`

--- a/examples/google-adk-integration/README.md
+++ b/examples/google-adk-integration/README.md
@@ -1,0 +1,67 @@
+# Google ADK + CubeSandbox Integration Example
+
+This example exposes CubeSandbox as a Google ADK function tool. The ADK agent
+keeps running in your local development environment, while generated Python
+code executes inside a temporary CubeSandbox MicroVM through the E2B-compatible
+SDK.
+
+## Files
+
+```text
+google-adk-integration/
+  agent.py            ADK root_agent definition
+  cube_code_tool.py   CubeSandbox-backed Python execution tool
+  smoke_test.py       Offline import and wiring checks
+  .env.example        Required environment variables
+  requirements.txt
+```
+
+## Setup
+
+```bash
+cd examples/google-adk-integration
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Edit `.env` with your CubeAPI endpoint, CubeSandbox template ID, and Google API
+key. A local unauthenticated CubeAPI deployment can use `E2B_API_KEY=e2b_000000`.
+
+## Run the checks
+
+```bash
+python smoke_test.py
+```
+
+Expected output:
+
+```text
+GOOGLE_ADK_CUBE_SMOKE_OK
+```
+
+## Run the ADK agent
+
+From the parent directory that contains this example:
+
+```bash
+adk run google-adk-integration
+```
+
+Ask the agent:
+
+```text
+Run Python in the sandbox to calculate the first 10 Fibonacci numbers.
+```
+
+The agent should call `run_python_in_cube`, create a CubeSandbox from
+`CUBE_TEMPLATE_ID`, execute the Python code, return stdout, and delete the
+temporary sandbox when the tool call finishes.
+
+## Notes
+
+- Use a template that supports the E2B code interpreter `run_code` path.
+- For production use, pin the resolved `google-adk` and `e2b-code-interpreter`
+  versions after validating them with your CubeSandbox release.
+- If your CubeAPI uses a self-signed certificate, set `CUBE_SSL_CERT_FILE`.

--- a/examples/google-adk-integration/README.md
+++ b/examples/google-adk-integration/README.md
@@ -68,8 +68,9 @@ temporary sandbox when the tool call finishes.
 - `CUBE_SANDBOX_TIMEOUT` controls the temporary sandbox lifetime.
   `CUBE_RUN_CODE_TIMEOUT` controls each `run_code` execution.
 - For local development without wildcard DNS, set `CUBE_USE_DEV_SIDECAR=true`
-  and configure the `CUBE_REMOTE_PROXY_*` variables documented in
-  `examples/e2b-dev-sidecar`.
+  and set the `CUBE_REMOTE_PROXY_*` variables in this example's `.env`, or
+  export them in the ADK process environment. Do not rely on
+  `examples/e2b-dev-sidecar/.env`; this example does not load that file.
 - If your CubeAPI uses a self-signed certificate, set `CUBE_SSL_CERT_FILE`.
   This exports `SSL_CERT_FILE` process-wide, so use a CA bundle that preserves
   trust for your model provider as well.

--- a/examples/google-adk-integration/README.md
+++ b/examples/google-adk-integration/README.md
@@ -62,6 +62,7 @@ temporary sandbox when the tool call finishes.
 ## Notes
 
 - Use a template that supports the E2B code interpreter `run_code` path.
-- For production use, pin the resolved `google-adk` and `e2b-code-interpreter`
-  versions after validating them with your CubeSandbox release.
+- The E2B packages are pinned to a pair that plain `pip` can install and that is
+  listed in the repository's SDK compatibility notes. Revalidate before changing
+  either package version.
 - If your CubeAPI uses a self-signed certificate, set `CUBE_SSL_CERT_FILE`.

--- a/examples/google-adk-integration/README_zh.md
+++ b/examples/google-adk-integration/README_zh.md
@@ -1,0 +1,60 @@
+# Google ADK + CubeSandbox 集成示例
+
+这个示例把 CubeSandbox 暴露成一个 Google ADK 函数工具。ADK agent 仍在你的本地开发环境运行，但它生成的 Python 代码会通过 E2B-compatible SDK 进入临时 CubeSandbox MicroVM 中执行。
+
+## 文件
+
+```text
+google-adk-integration/
+  agent.py            ADK root_agent 定义
+  cube_code_tool.py   基于 CubeSandbox 的 Python 执行工具
+  smoke_test.py       离线导入和接线检查
+  .env.example        必需环境变量
+  requirements.txt
+```
+
+## 配置
+
+```bash
+cd examples/google-adk-integration
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+编辑 `.env`，填入 CubeAPI 地址、CubeSandbox 模板 ID 和 Google API key。本地未启用认证的 CubeAPI 可使用 `E2B_API_KEY=e2b_000000`。
+
+## 运行检查
+
+```bash
+python smoke_test.py
+```
+
+期望输出：
+
+```text
+GOOGLE_ADK_CUBE_SMOKE_OK
+```
+
+## 运行 ADK agent
+
+从包含该示例目录的父目录运行：
+
+```bash
+adk run google-adk-integration
+```
+
+向 agent 提问：
+
+```text
+Run Python in the sandbox to calculate the first 10 Fibonacci numbers.
+```
+
+agent 应调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建 CubeSandbox，执行 Python 代码，返回 stdout，并在工具调用结束后删除临时沙箱。
+
+## 注意事项
+
+- 请使用支持 E2B code interpreter `run_code` 路径的模板。
+- 生产使用前，应在你的 CubeSandbox 版本上验证并固定 `google-adk` 和 `e2b-code-interpreter` 的具体版本。
+- 如果 CubeAPI 使用自签证书，请设置 `CUBE_SSL_CERT_FILE`。

--- a/examples/google-adk-integration/README_zh.md
+++ b/examples/google-adk-integration/README_zh.md
@@ -51,12 +51,14 @@ adk run google-adk-integration
 Run Python in the sandbox to calculate the first 10 Fibonacci numbers.
 ```
 
-agent 应调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建 CubeSandbox，执行 Python 代码，返回 stdout，并在工具调用结束后删除临时沙箱。
+agent 应调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建 CubeSandbox，执行 Python 代码，返回 stdout 和 stderr，并在工具调用结束后删除临时沙箱。
 
 ## 注意事项
 
 - 请使用支持 E2B code interpreter `run_code` 路径的模板。
-- E2B 相关包已固定到一个 plain `pip` 可直接安装、且记录在仓库 SDK compatibility notes 中的组合。修改任一版本前请重新验证。
+- E2B 相关包已固定到一个 plain `pip` 可直接安装、且记录在仓库 SDK compatibility notes 中的组合。
+  本示例的离线 smoke test 不会验证该精确组合连接真实 CubeSandbox 部署后的 live `run_code` 路径；
+  修改版本或作为生产基线使用前，请重新验证。
 - `CUBE_SANDBOX_TIMEOUT` 控制临时沙箱生命周期，`CUBE_RUN_CODE_TIMEOUT` 控制每次 `run_code` 执行。
 - 本地开发没有泛域名 DNS 时，可以设置 `CUBE_USE_DEV_SIDECAR=true`，并在本示例的 `.env`
   中配置 `CUBE_REMOTE_PROXY_*` 变量，或把它们导出到 ADK 进程环境中。不要只修改

--- a/examples/google-adk-integration/README_zh.md
+++ b/examples/google-adk-integration/README_zh.md
@@ -56,5 +56,5 @@ agent 应调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建 CubeSand
 ## 注意事项
 
 - 请使用支持 E2B code interpreter `run_code` 路径的模板。
-- 生产使用前，应在你的 CubeSandbox 版本上验证并固定 `google-adk` 和 `e2b-code-interpreter` 的具体版本。
+- E2B 相关包已固定到一个 plain `pip` 可直接安装、且记录在仓库 SDK compatibility notes 中的组合。修改任一版本前请重新验证。
 - 如果 CubeAPI 使用自签证书，请设置 `CUBE_SSL_CERT_FILE`。

--- a/examples/google-adk-integration/README_zh.md
+++ b/examples/google-adk-integration/README_zh.md
@@ -58,7 +58,8 @@ agent 应调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建 CubeSand
 - 请使用支持 E2B code interpreter `run_code` 路径的模板。
 - E2B 相关包已固定到一个 plain `pip` 可直接安装、且记录在仓库 SDK compatibility notes 中的组合。修改任一版本前请重新验证。
 - `CUBE_SANDBOX_TIMEOUT` 控制临时沙箱生命周期，`CUBE_RUN_CODE_TIMEOUT` 控制每次 `run_code` 执行。
-- 本地开发没有泛域名 DNS 时，可以设置 `CUBE_USE_DEV_SIDECAR=true`，并配置
-  `examples/e2b-dev-sidecar` 文档中的 `CUBE_REMOTE_PROXY_*` 变量。
+- 本地开发没有泛域名 DNS 时，可以设置 `CUBE_USE_DEV_SIDECAR=true`，并在本示例的 `.env`
+  中配置 `CUBE_REMOTE_PROXY_*` 变量，或把它们导出到 ADK 进程环境中。不要只修改
+  `examples/e2b-dev-sidecar/.env`；本示例不会加载那个文件。
 - 如果 CubeAPI 使用自签证书，请设置 `CUBE_SSL_CERT_FILE`。这会在进程级导出 `SSL_CERT_FILE`，
   因此 CA bundle 也需要保留模型提供商的 TLS 信任。

--- a/examples/google-adk-integration/README_zh.md
+++ b/examples/google-adk-integration/README_zh.md
@@ -57,4 +57,8 @@ agent 应调用 `run_python_in_cube`，基于 `CUBE_TEMPLATE_ID` 创建 CubeSand
 
 - 请使用支持 E2B code interpreter `run_code` 路径的模板。
 - E2B 相关包已固定到一个 plain `pip` 可直接安装、且记录在仓库 SDK compatibility notes 中的组合。修改任一版本前请重新验证。
-- 如果 CubeAPI 使用自签证书，请设置 `CUBE_SSL_CERT_FILE`。
+- `CUBE_SANDBOX_TIMEOUT` 控制临时沙箱生命周期，`CUBE_RUN_CODE_TIMEOUT` 控制每次 `run_code` 执行。
+- 本地开发没有泛域名 DNS 时，可以设置 `CUBE_USE_DEV_SIDECAR=true`，并配置
+  `examples/e2b-dev-sidecar` 文档中的 `CUBE_REMOTE_PROXY_*` 变量。
+- 如果 CubeAPI 使用自签证书，请设置 `CUBE_SSL_CERT_FILE`。这会在进程级导出 `SSL_CERT_FILE`，
+  因此 CA bundle 也需要保留模型提供商的 TLS 信任。

--- a/examples/google-adk-integration/agent.py
+++ b/examples/google-adk-integration/agent.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import os
 
-from dotenv import load_dotenv
 from google.adk import Agent
 
-from cube_code_tool import run_python_in_cube
+from cube_code_tool import load_environment, run_python_in_cube
 
 
-load_dotenv(override=False)
+load_environment()
 
 root_agent = Agent(
     name="cube_code_agent",

--- a/examples/google-adk-integration/agent.py
+++ b/examples/google-adk-integration/agent.py
@@ -1,0 +1,25 @@
+"""Google ADK agent wired to CubeSandbox for code execution."""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+from google.adk import Agent
+
+from cube_code_tool import run_python_in_cube
+
+
+load_dotenv(override=False)
+
+root_agent = Agent(
+    name="cube_code_agent",
+    model=os.environ.get("GOOGLE_ADK_MODEL", "gemini-2.5-flash"),
+    instruction=(
+        "You are a careful coding assistant. When the user asks you to run, "
+        "test, or inspect Python code, call run_python_in_cube so execution "
+        "happens inside an isolated CubeSandbox MicroVM. Explain results from "
+        "the tool output instead of claiming execution happened locally."
+    ),
+    tools=[run_python_in_cube],
+)

--- a/examples/google-adk-integration/cube_code_tool.py
+++ b/examples/google-adk-integration/cube_code_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +11,7 @@ from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
 
 
-def _load_env() -> None:
+def load_environment() -> None:
     """Load local .env values without overriding exported environment values."""
     for path in (Path(__file__).with_name(".env"), Path.cwd() / ".env"):
         if path.is_file():
@@ -20,6 +21,38 @@ def _load_env() -> None:
     cube_ssl = os.environ.get("CUBE_SSL_CERT_FILE")
     if cube_ssl and Path(cube_ssl).is_file():
         os.environ.setdefault("SSL_CERT_FILE", cube_ssl)
+
+
+def _read_int_env(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be an integer number of seconds") from exc
+
+
+def _bool_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _setup_optional_dev_sidecar() -> None:
+    if not _bool_env("CUBE_USE_DEV_SIDECAR"):
+        return
+
+    sidecar_dir = Path(__file__).resolve().parents[1] / "e2b-dev-sidecar"
+    sys.path.insert(0, str(sidecar_dir))
+    try:
+        from dev_sidecar import setup_dev_sidecar
+    except ImportError as exc:
+        raise RuntimeError(
+            "CUBE_USE_DEV_SIDECAR is enabled, but examples/e2b-dev-sidecar "
+            "could not be imported. Install this example's requirements and "
+            "run it from the CubeSandbox repository checkout."
+        ) from exc
+
+    setup_dev_sidecar()
 
 
 def _read_required_env(name: str) -> str:
@@ -40,7 +73,7 @@ def _execution_to_dict(execution: Any, stdout: list[Any]) -> dict[str, Any]:
     """Return a JSON-serializable result across E2B SDK versions."""
     logs = getattr(execution, "logs", None)
     captured_stdout = getattr(logs, "stdout", None) if logs else None
-    stdout_items = captured_stdout if captured_stdout is not None else stdout
+    stdout_items = captured_stdout or stdout
 
     result: dict[str, Any] = {
         "stdout": "".join(_stringify_log_item(item) for item in stdout_items),
@@ -68,15 +101,21 @@ def run_python_in_cube(code: str) -> dict[str, Any]:
     Returns:
         A dictionary containing stdout, text output, and any execution error.
     """
-    _load_env()
+    load_environment()
 
     if not code or not code.strip():
         return {"stdout": "", "text": "", "error": "code must not be empty"}
 
     template_id = _read_required_env("CUBE_TEMPLATE_ID")
-    timeout = int(os.environ.get("CUBE_SANDBOX_TIMEOUT", "300"))
+    sandbox_timeout = _read_int_env("CUBE_SANDBOX_TIMEOUT", 300)
+    run_code_timeout = _read_int_env("CUBE_RUN_CODE_TIMEOUT", 60)
 
     stdout: list[Any] = []
-    with Sandbox.create(template=template_id, timeout=timeout) as sandbox:
-        execution = sandbox.run_code(code, on_stdout=stdout.append)
+    _setup_optional_dev_sidecar()
+    with Sandbox.create(template=template_id, timeout=sandbox_timeout) as sandbox:
+        execution = sandbox.run_code(
+            code,
+            on_stdout=stdout.append,
+            timeout=run_code_timeout,
+        )
         return _execution_to_dict(execution, stdout)

--- a/examples/google-adk-integration/cube_code_tool.py
+++ b/examples/google-adk-integration/cube_code_tool.py
@@ -1,0 +1,71 @@
+"""CubeSandbox-backed code execution tool for Google ADK."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+
+def _load_env() -> None:
+    """Load local .env values without overriding exported environment values."""
+    for path in (Path(__file__).with_name(".env"), Path.cwd() / ".env"):
+        if path.is_file():
+            load_dotenv(path, override=False)
+            break
+
+    cube_ssl = os.environ.get("CUBE_SSL_CERT_FILE")
+    if cube_ssl and Path(cube_ssl).is_file():
+        os.environ.setdefault("SSL_CERT_FILE", cube_ssl)
+
+
+def _read_required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def _execution_to_dict(execution: Any, stdout: list[str]) -> dict[str, Any]:
+    """Return a JSON-serializable result across E2B SDK versions."""
+    result: dict[str, Any] = {
+        "stdout": "".join(stdout),
+        "text": getattr(execution, "text", None),
+        "error": None,
+    }
+
+    error = getattr(execution, "error", None)
+    if error:
+        result["error"] = str(error)
+
+    results = getattr(execution, "results", None)
+    if results is not None:
+        result["results_count"] = len(results)
+
+    return result
+
+
+def run_python_in_cube(code: str) -> dict[str, Any]:
+    """Execute Python code inside a temporary CubeSandbox MicroVM.
+
+    Args:
+        code: Python source code to execute in the sandbox.
+
+    Returns:
+        A dictionary containing stdout, text output, and any execution error.
+    """
+    _load_env()
+
+    if not code or not code.strip():
+        return {"stdout": "", "text": "", "error": "code must not be empty"}
+
+    template_id = _read_required_env("CUBE_TEMPLATE_ID")
+    timeout = int(os.environ.get("CUBE_SANDBOX_TIMEOUT", "300"))
+
+    stdout: list[str] = []
+    with Sandbox.create(template=template_id, timeout=timeout) as sandbox:
+        execution = sandbox.run_code(code, on_stdout=stdout.append)
+        return _execution_to_dict(execution, stdout)

--- a/examples/google-adk-integration/cube_code_tool.py
+++ b/examples/google-adk-integration/cube_code_tool.py
@@ -104,7 +104,12 @@ def run_python_in_cube(code: str) -> dict[str, Any]:
     load_environment()
 
     if not code or not code.strip():
-        return {"stdout": "", "text": "", "error": "code must not be empty"}
+        return {
+            "stdout": "",
+            "text": None,
+            "error": "code must not be empty",
+            "results_count": 0,
+        }
 
     template_id = _read_required_env("CUBE_TEMPLATE_ID")
     sandbox_timeout = _read_int_env("CUBE_SANDBOX_TIMEOUT", 300)

--- a/examples/google-adk-integration/cube_code_tool.py
+++ b/examples/google-adk-integration/cube_code_tool.py
@@ -29,10 +29,21 @@ def _read_required_env(name: str) -> str:
     return value
 
 
-def _execution_to_dict(execution: Any, stdout: list[str]) -> dict[str, Any]:
+def _stringify_log_item(item: Any) -> str:
+    line = getattr(item, "line", None)
+    if line is not None:
+        return str(line)
+    return str(item)
+
+
+def _execution_to_dict(execution: Any, stdout: list[Any]) -> dict[str, Any]:
     """Return a JSON-serializable result across E2B SDK versions."""
+    logs = getattr(execution, "logs", None)
+    captured_stdout = getattr(logs, "stdout", None) if logs else None
+    stdout_items = captured_stdout if captured_stdout is not None else stdout
+
     result: dict[str, Any] = {
-        "stdout": "".join(stdout),
+        "stdout": "".join(_stringify_log_item(item) for item in stdout_items),
         "text": getattr(execution, "text", None),
         "error": None,
     }
@@ -65,7 +76,7 @@ def run_python_in_cube(code: str) -> dict[str, Any]:
     template_id = _read_required_env("CUBE_TEMPLATE_ID")
     timeout = int(os.environ.get("CUBE_SANDBOX_TIMEOUT", "300"))
 
-    stdout: list[str] = []
+    stdout: list[Any] = []
     with Sandbox.create(template=template_id, timeout=timeout) as sandbox:
         execution = sandbox.run_code(code, on_stdout=stdout.append)
         return _execution_to_dict(execution, stdout)

--- a/examples/google-adk-integration/cube_code_tool.py
+++ b/examples/google-adk-integration/cube_code_tool.py
@@ -69,14 +69,21 @@ def _stringify_log_item(item: Any) -> str:
     return str(item)
 
 
-def _execution_to_dict(execution: Any, stdout: list[Any]) -> dict[str, Any]:
+def _execution_to_dict(
+    execution: Any,
+    stdout: list[Any],
+    stderr: list[Any],
+) -> dict[str, Any]:
     """Return a JSON-serializable result across E2B SDK versions."""
     logs = getattr(execution, "logs", None)
     captured_stdout = getattr(logs, "stdout", None) if logs else None
+    captured_stderr = getattr(logs, "stderr", None) if logs else None
     stdout_items = captured_stdout or stdout
+    stderr_items = captured_stderr or stderr
 
     result: dict[str, Any] = {
         "stdout": "".join(_stringify_log_item(item) for item in stdout_items),
+        "stderr": "".join(_stringify_log_item(item) for item in stderr_items),
         "text": getattr(execution, "text", None),
         "error": None,
     }
@@ -106,6 +113,7 @@ def run_python_in_cube(code: str) -> dict[str, Any]:
     if not code or not code.strip():
         return {
             "stdout": "",
+            "stderr": "",
             "text": None,
             "error": "code must not be empty",
             "results_count": 0,
@@ -116,11 +124,13 @@ def run_python_in_cube(code: str) -> dict[str, Any]:
     run_code_timeout = _read_int_env("CUBE_RUN_CODE_TIMEOUT", 60)
 
     stdout: list[Any] = []
+    stderr: list[Any] = []
     _setup_optional_dev_sidecar()
     with Sandbox.create(template=template_id, timeout=sandbox_timeout) as sandbox:
         execution = sandbox.run_code(
             code,
             on_stdout=stdout.append,
+            on_stderr=stderr.append,
             timeout=run_code_timeout,
         )
-        return _execution_to_dict(execution, stdout)
+        return _execution_to_dict(execution, stdout, stderr)

--- a/examples/google-adk-integration/requirements.txt
+++ b/examples/google-adk-integration/requirements.txt
@@ -1,4 +1,5 @@
 google-adk>=2.0.0
 e2b==2.26.0
 e2b-code-interpreter==2.8.1
+aiohttp>=3.9
 python-dotenv

--- a/examples/google-adk-integration/requirements.txt
+++ b/examples/google-adk-integration/requirements.txt
@@ -1,0 +1,3 @@
+google-adk>=2.0.0
+e2b-code-interpreter
+python-dotenv

--- a/examples/google-adk-integration/requirements.txt
+++ b/examples/google-adk-integration/requirements.txt
@@ -1,4 +1,4 @@
-google-adk>=2.0.0
+google-adk==2.7.1
 e2b==2.26.0
 e2b-code-interpreter==2.8.1
 aiohttp>=3.9

--- a/examples/google-adk-integration/requirements.txt
+++ b/examples/google-adk-integration/requirements.txt
@@ -1,3 +1,4 @@
 google-adk>=2.0.0
-e2b-code-interpreter
+e2b==2.26.0
+e2b-code-interpreter==2.8.1
 python-dotenv

--- a/examples/google-adk-integration/smoke_test.py
+++ b/examples/google-adk-integration/smoke_test.py
@@ -42,6 +42,7 @@ def main() -> None:
 
     class Logs:
         stdout = [LogItem(), "world\n"]
+        stderr = ["warning\n"]
 
     class Execution:
         logs = Logs()
@@ -49,25 +50,33 @@ def main() -> None:
         error = None
         results = []
 
-    result = cube_code_tool._execution_to_dict(Execution(), [])
+    result = cube_code_tool._execution_to_dict(Execution(), [], [])
     assert result["stdout"] == "hello\nworld\n"
+    assert result["stderr"] == "warning\n"
     assert result["text"] == "hello world"
     assert result["error"] is None
 
     class EmptyLogs:
         stdout: list[str] = []
+        stderr: list[str] = []
 
     class EmptyLogExecution:
         logs = EmptyLogs()
         text = ""
         error = None
 
-    fallback = cube_code_tool._execution_to_dict(EmptyLogExecution(), ["callback\n"])
+    fallback = cube_code_tool._execution_to_dict(
+        EmptyLogExecution(),
+        ["callback\n"],
+        ["callback error\n"],
+    )
     assert fallback["stdout"] == "callback\n"
+    assert fallback["stderr"] == "callback error\n"
 
     empty_code = cube_code_tool.run_python_in_cube("  ")
     assert empty_code == {
         "stdout": "",
+        "stderr": "",
         "text": None,
         "error": "code must not be empty",
         "results_count": 0,

--- a/examples/google-adk-integration/smoke_test.py
+++ b/examples/google-adk-integration/smoke_test.py
@@ -53,6 +53,17 @@ def main() -> None:
     assert result["stdout"] == "hello\nworld\n"
     assert result["text"] == "hello world"
     assert result["error"] is None
+
+    class EmptyLogs:
+        stdout: list[str] = []
+
+    class EmptyLogExecution:
+        logs = EmptyLogs()
+        text = ""
+        error = None
+
+    fallback = cube_code_tool._execution_to_dict(EmptyLogExecution(), ["callback\n"])
+    assert fallback["stdout"] == "callback\n"
     print("GOOGLE_ADK_CUBE_SMOKE_OK")
 
 

--- a/examples/google-adk-integration/smoke_test.py
+++ b/examples/google-adk-integration/smoke_test.py
@@ -1,0 +1,29 @@
+"""Offline smoke checks for the Google ADK integration example."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import agent
+import cube_code_tool
+
+
+def main() -> None:
+    assert agent.root_agent.name == "cube_code_agent"
+    assert cube_code_tool.run_python_in_cube in agent.root_agent.tools
+
+    signature = inspect.signature(cube_code_tool.run_python_in_cube)
+    assert list(signature.parameters) == ["code"]
+
+    ast.parse(
+        """
+numbers = [1, 2, 3, 4]
+print(sum(numbers))
+"""
+    )
+    print("GOOGLE_ADK_CUBE_SMOKE_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/google-adk-integration/smoke_test.py
+++ b/examples/google-adk-integration/smoke_test.py
@@ -2,26 +2,57 @@
 
 from __future__ import annotations
 
-import ast
 import inspect
+from typing import Any
 
 import agent
 import cube_code_tool
 
 
+def _tool_names(tools: list[Any]) -> list[str]:
+    names: list[str] = []
+    for tool in tools:
+        name = getattr(tool, "name", None)
+        if name:
+            names.append(str(name))
+            continue
+
+        func = getattr(tool, "func", None)
+        func_name = getattr(func, "__name__", None)
+        if func_name:
+            names.append(str(func_name))
+            continue
+
+        direct_name = getattr(tool, "__name__", None)
+        if direct_name:
+            names.append(str(direct_name))
+
+    return names
+
+
 def main() -> None:
     assert agent.root_agent.name == "cube_code_agent"
-    assert cube_code_tool.run_python_in_cube in agent.root_agent.tools
+    assert "run_python_in_cube" in _tool_names(agent.root_agent.tools)
 
     signature = inspect.signature(cube_code_tool.run_python_in_cube)
     assert list(signature.parameters) == ["code"]
 
-    ast.parse(
-        """
-numbers = [1, 2, 3, 4]
-print(sum(numbers))
-"""
-    )
+    class LogItem:
+        line = "hello\n"
+
+    class Logs:
+        stdout = [LogItem(), "world\n"]
+
+    class Execution:
+        logs = Logs()
+        text = "hello world"
+        error = None
+        results = []
+
+    result = cube_code_tool._execution_to_dict(Execution(), [])
+    assert result["stdout"] == "hello\nworld\n"
+    assert result["text"] == "hello world"
+    assert result["error"] is None
     print("GOOGLE_ADK_CUBE_SMOKE_OK")
 
 

--- a/examples/google-adk-integration/smoke_test.py
+++ b/examples/google-adk-integration/smoke_test.py
@@ -64,6 +64,14 @@ def main() -> None:
 
     fallback = cube_code_tool._execution_to_dict(EmptyLogExecution(), ["callback\n"])
     assert fallback["stdout"] == "callback\n"
+
+    empty_code = cube_code_tool.run_python_in_cube("  ")
+    assert empty_code == {
+        "stdout": "",
+        "text": None,
+        "error": "code must not be empty",
+        "results_count": 0,
+    }
     print("GOOGLE_ADK_CUBE_SMOKE_OK")
 
 


### PR DESCRIPTION
## Summary

- Add bilingual Google ADK integration guides under `docs/guide/integrations/` and `docs/zh/guide/integrations/`.
- Document how to expose CubeSandbox as a Google ADK function tool through the E2B-compatible `e2b-code-interpreter` SDK.
- Add a runnable `examples/google-adk-integration/` example with an ADK `root_agent`, Cube-backed code execution tool, bilingual README files, and an offline smoke test.
- Update both integration index pages.

Related to #244.

## Validation

- `python3 -m py_compile examples/google-adk-integration/*.py`
- Installed example dependencies in a clean virtualenv:
  - `google-adk 2.7.1`
  - `e2b-code-interpreter 2.9.1`
- `/tmp/cubesandbox-google-adk-venv/bin/python examples/google-adk-integration/smoke_test.py`
  - `GOOGLE_ADK_CUBE_SMOKE_OK`
- `cd docs && npm install && npm run docs:build`
- `git diff --check`

## Not verified

- I did not run the example against a live CubeSandbox cluster because no CubeAPI endpoint and `run_code`-capable `CUBE_TEMPLATE_ID` were available in this environment.
