### PR TITLE
fix(cubeproxy): disable HTTP and gRPC upstream keepalive

### DIFF
--- a/CubeProxy/nginx.conf
+++ b/CubeProxy/nginx.conf
@@ -95,11 +95,15 @@ http {
 
     underscores_in_headers on;
 
+    # HTTP and gRPC upstream keepalive is intentionally off. nginx keys idle
+    # connections by peer IP:port only. Sandbox rollback rewinds guest TCP
+    # (so a later FIN does not retire the pooled socket) and destroy reuses
+    # the same SandboxIP:container_port for the next sandbox; the next
+    # request then hits a stale connection and CubeProxy returns 502.
+    # Same-host handshake is sub-millisecond versus tens of ms for /execute.
     upstream backend {
         server 0.0.0.1:1234;
         balancer_by_lua_file lua/balancer_phase.lua;
-        keepalive 1500;
-        keepalive_timeout 80;
     }
 
     # Plaintext gRPC ingress. Clients dial this IP:port and set :authority to
@@ -107,8 +111,6 @@ http {
     upstream grpc_backend {
         server 0.0.0.1:1235;
         balancer_by_lua_file lua/balancer_phase.lua;
-        keepalive 200;
-        keepalive_timeout 80;
     }
 
     lua_shared_dict local_cache 100m;


### PR DESCRIPTION
nginx keys idle upstream sockets by peer IP:port. Sandbox rollback rewinds guest TCP so a later FIN does not retire the pooled connection, and destroy reuses the same SandboxIP:container_port. The next request then hits a stale socket and CubeProxy returns 502.

Same-host handshake is sub-millisecond versus tens of ms for /execute, so drop keepalive on both upstream backend and upstream grpc_backend. Leave client-facing keepalive_timeout and Redis keepalive unchanged.