### PR TITLE
feat(cubelet): restore XFS memory from the original snapshot file

### DIFF
--- a/Cubelet/storage/cow/store.go
+++ b/Cubelet/storage/cow/store.go
@@ -55,8 +55,10 @@ type Store interface {
 	CommitTemplateRootfs(ctx context.Context, sourceName, templateID string) (*Object, error)
 	CreateMemoryVolume(ctx context.Context, templateID string, sizeBytes uint64) (*Object, error)
 	CommitTemplateMemory(ctx context.Context, sourceName, templateID string, sizeBytes uint64) (*Object, error)
-	// CloneSandboxMemory copies package memory into sb-<id>-memory
-	// so Resume can drop the pause package afterwards.
+	// CloneSandboxMemory copies package memory into sb-<id>-memory.
+	// Same-node S3 pause resume uses this so the pause package can be
+	// dropped afterwards. XFS restore (template / resume / FromSnap)
+	// does not: CH mmap's the original snapshot MAP_PRIVATE.
 	CloneSandboxMemory(ctx context.Context, sandboxID, sourceName string) (*Object, error)
 	DeleteByKind(ctx context.Context, name, kind string) error
 	DeactivateByKind(ctx context.Context, name, kind string) error

--- a/Cubelet/storage/cubecow_volume_manager.go
+++ b/Cubelet/storage/cubecow_volume_manager.go
@@ -264,6 +264,9 @@ func (m *XfsCow) CommitTemplateMemory(ctx context.Context, sourceName, templateI
 	return newCowVolume(snapshotName, cowKindSnapshot, 0, devPath), nil
 }
 
+// CloneSandboxMemory is kept on the Store interface. XFS restore no
+// longer calls it (see prefetchRestoreMemoryVolURL); S3 pause resume
+// still does via S3Cow.
 func (m *XfsCow) CloneSandboxMemory(ctx context.Context, sandboxID, sourceName string) (*cowVolume, error) {
 	return cloneSandboxMemory(ctx, m, sandboxID, sourceName)
 }

--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -974,8 +974,8 @@ func (l *local) cleanupCreateResult(ctx context.Context, result *StorageInfo) er
 
 // prefetchRestoreMemoryVolURL resolves the memory image the shim restores
 // from, and reports the name of the disk when this create minted one of
-// its own (cross-node import or same-node pause-resume clone) rather than
-// pointing at the package's shared image.
+// its own (cross-node import or same-node S3 pause-resume clone) rather
+// than pointing at the package's shared image.
 func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.CreateContext) (string, string, error) {
 	if opts == nil || opts.ReqInfo == nil || opts.IsCreateSnapshot() {
 		return "", "", nil
@@ -992,10 +992,12 @@ func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.
 	// file:///dev/nvmeXn1 from a previous activate on this or another node.
 	// Always resolve the catalog vol name and Activate for the live path.
 	backend := createContextStorageBackend(opts)
-	// Cross-node imports a sandbox-private memory volume. Same-node pause
-	// resume clones the package memory snap onto sb-<id>-memory so the
-	// pause package can be deleted after Create. Other restores still
-	// attach the package snapshot (templates / customer snaps stay).
+	// Cross-node imports a sandbox-private memory volume. XFS template
+	// start / pause resume / FromSnap mmap the original snapshot file
+	// MAP_PRIVATE; CH keeps it open so later unlink of the package is
+	// safe and a clone would only duplicate bytes. Same-node S3 pause
+	// resume still clones onto sb-<id>-memory: deactivate of an NVMe
+	// lvol would yank the live disk, unlike an unlinked XFS file.
 	if imp := CrossNodeSandboxImport(annotations); imp != nil {
 		name, devPath, err := imp.Memory(ctx)
 		if err != nil {
@@ -1006,11 +1008,11 @@ func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.
 		}
 	}
 	pauseOwner := ""
-	if opts.IsPauseResume() && CrossNodeSandboxImport(annotations) == nil {
+	if pauseResumeClonesLiveMemory(backend) && opts.IsPauseResume() && CrossNodeSandboxImport(annotations) == nil {
 		pauseOwner = pauseResumeMemoryOwnerID(opts)
 		if pauseOwner == "" {
-			// Attaching the package then letting Master delete it would
-			// pull the disk out from under the restored VM.
+			// Attaching the S3 package then letting Master delete it
+			// would pull the NVMe out from under the restored VM.
 			return "", "", fmt.Errorf("pause resume requires sandbox id to clone memory off the package")
 		}
 	}
@@ -1050,11 +1052,21 @@ func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.
 	return cowFileURLFromPath(devPath), "", nil
 }
 
+// pauseResumeClonesLiveMemory is true when same-node pause resume must
+// copy package memory onto a sandbox-private volume before Create
+// returns. XFS is false: the original snapshot file is the restore
+// image. S3 is true because the live disk is an NVMe lvol.
+func pauseResumeClonesLiveMemory(backend string) bool {
+	normalized, err := cow.NormalizeBackend(backend)
+	return err == nil && normalized != cow.BackendXFS
+}
+
 // pauseResumeMemoryOwnerID is the sandbox that must own a private copy of the
-// pause package's memory. Empty means this is not a same-node pause resume
-// (cross-node already imported one, or this is a template／FromSnap create).
-// A same-node pause resume that still returns empty is missing its sandbox
-// id; the caller must fail rather than attach the package snapshot.
+// pause package's memory on backends that clone (S3). Empty means this is
+// not a same-node pause resume that clones (XFS attach, cross-node import,
+// or a template／FromSnap create). A same-node S3 pause resume that still
+// returns empty is missing its sandbox id; the caller must fail rather
+// than attach the package snapshot.
 func pauseResumeMemoryOwnerID(opts *workflow.CreateContext) string {
 	if opts == nil || !opts.IsPauseResume() {
 		return ""
@@ -1917,8 +1929,9 @@ type StorageInfo struct {
 	RestoreMemoryVolURL string `json:"-"`
 
 	// ImportedMemoryVol is the sandbox-private memory disk Create minted
-	// (cross-node import or same-node pause-resume clone). Destroy deletes
-	// it. Empty means this restore still reads a package memory snapshot.
+	// (cross-node import or same-node S3 pause-resume clone). Destroy
+	// deletes it. Empty means this restore still reads a package memory
+	// snapshot (XFS template / resume / FromSnap always leave this empty).
 	ImportedMemoryVol string `json:"importedMemoryVol,omitempty"`
 
 	// PluginVolumeBackendInfos records the result of every plugin_volume attach.

--- a/Cubelet/storage/local_pause_resume_memory_test.go
+++ b/Cubelet/storage/local_pause_resume_memory_test.go
@@ -8,11 +8,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/containerd/plugin"
 	"github.com/stretchr/testify/require"
 
 	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/workflow"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/storage/cow"
 )
 
 func pauseResumeCreateContext(sandboxID string, ann map[string]string) *workflow.CreateContext {
@@ -49,14 +51,37 @@ func TestPauseResumeMemoryOwnerID(t *testing.T) {
 	require.Empty(t, pauseResumeMemoryOwnerID(pauseResumeCreateContext("sb-1", cross)))
 }
 
-func TestPrefetchRestoreMemoryVolURLFailsClosedWithoutSandboxID(t *testing.T) {
+func TestPauseResumeClonesLiveMemory(t *testing.T) {
+	t.Parallel()
+	require.False(t, pauseResumeClonesLiveMemory(""))
+	require.False(t, pauseResumeClonesLiveMemory(cow.BackendXFS))
+	require.False(t, pauseResumeClonesLiveMemory("cubecow"))
+	require.True(t, pauseResumeClonesLiveMemory(cow.BackendS3))
+}
+
+func TestPrefetchRestoreMemoryVolURLS3FailsClosedWithoutSandboxID(t *testing.T) {
 	l := &local{config: &Config{StorageBackend: "cubecow"}}
 	_, _, err := l.prefetchRestoreMemoryVolURL(context.Background(), pauseResumeCreateContext("", map[string]string{
 		constants.MasterAnnotationPauseSnapshotID:   "snap-pause1",
 		constants.MasterAnnotationRuntimeSnapshotID: "snap-pause1",
+		constants.MasterAnnotationStorageBackend:    cow.BackendS3,
 	}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "sandbox id")
+}
+
+func TestPrefetchRestoreMemoryVolURLXFSPauseResumeDoesNotRequireSandboxID(t *testing.T) {
+	l := &local{config: &Config{StorageBackend: "cubecow"}}
+	_, imported, err := l.prefetchRestoreMemoryVolURL(context.Background(), pauseResumeCreateContext("", map[string]string{
+		constants.MasterAnnotationPauseSnapshotID:   "snap-pause1",
+		constants.MasterAnnotationRuntimeSnapshotID: "snap-pause1",
+	}))
+	// Catalog miss is expected; XFS mmap's the original snap file and
+	// must not fail closed waiting to clone.
+	if err != nil {
+		require.NotContains(t, err.Error(), "sandbox id")
+	}
+	require.Empty(t, imported)
 }
 
 func TestPrefetchRestoreMemoryVolURLFromSnapDoesNotClone(t *testing.T) {
@@ -70,4 +95,50 @@ func TestPrefetchRestoreMemoryVolURLFromSnapDoesNotClone(t *testing.T) {
 		require.NotContains(t, err.Error(), "sandbox id")
 	}
 	require.Empty(t, imported)
+}
+
+func TestPrefetchRestoreMemoryVolURLXFSPauseResumeUsesOriginalSnapshot(t *testing.T) {
+	cfg := makeTestConfig(t)
+	cfg.StorageBackend = "cubecow"
+	fake := &fakeCowVolumeManager{
+		resolvePaths: map[string]string{"tpl-snap-pause1-memory": "/data/cow/tpl-snap-pause1-memory"},
+	}
+	l := &local{config: cfg, cowManager: fake}
+	require.NoError(t, l.init(&plugin.InitContext{Context: context.Background()}))
+	seedTestSnapshotCatalog(t, "snap-pause1", "tpl-snap-pause1-memory", CowKindSnapshot)
+
+	url, imported, err := l.prefetchRestoreMemoryVolURL(context.Background(), pauseResumeCreateContext("sb-1", map[string]string{
+		constants.MasterAnnotationPauseSnapshotID:   "snap-pause1",
+		constants.MasterAnnotationRuntimeSnapshotID: "snap-pause1",
+	}))
+	require.NoError(t, err)
+	require.Empty(t, imported)
+	require.Equal(t, "file:///data/cow/tpl-snap-pause1-memory", url)
+	require.Empty(t, fake.cloneMemoryCalls)
+	require.Equal(t, []fakeCowResolveCall{{name: "tpl-snap-pause1-memory", kind: CowKindSnapshot}}, fake.resolveCalls)
+}
+
+func TestPrefetchRestoreMemoryVolURLS3PauseResumeClones(t *testing.T) {
+	cfg := makeTestConfig(t)
+	cfg.StorageBackend = "cubecow"
+	xfs := &fakeCowVolumeManager{}
+	s3 := &fakeCowVolumeManager{
+		resolvePaths: map[string]string{
+			SandboxMemoryName("sb-1"): "/dev/mapper/sb-sb-1-memory",
+		},
+	}
+	l := &local{config: cfg, cowManager: xfs, s3CowManager: s3}
+	require.NoError(t, l.init(&plugin.InitContext{Context: context.Background()}))
+	seedTestSnapshotCatalogFor(t, cow.BackendS3, "snap-pause1", "tpl-snap-pause1-memory", CowKindSnapshot)
+
+	url, imported, err := l.prefetchRestoreMemoryVolURL(context.Background(), pauseResumeCreateContext("sb-1", map[string]string{
+		constants.MasterAnnotationPauseSnapshotID:   "snap-pause1",
+		constants.MasterAnnotationRuntimeSnapshotID: "snap-pause1",
+		constants.MasterAnnotationStorageBackend:    cow.BackendS3,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, SandboxMemoryName("sb-1"), imported)
+	require.Equal(t, "file:///dev/mapper/sb-sb-1-memory", url)
+	require.Equal(t, []fakeCowCloneMemoryCall{{sandboxID: "sb-1", sourceName: "tpl-snap-pause1-memory"}}, s3.cloneMemoryCalls)
+	require.Empty(t, xfs.cloneMemoryCalls)
 }


### PR DESCRIPTION
## Summary
- On XFS, template start / pause resume / FromSnap restore memory from the original snapshot file. Cloud Hypervisor mmap's it MAP_PRIVATE and keeps the fd open, so later unlink of the package is safe.
- Same-node S3 pause resume still clones onto a sandbox-private volume: deactivating an NVMe lvol would yank the live disk.

## Test plan
- [x] `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c ./storage/` compiles
- [ ] CI Cubelet unit tests (`TestPrefetchRestoreMemoryVolURLXFSPauseResumeUsesOriginalSnapshot`, S3 clone still required)

Assisted-by: Cursor:Composer
Signed-off-by: ls-ggg <335814617@qq.com>
