### PR TITLE
test(e2e): stabilize template builds and cover dual-stack DNS

### DIFF
--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -358,9 +358,9 @@ Optional:
   `--run-e2e`, so the hermetic `framework` gate stays serial.
 - `SDK_E2E_TEMPLATE_BUILD_CONCURRENCY`: max concurrent live template builds
   across xdist workers. Defaults to `1` (builds fully serialized so results match
-  a serial run); values `< 1` or non-integer fall back to `1`. When the value is
-  at least the worker count the throttle is skipped. POSIX-only (a no-op without
-  `fcntl`). The throttle is namespaced per-UID, not per-run: two concurrent
+  a serial run); values `< 1` or non-integer fall back to `1`. POSIX-only (a
+  no-op without `fcntl`). The throttle is namespaced per-UID, not per-run: two
+  concurrent
   `--run-e2e` jobs of the same user on one host share the slots and serialize
   their builds against each other. This is intentional -- both jobs contend on
   the one shared build host -- and the `SDK_E2E_TEMPLATE_BUILD_WAIT` ceiling

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -308,7 +308,7 @@ cp env.example .env
   优先。不带 `--run-e2e` 时忽略，因此 hermetic `framework` gate 仍为串行；
 - `SDK_E2E_TEMPLATE_BUILD_CONCURRENCY`：xdist 各 worker 间并发的 live template
   build 上限，默认 `1`（完全串行，使结果与串行运行一致）；小于 `1` 或非整数回退
-  为 `1`；当取值不小于 worker 数时跳过节流；仅 POSIX（无 `fcntl` 时为 no-op）；
+  为 `1`；仅 POSIX（无 `fcntl` 时为 no-op）；
   节流按 UID 而非按 run 命名：同一用户在同一主机上并发的两个 `--run-e2e` 任务会
   共享 slot 并相互串行化其构建。这是有意为之——两个任务都在争用同一台共享构建
   主机——且 `SDK_E2E_TEMPLATE_BUILD_WAIT` 上限会限制任务在降级为不节流前的等待

--- a/tests/e2e/sdk_compat/cases/framework/test_parallel.py
+++ b/tests/e2e/sdk_compat/cases/framework/test_parallel.py
@@ -9,8 +9,9 @@ Marked ``framework`` so they run on every gate without a live environment
 
 from __future__ import annotations
 
-import pytest
+from unittest import mock
 
