### PR TITLE
fix(api): document the flat update-network body and reject shapes that clear it

### DIFF
--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -788,7 +788,16 @@ fn default_log_limit() -> i32 {
 ///
 /// `allowPublicTraffic` and `maskRequestHost` are CubeSandbox extensions; E2B's
 /// update schema carries neither.
+///
+/// Unknown fields are rejected. Under full-replacement semantics a key that fails
+/// to match is indistinguishable from one deliberately left out, so a typo like
+/// `allowOu` would clear that policy dimension and answer 204 -- and combined with
+/// an omitted `allowInternetAccess` it reopens egress the caller was restricting.
+/// Failing the request is the only outcome that cannot be mistaken for success.
+/// E2B's own update body carries only `allowOut`, `denyOut`, `rules` and
+/// `allowInternetAccess`, all accepted here, so strictness costs no compatibility.
 #[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct UpdateSandboxNetworkRequest {
     #[serde(rename = "allowInternetAccess", alias = "allow_internet_access")]
     pub allow_internet_access: Option<bool>,
@@ -932,6 +941,24 @@ mod tests {
         let (internet, net) = update_parts("{}").expect("valid body");
         assert!(internet.is_none());
         assert!(net.is_none());
+    }
+
+    #[test]
+    fn update_network_rejects_bodies_that_would_silently_clear_the_policy() {
+        // openapi.yml used to document the nested create shape for this endpoint.
+        // A client following it sent the whole policy under `network`, which
+        // deserialized into an all-None body and replaced the sandbox's egress
+        // policy with the platform default -- public egress reopened, answered
+        // with 204. A misspelled key clears one dimension the same silent way.
+        // Both have to fail, because under full replacement a key that does not
+        // match is indistinguishable from one deliberately omitted.
+        for body in [
+            r#"{"network": {"allowOut": ["8.8.8.8"]}}"#,
+            r#"{"allowOu": ["8.8.8.8"]}"#,
+        ] {
+            serde_json::from_str::<UpdateSandboxNetworkRequest>(body)
+                .expect_err(&format!("body must be rejected: {body}"));
+        }
     }
 
     #[test]

--- a/openapi.yml
+++ b/openapi.yml
@@ -2366,17 +2366,39 @@ components:
         Request body for PUT /sandboxes/{id}/network.
 
         The body is the complete desired egress policy, not a patch: any field left
-        out clears what the sandbox currently has. This mirrors how `network` is
-        interpreted at create time, so the same object can be sent to either.
+        out clears what the sandbox currently has. Fields sit at the top level
+        (E2B's update shape), not nested under `network`. Unknown fields are
+        rejected so a typo cannot silently clear a policy dimension.
       properties:
         allowInternetAccess:
           type:
           - boolean
           - 'null'
-        network:
+        allowOut:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+        allowPublicTraffic:
+          type:
+          - boolean
+          - 'null'
+        denyOut:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+        maskRequestHost:
+          type:
+          - string
+          - 'null'
+        rules:
           oneOf:
           - type: 'null'
-          - $ref: '#/components/schemas/SandboxNetworkConfig'
+          - $ref: '#/components/schemas/SandboxNetworkRulesInput'
+      additionalProperties: false
     Volume:
       type: object
       description: Volume descriptor returned in list responses (no token).


### PR DESCRIPTION
openapi.yml described PUT /sandboxes/{id}/network with the create-time shape -- `allowInternetAccess` plus a nested `network` -- while the handler has taken a flat body since the endpoint shipped, and the six flat fields were absent entirely. A client generated from the spec sent `{"network": {...}}`, every field deserialized to None, and the sandbox's egress policy was replaced with the platform default: public egress reopened, answered with 204. The spec was exported before the body was flattened and never regenerated, so it, not the handler, was the outlier.

Reject unknown fields on the request. Full replacement makes a key that fails to match indistinguishable from one deliberately omitted, so `allowOu` clears that dimension just as quietly, and with `allowInternetAccess` also omitted the sandbox ends up fully open. Failing the request is the only outcome a caller cannot mistake for success. E2B's update body carries only allowOut, denyOut, rules and allowInternetAccess, all accepted here, and our three SDKs emit nothing outside the six fields, so this costs no compatibility.

The schema is corrected by hand rather than by re-running the export, to keep the diff to the endpoint under review. A full regeneration also picks up unrelated drift that accumulated in the checked-in copy -- cpuMilli and memory descriptions, the ListSnapshotsQuery `backend` parameter, SandboxState still listing an `unknown` variant its Rust enum dropped -- and would add a second set of rule schemas, because the update path's Rust types duplicate the create path's. `rules` therefore points at the existing SandboxNetworkRulesInput, which describes the same array-or-host-map wire shape. Regenerating, and the type duplication behind it, are left for their own change.

A contract test pins the two shapes that used to pass silently, so a later change to the struct cannot reintroduce a spec-following client that wipes the policy it meant to set.