### PR TITLE
test(dataplane): resolve SPDK rpc.py from SPDK_ROOT or deps/spdk

### DIFF
--- a/CubeS3lvol/test/dataplane/run_agent_template_test.sh
+++ b/CubeS3lvol/test/dataplane/run_agent_template_test.sh
@@ -49,7 +49,7 @@ ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TOOLS="${ROOT}/test/tools"
 RPC_PY="${TOOLS}/s3lvol_rpc.py"
 # bdev_aio_create is an SPDK rpc, not an s3lvol one.
-SPDK_RPC_PY="${SPDK_RPC_PY:-${ROOT}/../spdk/scripts/rpc.py}"
+SPDK_RPC_PY="${SPDK_RPC_PY:-${SPDK_ROOT:-${ROOT}/deps/spdk}/scripts/rpc.py}"
 
 TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
 

--- a/CubeS3lvol/test/dataplane/run_decouple_queue_test.sh
+++ b/CubeS3lvol/test/dataplane/run_decouple_queue_test.sh
@@ -37,7 +37,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TOOLS_DIR="${REPO_ROOT}/test/tools"
 
 TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
-RPC_PY="${REPO_ROOT}/../spdk/scripts/rpc.py"
+RPC_PY="${SPDK_ROOT:-${REPO_ROOT}/deps/spdk}/scripts/rpc.py"
 RPC="${RPC_PY} -s /var/run/s3lvol.sock"
 RPC_SOCK="/var/run/s3lvol.sock"
 

--- a/CubeS3lvol/test/dataplane/run_export_test.sh
+++ b/CubeS3lvol/test/dataplane/run_export_test.sh
@@ -39,7 +39,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TOOLS_DIR="${REPO_ROOT}/test/tools"
 
 TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
-RPC_PY="${REPO_ROOT}/../spdk/scripts/rpc.py"
+RPC_PY="${SPDK_ROOT:-${REPO_ROOT}/deps/spdk}/scripts/rpc.py"
 # Every SPDK RPC needs the socket named explicitly: rpc.py defaults to
 # /var/tmp/spdk.sock, while the target now listens on /var/run/s3lvol.sock.
 RPC="${RPC_PY} -s /var/run/s3lvol.sock"

--- a/CubeS3lvol/test/dataplane/run_snapshot_test.sh
+++ b/CubeS3lvol/test/dataplane/run_snapshot_test.sh
@@ -40,7 +40,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TOOLS_DIR="${REPO_ROOT}/test/tools"
 
 TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
-RPC_PY="${REPO_ROOT}/../spdk/scripts/rpc.py"
+RPC_PY="${SPDK_ROOT:-${REPO_ROOT}/deps/spdk}/scripts/rpc.py"
 # Every SPDK RPC needs the socket named explicitly: rpc.py defaults to
 # /var/tmp/spdk.sock, while the target now listens on /var/run/s3lvol.sock.
 RPC="${RPC_PY} -s /var/run/s3lvol.sock"

--- a/CubeS3lvol/test/dataplane/run_srcdel_test.sh
+++ b/CubeS3lvol/test/dataplane/run_srcdel_test.sh
@@ -62,7 +62,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TOOLS_DIR="${REPO_ROOT}/test/tools"
 
 TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
-RPC_PY="${REPO_ROOT}/../spdk/scripts/rpc.py"
+RPC_PY="${SPDK_ROOT:-${REPO_ROOT}/deps/spdk}/scripts/rpc.py"
 RPC="${RPC_PY} -s /var/run/s3lvol.sock"
 RPC_SOCK="/var/run/s3lvol.sock"
 


### PR DESCRIPTION
Five dataplane test scripts hardcoded `${REPO_ROOT}/../spdk` for SPDK's `rpc.py` — the sibling-directory layout of the standalone s3lvol repo. In the CubeSandbox tree SPDK is built into `<repo>/deps/spdk`, so `bdev_aio_create` in `run_snapshot_test.sh`, `run_export_test.sh`, `run_srcdel_test.sh`, `run_decouple_queue_test.sh` and `run_agent_template_test.sh` failed with a missing `rpc.py`.

Resolved through `SPDK_ROOT` (falling back to `deps/spdk`), consistent with `run_dataplane_test.sh` and `rcow_common.sh`.

**Verified**: full offline+S3+dataplane regression against a real COS bucket is now 26/26 suites green (1075 assertions passed).