+import pytest
 from framework.build_throttle import _concurrency, template_build_slot
 from framework.parallel import (
     apply_worker_count,
@@ -109,9 +110,8 @@ def test_current_worker_count_falls_back_when_count_unusable(monkeypatch, bad_co
 
 @pytest.mark.parametrize("worker_name", ["gw0", "gw1", "gw3"])
 def test_current_worker_count_fallback_is_worker_agnostic(monkeypatch, worker_name):
-    # When the authoritative count is missing, every worker must resolve the SAME
-    # count so timeout/retry scaling and the throttle-skip condition stay in sync.
-    # Deriving ``gwN + 1`` would make gw0 skip the build lock while peers hold it.
+    # When the authoritative count is missing, every worker must resolve the same
+    # count so timeout and retry scaling stay in sync.
     _clear_xdist_env(monkeypatch)
     monkeypatch.setenv("PYTEST_XDIST_WORKER", worker_name)
     monkeypatch.setattr("framework.parallel.os.cpu_count", lambda: 6)
@@ -253,7 +253,6 @@ def test_apply_worker_count_raises_on_malformed_env(monkeypatch):
 
 
 def _force_throttle_active(monkeypatch):
-    # Make template_build_slot take the locking path: >1 worker, concurrency 1.
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
     monkeypatch.setenv("PYTEST_XDIST_WORKER_COUNT", "4")
     monkeypatch.delenv("SDK_E2E_TEMPLATE_BUILD_CONCURRENCY", raising=False)
@@ -290,17 +289,21 @@ def test_template_build_slot_degrades_on_timeout(monkeypatch):
     assert entered
 
 
-def test_template_build_slot_serial_is_noop(monkeypatch):
-    # A serial run (1 worker) never touches the lock dir at all.
+def test_template_build_slot_serial_uses_acquire_path(monkeypatch, tmp_path):
+    pytest.importorskip("fcntl")
     monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
     monkeypatch.delenv("PYTEST_XDIST_WORKER_COUNT", raising=False)
+    monkeypatch.setattr("framework.build_throttle._LOCK_DIR", tmp_path / "locks")
+    handle = mock.Mock()
+    handle.fileno.return_value = -1
 
-    def _should_not_run(_slots, _timeout):
-        raise AssertionError("serial run must not acquire a slot")
+    def _acquire(_slots, _timeout):
+        return handle, 0
 
-    monkeypatch.setattr("framework.build_throttle._acquire_any_slot", _should_not_run)
+    monkeypatch.setattr("framework.build_throttle._acquire_any_slot", _acquire)
     with template_build_slot(label="unit"):
-        pass
+        handle.close.assert_not_called()
+    handle.close.assert_called_once_with()
 
 
 def test_slot_wait_timeout_scales_with_workers(monkeypatch):

--- a/tests/e2e/sdk_compat/cases/network/test_dns_concurrent_af_unspec.py
+++ b/tests/e2e/sdk_compat/cases/network/test_dns_concurrent_af_unspec.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal reproduction for issue #1406.
+
+Concurrent A/AAAA (``AF_UNSPEC``) resolution inside a sandbox intermittently
+fails with ``EAI_AGAIN`` ("Temporary failure in name resolution"), while
+A-only and AAAA-only lookups are reliable and glibc ``RES_OPTIONS=single-request``
+(which serializes the paired queries) makes ``AF_UNSPEC`` reliable again.
+
+This embeds the issue's original ``getaddrinfo`` loop verbatim (only its output
+is made machine-parseable) and turns it into a regression gate:
+
+* ``AF_INET`` establishes that DNS + IPv4 egress work at all (environment sanity).
+* ``AF_UNSPEC`` + ``single-request`` is the control: the paired queries are
+  serialized, so this is expected to be fully reliable.
+* ``AF_UNSPEC`` (default) is the subject: glibc sends the A and AAAA queries
+  concurrently on the same UDP source port. On an affected build this is where
+  the sandbox UDP/TAP data path drops one of the pair.
+
+If the subject is materially less reliable than the (serialized) control while
+both baselines are healthy, #1406 is reproduced and the test FAILS. On a fixed
+build all three are reliable and the test passes.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shlex
+from collections import Counter
+
+import pytest
+from framework.assertions import assert_command_ok
+from framework.capabilities import NETWORK_DNS_ALLOW
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.network,
+    pytest.mark.p2,
+    pytest.mark.slow,
+    pytest.mark.requires_internet,
+    pytest.mark.requires_capability(NETWORK_DNS_ALLOW),
+]
+
+# A public hostname with both A and AAAA records, matching the issue report.
+REPRO_HOST = os.environ.get("SDK_E2E_DNS_REPRO_HOST", "www.example.com")
+REPRO_PORT = int(os.environ.get("SDK_E2E_DNS_REPRO_PORT", "443"))
+# Use enough attempts for the success-rate comparison to remain meaningful.
+REPRO_ATTEMPTS = int(os.environ.get("SDK_E2E_DNS_REPRO_ATTEMPTS", "30"))
+if REPRO_ATTEMPTS < 10:
+    raise ValueError("SDK_E2E_DNS_REPRO_ATTEMPTS must be at least 10")
+# Amplify the failure: 1s timeout and no glibc-level retry, so a single dropped
+# query surfaces as one lost attempt instead of being masked by a resolver retry.
+BASE_RES_OPTIONS = os.environ.get(
+    "SDK_E2E_DNS_REPRO_RES_OPTIONS", "timeout:1 attempts:1"
+)
+
+# The issue's original script, with its ``print(...)`` replaced by a stable
+# ``RESULT:<json>`` line so the harness can parse it deterministically.
+_REPRO_SCRIPT = (
+    "import json, os, socket\n"
+    "family = getattr(socket, os.environ['FAMILY'])\n"
+    "attempts = int(os.environ.get('ATTEMPTS', '30'))\n"
+    "host = os.environ.get('HOST', 'www.example.com')\n"
+    "port = int(os.environ.get('PORT', '443'))\n"
+    "success = 0\n"
+    "dual_stack = 0\n"
+    "errors = {}\n"
+    "for _ in range(attempts):\n"
+    "    try:\n"
+    "        addresses = socket.getaddrinfo(host, port, family, socket.SOCK_STREAM)\n"
+    "        success += 1\n"
+    "        families = {address[0] for address in addresses}\n"
+    "        dual_stack += socket.AF_INET in families and socket.AF_INET6 in families\n"
+    "    except OSError as exc:\n"
+    "        error = str(getattr(exc, 'errno', None)) + ':' + str(exc)\n"
+    "        errors[error] = errors.get(error, 0) + 1\n"
+    "print('RESULT:' + json.dumps({\n"
+    "    'family': os.environ['FAMILY'],\n"
+    "    'attempts': attempts,\n"
+    "    'success': success,\n"
+    "    'dual_stack': dual_stack,\n"
+    "    'errors': errors,\n"
+    "}))\n"
+)
+
+
+def _repro_command(family: str, res_options: str, attempts: int) -> str:
+    """Build the in-sandbox command running the repro script for one family."""
+    env_prefix = (
+        f"FAMILY={family} "
+        f"ATTEMPTS={attempts} "
+        f"HOST={shlex.quote(REPRO_HOST)} "
+        f"PORT={REPRO_PORT} "
+        f"RES_OPTIONS={shlex.quote(res_options)}"
+    )
+    return f"{env_prefix} python3 - <<'PY'\n{_REPRO_SCRIPT}PY"
+
+
+def _run_repro(
+    sdk_sandbox,
+    sdk_e2e_config,
+    family: str,
+    res_options: str,
+    attempts: int = REPRO_ATTEMPTS,
+) -> dict:
+    """Run one family/RES_OPTIONS combination and return the parsed RESULT dict."""
+    # The serialized control may wait on A and AAAA across several nameservers.
+    command_timeout = max(sdk_e2e_config.command_timeout, attempts * 6 + 30)
+    result = sdk_sandbox.run_command(
+        _repro_command(family, res_options, attempts),
+        timeout=command_timeout,
+    )
+    assert_command_ok(result)
+    line = next(
+        (
+            ln.strip()[len("RESULT:") :]
+            for ln in result.stdout.splitlines()
+            if ln.strip().startswith("RESULT:")
+        ),
+        None,
+    )
+    assert line is not None, (
+        f"repro script produced no RESULT line for FAMILY={family}; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    return json.loads(line)
+
+
+@pytest.mark.sandbox_create_options(allow_internet_access=True)
+def test_concurrent_af_unspec_resolution_matches_single_request(
+    sdk_sandbox,
+    sdk_e2e_config,
+):
+    """AF_UNSPEC must be as reliable as single-stack / serialized resolution."""
+    option_names = {option.split(":", 1)[0] for option in BASE_RES_OPTIONS.split()}
+    assert not option_names.intersection({"single-request", "single-request-reopen"}), (
+        "SDK_E2E_DNS_REPRO_RES_OPTIONS must not serialize A/AAAA queries"
+    )
+    tolerance = max(3, math.ceil(REPRO_ATTEMPTS * 0.15))
+
+    v4 = _run_repro(sdk_sandbox, sdk_e2e_config, "AF_INET", BASE_RES_OPTIONS)
+    if v4["success"] < REPRO_ATTEMPTS - tolerance:
+        pytest.skip(f"IPv4 DNS/egress unreliable in this environment; v4={v4!r}")
+
+    control = {"success": 0, "dual_stack": 0, "errors": Counter()}
+    subject = {"success": 0, "dual_stack": 0, "errors": Counter()}
+    batch_sizes = [REPRO_ATTEMPTS // 3] * 3
+    for index in range(REPRO_ATTEMPTS % 3):
+        batch_sizes[index] += 1
+
+    for index, attempts in enumerate(batch_sizes):
+        order = ("control", "subject") if index % 2 == 0 else ("subject", "control")
+        for kind in order:
+            res_options = (
+                f"single-request {BASE_RES_OPTIONS}"
+                if kind == "control"
+                else BASE_RES_OPTIONS
+            )
+            result = _run_repro(
+                sdk_sandbox,
+                sdk_e2e_config,
+                "AF_UNSPEC",
+                res_options,
+                attempts,
+            )
+            aggregate = control if kind == "control" else subject
+            aggregate["success"] += result["success"]
+            aggregate["dual_stack"] += result["dual_stack"]
+            aggregate["errors"].update(result["errors"])
+
+    control["errors"] = dict(control["errors"])
+    subject["errors"] = dict(subject["errors"])
+    context = f"v4={v4!r} control(single-request)={control!r} subject={subject!r}"
+
+    if control["dual_stack"] < REPRO_ATTEMPTS - tolerance:
+        pytest.skip(
+            "serialized AF_UNSPEC did not reliably return both address families; "
+            f"the DNS environment cannot exercise this regression; {context}"
+        )
+
+    assert subject["dual_stack"] >= control["dual_stack"] - tolerance, (
+        "concurrent AF_UNSPEC resolution returned both address families "
+        "significantly less reliably than serialized resolution, consistent with "
+        "issue #1406. Workaround: RES_OPTIONS=single-request. "
+        f"tolerance={tolerance} {context}"
+    )

--- a/tests/e2e/sdk_compat/cases/templates/test_alias.py
+++ b/tests/e2e/sdk_compat/cases/templates/test_alias.py
@@ -58,15 +58,29 @@ def _wait_for_ready(template_id, config, timeout=None):
     if timeout is None:
         timeout = scale_timeout_for_xdist(120)
     deadline = time.time() + timeout
+    last_info = None
     while time.time() < deadline:
         try:
-            info = Template.get(template_id, config=config)
-            if info.status in ("READY", "FAILED"):
-                return info
+            last_info = Template.get(template_id, config=config)
+            if last_info.status == "READY":
+                return last_info
+            if last_info.status == "FAILED":
+                pytest.fail(
+                    f"template {template_id} build failed; "
+                    f"last_error={last_info.last_error!r}"
+                )
         except TemplateNotFoundError:
             pass
         time.sleep(2)
-    pytest.fail(f"template {template_id} did not reach READY within {timeout}s")
+    if last_info is None:
+        pytest.fail(
+            f"template {template_id} did not reach READY within {timeout}s; "
+            "template was never observed"
+        )
+    pytest.fail(
+        f"template {template_id} did not reach READY within {timeout}s; "
+        f"last_status={last_info.status!r} last_error={last_info.last_error!r}"
+    )
 
 
 def _delete_with_retry(identifier, cfg, timeout=180):
@@ -103,7 +117,11 @@ def test_template_create_from_image_and_cleanup(sdk_backend, sdk_e2e_config):
     created_id = None
     try:
         with template_build_slot(label="alias_create_from_image"):
-            job = Template.build(image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            job = Template.build(
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                config=cfg,
+            )
             assert job.template_id.startswith("tpl-")
             created_id = job.template_id
             _wait_for_ready(created_id, cfg)
@@ -124,20 +142,18 @@ def test_template_build_preserves_advanced_create_options(
     cfg = _cfg(sdk_e2e_config)
     created_id = None
     try:
-        job = Template.build(
-            image=DEFAULT_IMAGE,
-            writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
-            exposed_ports=[49983, 49999],
-            probe_port=49999,
-            probe_path="/",
-            envs={"SDK_TEMPLATE_E2E": "advanced"},
-            config=cfg,
-        )
-        created_id = job.template_id
-        info = _wait_for_ready(created_id, cfg)
-        assert info.status == "READY", (
-            f"advanced template build failed: id={created_id} status={info.status!r}"
-        )
+        with template_build_slot(label="alias_advanced_options"):
+            job = Template.build(
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                exposed_ports=[49983, 49999],
+                probe_port=49999,
+                probe_path="/",
+                envs={"SDK_TEMPLATE_E2E": "advanced"},
+                config=cfg,
+            )
+            created_id = job.template_id
+            _wait_for_ready(created_id, cfg)
         detail = Template.get(created_id, config=cfg)
         request = detail.create_request or {}
         annotations = request.get("annotations") or {}
@@ -153,9 +169,9 @@ def test_template_build_preserves_advanced_create_options(
         assert container.get("envs") == [
             {"key": "SDK_TEMPLATE_E2E", "value": "advanced"}
         ], request
-        http_get = (
-            (container.get("probe") or {}).get("probe_handler") or {}
-        ).get("http_get") or {}
+        http_get = ((container.get("probe") or {}).get("probe_handler") or {}).get(
+            "http_get"
+        ) or {}
         assert http_get.get("port") == 49999, request
         assert http_get.get("path") == "/", request
 
@@ -194,7 +210,12 @@ def test_template_alias_create_get_and_delete(sdk_backend, sdk_e2e_config):
     created_id = None
     try:
         with template_build_slot(label="alias_create_get_delete"):
-            job = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            job = Template.build(
+                name=alias,
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                config=cfg,
+            )
             created_id = job.template_id
             _wait_for_ready(created_id, cfg)
         assert Template.get(alias, config=cfg).template_id == created_id
@@ -220,7 +241,12 @@ def test_template_alias_dedicated_lookup_endpoint(sdk_backend, sdk_e2e_config):
     created_id = None
     try:
         with template_build_slot(label="alias_dedicated_lookup"):
-            job = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            job = Template.build(
+                name=alias,
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                config=cfg,
+            )
             created_id = job.template_id
             _wait_for_ready(created_id, cfg)
         resp = requests.get(
@@ -246,17 +272,29 @@ def test_template_alias_rebuild_reassignment(sdk_backend, sdk_e2e_config):
     template_ids = []
     try:
         with template_build_slot(label="alias_rebuild_a"):
-            job_a = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            job_a = Template.build(
+                name=alias,
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                config=cfg,
+            )
             template_ids.append(job_a.template_id)
             _wait_for_ready(job_a.template_id, cfg)
         assert Template.get(alias, config=cfg).template_id == job_a.template_id
 
         with template_build_slot(label="alias_rebuild_b"):
-            job_b = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
+            job_b = Template.build(
+                name=alias,
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                config=cfg,
+            )
             template_ids.append(job_b.template_id)
             _wait_for_ready(job_b.template_id, cfg)
         assert Template.get(alias, config=cfg).template_id == job_b.template_id
-        assert Template.get(job_a.template_id, config=cfg).template_id == job_a.template_id
+        assert (
+            Template.get(job_a.template_id, config=cfg).template_id == job_a.template_id
+        )
     finally:
         time.sleep(1)
         for tid in template_ids:
@@ -274,9 +312,14 @@ def test_template_alias_set_on_existing_template(sdk_backend, sdk_e2e_config):
     created_id = None
     try:
         # 1. Create WITHOUT an alias.
-        job = Template.build(image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
-        created_id = job.template_id
-        _wait_for_ready(created_id, cfg)
+        with template_build_slot(label="alias_set_existing"):
+            job = Template.build(
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                config=cfg,
+            )
+            created_id = job.template_id
+            _wait_for_ready(created_id, cfg)
 
         with pytest.raises(ApiError) as exc:
             Template.set_alias(created_id, "My-Alias", config=cfg)
@@ -314,14 +357,25 @@ def test_template_alias_set_reassign_between_templates(sdk_backend, sdk_e2e_conf
     template_ids = []
     try:
         # 1. Create T1 WITH alias A.
-        job_a = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
-        template_ids.append(job_a.template_id)
-        _wait_for_ready(job_a.template_id, cfg)
+        with template_build_slot(label="alias_set_reassign_a"):
+            job_a = Template.build(
+                name=alias,
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                config=cfg,
+            )
+            template_ids.append(job_a.template_id)
+            _wait_for_ready(job_a.template_id, cfg)
 
         # 2. Create T2 WITHOUT alias.
-        job_b = Template.build(image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
-        template_ids.append(job_b.template_id)
-        _wait_for_ready(job_b.template_id, cfg)
+        with template_build_slot(label="alias_set_reassign_b"):
+            job_b = Template.build(
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                config=cfg,
+            )
+            template_ids.append(job_b.template_id)
+            _wait_for_ready(job_b.template_id, cfg)
 
         # 3. set_alias(T2, A) should release A from T1 and claim for T2.
         Template.set_alias(job_b.template_id, alias, config=cfg)

--- a/tests/e2e/sdk_compat/framework/build_throttle.py
+++ b/tests/e2e/sdk_compat/framework/build_throttle.py
@@ -20,8 +20,8 @@ build *and* the wait for READY, so the number of in-flight builds never exceeds
 
 The lock is a POSIX ``fcntl`` advisory lock over a small set of slot files in a
 per-UID temp dir. It degrades to a no-op if ``fcntl`` is unavailable (non-POSIX),
-the configured concurrency already covers every worker, or the lock dir cannot be
-created/trusted, so it never blocks a run it cannot coordinate.
+or the lock dir cannot be created/trusted, so it never blocks a run it cannot
+coordinate.
 """
 
 from __future__ import annotations
@@ -57,9 +57,7 @@ except ImportError:  # pragma: no cover - non-POSIX fallback
 # the contention the throttle prevents. The bounded ``_slot_wait_timeout`` still
 # caps how long such cross-run waiting can last before degrading to unthrottled.
 _UID = getattr(os, "getuid", lambda: "shared")()
-_LOCK_DIR = (
-    Path(tempfile.gettempdir()) / f"cube-sdk-e2e-template-build.locks-{_UID}"
-)
+_LOCK_DIR = Path(tempfile.gettempdir()) / f"cube-sdk-e2e-template-build.locks-{_UID}"
 
 _DEFAULT_CONCURRENCY = 1
 _POLL_INTERVAL = 0.5
@@ -67,14 +65,20 @@ _POLL_INTERVAL = 0.5
 # stall every other template-building worker forever. The holder keeps the slot
 # across ``Template.build`` *and* the worker-count-scaled READY wait, so size the
 # ceiling generously (per-worker, since up to N-1 peers may build ahead of us),
-# but keep it finite. Overridable via env for slow control planes.
+# but keep it finite. A serial run can wait this full base behind another same-UID
+# run because the per-UID namespace intentionally coordinates across runs.
+# Overridable via env for slow control planes.
 _DEFAULT_SLOT_WAIT_BASE = 1800  # 30 min per potential predecessor build
 
 
 def _log(message: str) -> None:
     worker = os.environ.get("PYTEST_XDIST_WORKER", "-")
     timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
-    print(f"[sdk-e2e][{timestamp}][{worker}] build-throttle {message}", file=sys.stderr, flush=True)
+    print(
+        f"[sdk-e2e][{timestamp}][{worker}] build-throttle {message}",
+        file=sys.stderr,
+        flush=True,
+    )
 
 
 def _slot_wait_timeout() -> float:
@@ -114,19 +118,15 @@ def template_build_slot(label: str = "") -> Iterator[None]:
 
     Acquire before ``Template.build`` and keep the context open until the
     template has reached READY (or failed), so concurrent in-flight builds stay
-    bounded. A no-op when the lock cannot help or is unnecessary: ``fcntl`` is
-    unavailable (non-POSIX), the allowed build concurrency already covers every
-    worker (so the lock could never block), or the lock dir cannot be created.
+    bounded. A no-op when the lock cannot help: ``fcntl`` is unavailable
+    (non-POSIX), or the lock dir cannot be created.
 
     ``label`` names the build site (e.g. ``alias_rebuild_a``) and is logged on
     slot wait/acquire/release so throttle contention is diagnosable when a
     parallel run stalls on the shared build host.
     """
     slots = _concurrency()
-    # If the operator allows at least as many concurrent builds as there are
-    # workers, the lock would never block, so skip it. A serial run has one
-    # worker, so the default concurrency of 1 already covers it.
-    if fcntl is None or slots >= current_worker_count():
+    if fcntl is None:
         yield
         return
     try:
@@ -143,7 +143,9 @@ def template_build_slot(label: str = "") -> Iterator[None]:
         return
 
     timeout = _slot_wait_timeout()
-    _log(f"waiting for a build slot ({slots} slot(s), timeout={timeout}s) label={label!r}")
+    _log(
+        f"waiting for a build slot ({slots} slot(s), timeout={timeout}s) label={label!r}"
+    )
     try:
         acquired = _acquire_any_slot(slots, timeout)
     except OSError as exc:
@@ -152,7 +154,9 @@ def template_build_slot(label: str = "") -> Iterator[None]:
         # The throttle promises never to block a run it cannot coordinate, so
         # degrade to serial (yield through) rather than failing the build with
         # an error unrelated to what the test is exercising.
-        _log(f"could not acquire a slot ({exc}); proceeding unthrottled label={label!r}")
+        _log(
+            f"could not acquire a slot ({exc}); proceeding unthrottled label={label!r}"
+        )
         yield
         return
 
@@ -161,7 +165,9 @@ def template_build_slot(label: str = "") -> Iterator[None]:
         # wedged. Proceed unthrottled rather than stalling this worker forever;
         # the OS releases the peer's flock on process death, so this is a
         # last-resort escape, not a silent disable of the throttle.
-        _log(f"timed out after {timeout}s waiting for a slot; proceeding unthrottled label={label!r}")
+        _log(
+            f"timed out after {timeout}s waiting for a slot; proceeding unthrottled label={label!r}"
+        )
         yield
         return
 
@@ -192,7 +198,7 @@ def _acquire_any_slot(slots: int, timeout: float = float("inf")):
             # O_NOFOLLOW + owner-only perms: never follow a symlink someone may
             # have planted at a predictable slot path on a shared host.
             fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
-            handles.append((index, os.fdopen(fd, "w")))  # noqa: SIM115 - closed by caller
+            handles.append((index, os.fdopen(fd, "w")))
         while True:
             for index, handle in handles:
                 try:

--- a/tests/e2e/sdk_compat/framework/parallel.py
+++ b/tests/e2e/sdk_compat/framework/parallel.py
@@ -16,8 +16,8 @@ import os
 # ``PYTEST_XDIST_WORKER_COUNT`` is missing. The fallback multiplies timeout and
 # capacity-retry budgets, so an uncapped ``os.cpu_count()`` on a many-core box
 # would inflate a 300s READY budget into hours. Cap it to a sane ceiling: still
-# large enough to keep the throttle engaged and the budgets generous, but not
-# absurd. The authoritative count (when present) is trusted as-is because the
+# large enough to keep timeout and retry budgets generous, but not absurd. The
+# authoritative count (when present) is trusted as-is because the
 # operator chose it explicitly via ``-n``/``SDK_E2E_WORKERS``.
 _MAX_FALLBACK_WORKERS = 8
 
@@ -64,14 +64,13 @@ def current_worker_count() -> int:
     (present since well before the pinned ``>=3.0``). It reflects the operator's
     chosen ``-n``, so it is trusted as-is with no cap. If it is somehow absent we
     cannot know the true count -- deriving ``gwN + 1`` from ``PYTEST_XDIST_WORKER``
-    would return a *different* value on every worker (``gw0``->1, ``gw1``->2, ...),
-    which would desync ``scale_timeout_for_xdist``/``_scale_capacity_retries_for_xdist``
-    across workers and, worse, let ``gw0`` evaluate ``slots >= 1`` and skip the
-    build throttle entirely while its peers serialize. So when the authoritative
-    count is missing, fall back to a value every worker agrees on: ``os.cpu_count()``
-    (a host constant) capped at ``_MAX_FALLBACK_WORKERS`` -- biased high enough to
-    keep the throttle engaged, but bounded so timeout/retry budgets are not
-    inflated into hours on a many-core box. If we are not under xdist at all, the
+    would return a *different* value on every worker (``gw0``->1, ``gw1``->2, ...)
+    and desync ``scale_timeout_for_xdist`` and
+    ``_scale_capacity_retries_for_xdist`` across workers. Fall back to a value
+    every worker agrees on: ``os.cpu_count()`` (a host constant) capped at
+    ``_MAX_FALLBACK_WORKERS`` -- biased high enough to keep timeout/retry budgets
+    generous, but bounded so they are not inflated into hours on a many-core box.
+    If we are not under xdist at all, the
     run is serial, so return ``1``.
     """
     count = os.environ.get("PYTEST_XDIST_WORKER_COUNT")


### PR DESCRIPTION
## Summary

- serialize live template builds across concurrent test runs, document cross-run waiting, and keep worker timeout scaling consistent
- stabilize template alias lifecycle coverage, including clearer build failure diagnostics and portable POSIX-only assertions
- add a CubeSandbox-capability-gated regression test for concurrent `AF_UNSPEC` A/AAAA DNS resolution with early configuration validation, serialized-control timeout budgeting, and resolver-noise tolerance
- update bilingual SDK E2E documentation for the template-build throttle behavior

## Test plan

- [x] `python3 -m pytest tests/e2e/sdk_compat/cases/framework/test_parallel.py -q`
- [x] Ruff lint and format checks for all changed Python files
- [x] `git diff --check`
- [ ] Live SDK E2E tests in a deployed CubeSandbox environment