### PR TITLE
fix(network): return 409/404 from update_network, and keep UDP flows across policy bumps

### DIFF
--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -523,11 +523,11 @@ impl SandboxService {
             .cubemaster
             .update_sandbox_network(&req)
             .await
-            .map_err(|e| sandbox_not_found_or_internal(e, sandbox_id))?;
+            .map_err(|e| map_update_cubemaster_err(e, sandbox_id))?;
 
         resp.ret
             .into_result()
-            .map_err(|e| sandbox_not_found_or_internal(e, sandbox_id))?;
+            .map_err(|e| map_update_cubemaster_err(e, sandbox_id))?;
 
         Ok(())
     }
@@ -1321,6 +1321,30 @@ mod tests {
             .await
             .expect_err("rejected timeout update should not succeed");
         assert_bad_request(err, reason);
+    }
+
+    #[tokio::test]
+    async fn update_network_maps_cubemaster_conflict_to_conflict() {
+        // The handler's utoipa annotation, the examples README and the Go SDK all
+        // promise 409 for a sandbox that is not running. Cubelet reports it as
+        // 130409 and CubeMaster forwards it verbatim, so mapping anything but
+        // not-found to internal turned a documented client-state condition into a
+        // 500 and charged it against the server's error rate.
+        let reason = "sandbox is paused";
+        let service = spawn_fake_cubemaster(Router::new().route(
+            "/cube/sandbox/network",
+            post(move || async move { ret_envelope(130409, reason) }),
+        ))
+        .await;
+
+        let err = service
+            .update_network("sbx-1", Some(false), None)
+            .await
+            .expect_err("a paused sandbox must not report a successful update");
+        match err {
+            AppError::Conflict(message) => assert_eq!(message, reason),
+            other => panic!("expected conflict error, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/CubeMaster/pkg/service/sandbox/sandbox_update.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_update.go
@@ -169,7 +169,7 @@ func UpdateNetwork(ctx context.Context, req *types.UpdateNetworkRequest) (rsp *t
 		ctx = context.WithoutCancel(ctx)
 		hostIP, ok := resolveSandboxHostIP(ctx, req.SandboxID)
 		if !ok {
-			rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+			rsp.Ret.RetCode = int(errorcode.ErrorCode_NotFound)
 			rsp.Ret.RetMsg = "sandbox not found"
 			return nil
 		}

--- a/CubeNet/cubevs/egress_policy_test.go
+++ b/CubeNet/cubevs/egress_policy_test.go
@@ -322,6 +322,7 @@ type sessionRecheckCase struct {
 	dport             uint16
 	packetClass       uint8
 	l7Scheme          uint8
+	protocol          uint8
 }
 
 type sessionRecheckResult struct {
@@ -340,6 +341,7 @@ func runSessionRecheckCase(t *testing.T, prog *ebpf.Program, tc sessionRecheckCa
 	binary.LittleEndian.PutUint16(data[20:22], tc.dport)
 	data[22] = tc.packetClass
 	data[23] = tc.l7Scheme
+	data[25] = tc.protocol
 
 	ret, out, err := prog.Test(data)
 	if err != nil {
@@ -373,6 +375,8 @@ func TestSessionPolicyRevoked(t *testing.T) {
 		schemeNone  = uint8(0)
 		schemeHTTP  = uint8(1)
 		schemeHTTPS = uint8(2)
+		protoTCP    = uint8(6)  // IPPROTO_TCP
+		protoUDP    = uint8(17) // IPPROTO_UDP
 	)
 
 	env := loadEgressPolicyTestEnv(t)
@@ -439,11 +443,11 @@ func TestSessionPolicyRevoked(t *testing.T) {
 		},
 		{
 			// SNAT and L7 disagree on the reply tuple and on who terminates
-			// the connection, so a flow cannot migrate between them.
+			// the connection, so a TCP flow cannot migrate between them.
 			name: "verdict change SNAT to L7 is revoked",
 			tc: sessionRecheckCase{
 				ifindex: ifindex, daddr: l7Host.IP, dport: otherPort,
-				packetClass: packetSNAT, l7Scheme: schemeNone,
+				packetClass: packetSNAT, l7Scheme: schemeNone, protocol: protoTCP,
 				sessPolicyVersion: 5, metaPolicyVersion: 6,
 			},
 			wantRevoked: true,
@@ -453,7 +457,7 @@ func TestSessionPolicyRevoked(t *testing.T) {
 			name: "verdict change L7 scheme is revoked",
 			tc: sessionRecheckCase{
 				ifindex: ifindex, daddr: l7Host.IP, dport: otherPort,
-				packetClass: packetL7, l7Scheme: schemeHTTP,
+				packetClass: packetL7, l7Scheme: schemeHTTP, protocol: protoTCP,
 				sessPolicyVersion: 5, metaPolicyVersion: 6,
 			},
 			wantRevoked: true,
@@ -463,7 +467,20 @@ func TestSessionPolicyRevoked(t *testing.T) {
 			name: "unchanged L7 verdict is restamped",
 			tc: sessionRecheckCase{
 				ifindex: ifindex, daddr: l7Host.IP, dport: otherPort,
-				packetClass: packetL7, l7Scheme: schemeHTTPS,
+				packetClass: packetL7, l7Scheme: schemeHTTPS, protocol: protoTCP,
+				sessPolicyVersion: 5, metaPolicyVersion: 6,
+			},
+			wantRevoked: false,
+			wantVersion: 6,
+		},
+		{
+			// UDP is always SNAT. classify_egress_flow has no protocol, so an
+			// L7 allow on :443 still returns FLOW_HTTPS for QUIC; that standing
+			// mismatch is not a policy change and must not kill the flow.
+			name: "UDP SNAT against an L7 dest is restamped",
+			tc: sessionRecheckCase{
+				ifindex: ifindex, daddr: l7Host.IP, dport: otherPort,
+				packetClass: packetSNAT, l7Scheme: schemeNone, protocol: protoUDP,
 				sessPolicyVersion: 5, metaPolicyVersion: 6,
 			},
 			wantRevoked: false,

--- a/CubeNet/src/egress_policy_test.bpf.c
+++ b/CubeNet/src/egress_policy_test.bpf.c
@@ -41,7 +41,8 @@ struct session_recheck_case {
 	__u8 packet_class;
 	__u8 l7_scheme;
 	__u8 revoked;
-	__u8 reserved[3];
+	__u8 protocol;
+	__u8 reserved[2];
 };
 
 SEC("tc")
@@ -58,7 +59,8 @@ int test_session_policy_revoked(struct __sk_buff *skb)
 	sess.policy_version = tc.sess_policy_version;
 
 	tc.revoked = session_policy_revoked(&sess, tc.meta_policy_version,
-					    tc.ifindex, tc.daddr, tc.dport);
+					    tc.ifindex, tc.daddr, tc.dport,
+					    tc.protocol);
 	tc.policy_version_out = sess.policy_version;
 
 	if (bpf_skb_store_bytes(skb, 0, &tc, sizeof(tc), 0))

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -380,7 +380,7 @@ static __always_inline __u32 do_icmp_nat(struct __sk_buff *skb, struct mvm_meta 
 		 * there is nothing to reset on ICMP
 		 */
 		if (session_policy_revoked(sess, policy_version, skb->ingress_ifindex,
-					   key.dst_ip, key.dst_port)) {
+					   key.dst_ip, key.dst_port, key.protocol)) {
 			del_session(&key, sess);
 			return 0;
 		}
@@ -489,7 +489,7 @@ static __always_inline __u32 do_udp_nat_inline(struct __sk_buff *skb,
 		 * there is nothing to reset on UDP
 		 */
 		if (session_policy_revoked(sess, policy_version, skb->ingress_ifindex,
-					   key.dst_ip, key.dst_port)) {
+					   key.dst_ip, key.dst_port, key.protocol)) {
 			del_session(&key, sess);
 			return 0;
 		}
@@ -734,7 +734,7 @@ do_update:
 	 * as a probe, deferring the revocation by one more packet.
 	 */
 	if (session_policy_revoked(sess, policy_version, skb->ingress_ifindex,
-				   key.dst_ip, key.dst_port)) {
+				   key.dst_ip, key.dst_port, key.protocol)) {
 		del_session(&key, sess);
 		return rst ? TCP_NAT_DROP : TCP_NAT_RESET;
 	}

--- a/CubeNet/src/session.h
+++ b/CubeNet/src/session.h
@@ -265,6 +265,7 @@ static __always_inline __u8 session_verdict(const struct nat_session *sess)
  * @ifindex:   TAP ifindex of the originating MVM
  * @daddr:     destination IP in network byte order
  * @dport:     destination port in network byte order (0 for ICMP)
+ * @protocol:  IPPROTO_* of the flow, from the session key
  *
  * Returns true when this flow may no longer carry traffic. Callers retire the
  * session pair with del_session() and reject the packet: TCP answers with an RST
@@ -276,10 +277,14 @@ static __always_inline __u8 session_verdict(const struct nat_session *sess)
  * flow cannot resume even if a subsequent update re-allows the destination,
  * while a SYN legitimately opens a fresh connection under the current policy.
  *
- * A verdict *change* counts as revocation, not just FLOW_REJECT. Once a flow
- * must switch between plain SNAT and L7 interception there is no way to migrate
- * it -- the two paths disagree on both the reply tuple and who terminates the
- * TCP connection -- so the flow is retired and the client reconnects.
+ * A verdict *change* counts as revocation, not just FLOW_REJECT, but only for
+ * TCP. Once a TCP flow must switch between plain SNAT and L7 interception there
+ * is no way to migrate it -- the two paths disagree on both the reply tuple and
+ * who terminates the connection -- so the flow is retired and the client
+ * reconnects. UDP and ICMP are always SNAT; classify_egress_flow has no
+ * protocol, so an L7 allow on the same (ip, port) returns FLOW_HTTP/HTTPS for
+ * them too. That standing mismatch is not a policy change and must not kill
+ * the flow. Non-TCP sessions are therefore revoked only on FLOW_REJECT.
  *
  * Called before update_session(): there is no point advancing the conntrack
  * state of a flow that is about to be deleted.
@@ -295,7 +300,7 @@ static __always_inline __u8 session_verdict(const struct nat_session *sess)
 static __always_inline bool session_policy_revoked(struct nat_session *sess,
 						   __u32 policy_version,
 						   __u32 ifindex, __u32 daddr,
-						   __u16 dport)
+						   __u16 dport, __u8 protocol)
 {
 	__u8 verdict;
 
@@ -303,7 +308,9 @@ static __always_inline bool session_policy_revoked(struct nat_session *sess,
 		return false;
 
 	verdict = classify_egress_flow(ifindex, daddr, dport);
-	if (verdict == FLOW_REJECT || verdict != session_verdict(sess))
+	if (verdict == FLOW_REJECT)
+		return true;
+	if (protocol == IPPROTO_TCP && verdict != session_verdict(sess))
 		return true;
 	sess->policy_version = policy_version;
 	return false;


### PR DESCRIPTION
## Summary
Follow-ups to in-place egress policy update. Two independent bugs, both already showing up on the live path.

- **UDP first-bump kill.** `classify_egress_flow` has no protocol, so a UDP flow to an L7-covered port (QUIC/HTTP3 on `:443`) is admitted as SNAT but re-classifies as HTTP/HTTPS. `session_policy_revoked` treated that standing mismatch as a verdict change and deleted the session on the first `policy_version` bump — including unrelated updates. Verdict-change comparison is now TCP-only (SNAT ↔ L7 still cannot be migrated in place). UDP/ICMP revoke only on `FLOW_REJECT`. ICMP is the same branch; it previously survived only because its key uses `dst_port = 0` and missed `/48` L7 entries.
- **Wrong HTTP status from `PUT /sandboxes/{id}/network`.** CubeAPI mapped every CubeMaster failure through `sandbox_not_found_or_internal`, which only understands 404, so a paused / network-less sandbox (`ErrorCode_Conflict`, 130409) became HTTP 500 — contradicting the handler annotation, the troubleshooting table, and the Go SDK. Route it through `map_update_cubemaster_err` like pause/resume. CubeMaster also returned `MasterParamsError` when it could not resolve the sandbox host, which CubeAPI can only read as 400; that branch is now `ErrorCode_NotFound`, consistent with ID resolve and with remove/info/timeout/list. Pause/resume in the same function is a different endpoint and is left unchanged. The two halves compose: CubeMaster emits 130404, CubeAPI maps it to NotFound.