### PR TITLE
fix(cubelog): stop unbounded .log growth when file_num is 0

### DIFF
--- a/cubelog/logwriter.go
+++ b/cubelog/logwriter.go
@@ -18,6 +18,15 @@ const (
 	HOUR
 )
 
+// Defaults match CubeMaster's shipped 10 files / 100MB. Cubelet applies its
+// own 500MB default before calling this constructor. NewRollFileWriter used
+// to treat 0 as "never rename", so a missing file_num/file_size left a single
+// unbounded .log (seen as multi-GB cubemaster-req.log files).
+const (
+	defaultRollFileNum    = 10
+	defaultRollFileSizeMB = 100
+)
+
 type ConsoleWriter struct {
 }
 
@@ -74,9 +83,26 @@ func (w *RollFileWriter) Write(v []byte) (int, error) {
 	}
 	n, _ := w.currFile.Write(v)
 	w.currSize += int64(n)
-	if w.currSize >= w.size {
-		w.currSize = 0
-		for i := w.num; i >= 1; i-- {
+	if w.size > 0 && w.num >= 1 && w.currSize >= w.size {
+		// file_num is total retained files (live + numbered backups), matching
+		// Cubelet config.toml. Shift only through `.log.(num-1)` so we do
+		// not keep an extra `.log.num` after dropping the racy async delete.
+		live := filepath.Join(w.logpath, fmt.Sprintf("%s.log", w.name))
+		if w.num == 1 {
+			if w.currFile != nil {
+				_ = w.currFile.Close()
+				w.currFile = nil
+			}
+			if err := os.Truncate(live, 0); err != nil && !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "cubelog: failed to truncate %s: %v\n", live, err)
+				return n, nil
+			}
+			w.currSize = 0
+			reOpenFile(live, &w.currFile, &w.openTime)
+			return n, nil
+		}
+		var liveRenameErr error
+		for i := w.num - 1; i >= 1; i-- {
 			var n1, n2 string
 			if i > 1 {
 				n1 = strconv.Itoa(i - 1)
@@ -85,23 +111,52 @@ func (w *RollFileWriter) Write(v []byte) (int, error) {
 			p1 := filepath.Join(w.logpath, fmt.Sprintf("%s.log.%s", w.name, n1))
 			p2 := filepath.Join(w.logpath, fmt.Sprintf("%s.log.%s", w.name, n2))
 			if n1 == "" {
-				p1 = filepath.Join(w.logpath, fmt.Sprintf("%s.log", w.name))
+				p1 = live
 			}
-			if _, err := os.Stat(p1); !os.IsNotExist(err) {
-				os.Rename(p1, p2)
+			err := os.Rename(p1, p2)
+			if i == 1 {
+				liveRenameErr = err
+			}
+			if err != nil && !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "cubelog: failed to rotate %s to %s: %v\n", p1, p2, err)
 			}
 		}
-		go func() {
-			os.Remove(filepath.Join(w.logpath, fmt.Sprintf("%s.log.%d", w.name, w.num)))
-		}()
-		fullPath := filepath.Join(w.logpath, fmt.Sprintf("%s.log", w.name))
-		reOpenFile(fullPath, &w.currFile, &w.openTime)
+		if liveRenameErr != nil && !os.IsNotExist(liveRenameErr) {
+			// Keep currSize so a failed live rename cannot restart the
+			// unbounded-append path this PR is closing. ENOENT means the
+			// live path is gone (e.g. operator deleted it); fall through
+			// and reopen so later writes are not lost on the unlinked inode.
+			// This guard only fires when `.log.1` itself cannot be replaced
+			// (typical num==2). For num>=3 a blocker at `.log.1` is shifted
+			// to `.log.2` first, so the live rename usually succeeds.
+			return n, nil
+		}
+		w.currSize = 0
+		reOpenFile(live, &w.currFile, &w.openTime)
 	}
 
 	return n, nil
 }
 
