### PR TITLE
chore(sdk/python): bump version to 0.7.0

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/TencentCloud/CubeSandbox"><img src="https://img.shields.io/badge/CubeSandbox-GitHub-blue" alt="CubeSandbox" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Python-3.9%2B-blue" alt="Python 3.9+" />
-  <img src="https://img.shields.io/badge/version-0.6.0-orange" alt="v0.6.0" />
+  <img src="https://img.shields.io/badge/version-0.7.0-orange" alt="v0.7.0" />
 </p>
 
 ---

--- a/sdk/python/cubesandbox/__init__.py
+++ b/sdk/python/cubesandbox/__init__.py
@@ -47,4 +47,4 @@ __all__ = [
     "Inject",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubesandbox"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python SDK for CubeSandbox"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"


### PR DESCRIPTION
Bump Python SDK version from 0.6.0 to 0.7.0.

Files changed:
- sdk/python/pyproject.toml
- sdk/python/cubesandbox/__init__.py
- sdk/python/README.md

Note: Please ensure the human submitter adds their own Signed-off-by tag for DCO compliance.