+func normalizeRollArgs(num, sizeMB int) (int, int) {
+	// 0 is the YAML zero value for unset fields, not a misconfiguration.
+	if num < 0 {
+		fmt.Fprintf(os.Stderr, "cubelog: invalid roll file_num=%d, defaulting to %d\n", num, defaultRollFileNum)
+		num = defaultRollFileNum
+	} else if num == 0 {
+		num = defaultRollFileNum
+	}
+	if sizeMB < 0 {
+		fmt.Fprintf(os.Stderr, "cubelog: invalid roll file_size=%d, defaulting to %d MB\n", sizeMB, defaultRollFileSizeMB)
+		sizeMB = defaultRollFileSizeMB
+	} else if sizeMB == 0 {
+		sizeMB = defaultRollFileSizeMB
+	}
+	return num, sizeMB
+}
+
 func NewRollFileWriter(logpath, name string, num, sizeMB int) *RollFileWriter {
+	num, sizeMB = normalizeRollArgs(num, sizeMB)
 	w := &RollFileWriter{
 		logpath: logpath,
 		name:    name,

--- a/cubelog/logwriter_test.go
+++ b/cubelog/logwriter_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package CubeLog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewRollFileWriterDefaultsZeroArgs(t *testing.T) {
+	dir := t.TempDir()
+	w := NewRollFileWriter(dir, "cubemaster-req", 0, 0)
+	if w.num != defaultRollFileNum {
+		t.Fatalf("num = %d, want %d", w.num, defaultRollFileNum)
+	}
+	wantSize := int64(defaultRollFileSizeMB) * 1024 * 1024
+	if w.size != wantSize {
+		t.Fatalf("size = %d, want %d", w.size, wantSize)
+	}
+}
+
+func TestNewRollFileWriterKeepsExplicitArgs(t *testing.T) {
+	dir := t.TempDir()
+	w := NewRollFileWriter(dir, "cubemaster-req", 3, 1)
+	if w.num != 3 {
+		t.Fatalf("num = %d, want 3", w.num)
+	}
+	if w.size != 1024*1024 {
+		t.Fatalf("size = %d, want 1MiB", w.size)
+	}
+}
+
+func TestRollFileWriterRotatesWhenSizeExceeded(t *testing.T) {
+	dir := t.TempDir()
+	w := NewRollFileWriter(dir, "cubemaster-req", 3, 1)
+
+	chunk := make([]byte, 512*1024)
+	for i := 0; i < 3; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	live := filepath.Join(dir, "cubemaster-req.log")
+	rotated := filepath.Join(dir, "cubemaster-req.log.1")
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("current log missing: %v", err)
+	}
+	st, err := os.Stat(rotated)
+	if err != nil {
+		t.Fatalf("rotated log missing: %v", err)
+	}
+	if st.Size() == 0 {
+		t.Fatal("rotated log is empty")
+	}
+}
+
+func TestRollFileWriterKeepsNumRotatedFiles(t *testing.T) {
+	dir := t.TempDir()
+	const rollNum = 2
+	w := NewRollFileWriter(dir, "cubemaster-req", rollNum, 1)
+
+	chunk := make([]byte, 512*1024)
+	// 2 writes ≈ 1MiB trigger one rotation; 6 writes ≈ 3 rotations.
+	for i := 0; i < 6; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	live := filepath.Join(dir, "cubemaster-req.log")
+	first := filepath.Join(dir, "cubemaster-req.log.1")
+	second := filepath.Join(dir, "cubemaster-req.log.2")
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("current log missing: %v", err)
+	}
+	if _, err := os.Stat(first); err != nil {
+		t.Fatalf(".log.1 missing: %v", err)
+	}
+	if _, err := os.Stat(second); !os.IsNotExist(err) {
+		t.Fatalf(".log.2 should not exist when file_num=2 (live + one backup): %v", err)
+	}
+}
+
+func TestRollFileWriterKeepsSizeWhenLiveRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	// num=2 shifts `.log` → `.log.1` only. A directory at `.log.1` makes
+	// that file-over-dir rename fail.
+	w := NewRollFileWriter(dir, "cubemaster-req", 2, 1)
+	if err := os.Mkdir(filepath.Join(dir, "cubemaster-req.log.1"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	chunk := make([]byte, 512*1024)
+	for i := 0; i < 3; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	if w.currSize < 1024*1024 {
+		t.Fatalf("currSize = %d after failed live rename, want >= 1MiB", w.currSize)
+	}
+}
+
+func TestRollFileWriterRecoversWhenLiveFileRemoved(t *testing.T) {
+	dir := t.TempDir()
+	w := NewRollFileWriter(dir, "cubemaster-req", 2, 1)
+	chunk := make([]byte, 512*1024)
+	for i := 0; i < 2; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	live := filepath.Join(dir, "cubemaster-req.log")
+	if err := os.Remove(live); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write after remove %d: %v", i, err)
+		}
+	}
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("live log not recreated after ENOENT rotate: %v", err)
+	}
+}
+
+func TestRollFileWriterTruncatesWhenNumIsOne(t *testing.T) {
+	dir := t.TempDir()
+	w := NewRollFileWriter(dir, "cubemaster-req", 1, 1)
+	chunk := make([]byte, 512*1024)
+	for i := 0; i < 3; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	live := filepath.Join(dir, "cubemaster-req.log")
+	st, err := os.Stat(live)
+	if err != nil {
+		t.Fatalf("live log missing: %v", err)
+	}
+	if st.Size() >= 1024*1024 {
+		t.Fatalf("live size %d after num=1 rotate, want truncated below 1MiB", st.Size())
+	}
+	if _, err := os.Stat(live + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("num=1 must not create .log.1: %v", err)
+	}
+}
+
+func TestRollFileWriterShiftsLog1BlockerWhenNumAtLeast3(t *testing.T) {
+	dir := t.TempDir()
+	w := NewRollFileWriter(dir, "cubemaster-req", 3, 1)
+	if err := os.Mkdir(filepath.Join(dir, "cubemaster-req.log.1"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	chunk := make([]byte, 512*1024)
+	for i := 0; i < 3; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	live := filepath.Join(dir, "cubemaster-req.log")
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("live log missing: %v", err)
+	}
+	st, err := os.Stat(filepath.Join(dir, "cubemaster-req.log.1"))
+	if err != nil {
+		t.Fatalf(".log.1 missing after shift: %v", err)
+	}
+	if st.IsDir() {
+		t.Fatal("num>=3 should shift the .log.1 directory aside so live rename succeeds")
+	}
+}


### PR DESCRIPTION
## Bug

Request/stat logs written by `cubelog` (`cubemaster-req.log`, `cubelet-req.log`, …) can grow as **a single file with no rotation**:

- no `*.log.1` / `.log.2` ever appears
- the live `.log` keeps appending until it reaches multiple GB
```
# kubectl -n cube-system exec deploy/cube-master -- ls -lh /data/log/CubeMaster/
total 5.2G
-rw-r--r--. 1 root root 5.2G Aug 26 11:32 cubemaster-req.log
```
- this happens when `file_num` / `file_size` are **0** (missing YAML keys, or a zero-value config passed into `NewRollFileWriter`)

## Cause

Rotation only shifts files inside `for i := file_num; i >= 1`. If `file_num == 0` that loop is a no-op, then the writer reopens the same path in append mode. CubeMaster `log.Init` (and other callers) pass config through with no library defaults, so unset config hits this path.

## Fix

- Treat `0` as unset and default to **10 files / 100MB** (CubeMaster shipped values). Cubelet still applies 500MB in its own config before this constructor.
- Negative values still default, and log that fallback to stderr. Unset (`0`) is silent.
- If the live `.log` → `.log.1` rename fails, keep `currSize` so append cannot start unbounded again.
- Drop the extra async delete of `.log.N` (the shift already overwrites that slot).

Passing `0` to mean “never rotate” is no longer supported. In-tree callers already pass explicit values or pre-default.

## Test plan

- [x] `cd cubelog && go test -count=1 ./...` (or `make cubelog-test`)