### PR TITLE
s3lvol: rename COS to S3, add MinIO support, portable ISA and py3.8 RPC client

### DIFF
--- a/CubeS3lvol/README.md
+++ b/CubeS3lvol/README.md
@@ -29,8 +29,10 @@ s3lvol-<version>/
 ├── scripts/
 │   ├── rcow_start.sh rcow_stop.sh rcow_recovery.sh rcow_common.sh
 │   ├── rcow_purge.sh  s3lvol_rpc.py  s3_prefix_rm.py
-│   ├── rpc.py         # SPDK's, unmodified
-│   └── python/spdk/   # what rpc.py imports
+│   ├── rpc.py         # this repo's launcher (3.8 argparse shim)
+│   ├── rpc_compat.py  # BooleanOptionalAction backfill for Python 3.8
+│   ├── spdk_rpc.py    # SPDK's rpc.py, unmodified
+│   └── python/spdk/   # what SPDK rpc.py imports
 ├── VERSION            # what this package is and what it was built from
 └── README.md
 ```
@@ -38,11 +40,13 @@ s3lvol-<version>/
 Notes for a fresh build machine:
 
 - The script needs an SPDK checkout at `deps/spdk` or `../spdk` (or `SPDK_ROOT`
-  in the environment) to copy `rpc.py` and its library from; it refuses to run
-  without one. `setup_dep.sh` arranges this.
-- It runs a short **smoke test** that actually starts `bin/s3lvol_tgt` to prove
-  DPDK EAL initialises and the RPC socket comes up. On a restricted CI node that
-  cannot run DPDK, pass `--skip-smoke` to package without that check.
+  in the environment) to copy `spdk_rpc.py` and its library from; it refuses to
+  run without one. `setup_dep.sh` arranges this. `scripts/rpc.py` in the package
+  is this repo's launcher: it backfills `argparse.BooleanOptionalAction` so the
+  unmodified SPDK client can run on Python 3.8 (Ubuntu 20.04).
+- Layout detection and `rpc.py --help` always run. A separate **EAL smoke**
+  starts `bin/s3lvol_tgt` to prove DPDK initialises. On a restricted CI node that
+  cannot run DPDK, pass `--skip-smoke` to skip only that EAL check.
 - Both build types are recorded in `VERSION`. The development defaults are not a
   release build; for something meant to be deployed:
 
@@ -67,12 +71,19 @@ apt install -y nvme-cli python3 libssl1.1 libuuid1 libaio1 libnuma1
 openssl**: the package is built against the build machine's `libssl.so.1.1`, and
 the target's major version must match (1.1 and 3.x are not interchangeable).
 
+**CPU ISA (x86_64).** Release binaries are built for **Haswell / AVX2**, not
+the packager's CPU. `setup_dep.sh` passes `--target-arch=haswell` to SPDK
+(aarch64: `armv8.2-a+crypto`) so DPDK does not bake in VAES / VPCLMULQDQ from
+`-march=native`. Override with `SPDK_TARGET_ARCH` or replace the whole
+`./configure` line with `SPDK_CONFIGURE_ARGS`. `make_release.sh` refuses a
+`native` tree. The host needs `avx2` in `/proc/cpuinfo`.
+
 **Two pieces of per-machine state**, neither of them in the package, because they
 cannot be copied from another machine:
 
 | Path | What it is | Why it is not packaged |
 |---|---|---|
-| `/data/cubelet/cos.cfg` | COS endpoint, region, bucket, credentials | Holds secrets, and differs per machine |
+| `/data/cubelet/s3.cfg` | S3 endpoint, region, bucket, credentials | Holds secrets, and differs per machine |
 | `/data/cubelet/rcow/wal_bdev.img` | Backing file for the WAL and metadata journal | **Its size fixes the journal/WAL layout**; a copied image is an lvstore whose log belongs to another node |
 
 Create the WAL image, sized to leave room for `RCOW_JOURNAL_MB` +
@@ -106,8 +117,25 @@ scripts/rcow_purge.sh          # delete the whole lvstore back to a clean state 
 `rcow_start.sh` is idempotent: if already running it tells you and exits rather
 than starting a second instance.
 
-Credentials are read from `cos.cfg` and passed on **only through the target
+Credentials are read from `s3.cfg` and passed on **only through the target
 process's environment** — never on the command line, never into logs.
+
+one-click writes this file from `CUBE_S3_*` when `ONE_CLICK_ENABLE_S3LVOL=1`.
+If you write it by hand, values must be double-quoted and `endpoint` must
+**not** include a scheme (`http://` / `https://` become `no_tls` instead):
+
+```
+access_key_id="..."
+secret_access_key="..."
+endpoint="10.0.0.11:9000"
+region="us-east-1"
+buckets=["cube-s3lvol"]
+path_style="true"
+no_tls="true"
+```
+
+There is no fallback from the old `/data/cubelet/cos.cfg` name or field
+names (`secretid` / `cos_endpoint` / …). Rename the file and switch keys.
 
 ## Environment variables
 
@@ -116,7 +144,7 @@ used ones:
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `RCOW_COS_CFG` | `/data/cubelet/cos.cfg` | |
+| `RCOW_S3_CFG` | `/data/cubelet/s3.cfg` | |
 | `RCOW_WAL_IMG` | `/data/cubelet/rcow/wal_bdev.img` | |
 | `RCOW_LVS_NAME` | derived `rcow-<hostname-hash>`; a pre-existing `rcow` entry is honoured | lvstore name, also the prefix in S3 |
 | `RCOW_CAPACITY_GB` | `16384` | used only at first create; thin, unused space costs nothing |
@@ -152,9 +180,10 @@ outright rather than silently degrading if `nr_hugepages=0`.
 ## Operations
 
 All of this project's RPCs go through `scripts/s3lvol_rpc.py` (raw JSON-RPC);
-SPDK's own go through `scripts/rpc.py`. The two are not interchangeable: `rpc.py`
-only knows methods it has a Python wrapper for, while `rcow_*` are registered by
-this project and it refuses them directly.
+SPDK's own go through `scripts/rpc.py` (the launcher, which runs `spdk_rpc.py`).
+The two are not interchangeable: SPDK's client only knows methods it has a
+Python wrapper for, while `rcow_*` are registered by this project and it refuses
+them directly.
 
 **Volume lifecycle** (the first lvstore is created by `rcow_start.sh`):
 

--- a/CubeS3lvol/make_release.sh
+++ b/CubeS3lvol/make_release.sh
@@ -12,7 +12,8 @@
 #    ./make_release.sh --outdir /tmp/rel     # default is ./release
 #    ./make_release.sh --no-tar              # leave the directory, skip the tarball
 #    ./make_release.sh --skip-build           # package whatever is already built
-#    ./make_release.sh --skip-smoke           # package, skip the runtime smoke tests
+#    ./make_release.sh --skip-smoke           # skip the DPDK EAL target smoke only
+#                                             # (layout + rpc.py --help still run)
 #
 #  Both build types are recorded in VERSION, and a package that is not a release
 #  build says so at the end. They default to the development setting, which is
@@ -30,8 +31,11 @@
 #    │   ├── rcow_purge.sh        delete an lvstore outright (irreversible)
 #    │   ├── s3lvol_rpc.py        this repo's raw JSON-RPC client
 #    │   ├── s3_prefix_rm.py      bucket cleanup, what rcow_purge.sh deletes with
-#    │   ├── rpc.py               SPDK's, unmodified
-#    │   └── python/spdk/...      what rpc.py imports
+#    │   ├── s3_bucket.py         ensure-bucket, what the one-click supervisor uses
+#    │   ├── rpc.py               this repo's launcher (3.8 argparse shim)
+#    │   ├── rpc_compat.py        BooleanOptionalAction backfill for Python 3.8
+#    │   ├── spdk_rpc.py          SPDK's rpc.py, unmodified
+#    │   └── python/spdk/...      what SPDK rpc.py imports
 #    ├── VERSION
 #    └── README.md
 #
@@ -54,7 +58,7 @@
 #    spdkcli/ wants configshell. Shipping them would put imports in the package
 #    that cannot succeed, and the first person to hit one has to work out whether
 #    it matters.
-#  - cos.cfg and the WAL image. Both are per-machine state: cos.cfg holds
+#  - s3.cfg and the WAL image. Both are per-machine state: s3.cfg holds
 #    credentials, and the WAL image's size fixes the journal layout, so a copy
 #    from elsewhere is an lvstore whose log belongs to another node.
 #  - the test suite. It needs a source tree, fio, and its own credentials.
@@ -112,12 +116,13 @@ PKG_NAME="s3lvol-${VERSION}"
 PKG_DIR="${OUTDIR}/${PKG_NAME}"
 
 # ---------------------------------------------------------------------------
-# Where SPDK is, for rpc.py and its library
+# Where SPDK is, for spdk_rpc.py and its library
 #
-# Resolved the same way the build does, so the rpc.py that ships comes from the
-# SPDK the binary was linked against. Taking it from a different checkout would
-# usually work and occasionally not, in the form of an RPC whose arguments have
-# been renamed.
+# Resolved the same way the build does, so the SPDK client that ships comes from
+# the SPDK the binary was linked against. Taking it from a different checkout
+# would usually work and occasionally not, in the form of an RPC whose arguments
+# have been renamed. The file is installed as scripts/spdk_rpc.py; scripts/rpc.py
+# is this repo's launcher.
 # ---------------------------------------------------------------------------
 if [ -z "${SPDK_ROOT:-}" ]; then
 	if [ -f "${REPO_ROOT}/deps/spdk/scripts/rpc.py" ]; then
@@ -265,8 +270,20 @@ log "scripts/s3_prefix_rm.py (bucket cleanup, used by rcow_purge.sh)"
 install -m 0755 "${REPO_ROOT}/test/tools/s3_prefix_rm.py" \
 	"${PKG_DIR}/scripts/s3_prefix_rm.py" || die "install failed"
 
-log "scripts/rpc.py + scripts/python/spdk (from ${SPDK_ROOT})"
-install -m 0755 "${SPDK_ROOT}/scripts/rpc.py" "${PKG_DIR}/scripts/rpc.py" ||
+# cube-s3lvol-supervise.sh uses this to create the per-backend bucket before
+# rcow_start.sh. Same stdlib SigV4 client as s3_prefix_rm.py -- no aws-cli.
+log "scripts/s3_bucket.py (ensure-bucket, used by the one-click supervisor)"
+install -m 0755 "${REPO_ROOT}/test/tools/s3_bucket.py" \
+	"${PKG_DIR}/scripts/s3_bucket.py" || die "install failed"
+
+log "scripts/rpc.py + scripts/rpc_compat.py (this repo's 3.8-compatible launcher)"
+install -m 0755 "${REPO_ROOT}/scripts/rpc.py" "${PKG_DIR}/scripts/rpc.py" ||
+	die "install failed"
+install -m 0755 "${REPO_ROOT}/scripts/rpc_compat.py" \
+	"${PKG_DIR}/scripts/rpc_compat.py" || die "install failed"
+
+log "scripts/spdk_rpc.py + scripts/python/spdk (from ${SPDK_ROOT})"
+install -m 0755 "${SPDK_ROOT}/scripts/rpc.py" "${PKG_DIR}/scripts/spdk_rpc.py" ||
 	die "install failed"
 
 # Only what rpc.py reaches. cli/ and rpc/ plus the two top-level modules; see
@@ -421,11 +438,12 @@ smoke_test()
 }
 
 # Checked separately because it is a different failure: the target can be fine
-# while rpc.py cannot import its library, and that only shows up when a script
-# tries to create a subsystem.
+# while the launcher cannot start SPDK's client (missing python/spdk, or a
+# Python that still chokes after the 3.8 shim). That only shows up when a
+# script tries to create a subsystem.
 smoke_test_rpc_py()
 {
-	log "smoke test: rpc.py can import its library from scripts/python"
+	log "smoke test: rpc.py launcher can start SPDK's client from scripts/python"
 	if (cd "${PKG_DIR}/scripts" &&
 	    env -i PATH=/usr/bin:/bin PYTHONPATH="${PKG_DIR}/scripts/python" \
 		python3 ./rpc.py --help >/dev/null 2>&1); then
@@ -461,12 +479,16 @@ smoke_test_layout()
 	return 1
 }
 
+# Layout + rpc.py --help need no DPDK and no target. They are the check that
+# would have caught "rpc.py cannot even parse --help on Python 3.8", and they
+# stay on when --skip-smoke is used to dodge the EAL affinity smoke on the
+# builder.
+smoke_test_layout || die "package is broken"
+smoke_test_rpc_py || die "package is broken"
 if [ "${DO_SMOKE}" -eq 1 ]; then
-	smoke_test_layout   || die "package is broken"
-	smoke_test_rpc_py   || die "package is broken"
-	smoke_test          || die "package is broken"
+	smoke_test || die "package is broken"
 else
-	log "--skip-smoke: skipping the runtime smoke tests"
+	log "--skip-smoke: skipping the DPDK EAL target smoke"
 fi
 
 # ---------------------------------------------------------------------------
@@ -516,5 +538,5 @@ fi
 echo ""
 log "on the target machine:"
 log "    tar xzf ${PKG_NAME}.tar.gz && cd ${PKG_NAME}"
-log "    less README.md            # cos.cfg and the WAL image are not included"
+log "    less README.md            # s3.cfg and the WAL image are not included"
 log "    scripts/rcow_start.sh"

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
@@ -212,7 +212,7 @@ struct spdk_bs_dev     *s3lvol_lvstore_get_bs_dev(struct s3lvol_lvstore *lvs);
 /**
  * Return the namespace this lvstore was created in.
  *
- * Every lvstore belongs to a namespace, which maps to a COS target through
+ * Every lvstore belongs to a namespace, which maps to an S3 target through
  * rcow_namespace_to_target(). An import defaults to the same namespace, which is
  * the common case.
  */
@@ -227,10 +227,10 @@ const char *s3lvol_lvstore_get_namespace(struct s3lvol_lvstore *lvs);
  * ========================================================================== */
 
 /**
- * Register a namespace that maps to a COS bucket.
+ * Register a namespace that maps to an S3 bucket.
  *
  * \param name      identifier used by create_lvstore / attach_lvstore
- * \param target    COS connection details; only endpoint/bucket/region/
+ * \param target    S3 connection details; only endpoint/bucket/region/
  *                  use_path_style/verify_tls are read, credentials come from
  *                  the environment
  * \return 0 on success, -EEXIST when the name is already taken.
@@ -238,7 +238,7 @@ const char *s3lvol_lvstore_get_namespace(struct s3lvol_lvstore *lvs);
 int rcow_namespace_add(const char *name, const struct s3_target *target);
 
 /**
- * Resolve a namespace name to a COS target.
+ * Resolve a namespace name to an S3 target.
  *
  * \return the registered target, or NULL when the namespace is unknown.
  */

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_namespace.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_namespace.c
@@ -1,12 +1,12 @@
 /* Copyright (c) 2026 Tencent Inc.
  * SPDX-License-Identifier: Apache-2.0 */
 /*
- *   vbdev_s3lvol_namespace -- namespace-to-COS-target registry
+ *   vbdev_s3lvol_namespace -- namespace-to-S3-target registry
  *
- *   Every lvstore lives in a *namespace*, which maps to a COS target (endpoint,
+ *   Every lvstore lives in a *namespace*, which maps to an S3 target (endpoint,
  *   bucket, region, and associated TLS / path-style settings). The registry lives
  *   in process memory -- it is populated by the startup script through
- *   rcow_add_cos_config and does not survive a restart, because the same startup
+ *   rcow_add_s3_config and does not survive a restart, because the same startup
  *   script repopulates it every time.
  *
  *   For now the mapping is a direct TAILQ lookup. That will be replaced by
@@ -68,7 +68,7 @@ rcow_namespace_add(const char *name, const struct s3_target *target)
 		return -ENOMEM;
 	}
 
-	/* Copy only the fields that matter for the COS connection. Credential
+	/* Copy only the fields that matter for the S3 connection. Credential
 	 * fields (access_key / secret_key / session_token) are populated from the
 	 * environment inside s3_client_get_or_create(), never from the RPC.
 	 *

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
@@ -20,7 +20,7 @@
  *
  *     rcow_create_lvstore / rcow_attach_lvstore / rcow_delete_lvstore
  *     rcow_unload_lvstore / rcow_flush_lvstore / rcow_checkpoint_lvstore
- *     rcow_get_lvstores / rcow_add_cos_config
+ *     rcow_get_lvstores / rcow_add_s3_config
  *     rcow_create_lvol / rcow_delete_lvol / rcow_resize_lvol
  *     rcow_create_snapshot / rcow_create_clone
  *     rcow_export_snapshot / rcow_get_snapshot_status / rcow_import_lvol
@@ -1346,9 +1346,9 @@ SPDK_RPC_REGISTER("rcow_checkpoint_lvstore",
 		  rpc_rcow_checkpoint_lvstore, SPDK_RPC_RUNTIME)
 
 /* ==========================================================================
- * rcow_add_cos_config
+ * rcow_add_s3_config
  *
- * Register a namespace that maps to a COS bucket. Meant to be called by a
+ * Register a namespace that maps to an S3 bucket. Meant to be called by a
  * startup script once per bucket before any lvstore is created or attached.
  *
  * The namespace name is typically the bucket name, which makes it easy to read
@@ -1359,7 +1359,7 @@ SPDK_RPC_REGISTER("rcow_checkpoint_lvstore",
  * environment (S3_AUTH_ENV), the same as before.
  * ========================================================================== */
 
-struct rpc_add_cos_config {
+struct rpc_add_s3_config {
 	char *ns_name;
 	char *endpoint;
 	char *bucket;
@@ -1369,7 +1369,7 @@ struct rpc_add_cos_config {
 };
 
 static void
-free_rpc_add_cos_config(struct rpc_add_cos_config *req)
+free_rpc_add_s3_config(struct rpc_add_s3_config *req)
 {
 	free(req->ns_name);
 	free(req->endpoint);
@@ -1377,25 +1377,25 @@ free_rpc_add_cos_config(struct rpc_add_cos_config *req)
 	free(req->region);
 }
 
-static const struct spdk_json_object_decoder rpc_add_cos_config_decoders[] = {
-	{"namespace",  offsetof(struct rpc_add_cos_config, ns_name),  spdk_json_decode_string, false},
-	{"endpoint",   offsetof(struct rpc_add_cos_config, endpoint),   spdk_json_decode_string, false},
-	{"bucket",     offsetof(struct rpc_add_cos_config, bucket),     spdk_json_decode_string, false},
-	{"region",     offsetof(struct rpc_add_cos_config, region),     spdk_json_decode_string, true},
-	{"path_style", offsetof(struct rpc_add_cos_config, path_style), spdk_json_decode_bool,   true},
-	{"no_tls",     offsetof(struct rpc_add_cos_config, no_tls),     spdk_json_decode_bool,   true},
+static const struct spdk_json_object_decoder rpc_add_s3_config_decoders[] = {
+	{"namespace",  offsetof(struct rpc_add_s3_config, ns_name),  spdk_json_decode_string, false},
+	{"endpoint",   offsetof(struct rpc_add_s3_config, endpoint),   spdk_json_decode_string, false},
+	{"bucket",     offsetof(struct rpc_add_s3_config, bucket),     spdk_json_decode_string, false},
+	{"region",     offsetof(struct rpc_add_s3_config, region),     spdk_json_decode_string, true},
+	{"path_style", offsetof(struct rpc_add_s3_config, path_style), spdk_json_decode_bool,   true},
+	{"no_tls",     offsetof(struct rpc_add_s3_config, no_tls),     spdk_json_decode_bool,   true},
 };
 
 static void
-rpc_rcow_add_cos_config(struct spdk_jsonrpc_request *request,
+rpc_rcow_add_s3_config(struct spdk_jsonrpc_request *request,
 			const struct spdk_json_val *params)
 {
-	struct rpc_add_cos_config req = {0};
+	struct rpc_add_s3_config req = {0};
 	struct s3_target target = {0};
 	int rc;
 
-	if (spdk_json_decode_object(params, rpc_add_cos_config_decoders,
-				    SPDK_COUNTOF(rpc_add_cos_config_decoders),
+	if (spdk_json_decode_object(params, rpc_add_s3_config_decoders,
+				    SPDK_COUNTOF(rpc_add_s3_config_decoders),
 				    &req)) {
 		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
 						 "Invalid parameters");
@@ -1425,9 +1425,9 @@ rpc_rcow_add_cos_config(struct spdk_jsonrpc_request *request,
 	}
 
 cleanup:
-	free_rpc_add_cos_config(&req);
+	free_rpc_add_s3_config(&req);
 }
-SPDK_RPC_REGISTER("rcow_add_cos_config", rpc_rcow_add_cos_config, SPDK_RPC_RUNTIME)
+SPDK_RPC_REGISTER("rcow_add_s3_config", rpc_rcow_add_s3_config, SPDK_RPC_RUNTIME)
 
 /* ==========================================================================
  * rcow_get_lvstores

--- a/CubeS3lvol/scripts/rcow_common.sh
+++ b/CubeS3lvol/scripts/rcow_common.sh
@@ -57,8 +57,8 @@ RCOW_REPO_ROOT="${RCOW_REPO_ROOT:-$(cd "${RCOW_SCRIPT_DIR}/.." && pwd)}"
 # These run both from a source checkout and from a release package, whose layout
 # is flat and has no SPDK tree beside it:
 #
-#   repo:      scripts/rcow_*.sh   app/s3lvol_tgt/s3lvol_tgt   ../spdk/scripts/rpc.py
-#   package:   scripts/rcow_*.sh   bin/s3lvol_tgt              scripts/rpc.py
+#   repo:      scripts/rcow_*.sh   app/s3lvol_tgt/s3lvol_tgt   scripts/rpc.py -> $SPDK_ROOT/scripts/rpc.py
+#   package:   scripts/rcow_*.sh   bin/s3lvol_tgt              scripts/rpc.py -> scripts/spdk_rpc.py
 #
 # Detected rather than substituted at packaging time. Rewriting these paths while
 # building the package would mean the scripts that ship are not the scripts that
@@ -102,7 +102,11 @@ else
 
 	RCOW_TGT_BIN="${RCOW_TGT_BIN:-${RCOW_REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt}"
 	RCOW_RPC_PY="${RCOW_RPC_PY:-${RCOW_REPO_ROOT}/test/tools/s3lvol_rpc.py}"
-	RCOW_SPDK_RPC_PY="${RCOW_SPDK_RPC_PY:-${SPDK_ROOT}/scripts/rpc.py}"
+	# Same launcher as the package: it applies the 3.8 argparse shim and
+	# then runs $SPDK_ROOT/scripts/rpc.py. Calling the SPDK file directly
+	# would blow up on Ubuntu 20.04 (no BooleanOptionalAction).
+	RCOW_SPDK_RPC_PY="${RCOW_SPDK_RPC_PY:-${RCOW_SCRIPT_DIR}/rpc.py}"
+	export SPDK_ROOT
 fi
 
 RCOW_RPC_SOCK="${RCOW_RPC_SOCK:-/var/run/s3lvol.sock}"
@@ -115,9 +119,9 @@ RCOW_RPC_SOCK="${RCOW_RPC_SOCK:-/var/run/s3lvol.sock}"
 # the same either way.
 # --------------------------------------------------------------------------
 
-# Read for the COS endpoint, region, bucket list and credentials. Credentials
+# Read for the S3 endpoint, region, bucket list and credentials. Credentials
 # leave this file only through the environment of the target process.
-RCOW_COS_CFG="${RCOW_COS_CFG:-/data/cubelet/cos.cfg}"
+RCOW_S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
 
 # The local device behind the metadata journal and the WAL. Fixed rather than
 # discovered: it is the one piece of state that must not move between boots, and
@@ -393,7 +397,7 @@ rcow_ensure_run_dir()
 }
 
 # --------------------------------------------------------------------------
-# cos.cfg
+# s3.cfg
 #
 # Parsed with sed rather than sourced. The file is TOML-shaped and holds the
 # account credentials; running it as shell would execute whatever ends up in it,
@@ -403,17 +407,17 @@ rcow_ensure_run_dir()
 rcow_cfg_get()
 {
 	sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*/\1/p" \
-		"${RCOW_COS_CFG}" 2>/dev/null | head -1 | tr -d '\r'
+		"${RCOW_S3_CFG}" 2>/dev/null | head -1 | tr -d '\r'
 }
 
-# cos_bucket_name is a list -- the config already allows several buckets even
+# buckets is a list -- the config already allows several buckets even
 # though only the first carries an lvstore today. All of them are registered as
 # namespaces, so that a volume imported from another bucket can be reached
 # without a config change.
-rcow_cos_buckets()
+rcow_s3_buckets()
 {
-	sed -n 's/^[[:space:]]*cos_bucket_name[[:space:]]*=[[:space:]]*\[\(.*\)\].*/\1/p' \
-		"${RCOW_COS_CFG}" 2>/dev/null | head -1 | tr ',' '\n' |
+	sed -n 's/^[[:space:]]*buckets[[:space:]]*=[[:space:]]*\[\(.*\)\].*/\1/p' \
+		"${RCOW_S3_CFG}" 2>/dev/null | head -1 | tr ',' '\n' |
 		sed -n 's/^[[:space:]]*"\([^"]*\)".*/\1/p' | tr -d '\r'
 }
 
@@ -424,8 +428,8 @@ rcow_load_credentials()
 {
 	local id key
 
-	id="$(rcow_cfg_get secretid)"
-	key="$(rcow_cfg_get secretkey)"
+	id="$(rcow_cfg_get access_key_id)"
+	key="$(rcow_cfg_get secret_access_key)"
 
 	if [ -z "${id}" ] || [ -z "${key}" ]; then
 		return 1
@@ -433,6 +437,22 @@ rcow_load_credentials()
 
 	export AWS_ACCESS_KEY_ID="${id}"
 	export AWS_SECRET_ACCESS_KEY="${key}"
+	return 0
+}
+
+# Append --path-style / --no-tls onto the named bash array (caller must pass a
+# hardcoded identifier such as s3_flags or S3_ADDR_FLAGS, never user input).
+rcow_s3_addr_flags()
+{
+	local dest="$1"
+
+	case "${dest}" in
+	''|*[!A-Za-z0-9_]*|[0-9]*)
+		return 0
+		;;
+	esac
+	[ "$(rcow_cfg_get path_style)" = "true" ] && eval "${dest}+=(--path-style)"
+	[ "$(rcow_cfg_get no_tls)" = "true" ] && eval "${dest}+=(--no-tls)"
 	return 0
 }
 
@@ -652,15 +672,22 @@ rcow_wait_rpc()
 	local deadline=$((SECONDS + ${1:-30}))
 	local pid="${2:-}"
 
+	local last_err=""
+
 	while [ "${SECONDS}" -lt "${deadline}" ]; do
-		if RCOW_RPC_TIMEOUT=5 rcow_srpc spdk_get_version >/dev/null 2>&1; then
+		if last_err="$(RCOW_RPC_TIMEOUT=5 rcow_srpc spdk_get_version 2>&1)"; then
 			return 0
 		fi
 		if [ -n "${pid}" ] && ! kill -0 "${pid}" 2>/dev/null; then
+			[ -n "${last_err}" ] && rcow_err "last rpc.py output: ${last_err}"
 			return 1
 		fi
 		sleep 0.2
 	done
+	if [ -n "${last_err}" ]; then
+		rcow_err "rpc.py did not succeed; last output:"
+		printf '%s\n' "${last_err}" | sed 's/^/    /' >&2
+	fi
 	return 1
 }
 

--- a/CubeS3lvol/scripts/rcow_purge.sh
+++ b/CubeS3lvol/scripts/rcow_purge.sh
@@ -198,13 +198,17 @@ else
 AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, or pass --keep-s3 to purge local state \
 only"
 	fi
-	S3_ENDPOINT="$(rcow_cfg_get cos_endpoint)"
+	S3_ENDPOINT="$(rcow_cfg_get endpoint)"
 	S3_REGION="$(rcow_cfg_get region)"
-	S3_BUCKET="$(rcow_cos_buckets | head -1)"
-	[ -n "${S3_BUCKET}" ] || rcow_die "no bucket in ${RCOW_COS_CFG}"
+	S3_BUCKET="$(rcow_s3_buckets | head -1)"
+	[ -n "${S3_BUCKET}" ] || rcow_die "no bucket in ${RCOW_S3_CFG}"
+	S3_ADDR_FLAGS=()
+	rcow_s3_addr_flags S3_ADDR_FLAGS
 
 	S3_COUNT="$(python3 "${PREFIX_RM}" -e "${S3_ENDPOINT}" -b "${S3_BUCKET}" \
-		-r "${S3_REGION}" -p "${S3_PREFIX}" --list 2>/dev/null | grep -c . || true)"
+		-r "${S3_REGION}" -p "${S3_PREFIX}" --list \
+		"${S3_ADDR_FLAGS[@]+"${S3_ADDR_FLAGS[@]}"}" \
+		2>/dev/null | grep -c . || true)"
 	rcow_log "S3: ${S3_COUNT} object(s) under ${S3_BUCKET}/${S3_PREFIX}"
 fi
 
@@ -256,13 +260,15 @@ FAILED=0
 if [ "${KEEP_S3}" -eq 0 ]; then
 	rcow_log "deleting ${S3_COUNT} object(s) under ${S3_PREFIX}"
 	if python3 "${PREFIX_RM}" -e "${S3_ENDPOINT}" -b "${S3_BUCKET}" \
-			-r "${S3_REGION}" -p "${S3_PREFIX}" 2>&1 | tail -2; then
+			-r "${S3_REGION}" -p "${S3_PREFIX}" \
+			"${S3_ADDR_FLAGS[@]+"${S3_ADDR_FLAGS[@]}"}" 2>&1 | tail -2; then
 		# Verified rather than trusted: a partial delete leaves an owner marker
 		# or a checkpoint behind, and the next create then refuses with -EEXIST
 		# for a prefix that looks empty in every other respect.
 		LEFT="$(python3 "${PREFIX_RM}" -e "${S3_ENDPOINT}" -b "${S3_BUCKET}" \
-			-r "${S3_REGION}" -p "${S3_PREFIX}" --list 2>/dev/null | \
-			grep -c . || true)"
+			-r "${S3_REGION}" -p "${S3_PREFIX}" --list \
+			"${S3_ADDR_FLAGS[@]+"${S3_ADDR_FLAGS[@]}"}" \
+			2>/dev/null | grep -c . || true)"
 		if [ "${LEFT}" -eq 0 ]; then
 			rcow_log "S3 prefix is empty"
 		else

--- a/CubeS3lvol/scripts/rcow_start.sh
+++ b/CubeS3lvol/scripts/rcow_start.sh
@@ -11,7 +11,7 @@
 #                                    creation, so the grid is built up front --
 #                                    but without listeners; see step 7
 #    3. WAL bdev                     the lvstore attach needs it by name
-#    4. COS namespaces               the lvstore attach resolves its namespace
+#    4. S3 namespaces                the lvstore attach resolves its namespace
 #                                    through them
 #    5. lvstore: attach or create    see below
 #    6. replay the active registry   volumes come back where they were
@@ -131,7 +131,7 @@ rcow_ensure_run_dir
 rcow_check_tgt_deps
 [ -x "${RCOW_SPDK_RPC_PY}" ] || rcow_die "SPDK rpc.py not found: ${RCOW_SPDK_RPC_PY} \
 (set SPDK_ROOT)"
-[ -r "${RCOW_COS_CFG}" ] || rcow_die "COS config not readable: ${RCOW_COS_CFG}"
+[ -r "${RCOW_S3_CFG}" ] || rcow_die "S3 config not readable: ${RCOW_S3_CFG}"
 [ -e "${RCOW_WAL_IMG}" ] || rcow_die "WAL image not found: ${RCOW_WAL_IMG}. It \
 is deliberately not created here -- its size fixes the journal and WAL layout, \
 and an empty file where the old one used to be looks to the attach path like an \
@@ -162,18 +162,18 @@ rm -f "${RCOW_RPC_SOCK}" "${RCOW_RPC_SOCK}.lock" "/var/tmp/spdk_cpu_lock_"* \
 	"${RCOW_PIDFILE}"
 
 rcow_load_credentials ||
-	rcow_die "could not read secretid/secretkey from ${RCOW_COS_CFG}"
+	rcow_die "could not read access_key_id/secret_access_key from ${RCOW_S3_CFG}"
 
-COS_ENDPOINT="$(rcow_cfg_get cos_endpoint)"
-COS_REGION="$(rcow_cfg_get region)"
-COS_BUCKETS="$(rcow_cos_buckets)"
+S3_ENDPOINT="$(rcow_cfg_get endpoint)"
+S3_REGION="$(rcow_cfg_get region)"
+S3_BUCKETS="$(rcow_s3_buckets)"
 
-[ -n "${COS_ENDPOINT}" ] || rcow_die "no cos_endpoint in ${RCOW_COS_CFG}"
-[ -n "${COS_BUCKETS}" ]  || rcow_die "no cos_bucket_name in ${RCOW_COS_CFG}"
-[ -n "${COS_REGION}" ]   || COS_REGION="us-east-1"
+[ -n "${S3_ENDPOINT}" ] || rcow_die "no endpoint in ${RCOW_S3_CFG}"
+[ -n "${S3_BUCKETS}" ]  || rcow_die "no buckets in ${RCOW_S3_CFG}"
+[ -n "${S3_REGION}" ]   || S3_REGION="us-east-1"
 
-rcow_log "endpoint ${COS_ENDPOINT}, region ${COS_REGION}"
-rcow_log "buckets: $(printf '%s ' ${COS_BUCKETS})"
+rcow_log "endpoint ${S3_ENDPOINT}, region ${S3_REGION}"
+rcow_log "buckets: $(printf '%s ' ${S3_BUCKETS})"
 rcow_log "lvstore '${RCOW_LVS_NAME}', WAL image ${RCOW_WAL_IMG}"
 
 # ==========================================================================
@@ -247,7 +247,7 @@ HAVE_SUBSYS="$(rcow_subsys_count)"
 	bail "only ${HAVE_SUBSYS} of ${RCOW_NUM_SUBSYS} subsystems exist"
 
 # ==========================================================================
-rcow_step "local device and COS namespaces"
+rcow_step "local device and S3 namespaces"
 
 rcow_srpc bdev_aio_create "${RCOW_WAL_IMG}" "${RCOW_WAL_BDEV}" 4096 \
 	>/dev/null 2>&1 ||
@@ -258,18 +258,18 @@ rcow_log "WAL bdev '${RCOW_WAL_BDEV}' on ${RCOW_WAL_IMG}"
 # blobstore per node), but an import reads from whichever namespace the source
 # lives in, so they are all registered.
 #
-# The COS config may name a path-style, plain-HTTP backend (MinIO in CI): the
+# The S3 config may name a path-style, plain-HTTP backend (MinIO in CI): the
 # two optional flags are read once and folded into every registration.
-RCOW_COS_EXTRA_JSON=""
-[ "$(rcow_cfg_get path_style)" = "true" ] && RCOW_COS_EXTRA_JSON+=',"path_style":true'
-[ "$(rcow_cfg_get no_tls)" = "true" ] && RCOW_COS_EXTRA_JSON+=',"no_tls":true'
+RCOW_S3_EXTRA_JSON=""
+[ "$(rcow_cfg_get path_style)" = "true" ] && RCOW_S3_EXTRA_JSON+=',"path_style":true'
+[ "$(rcow_cfg_get no_tls)" = "true" ] && RCOW_S3_EXTRA_JSON+=',"no_tls":true'
 
-for bucket in ${COS_BUCKETS}; do
-	rcow_rpc rcow_add_cos_config \
+for bucket in ${S3_BUCKETS}; do
+	rcow_rpc rcow_add_s3_config \
 		"$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
-			"${bucket}" "${COS_ENDPOINT}" "${bucket}" "${COS_REGION}" \
-			"${RCOW_COS_EXTRA_JSON}")" \
-		>/dev/null || bail "rcow_add_cos_config failed for bucket ${bucket}"
+			"${bucket}" "${S3_ENDPOINT}" "${bucket}" "${S3_REGION}" \
+			"${RCOW_S3_EXTRA_JSON}")" \
+		>/dev/null || bail "rcow_add_s3_config failed for bucket ${bucket}"
 	rcow_log "namespace '${bucket}' registered"
 done
 
@@ -284,9 +284,9 @@ if BSTORE_ENTRY="$(rcow_bstore_entry "${RCOW_LVS_NAME}")"; then
 '${RCOW_LVS_NAME}' has no namespace; it cannot be attached without knowing \
 which bucket it lives in"
 
-	if ! printf '%s\n' "${COS_BUCKETS}" | grep -qxF "${LVS_NS}"; then
+	if ! printf '%s\n' "${S3_BUCKETS}" | grep -qxF "${LVS_NS}"; then
 		bail "'${RCOW_LVS_NAME}' lives in namespace '${LVS_NS}', which is not \
-among the buckets in ${RCOW_COS_CFG}. Attaching it against a different bucket \
+among the buckets in ${RCOW_S3_CFG}. Attaching it against a different bucket \
 would read someone else's metadata"
 	fi
 
@@ -346,7 +346,7 @@ else
 	[ "${DO_CREATE}" -eq 1 ] || bail "no ${RCOW_BSTORE_FILE} entry for \
 '${RCOW_LVS_NAME}' and --no-create was given"
 
-	LVS_NS="$(printf '%s\n' "${COS_BUCKETS}" | head -1)"
+	LVS_NS="$(printf '%s\n' "${S3_BUCKETS}" | head -1)"
 
 	rcow_log "no entry in ${RCOW_BSTORE_FILE}: creating a new lvstore in \
 namespace ${LVS_NS}, capacity ${RCOW_CAPACITY_GB} GiB, journal \

--- a/CubeS3lvol/scripts/rpc.py
+++ b/CubeS3lvol/scripts/rpc.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+#  Entry point used by rcow_srpc in both the source checkout and the release
+#  package. Applies the 3.8 stdlib shim, then runs SPDK's rpc.py unchanged:
+#
+#    package:  scripts/spdk_rpc.py   (copied by make_release.sh)
+#    repo:     $SPDK_ROOT/scripts/rpc.py
+#
+#  argv is forwarded as-is so existing `rpc.py -s sock -t 5 spdk_get_version`
+#  callers do not change.
+#
+#  S3LVOL_RPC_DISABLE_FALLBACKS: test-only. When set to a non-empty value,
+#  skip the machine-level search (deps/spdk, /opt/s3lvol-spdk, ../spdk,
+#  /data/home/cow/spdk) so a suite can assert the missing-upstream error
+#  even inside the builder image. Sibling, SPDK_RPC_PY, and SPDK_ROOT
+#  still win. Do not set this in a deployment.
+
+import os
+import runpy
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+_packaged_python = os.path.join(HERE, 'python')
+if os.path.isdir(_packaged_python):
+    sys.path.insert(0, _packaged_python)
+
+import rpc_compat  # noqa: E402  # patches argparse before SPDK rpc.py imports it
+
+
+def _existing(path):
+    return path if path and os.path.isfile(path) else ''
+
+
+def find_upstream_rpc_py():
+    sibling = _existing(os.path.join(HERE, 'spdk_rpc.py'))
+    if sibling:
+        return sibling
+
+    env_rpc = _existing(os.environ.get('SPDK_RPC_PY', ''))
+    if env_rpc:
+        return env_rpc
+
+    spdk_root = os.environ.get('SPDK_ROOT', '')
+    from_root = _existing(os.path.join(spdk_root, 'scripts', 'rpc.py')) if spdk_root else ''
+    if from_root:
+        return from_root
+
+    if not os.environ.get('S3LVOL_RPC_DISABLE_FALLBACKS'):
+        repo_root = os.path.dirname(HERE)
+        for candidate in (
+                os.path.join(repo_root, 'deps', 'spdk', 'scripts', 'rpc.py'),
+                '/opt/s3lvol-spdk/scripts/rpc.py',
+                os.path.join(repo_root, '..', 'spdk', 'scripts', 'rpc.py'),
+                '/data/home/cow/spdk/scripts/rpc.py',
+        ):
+            found = _existing(os.path.abspath(candidate))
+            if found:
+                return found
+
+    sys.stderr.write(
+        'cannot find SPDK rpc.py: expected scripts/spdk_rpc.py in a package, '
+        'or SPDK_ROOT/scripts/rpc.py in a checkout\n')
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    runpy.run_path(find_upstream_rpc_py(), run_name='__main__')

--- a/CubeS3lvol/scripts/rpc_compat.py
+++ b/CubeS3lvol/scripts/rpc_compat.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+#  Stdlib gaps that SPDK's unmodified rpc.py assumes.
+#
+#  Ubuntu 20.04 ships Python 3.8. SPDK v26.09-pre rpc.py uses
+#  argparse.BooleanOptionalAction, which landed in 3.9. Without this backfill
+#  rcow_wait_rpc treats every probe as "target not answering" and the unit
+#  crash-loops. 3.9+ is a no-op: only missing attributes are filled in.
+#
+#  Semantics match CPython 3.9: --foo sets True, --no-foo sets False.
+
+import argparse
+
+
+def _boolean_optional_action():
+    class BooleanOptionalAction(argparse.Action):
+        def __init__(self,
+                     option_strings,
+                     dest,
+                     default=None,
+                     type=None,
+                     choices=None,
+                     required=False,
+                     help=None,
+                     metavar=None):
+            strings = []
+            for option_string in option_strings:
+                strings.append(option_string)
+                if option_string.startswith('--'):
+                    strings.append('--no-' + option_string[2:])
+            super().__init__(
+                option_strings=strings,
+                dest=dest,
+                nargs=0,
+                default=default,
+                type=type,
+                choices=choices,
+                required=required,
+                help=help,
+                metavar=metavar)
+
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest,
+                    not str(option_string).startswith('--no-'))
+
+        def format_usage(self):
+            return ' | '.join(self.option_strings)
+
+    return BooleanOptionalAction
+
+
+def apply():
+    if not hasattr(argparse, 'BooleanOptionalAction'):
+        argparse.BooleanOptionalAction = _boolean_optional_action()
+
+
+apply()

--- a/CubeS3lvol/test/README.md
+++ b/CubeS3lvol/test/README.md
@@ -21,8 +21,8 @@ test/run_all.sh --no-dataplane  # both integration layers, no dataplane
 The reason `run_all.sh` exists is that the suites' preconditions had drifted
 apart: ten integration tests run anywhere, two need real credentials, ten
 dataplane scripts need root + credentials + a writable `/data` + exclusive use
-of the machine's nvme stack; and the arguments differ too (four take
-`-e/-b/-r`, six read `cos.cfg` themselves). So "run the tests" had become
+of the machine's nvme stack; and the arguments differ too (seven take
+`-e/-b/-r`, six read `s3.cfg` themselves). So "run the tests" had become
 "remember twenty-two invocations", and in practice meant running only the two
 or three related to whatever had just changed.
 
@@ -144,7 +144,7 @@ export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
 ./test/dataplane/run_recovery_test.sh  -e cos.ap-nanjing.myqcloud.com -b <bucket> -r ap-nanjing
 ./test/dataplane/run_snapshot_test.sh  -e cos.ap-nanjing.myqcloud.com -b <bucket> -r ap-nanjing
 ./test/dataplane/run_export_test.sh    -e cos.ap-nanjing.myqcloud.com -b <bucket> -r ap-nanjing
-./test/dataplane/run_selfimport_test.sh    # reads /data/cubelet/cos.cfg, no arguments
+./test/dataplane/run_selfimport_test.sh    # reads /data/cubelet/s3.cfg, no arguments
 ./test/dataplane/run_snapdelete_test.sh    # same
 ./test/dataplane/run_activation_test.sh    # same
 ./test/dataplane/run_fs_test.sh            # same; really does mkfs.xfs + mount
@@ -443,8 +443,8 @@ export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
   next round red while **the round that actually produced it shows all green**,
   wrong on both ends.
 
-Common conventions of the dataplane scripts (four of them take `-e/-b/-r`
-arguments, the other six read `/data/cubelet/cos.cfg` themselves):
+Common conventions of the dataplane scripts (seven take `-e/-b/-r`
+arguments, the other six read `/data/cubelet/s3.cfg` themselves):
 
 | Environment variable | Effect |
 |----------|------|

--- a/CubeS3lvol/test/dataplane/run_activation_test.sh
+++ b/CubeS3lvol/test/dataplane/run_activation_test.sh
@@ -25,7 +25,7 @@ SPDK_RPC_PY="${SPDK_ROOT}/scripts/rpc.py"
 SPDK_RPC="${SPDK_RPC_PY} -s /var/run/s3lvol.sock"
 PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
 TGT="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
-COS_CFG="${RCOW_COS_CFG:-/data/cubelet/cos.cfg}"
+S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
 ACTIVE_FILE=/data/cubelet/rcow/active_lvols
 
 LVS=actprobe
@@ -44,11 +44,11 @@ info() { echo "  ---- $*"; }
 TGT_PID=""
 declare -a CONNECTED_NQNS=()
 
-cfg() { sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*/\1/p" "${COS_CFG}" | head -1; }
-ENDPOINT="$(cfg cos_endpoint)"; REGION="$(cfg region)"
-BUCKET="$(sed -n 's/^[[:space:]]*cos_bucket_name[[:space:]]*=[[:space:]]*\[\(.*\)\].*/\1/p' "${COS_CFG}" | head -1 | tr ',' '\n' | sed -n 's/^[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
-export AWS_ACCESS_KEY_ID="$(cfg secretid)"
-export AWS_SECRET_ACCESS_KEY="$(cfg secretkey)"
+cfg() { sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*/\1/p" "${S3_CFG}" | head -1; }
+ENDPOINT="$(cfg endpoint)"; REGION="$(cfg region)"
+BUCKET="$(sed -n 's/^[[:space:]]*buckets[[:space:]]*=[[:space:]]*\[\(.*\)\].*/\1/p' "${S3_CFG}" | head -1 | tr ',' '\n' | sed -n 's/^[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+export AWS_ACCESS_KEY_ID="$(cfg access_key_id)"
+export AWS_SECRET_ACCESS_KEY="$(cfg secret_access_key)"
 
 cleanup() {
 	echo ""
@@ -86,8 +86,8 @@ trap cleanup EXIT
 # --------------------------------------------------------------------------
 echo "=== [1] target, lvstore, volumes"
 [ -x "${TGT}" ] || { echo "target not built: ${TGT}" >&2; exit 1; }
-[ -r "${COS_CFG}" ] || {
-	echo "no COS config at ${COS_CFG}; set RCOW_COS_CFG to point at one" >&2
+[ -r "${S3_CFG}" ] || {
+	echo "no S3 config at ${S3_CFG}; set RCOW_S3_CFG to point at one" >&2
 	exit 1
 }
 if [ -z "${S3LVOL_SKIP_FRESH_CHECK:-}" ]; then
@@ -95,7 +95,7 @@ if [ -z "${S3LVOL_SKIP_FRESH_CHECK:-}" ]; then
 fi
 if [ -z "${ENDPOINT}" ] || [ -z "${BUCKET}" ] || \
    [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-	echo "could not parse endpoint/bucket/credentials from ${COS_CFG}" >&2
+	echo "could not parse endpoint/bucket/credentials from ${S3_CFG}" >&2
 	exit 1
 fi
 # -x, not -f: matching the whole command line makes any process that merely
@@ -128,7 +128,7 @@ if [ -z "${S3LVOL_TEST_S3FLAGS:-}" ]; then
 	[ "${S3LVOL_TEST_PATH_STYLE:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --path-style"
 	[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --no-tls"
 fi
-"${RPC}" rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+"${RPC}" rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 	"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" >/dev/null || exit 1
 "${RPC}" rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":8,"wal_bdev":"%s","journal_size_mb":64,"wal_size_mb":128}' \
 	"${LVS}" "${BUCKET}" "${WAL_BDEV}")" >/dev/null || exit 1

--- a/CubeS3lvol/test/dataplane/run_agent_template_test.sh
+++ b/CubeS3lvol/test/dataplane/run_agent_template_test.sh
@@ -412,9 +412,9 @@ if [ -z "${S3LVOL_TEST_S3FLAGS:-}" ]; then
 	[ "${S3LVOL_TEST_PATH_STYLE:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --path-style"
 	[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --no-tls"
 fi
-rpc_a rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+rpc_a rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 	"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" >/dev/null 2>&1 \
-	|| { fail "A add_cos_config"; exit 1; }
+	|| { fail "A add_s3_config"; exit 1; }
 rpc_a rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":%d,"wal_bdev":"%s","journal_size_mb":%d,"wal_size_mb":%d}' \
 	"${LVS_A}" "${BUCKET}" "${CAPACITY_GIB}" "${WAL_A_BDEV}" \
 	"${JOURNAL_MB}" "${WAL_MB}")" >/dev/null 2>&1 \
@@ -614,9 +614,9 @@ EXPECTED="$( { echo "${TMPL_MANIFEST}"; echo "${AGENT_MANIFEST}"; } | sort -u )"
 echo ""
 echo "[4] B: import and verify the data"
 
-rpc_b rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+rpc_b rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 	"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" >/dev/null 2>&1 \
-	|| { fail "B add_cos_config"; exit 1; }
+	|| { fail "B add_s3_config"; exit 1; }
 rpc_b rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":%d,"wal_bdev":"%s","journal_size_mb":%d,"wal_size_mb":%d}' \
 	"${LVS_B}" "${BUCKET}" "${CAPACITY_GIB}" "${WAL_B_BDEV}" \
 	"${JOURNAL_MB}" "${WAL_MB}")" >/dev/null 2>&1 \

--- a/CubeS3lvol/test/dataplane/run_control_test.sh
+++ b/CubeS3lvol/test/dataplane/run_control_test.sh
@@ -41,7 +41,7 @@
 #  Usage:
 #    sudo -E ./test/dataplane/run_control_test.sh
 #
-#  Needs root (the target, nvme connect) and a readable /data/cubelet/cos.cfg.
+#  Needs root (the target, nvme connect) and a readable /data/cubelet/s3.cfg.
 
 set -u
 
@@ -65,7 +65,7 @@ export RCOW_RUN_DIR=/var/tmp/rcow_ctltest
 # outside it and shared with every other instance on the host -- so the wipe missed
 # and a crash from hours earlier was reported as this run's failure.
 export RCOW_LOG_DIR=/var/tmp/rcow_ctltest/log
-export RCOW_COS_CFG="${RCOW_COS_CFG:-/data/cubelet/cos.cfg}"
+export RCOW_S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
 
 # This suite's own registries, not the host's. They used to be the compiled-in
 # /var/tmp paths, shared with every instance on the machine -- and cleanup below
@@ -161,9 +161,9 @@ cleanup()
 
 	# Whatever the target did not remove.
 	if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
-		ENDPOINT="$(rcow_cfg_get cos_endpoint)"
+		ENDPOINT="$(rcow_cfg_get endpoint)"
 		REGION="$(rcow_cfg_get region)"
-		BUCKET="$(rcow_cos_buckets | head -1)"
+		BUCKET="$(rcow_s3_buckets | head -1)"
 		rcow_load_credentials
 		python3 "${PREFIX_RM}" -e "${ENDPOINT}" -b "${BUCKET}" -r "${REGION}" \
 			-p "${RCOW_LVS_NAME}/" 2>&1 | tail -1
@@ -194,7 +194,7 @@ echo "=== [0] preconditions"
 
 [ "$(id -u)" -eq 0 ] || { echo "must run as root" >&2; exit 1; }
 [ -x "${ROOT}/app/s3lvol_tgt/s3lvol_tgt" ] || { echo "target not built" >&2; exit 1; }
-[ -r "${RCOW_COS_CFG}" ] || { echo "no COS config at ${RCOW_COS_CFG}" >&2; exit 1; }
+[ -r "${RCOW_S3_CFG}" ] || { echo "no S3 config at ${RCOW_S3_CFG}" >&2; exit 1; }
 command -v nvme >/dev/null || { echo "nvme-cli is required" >&2; exit 1; }
 
 # The registry is this suite's own now, so a stale one is leftover state rather

--- a/CubeS3lvol/test/dataplane/run_dataplane_test.sh
+++ b/CubeS3lvol/test/dataplane/run_dataplane_test.sh
@@ -596,10 +596,10 @@ if [ -z "${S3LVOL_TEST_S3FLAGS:-}" ]; then
 	[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --no-tls"
 fi
 
-if ! raw_rpc rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+if ! raw_rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" \
 		>/dev/null 2>"${WORKDIR}/cos_config.err"; then
-	fail "rcow_add_cos_config"
+	fail "rcow_add_s3_config"
 	sed 's/^/       /' "${WORKDIR}/cos_config.err"
 	exit 1
 fi

--- a/CubeS3lvol/test/dataplane/run_decouple_queue_test.sh
+++ b/CubeS3lvol/test/dataplane/run_decouple_queue_test.sh
@@ -296,10 +296,10 @@ if [ -z "${S3LVOL_TEST_S3FLAGS:-}" ]; then
 	[ "${S3LVOL_TEST_PATH_STYLE:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --path-style"
 	[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --no-tls"
 fi
-raw_rpc rcow_add_cos_config \
+raw_rpc rcow_add_s3_config \
 	"$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" >/dev/null 2>&1 \
-	|| { fail "add_cos_config"; exit 1; }
+	|| { fail "add_s3_config"; exit 1; }
 raw_rpc rcow_create_lvstore \
 	"$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":%d,"wal_bdev":"%s","journal_size_mb":%d,"wal_size_mb":%d}' \
 		"${SRC_LVS}" "${BUCKET}" "${CAPACITY_GIB}" "${SRC_WAL_BDEV}" \

--- a/CubeS3lvol/test/dataplane/run_export_test.sh
+++ b/CubeS3lvol/test/dataplane/run_export_test.sh
@@ -628,7 +628,7 @@ echo "[2] creating the source volume and writing pattern A"
 # Register the namespace once. The namespace is the bucket name, which is the
 # simplest mapping and the one the startup script will use until the mapping
 # service is added.
-# A path-style, plain-HTTP backend (MinIO in CI) is configured in cos.cfg and
+# A path-style, plain-HTTP backend (MinIO in CI) is configured in s3.cfg and
 # exported by run_all.sh; fold the two flags into the registration.
 S3LVOL_EXTRA_JSON=""
 [ "${S3LVOL_TEST_PATH_STYLE:-0}" -eq 1 ] && S3LVOL_EXTRA_JSON+=',"path_style":true'
@@ -642,10 +642,10 @@ if [ -z "${S3LVOL_TEST_S3FLAGS:-}" ]; then
 	[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --no-tls"
 fi
 
-if ! raw_rpc rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+if ! raw_rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" \
 		>/dev/null 2>"${WORKDIR}/cos_config.err"; then
-	fail "rcow_add_cos_config"
+	fail "rcow_add_s3_config"
 	sed 's/^/       /' "${WORKDIR}/cos_config.err"
 	exit 1
 fi

--- a/CubeS3lvol/test/dataplane/run_fs_test.sh
+++ b/CubeS3lvol/test/dataplane/run_fs_test.sh
@@ -98,7 +98,7 @@
 #  Usage:
 #    sudo -E ./test/dataplane/run_fs_test.sh
 #
-#  Needs root (target, nvme connect, mount), a readable /data/cubelet/cos.cfg,
+#  Needs root (target, nvme connect, mount), a readable /data/cubelet/s3.cfg,
 #  nvme-cli and xfsprogs.
 
 set -u
@@ -119,7 +119,7 @@ export RCOW_WAL_MB=256
 export RCOW_TGT_MEM_MB=2048
 export RCOW_RUN_DIR=/var/tmp/rcow_fstest
 export RCOW_LOG_DIR=/var/tmp/rcow_fstest/log
-export RCOW_COS_CFG="${RCOW_COS_CFG:-/data/cubelet/cos.cfg}"
+export RCOW_S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
 
 # This suite's own registries, not the host's. They used to be the compiled-in
 # /var/tmp paths, shared with every instance on the machine -- and cleanup below
@@ -259,9 +259,9 @@ cleanup()
 	[ "${STARTED}" -eq 1 ] && "${SCRIPTS}/rcow_stop.sh" --force >/dev/null 2>&1
 
 	if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
-		ENDPOINT="$(rcow_cfg_get cos_endpoint)"
+		ENDPOINT="$(rcow_cfg_get endpoint)"
 		REGION="$(rcow_cfg_get region)"
-		BUCKET="$(rcow_cos_buckets | head -1)"
+		BUCKET="$(rcow_s3_buckets | head -1)"
 		rcow_load_credentials
 		python3 "${PREFIX_RM}" -e "${ENDPOINT}" -b "${BUCKET}" \
 			-r "${REGION}" -p "${RCOW_LVS_NAME}/" 2>&1 | tail -1
@@ -292,7 +292,7 @@ echo "=== [0] preconditions"
 
 [ "$(id -u)" -eq 0 ] || { echo "must run as root" >&2; exit 1; }
 [ -x "${ROOT}/app/s3lvol_tgt/s3lvol_tgt" ] || { echo "target not built" >&2; exit 1; }
-[ -r "${RCOW_COS_CFG}" ] || { echo "no COS config at ${RCOW_COS_CFG}" >&2; exit 1; }
+[ -r "${RCOW_S3_CFG}" ] || { echo "no S3 config at ${RCOW_S3_CFG}" >&2; exit 1; }
 
 for tool in nvme mkfs.xfs xfs_freeze xfs_repair mountpoint md5sum python3; do
 	command -v "${tool}" >/dev/null 2>&1 || {

--- a/CubeS3lvol/test/dataplane/run_guards_test.sh
+++ b/CubeS3lvol/test/dataplane/run_guards_test.sh
@@ -45,7 +45,7 @@
 #  Usage:
 #    sudo -E ./test/dataplane/run_guards_test.sh
 #
-#  Needs root, a readable /data/cubelet/cos.cfg and nvme-cli. Uses its own lvstore
+#  Needs root, a readable /data/cubelet/s3.cfg and nvme-cli. Uses its own lvstore
 #  name, WAL image and registries, so a production instance is untouched.
 
 set -u
@@ -65,7 +65,7 @@ export RCOW_WAL_MB=256
 export RCOW_TGT_MEM_MB=2048
 export RCOW_RUN_DIR=/var/tmp/rcow_guardtest
 export RCOW_LOG_DIR=/var/tmp/rcow_guardtest/log
-export RCOW_COS_CFG="${RCOW_COS_CFG:-/data/cubelet/cos.cfg}"
+export RCOW_S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
 
 # The point of guard 1: this suite's own registries, under its own run directory.
 export RCOW_ACTIVE_FILE=/var/tmp/rcow_guardtest/active_lvols
@@ -116,7 +116,7 @@ cleanup()
 
 	if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
 		rcow_load_credentials
-		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get cos_endpoint)" -b "${BUCKET}" \
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "${BUCKET}" \
 			-r "$(rcow_cfg_get region)" -p "${RCOW_LVS_NAME}/" 2>&1 | tail -1
 		rm -f "${RCOW_WAL_IMG}"
 		rm -rf "${RCOW_RUN_DIR}" "${WORKDIR}"
@@ -141,11 +141,11 @@ echo "=== [0] preconditions"
 
 [ "$(id -u)" -eq 0 ] || { echo "must run as root" >&2; exit 1; }
 [ -x "${ROOT}/app/s3lvol_tgt/s3lvol_tgt" ] || { echo "target not built" >&2; exit 1; }
-[ -r "${RCOW_COS_CFG}" ] || { echo "no COS config at ${RCOW_COS_CFG}" >&2; exit 1; }
+[ -r "${RCOW_S3_CFG}" ] || { echo "no S3 config at ${RCOW_S3_CFG}" >&2; exit 1; }
 command -v nvme >/dev/null || { echo "nvme-cli is required" >&2; exit 1; }
 [ -n "$(rcow_target_instances)" ] && { echo "a target is already running" >&2; exit 1; }
 
-BUCKET="$(rcow_cos_buckets | head -1)"
+BUCKET="$(rcow_s3_buckets | head -1)"
 WORKDIR="$(mktemp -d /tmp/rcow_guard.XXXXXX)"
 
 rm -rf "${RCOW_RUN_DIR}"

--- a/CubeS3lvol/test/dataplane/run_recovery_test.sh
+++ b/CubeS3lvol/test/dataplane/run_recovery_test.sh
@@ -547,10 +547,10 @@ if [ -z "${S3LVOL_TEST_S3FLAGS:-}" ]; then
 	[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --no-tls"
 fi
 
-if ! raw_rpc rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+if ! raw_rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" \
 		>/dev/null 2>"${WORKDIR}/cos_config.err"; then
-	fail "rcow_add_cos_config"
+	fail "rcow_add_s3_config"
 	sed 's/^/       /' "${WORKDIR}/cos_config.err"
 	exit 1
 fi
@@ -657,10 +657,10 @@ echo "[round 2] attach, verify A, write pattern B, then SIGKILL"
 start_target || exit 1
 attach_local_dev || exit 1
 
-if ! raw_rpc rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+if ! raw_rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" \
 		>/dev/null 2>"${WORKDIR}/cos_config_r2.err"; then
-	fail "rcow_add_cos_config (round 2)"
+	fail "rcow_add_s3_config (round 2)"
 	exit 1
 fi
 
@@ -822,10 +822,10 @@ echo "[round 3] attach after the crash and verify both patterns"
 start_target || exit 1
 attach_local_dev || exit 1
 
-if ! raw_rpc rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+if ! raw_rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" \
 		>/dev/null 2>"${WORKDIR}/cos_config_r3.err"; then
-	fail "rcow_add_cos_config (round 3)"
+	fail "rcow_add_s3_config (round 3)"
 	exit 1
 fi
 

--- a/CubeS3lvol/test/dataplane/run_selfimport_test.sh
+++ b/CubeS3lvol/test/dataplane/run_selfimport_test.sh
@@ -47,7 +47,7 @@
 #  Usage:
 #    sudo -E ./test/dataplane/run_selfimport_test.sh
 #
-#  Needs root, a readable /data/cubelet/cos.cfg, and nvme-cli.
+#  Needs root, a readable /data/cubelet/s3.cfg, and nvme-cli.
 
 set -u
 
@@ -68,7 +68,7 @@ export RCOW_RUN_DIR=/var/tmp/rcow_selfimport
 export RCOW_LOG_DIR=/var/tmp/rcow_selfimport/log
 export RCOW_ACTIVE_FILE=/var/tmp/rcow_selfimport/active_lvols
 export RCOW_BSTORE_FILE=/var/tmp/rcow_selfimport/bstore.json
-export RCOW_COS_CFG="${RCOW_COS_CFG:-/data/cubelet/cos.cfg}"
+export RCOW_S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
 
 PASS=0; FAIL=0
 pass() { PASS=$((PASS+1)); echo "  [PASS] $*"; }
@@ -220,7 +220,7 @@ cleanup()
 
 	if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
 		rcow_load_credentials
-		EP="$(rcow_cfg_get cos_endpoint)"; RG="$(rcow_cfg_get region)"
+		EP="$(rcow_cfg_get endpoint)"; RG="$(rcow_cfg_get region)"
 		python3 "${PREFIX_RM}" -e "${EP}" -b "${BUCKET}" -r "${RG}" \
 			-p "${RCOW_LVS_NAME}/" 2>&1 | tail -1
 		# exports/ is bucket-level and shared, so only this run's manifests.
@@ -245,11 +245,11 @@ echo "=== [0] preconditions"
 
 [ "$(id -u)" -eq 0 ] || { echo "must run as root" >&2; exit 1; }
 [ -x "${ROOT}/app/s3lvol_tgt/s3lvol_tgt" ] || { echo "target not built" >&2; exit 1; }
-[ -r "${RCOW_COS_CFG}" ] || { echo "no COS config" >&2; exit 1; }
+[ -r "${RCOW_S3_CFG}" ] || { echo "no S3 config" >&2; exit 1; }
 command -v nvme >/dev/null || { echo "nvme-cli is required" >&2; exit 1; }
 [ -n "$(rcow_target_instances)" ] && { echo "a target is already running" >&2; exit 1; }
 
-BUCKET="$(rcow_cos_buckets | head -1)"
+BUCKET="$(rcow_s3_buckets | head -1)"
 WORKDIR="$(mktemp -d /tmp/rcow_selfimp.XXXXXX)"
 rm -rf "${RCOW_RUN_DIR}"; mkdir -p "${RCOW_RUN_DIR}"
 rm -f "${RCOW_WAL_IMG}"; truncate -s 1G "${RCOW_WAL_IMG}"

--- a/CubeS3lvol/test/dataplane/run_snapdelete_test.sh
+++ b/CubeS3lvol/test/dataplane/run_snapdelete_test.sh
@@ -54,7 +54,7 @@
 #  Usage:
 #    sudo -E ./test/dataplane/run_snapdelete_test.sh
 #
-#  Needs root, a readable /data/cubelet/cos.cfg and nvme-cli. Uses its own lvstore,
+#  Needs root, a readable /data/cubelet/s3.cfg and nvme-cli. Uses its own lvstore,
 #  WAL image and registries, so a production instance is untouched.
 
 set -u
@@ -76,7 +76,7 @@ export RCOW_RUN_DIR=/var/tmp/rcow_snapdel
 export RCOW_LOG_DIR=/var/tmp/rcow_snapdel/log
 export RCOW_ACTIVE_FILE=/var/tmp/rcow_snapdel/active_lvols
 export RCOW_BSTORE_FILE=/var/tmp/rcow_snapdel/bstore.json
-export RCOW_COS_CFG="${RCOW_COS_CFG:-/data/cubelet/cos.cfg}"
+export RCOW_S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
 
 VOL=v
 REGION_MB=4
@@ -186,7 +186,7 @@ except Exception:
 
 	if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
 		rcow_load_credentials
-		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get cos_endpoint)" -b "${BUCKET}" \
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "${BUCKET}" \
 			-r "$(rcow_cfg_get region)" -p "${RCOW_LVS_NAME}/" 2>&1 | tail -1
 		rm -f "${RCOW_WAL_IMG}"
 		rm -rf "${RCOW_RUN_DIR}" "${WORKDIR}"
@@ -205,11 +205,11 @@ echo "=== [0] preconditions"
 
 [ "$(id -u)" -eq 0 ] || { echo "must run as root" >&2; exit 1; }
 [ -x "${ROOT}/app/s3lvol_tgt/s3lvol_tgt" ] || { echo "target not built" >&2; exit 1; }
-[ -r "${RCOW_COS_CFG}" ] || { echo "no COS config" >&2; exit 1; }
+[ -r "${RCOW_S3_CFG}" ] || { echo "no S3 config" >&2; exit 1; }
 command -v nvme >/dev/null || { echo "nvme-cli is required" >&2; exit 1; }
 [ -n "$(rcow_target_instances)" ] && { echo "a target is already running" >&2; exit 1; }
 
-BUCKET="$(rcow_cos_buckets | head -1)"
+BUCKET="$(rcow_s3_buckets | head -1)"
 WORKDIR="$(mktemp -d /tmp/rcow_snapdel.XXXXXX)"
 rm -rf "${RCOW_RUN_DIR}"; mkdir -p "${RCOW_RUN_DIR}"
 rm -f "${RCOW_WAL_IMG}"; truncate -s 1G "${RCOW_WAL_IMG}"

--- a/CubeS3lvol/test/dataplane/run_snapshot_test.sh
+++ b/CubeS3lvol/test/dataplane/run_snapshot_test.sh
@@ -409,10 +409,10 @@ if [ -z "${S3LVOL_TEST_S3FLAGS:-}" ]; then
 	[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --no-tls"
 fi
 
-if ! raw_rpc rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+if ! raw_rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" \
 		>/dev/null 2>"${WORKDIR}/cos_config.err"; then
-	fail "rcow_add_cos_config"
+	fail "rcow_add_s3_config"
 	sed 's/^/       /' "${WORKDIR}/cos_config.err"
 	exit 1
 fi

--- a/CubeS3lvol/test/dataplane/run_srcdel_test.sh
+++ b/CubeS3lvol/test/dataplane/run_srcdel_test.sh
@@ -503,10 +503,10 @@ if [ -z "${S3LVOL_TEST_S3FLAGS:-}" ]; then
 	[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --no-tls"
 fi
 
-if ! raw_rpc rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+if ! raw_rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
 		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" \
 		>/dev/null 2>"${WORKDIR}/cos_config.err"; then
-	fail "rcow_add_cos_config"
+	fail "rcow_add_s3_config"
 	sed 's/^/       /' "${WORKDIR}/cos_config.err"
 	exit 1
 fi

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -6,7 +6,7 @@
 #  things. Ten integration tests run anywhere; two more want real S3 credentials;
 #  ten dataplane scripts want root, credentials, a writable /data, and exclusive
 #  use of the machine's nvme stack. Their arguments differ too -- four take
-#  -e/-b/-r, six read /data/cubelet/cos.cfg themselves. So "run the tests" meant
+#  -e/-b/-r, six read /data/cubelet/s3.cfg themselves. So "run the tests" meant
 #  remembering twenty-two invocations, and in practice meant running the two or
 #  three related to whatever had just changed.
 #
@@ -48,9 +48,9 @@
 #    test/run_all.sh --list          show what would run, run nothing
 #
 #  Environment:
-#    S3LVOL_TEST_BUCKET   override the bucket taken from cos.cfg
+#    S3LVOL_TEST_BUCKET   override the bucket taken from s3.cfg
 #    AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
-#                         used as-is when set; otherwise read from cos.cfg
+#                         used as-is when set; otherwise read from s3.cfg
 #
 
 set -u
@@ -59,7 +59,7 @@ SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SELF_DIR}/.." && pwd)"
 cd "${ROOT}" || exit 1
 
-COS_CFG="${RCOW_COS_CFG:-/data/cubelet/cos.cfg}"
+S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
 
 MODE=all
 for arg in "$@"; do
@@ -188,11 +188,11 @@ HAVE_ROOT=0
 [ "$(id -u)" -eq 0 ] && HAVE_ROOT=1
 
 # Credentials: whatever is already exported wins, so a run can use a different
-# account than cos.cfg names without editing it.
+# account than s3.cfg names without editing it.
 HAVE_CREDS=0
 if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
 	HAVE_CREDS=1
-elif [ -r "${COS_CFG}" ]; then
+elif [ -r "${S3_CFG}" ]; then
 	# shellcheck source=../scripts/rcow_common.sh
 	. "${ROOT}/scripts/rcow_common.sh"
 	if rcow_load_credentials 2>/dev/null; then
@@ -201,9 +201,9 @@ elif [ -r "${COS_CFG}" ]; then
 fi
 
 ENDPOINT=""; BUCKET=""; REGION=""
-if [ -r "${COS_CFG}" ]; then
-	ENDPOINT="$(sed -n 's/^[[:space:]]*cos_endpoint[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "${COS_CFG}" | head -1)"
-	REGION="$(sed -n 's/^[[:space:]]*region[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "${COS_CFG}" | head -1)"
+if [ -r "${S3_CFG}" ]; then
+	ENDPOINT="$(sed -n 's/^[[:space:]]*endpoint[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "${S3_CFG}" | head -1)"
+	REGION="$(sed -n 's/^[[:space:]]*region[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "${S3_CFG}" | head -1)"
 fi
 
 # Kept out of a ${VAR:-$(...)} default: nesting a command substitution that
@@ -211,24 +211,24 @@ fi
 # quote parsing stops agreeing with the obvious reading, and it fails as a syntax
 # error at the end of the file rather than here.
 BUCKET="${S3LVOL_TEST_BUCKET:-}"
-if [ -z "${BUCKET}" ] && [ -r "${COS_CFG}" ]; then
-	BUCKET="$(sed -n 's/^[[:space:]]*cos_bucket_name[[:space:]]*=[[:space:]]*\[\(.*\)\].*/\1/p' "${COS_CFG}" |
+if [ -z "${BUCKET}" ] && [ -r "${S3_CFG}" ]; then
+	BUCKET="$(sed -n 's/^[[:space:]]*buckets[[:space:]]*=[[:space:]]*\[\(.*\)\].*/\1/p' "${S3_CFG}" |
 		head -1 | tr ',' '\n' |
 		sed -n 's/^[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 fi
 [ -n "${REGION}" ] || REGION=us-east-1
 
 # A path-style, plain-HTTP backend (MinIO in CI) has to be addressed
-# differently from the default virtual-hosted, HTTPS COS. The COS config may
+# differently from the default virtual-hosted, HTTPS S3. The S3 config may
 # carry both flags; whatever run_all.sh reads is exported so the dataplane
-# scripts fold it into their rcow_add_cos_config calls too.
+# scripts fold it into their rcow_add_s3_config calls too.
 S3LVOL_TEST_PATH_STYLE=0
 S3LVOL_TEST_NO_TLS=0
-if [ -r "${COS_CFG}" ]; then
+if [ -r "${S3_CFG}" ]; then
 	[ "$(sed -n 's/^[[:space:]]*path_style[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
-		"${COS_CFG}" | head -1)" = "true" ] && S3LVOL_TEST_PATH_STYLE=1
+		"${S3_CFG}" | head -1)" = "true" ] && S3LVOL_TEST_PATH_STYLE=1
 	[ "$(sed -n 's/^[[:space:]]*no_tls[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
-		"${COS_CFG}" | head -1)" = "true" ] && S3LVOL_TEST_NO_TLS=1
+		"${S3_CFG}" | head -1)" = "true" ] && S3LVOL_TEST_NO_TLS=1
 fi
 # The same two flags in the string form s3_prefix_rm.py takes, so count_objects
 # and remove_prefix in the dataplane scripts can address the backend identically.
@@ -309,7 +309,9 @@ echo ""
 # Integration, no S3
 # --------------------------------------------------------------------------
 echo "--- offline tools"
+run_suite s3_bucket_selftest python3 ./test/tools/s3_bucket.py --self-test
 run_suite isa_baseline ./test/tools/test_isa_baseline.sh
+run_suite rpc_py38_compat ./test/tools/test_rpc_py38_compat.sh
 echo ""
 
 echo "--- integration (no S3, no root)"
@@ -430,7 +432,7 @@ else
 		echo "--- dataplane (root, real S3, exclusive use of this machine)"
 		# activation and control last: they are the most sensitive to global
 		# state, so they are also the most useful check that the rest tidied
-		# up after themselves. They read cos.cfg on their own and take no
+		# up after themselves. They read s3.cfg on their own and take no
 		# arguments.
 		run_suite run_dataplane_test.sh \
 			./test/dataplane/run_dataplane_test.sh "${S3_ARGS[@]}"

--- a/CubeS3lvol/test/tools/s3_bucket.py
+++ b/CubeS3lvol/test/tools/s3_bucket.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+#  Create (or confirm) an S3 bucket. Pure stdlib, same bargain as
+#  s3_prefix_rm.py: no aws-cli, no boto3. Used by the one-click supervisor
+#  before rcow_start.sh, because s3lvol will not create the bucket itself.
+#
+#  === Usage ===
+#
+#    export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
+#    s3_bucket.py ensure -e 127.0.0.1:9000 -b cube-s3lvol -r us-east-1 \
+#                        --path-style --no-tls
+#
+#  Credentials from the environment only: argv is visible in ps.
+
+import argparse
+import datetime
+import hashlib
+import hmac
+import http.client
+import os
+import sys
+import urllib.parse
+import xml.etree.ElementTree as ET
+
+EMPTY_SHA = hashlib.sha256(b"").hexdigest()
+
+CREATE_BUCKET_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+    "<LocationConstraint>%s</LocationConstraint>"
+    "</CreateBucketConfiguration>"
+)
+
+
+def _sign(key, msg):
+    return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+
+def host_for(endpoint, bucket, path_style):
+    return endpoint if path_style else "%s.%s" % (bucket, endpoint)
+
+
+def path_for(bucket, path_style, extra=""):
+    # Virtual-hosted: canonical path is "/" (never empty -- SigV4 rejects "").
+    # Path-style: "/<bucket>" plus any extra (unused today).
+    if path_style:
+        base = "/%s" % bucket
+        return base + extra if extra else base
+    return extra if extra else "/"
+
+
+def payload_hash(body):
+    return hashlib.sha256(body).hexdigest()
+
+
+def sign_request(method, host, path, query, body, region, ak, sk, amzdate, datestamp):
+    """Return (authorization, payload_sha). Deterministic given amzdate."""
+    body = body if body is not None else b""
+    payload_sha = payload_hash(body)
+    canonical_headers = ("host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n"
+                         % (host, payload_sha, amzdate))
+    signed_headers = "host;x-amz-content-sha256;x-amz-date"
+    canonical_request = "\n".join([method, path, query, canonical_headers,
+                                   signed_headers, payload_sha])
+    scope = "%s/%s/s3/aws4_request" % (datestamp, region)
+    to_sign = "\n".join([
+        "AWS4-HMAC-SHA256", amzdate, scope,
+        hashlib.sha256(canonical_request.encode()).hexdigest()])
+    k = _sign(("AWS4" + sk).encode(), datestamp)
+    k = _sign(k, region)
+    k = _sign(k, "s3")
+    k = _sign(k, "aws4_request")
+    signature = hmac.new(k, to_sign.encode(), hashlib.sha256).hexdigest()
+    auth = ("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, "
+            "Signature=%s" % (ak, scope, signed_headers, signature))
+    return auth, payload_sha
+
+
+class Client:
+    def __init__(self, endpoint, bucket, region, path_style, ak, sk, no_tls=False):
+        self.bucket = bucket
+        self.region = region
+        self.path_style = path_style
+        self.no_tls = no_tls
+        self.ak = ak
+        self.sk = sk
+        self.host = host_for(endpoint, bucket, path_style)
+
+    def request(self, method, path, query="", body=b""):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        amzdate = now.strftime("%Y%m%dT%H%M%SZ")
+        datestamp = now.strftime("%Y%m%d")
+        body = body if body is not None else b""
+        auth, payload_sha = sign_request(
+            method, self.host, path, query, body, self.region,
+            self.ak, self.sk, amzdate, datestamp)
+
+        if self.no_tls:
+            conn = http.client.HTTPConnection(self.host, timeout=60)
+        else:
+            conn = http.client.HTTPSConnection(self.host, timeout=60)
+        try:
+            headers = {
+                "Host": self.host,
+                "x-amz-date": amzdate,
+                "x-amz-content-sha256": payload_sha,
+                "Authorization": auth,
+            }
+            if body:
+                headers["Content-Type"] = "application/xml"
+                headers["Content-Length"] = str(len(body))
+            conn.request(method, path + ("?" + query if query else ""),
+                         body=body, headers=headers)
+            resp = conn.getresponse()
+            return resp.status, resp.read()
+        finally:
+            conn.close()
+
+    def head_bucket(self):
+        return self.request("HEAD", path_for(self.bucket, self.path_style))
+
+    def put_bucket(self):
+        body = b""
+        if self.region and self.region not in ("us-east-1", "auto"):
+            body = (CREATE_BUCKET_XML % self.region).encode()
+        return self.request("PUT", path_for(self.bucket, self.path_style),
+                            body=body)
+
+
+def _already_exists(status, body):
+    if status in (200, 204):
+        return True
+    if status != 409:
+        return False
+    text = body.decode(errors="replace") if body else ""
+    return "BucketAlreadyOwnedByYou" in text or "BucketAlreadyExists" in text
+
+
+def ensure(client):
+    """HEAD then PUT. 200/403 on HEAD means the bucket is there (403 is a
+    common 'exists but HeadBucket is denied' response). 404 triggers create.
+    409 on create is treated as success."""
+    status, body = client.head_bucket()
+    if status in (200, 403):
+        return 0, "exists (HEAD %d)" % status
+    if status != 404:
+        return 1, "HEAD returned HTTP %d\n%s" % (
+            status, body[:800].decode(errors="replace"))
+
+    status, body = client.put_bucket()
+    if status in (200, 204) or _already_exists(status, body):
+        return 0, "created (PUT %d)" % status
+    return 1, "PUT returned HTTP %d\n%s" % (
+        status, body[:800].decode(errors="replace"))
+
+
+def self_test():
+    passed = 0
+    failed = 0
+
+    def check(name, cond, detail=""):
+        nonlocal passed, failed
+        if cond:
+            passed += 1
+            print("  [PASS] %s" % name)
+        else:
+            failed += 1
+            print("  [FAIL] %s%s" % (name, (" -- " + detail) if detail else ""))
+
+    check("path-style host is the endpoint",
+          host_for("127.0.0.1:9000", "cube-s3lvol", True) == "127.0.0.1:9000")
+    check("virtual-hosted host prefixes the bucket",
+          host_for("s3.amazonaws.com", "cube-s3lvol", False)
+          == "cube-s3lvol.s3.amazonaws.com")
+    check("path-style path is /bucket",
+          path_for("cube-s3lvol", True) == "/cube-s3lvol")
+    check("virtual-hosted path is / not empty",
+          path_for("cube-s3lvol", False) == "/")
+
+    ak = "AKIAIOSFODNN7EXAMPLE"
+    sk = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    amzdate = "20130524T000000Z"
+    datestamp = "20130524"
+    auth1, sha1 = sign_request(
+        "HEAD", "127.0.0.1:9000", "/cube-s3lvol", "", b"",
+        "us-east-1", ak, sk, amzdate, datestamp)
+    auth2, sha2 = sign_request(
+        "HEAD", "127.0.0.1:9000", "/cube-s3lvol", "", b"",
+        "us-east-1", ak, sk, amzdate, datestamp)
+    check("empty body hashes to EMPTY_SHA", sha1 == EMPTY_SHA)
+    check("signature is deterministic", auth1 == auth2)
+    check("authorization uses SigV4", auth1.startswith("AWS4-HMAC-SHA256 Credential="))
+
+    body = (CREATE_BUCKET_XML % "ap-guangzhou").encode()
+    _, sha_body = sign_request(
+        "PUT", "cos.ap-guangzhou.myqcloud.com", "/cube-s3lvol", "", body,
+        "ap-guangzhou", ak, sk, amzdate, datestamp)
+    check("non-empty body changes the payload hash", sha_body != EMPTY_SHA)
+    check("payload hash matches sha256(body)", sha_body == payload_hash(body))
+
+    # LocationConstraint XML must remain well-formed -- a typo here would
+    # create the bucket in the wrong region or fail the PUT.
+    try:
+        ET.fromstring(CREATE_BUCKET_XML % "ap-guangzhou")
+        xml_ok = True
+    except ET.ParseError:
+        xml_ok = False
+    check("CreateBucketConfiguration XML parses", xml_ok)
+
+    print("result: %d passed, %d failed" % (passed, failed))
+    return 0 if failed == 0 else 1
+
+
+def main():
+    p = argparse.ArgumentParser(description="ensure an S3 bucket exists")
+    p.add_argument("command", nargs="?", default="ensure",
+                   choices=("ensure",),
+                   help="ensure: HEAD then create if missing (default)")
+    p.add_argument("-e", "--endpoint", help="S3 endpoint host, no scheme")
+    p.add_argument("-b", "--bucket", help="bucket name")
+    p.add_argument("-r", "--region", default="us-east-1")
+    p.add_argument("--path-style", action="store_true")
+    p.add_argument("--no-tls", action="store_true")
+    p.add_argument("--self-test", action="store_true",
+                   help="run offline construction/signature checks and exit")
+    args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not args.endpoint or not args.bucket:
+        print("ensure needs -e/--endpoint and -b/--bucket", file=sys.stderr)
+        return 2
+
+    try:
+        ak = os.environ["AWS_ACCESS_KEY_ID"]
+        sk = os.environ["AWS_SECRET_ACCESS_KEY"]
+    except KeyError as e:
+        print("%s is not set" % e.args[0], file=sys.stderr)
+        return 2
+
+    client = Client(args.endpoint, args.bucket, args.region,
+                    args.path_style, ak, sk, no_tls=args.no_tls)
+    rc, msg = ensure(client)
+    print("%s: %s" % (args.bucket, msg), file=sys.stderr if rc else sys.stdout)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CubeS3lvol/test/tools/test_isa_baseline.sh
+++ b/CubeS3lvol/test/tools/test_isa_baseline.sh
@@ -13,6 +13,7 @@ SETUP="${ROOT}/setup_dep.sh"
 
 fail() {
 	echo "FAIL: $*" >&2
+	echo "result: 0 passed, 1 failed"
 	exit 1
 }
 
@@ -84,3 +85,4 @@ s3lvol_verify_portable_isa "${tmp}/ok" "${tmp}/okflags.h" \
 	|| fail "AVX2-only compile-time flags must pass the ISA gate"
 
 echo "isa baseline tests OK"
+echo "result: 14 passed, 0 failed"

--- a/CubeS3lvol/test/tools/test_rpc_py38_compat.sh
+++ b/CubeS3lvol/test/tools/test_rpc_py38_compat.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Offline tests for the rpc.py 3.8 launcher. Does not need SPDK or a target:
+# BooleanOptionalAction is stripped from argparse in-process so a 3.9 builder
+# still exercises the backfill that Ubuntu 20.04 needs.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LAUNCHER="${ROOT}/scripts/rpc.py"
+COMPAT="${ROOT}/scripts/rpc_compat.py"
+
+fail() {
+	echo "FAIL: $*" >&2
+	echo "result: 0 passed, 1 failed"
+	exit 1
+}
+
+[[ -f "${LAUNCHER}" ]] || fail "missing ${LAUNCHER}"
+[[ -f "${COMPAT}" ]] || fail "missing ${COMPAT}"
+
+python3 - "${ROOT}" <<'PY' || fail "rpc_compat backfill"
+import argparse
+import importlib
+import sys
+
+root = sys.argv[1]
+sys.path.insert(0, root + "/scripts")
+
+if hasattr(argparse, "BooleanOptionalAction"):
+    delattr(argparse, "BooleanOptionalAction")
+
+import rpc_compat
+importlib.reload(rpc_compat)
+
+if not hasattr(argparse, "BooleanOptionalAction"):
+    raise SystemExit("rpc_compat did not install BooleanOptionalAction")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--batch-mode", action=argparse.BooleanOptionalAction)
+ns = parser.parse_args(["--batch-mode"])
+if ns.batch_mode is not True:
+    raise SystemExit("--batch-mode must set True")
+ns = parser.parse_args(["--no-batch-mode"])
+if ns.batch_mode is not False:
+    raise SystemExit("--no-batch-mode must set False")
+print("rpc_compat backfill OK")
+PY
+
+tmp="$(mktemp -d)"
+cleanup() { rm -rf "${tmp}"; }
+trap cleanup EXIT
+
+cp "${LAUNCHER}" "${tmp}/rpc.py"
+cp "${COMPAT}" "${tmp}/rpc_compat.py"
+cat >"${tmp}/spdk_rpc.py" <<'PY'
+#!/usr/bin/env python3
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog="spdk_rpc_fake")
+parser.add_argument("-b", "--batch-mode", action=argparse.BooleanOptionalAction,
+                    help="batch")
+args = parser.parse_args()
+if "--help" in sys.argv:
+    parser.print_help()
+    sys.exit(0)
+print("fake-upstream-ok batch_mode=%s" % args.batch_mode)
+PY
+
+cat >"${tmp}/run_as_py38.py" <<'PY'
+"""Start rpc.py after removing BooleanOptionalAction, like CPython 3.8."""
+import argparse
+import runpy
+import sys
+
+if hasattr(argparse, "BooleanOptionalAction"):
+    delattr(argparse, "BooleanOptionalAction")
+sys.argv = sys.argv[1:]
+runpy.run_path(sys.argv[0], run_name="__main__")
+PY
+
+python3 - "${tmp}" <<'PY' || fail "launcher under stripped BooleanOptionalAction"
+import os
+import subprocess
+import sys
+
+tmp = sys.argv[1]
+env = os.environ.copy()
+env.pop("SPDK_ROOT", None)
+env.pop("SPDK_RPC_PY", None)
+runner = [sys.executable, os.path.join(tmp, "run_as_py38.py"),
+          os.path.join(tmp, "rpc.py")]
+
+help_out = subprocess.check_output(
+    runner + ["--help"], env=env, stderr=subprocess.STDOUT, text=True)
+if "batch" not in help_out:
+    raise SystemExit("launcher --help did not reach fake upstream: %r" % help_out)
+
+out = subprocess.check_output(
+    runner + ["--batch-mode"], env=env, stderr=subprocess.STDOUT, text=True)
+if "fake-upstream-ok batch_mode=True" not in out:
+    raise SystemExit("launcher did not exec sibling spdk_rpc.py: %r" % out)
+
+os.remove(os.path.join(tmp, "spdk_rpc.py"))
+env["S3LVOL_RPC_DISABLE_FALLBACKS"] = "1"
+proc = subprocess.run(
+    runner + ["--help"], env=env, stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT, text=True)
+if proc.returncode == 0:
+    raise SystemExit("launcher must fail when no upstream rpc.py is present")
+if "cannot find SPDK rpc.py" not in proc.stdout:
+    raise SystemExit("missing-upstream error unclear: %r" % proc.stdout)
+print("launcher sibling + missing-upstream OK")
+PY
+
+# Repo layout must use the launcher, not SPDK's rpc.py directly.
+# Pin RCOW_LVS_NAME so sourcing does not depend on hostname -s (empty in
+# some builder containers, and rcow_common.sh then exits 1).
+# shellcheck source=../../scripts/rcow_common.sh
+RCOW_LAYOUT_OUT="$(cd "${ROOT}/scripts" && RCOW_LVS_NAME=rpc-py38-compat bash -c '
+	source ./rcow_common.sh
+	echo "${RCOW_LAYOUT}|${RCOW_SPDK_RPC_PY}"
+')" || fail "sourcing rcow_common.sh failed"
+[[ "${RCOW_LAYOUT_OUT}" == "repo|${ROOT}/scripts/rpc.py" ]] \
+	|| fail "repo layout must resolve RCOW_SPDK_RPC_PY to the launcher (got ${RCOW_LAYOUT_OUT})"
+
+echo "rpc.py 3.8 compat tests OK"
+echo "result: 4 passed, 0 failed"

--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -241,6 +241,14 @@ role target:
 - **Enable/disable**: flip `ONE_CLICK_ENABLE_S3LVOL` to 1/0 in `.env` and
   re-run `install.sh` (or `systemctl enable/disable
   cube-sandbox-s3lvol.service` directly).
+- **S3 backend**: when enabled, `install.sh` writes `/data/cubelet/s3.cfg`
+  from `CUBE_S3_*` (bundled MinIO fill, or the operator's external store).
+  s3lvol uses its own bucket (`CUBE_S3LVOL_BUCKET`, default `cube-s3lvol`)
+  so it never shares prefixes with the volume plugin's `cube-volumes`.
+  The supervisor idempotently creates that bucket with a stdlib SigV4
+  tool — no awscli. A hand-written `s3.cfg` without the one-click sentinel
+  is left alone. There is **no fallback** from the old `/data/cubelet/cos.cfg`;
+  rename it and switch to the new field names.
 
 ### Digital Assistant Environment Variables
 
@@ -478,7 +486,7 @@ Conditional commands:
 - If the packaged `Cubelet/config/config.toml` enables `storage_backend = "cubecow"`, one-click also checks:
   `mkfs.ext4`, `mount`, `umount`, `losetup`
 - If `ONE_CLICK_ENABLE_S3LVOL=1` and the package ships `CubeS3lvol/bin/s3lvol_tgt`, one-click also checks:
-  `nvme` (nvme-cli), `python3`, `truncate`, and the shared libraries `s3lvol_tgt` links against (`ldd`; notably `libssl.so.1.1` / `libcrypto.so.1.1`, the OpenSSL 1.1 branch)
+  `nvme` (nvme-cli), `python3`, `truncate`, the shared libraries `s3lvol_tgt` links against (`ldd`; notably `libssl.so.1.1` / `libcrypto.so.1.1`, the OpenSSL 1.1 branch), and (x86_64) `avx2` in `/proc/cpuinfo`. Release `s3lvol_tgt` is built for Haswell/AVX2, not the packager's native CPU. `install.sh` installs `nvme-cli` via the system package manager when `nvme` is missing. `python3` must be able to run `CubeS3lvol/scripts/rpc.py --help` (Python 3.8 is enough; the packaged launcher supplies the 3.9 `argparse` bits SPDK's client needs).
 
 Recommended packages to satisfy the cubecow command set:
 
@@ -497,15 +505,15 @@ sudo dnf install -y e2fsprogs util-linux || \
 sudo yum install -y e2fsprogs util-linux
 ```
 
-Additional packages for `ONE_CLICK_ENABLE_S3LVOL=1`:
+Additional packages for `ONE_CLICK_ENABLE_S3LVOL=1` (libraries only; `nvme-cli` is installed by `install.sh`):
 
 ```bash
 # Debian / Ubuntu (OpenSSL 1.1 is usually already present; confirm with ldd)
-sudo apt-get install -y nvme-cli python3 libaio1 libnuma1 uuid-runtime
+sudo apt-get install -y python3 libaio1 libnuma1 uuid-runtime
 
 # OpenCloudOS / RHEL / CentOS (OpenSSL 3 needs compat-openssl11)
-sudo dnf install -y nvme-cli python3 libaio libnuma libuuid compat-openssl11 || \
-sudo yum install -y nvme-cli python3 libaio libnuma libuuid compat-openssl11
+sudo dnf install -y python3 libaio libnuma libuuid compat-openssl11 || \
+sudo yum install -y python3 libaio libnuma libuuid compat-openssl11
 ```
 
 ### Control Role (`install.sh`, default)
@@ -536,7 +544,7 @@ Conditional commands:
 - If the packaged `Cubelet/config/config.toml` enables `storage_backend = "cubecow"`, one-click also checks:
   `mkfs.ext4`, `mount`, `umount`, `losetup`
 - If `ONE_CLICK_ENABLE_S3LVOL=1` and the package ships `CubeS3lvol/bin/s3lvol_tgt`, one-click also checks:
-  `nvme` (nvme-cli), `python3`, `truncate`, and the shared libraries `s3lvol_tgt` links against (`ldd`; notably `libssl.so.1.1` / `libcrypto.so.1.1`, the OpenSSL 1.1 branch)
+  `nvme` (nvme-cli), `python3`, `truncate`, the shared libraries `s3lvol_tgt` links against (`ldd`; notably `libssl.so.1.1` / `libcrypto.so.1.1`, the OpenSSL 1.1 branch), and (x86_64) `avx2` in `/proc/cpuinfo`. Release `s3lvol_tgt` is built for Haswell/AVX2, not the packager's native CPU. `install.sh` installs `nvme-cli` via the system package manager when `nvme` is missing. `python3` must be able to run `CubeS3lvol/scripts/rpc.py --help` (Python 3.8 is enough; the packaged launcher supplies the 3.9 `argparse` bits SPDK's client needs).
 
 Recommended packages to satisfy the cubecow command set:
 
@@ -555,15 +563,15 @@ sudo dnf install -y e2fsprogs util-linux || \
 sudo yum install -y e2fsprogs util-linux
 ```
 
-Additional packages for `ONE_CLICK_ENABLE_S3LVOL=1`:
+Additional packages for `ONE_CLICK_ENABLE_S3LVOL=1` (libraries only; `nvme-cli` is installed by `install.sh`):
 
 ```bash
 # Debian / Ubuntu (OpenSSL 1.1 is usually already present; confirm with ldd)
-sudo apt-get install -y nvme-cli python3 libaio1 libnuma1 uuid-runtime
+sudo apt-get install -y python3 libaio1 libnuma1 uuid-runtime
 
 # OpenCloudOS / RHEL / CentOS (OpenSSL 3 needs compat-openssl11)
-sudo dnf install -y nvme-cli python3 libaio libnuma libuuid compat-openssl11 || \
-sudo yum install -y nvme-cli python3 libaio libnuma libuuid compat-openssl11
+sudo dnf install -y python3 libaio libnuma libuuid compat-openssl11 || \
+sudo yum install -y python3 libaio libnuma libuuid compat-openssl11
 ```
 
 ## Prerequisites

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -202,6 +202,7 @@ CubeS3lvol（s3lvol）作为 `cube-sandbox-*` 角色 target 的 `Wants=` 成员�
 - **停止（`down.sh` / `systemctl stop cube-sandbox-{control,compute}.target`）**：s3lvol 单元会走 `cube-s3lvol-stop.sh` 的**条件卸载**——target 进程存活时完整执行 `rcow_stop.sh`（断开 initiator → 卸载 lvstore/回刷 → 终止 target），target 已崩溃时只清理 target 侧残留、绝不断开 NVMf initiator。`down.sh` 只停止服务，**不删除任何数据**（`/data/cubelet/rcow/wal_bdev.img` 与 bstore 元数据保留），再次启动走 attach/replay 恢复。
 - **升级（`install.sh` 升级模式）**：旧 `CubeS3lvol/` 目录被替换（新二进制自动生效），随后 target 随角色 target 重启。`wal_bdev.img` **永不覆盖**（仅首次安装创建，其尺寸固定 journal/WAL 布局），`.one-click.env` 中 `RCOW_*` 配置经升级合并保留。
 - **启停开关**：`.env` 里 `ONE_CLICK_ENABLE_S3LVOL` 翻转为 1/0 后重跑 `install.sh`（或直接 `systemctl enable/disable cube-sandbox-s3lvol.service`）即可。
+- **S3 后端**：启用后 `install.sh` 用 `CUBE_S3_*` 自动写出 `/data/cubelet/s3.cfg`（默认对接内置 MinIO；配了外部 S3 就跟外部走）。s3lvol 使用独立桶 `CUBE_S3LVOL_BUCKET`（默认 `cube-s3lvol`），与 volume 插件的 `cube-volumes` 分开。supervisor 启动前会用 stdlib SigV4 工具幂等建桶，不依赖 awscli。手写且不含 one-click sentinel 的 `s3.cfg` 不会被覆盖。开发机上旧的 `/data/cubelet/cos.cfg` **不会回落**，请改名为 `s3.cfg` 并换成新字段名。
 
 控制节点安装完成后，可以打开 Dashboard：
 
@@ -440,7 +441,7 @@ export E2B_API_KEY=e2b_000000
 - 若打包内 `Cubelet/config/config.toml` 启用了 `storage_backend = "cubecow"`，还会额外检查：
   `mkfs.ext4`、`mount`、`umount`、`losetup`
 - 若 `ONE_CLICK_ENABLE_S3LVOL=1` 且包内存在 `CubeS3lvol/bin/s3lvol_tgt`，还会额外检查：
-  `nvme`（nvme-cli）、`python3`、`truncate`，以及 `s3lvol_tgt` 动态链接的共享库（`ldd` 探测；重点：`libssl.so.1.1` / `libcrypto.so.1.1` 属于 OpenSSL 1.1 分支）
+  `nvme`（nvme-cli）、`python3`、`truncate`，`s3lvol_tgt` 动态链接的共享库（`ldd` 探测；重点：`libssl.so.1.1` / `libcrypto.so.1.1` 属于 OpenSSL 1.1 分支），以及（x86_64）`/proc/cpuinfo` 里的 `avx2`。发布包按 Haswell/AVX2 编，不是打包机的 `native`。缺 `nvme` 时 `install.sh` 会通过系统包管理器自动安装 `nvme-cli`。系统 `python3` 必须能跑通 `CubeS3lvol/scripts/rpc.py --help`（3.8 即可；发布包里的启动器会补上 SPDK 客户端所需的 3.9 `argparse` 接口）。
 
 推荐安装包（覆盖上述 `cubecow` 依赖）：
 
@@ -458,15 +459,15 @@ sudo dnf install -y e2fsprogs util-linux || \
 sudo yum install -y e2fsprogs util-linux
 ```
 
-启用 `ONE_CLICK_ENABLE_S3LVOL=1` 时额外安装包：
+启用 `ONE_CLICK_ENABLE_S3LVOL=1` 时额外安装包（库依赖；`nvme-cli` 由 `install.sh` 自动安装）：
 
 ```bash
 # Debian / Ubuntu（openssl 1.1 通常已满足；缺库时用 ldd 确认）
-sudo apt-get install -y nvme-cli python3 libaio1 libnuma1 uuid-runtime
+sudo apt-get install -y python3 libaio1 libnuma1 uuid-runtime
 
 # OpenCloudOS / RHEL / CentOS（openssl 3 需 compat-openssl11）
-sudo dnf install -y nvme-cli python3 libaio libnuma libuuid compat-openssl11 || \
-sudo yum install -y nvme-cli python3 libaio libnuma libuuid compat-openssl11
+sudo dnf install -y python3 libaio libnuma libuuid compat-openssl11 || \
+sudo yum install -y python3 libaio libnuma libuuid compat-openssl11
 ```
 
 ### control 角色（`install.sh`，默认）
@@ -497,7 +498,7 @@ sudo yum install -y nvme-cli python3 libaio libnuma libuuid compat-openssl11
 - 若打包内 `Cubelet/config/config.toml` 启用了 `storage_backend = "cubecow"`，还会额外检查：
   `mkfs.ext4`、`mount`、`umount`、`losetup`
 - 若 `ONE_CLICK_ENABLE_S3LVOL=1` 且包内存在 `CubeS3lvol/bin/s3lvol_tgt`，还会额外检查：
-  `nvme`（nvme-cli）、`python3`、`truncate`，以及 `s3lvol_tgt` 动态链接的共享库（`ldd` 探测；重点：`libssl.so.1.1` / `libcrypto.so.1.1` 属于 OpenSSL 1.1 分支）
+  `nvme`（nvme-cli）、`python3`、`truncate`，`s3lvol_tgt` 动态链接的共享库（`ldd` 探测；重点：`libssl.so.1.1` / `libcrypto.so.1.1` 属于 OpenSSL 1.1 分支），以及（x86_64）`/proc/cpuinfo` 里的 `avx2`。发布包按 Haswell/AVX2 编，不是打包机的 `native`。缺 `nvme` 时 `install.sh` 会通过系统包管理器自动安装 `nvme-cli`。系统 `python3` 必须能跑通 `CubeS3lvol/scripts/rpc.py --help`（3.8 即可；发布包里的启动器会补上 SPDK 客户端所需的 3.9 `argparse` 接口）。
 
 推荐安装包（覆盖上述 `cubecow` 依赖）：
 
@@ -515,15 +516,15 @@ sudo dnf install -y e2fsprogs util-linux || \
 sudo yum install -y e2fsprogs util-linux
 ```
 
-启用 `ONE_CLICK_ENABLE_S3LVOL=1` 时额外安装包：
+启用 `ONE_CLICK_ENABLE_S3LVOL=1` 时额外安装包（库依赖；`nvme-cli` 由 `install.sh` 自动安装）：
 
 ```bash
 # Debian / Ubuntu（openssl 1.1 通常已满足；缺库时用 ldd 确认）
-sudo apt-get install -y nvme-cli python3 libaio1 libnuma1 uuid-runtime
+sudo apt-get install -y python3 libaio1 libnuma1 uuid-runtime
 
 # OpenCloudOS / RHEL / CentOS（openssl 3 需 compat-openssl11）
-sudo dnf install -y nvme-cli python3 libaio libnuma libuuid compat-openssl11 || \
-sudo yum install -y nvme-cli python3 libaio libnuma libuuid compat-openssl11
+sudo dnf install -y python3 libaio libnuma libuuid compat-openssl11 || \
+sudo yum install -y python3 libaio libnuma libuuid compat-openssl11
 ```
 
 ## 前置条件

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -198,16 +198,22 @@ CUBE_EGRESS_ADMIN_PORT=9091
 # into the storage path (cubecow S3lvolEngine) -- safe to enable earlier
 # for manual data-plane bring-up.
 ONE_CLICK_ENABLE_S3LVOL=0
-# COS credentials and bucket list for the s3lvol target. The target reads
-# them from /data/cubelet/cos.cfg (override with RCOW_COS_CFG), NOT from
-# this file. install.sh's preflight fails fast when the file is missing and
-# ONE_CLICK_ENABLE_S3LVOL=1, so create it before enabling:
+# When enabled, install.sh writes /data/cubelet/s3.cfg from CUBE_S3_*
+# (bundled MinIO fill, or the operator's external S3). s3lvol uses its own
+# bucket so it never shares prefixes with the volume plugin.
+# CUBE_S3LVOL_BUCKET=cube-s3lvol
+# Override path-style addressing (empty = auto: on for MinIO / s3fs path-style).
+# CUBE_S3LVOL_PATH_STYLE=
+# A hand-written /data/cubelet/s3.cfg without the one-click sentinel is kept.
+# Format if you write it yourself (quoted values, endpoint has NO scheme):
 #
-#   # /data/cubelet/cos.cfg
-#   secretid=<access key id>
-#   secretkey=<secret access key>
-#   cos_endpoint=https://cos.ap-guangzhou.myqcloud.com
-#   cos_bucket_name=["<bucket-a>", "<bucket-b>"]   # one entry per bucket
+#   access_key_id="..."
+#   secret_access_key="..."
+#   endpoint="10.0.0.11:9000"
+#   region="us-east-1"
+#   buckets=["cube-s3lvol"]
+#   path_style="true"
+#   no_tls="true"
 #
 # WAL + metadata journal image size in MiB (wal_bdev.img is created on
 # first install only; upgrading never recreates it). Defaults mirror

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -95,6 +95,10 @@ init_external_dep_defaults() {
   CUBE_S3_BUCKET="${CUBE_S3_BUCKET:-cube-volumes}"
   CUBE_S3_REGION="${CUBE_S3_REGION:-us-east-1}"
   CUBE_S3_S3FS_EXTRA_OPTS="${CUBE_S3_S3FS_EXTRA_OPTS:-}"
+  # s3lvol uses the same CUBE_S3_* store but a dedicated bucket so its
+  # prefixes never collide with the volume plugin's volumes/<id>/ tree.
+  CUBE_S3LVOL_BUCKET="${CUBE_S3LVOL_BUCKET:-cube-s3lvol}"
+  CUBE_S3LVOL_PATH_STYLE="${CUBE_S3LVOL_PATH_STYLE:-}"
 }
 
 # Guard against shipping the example/default credentials to a real external
@@ -1575,9 +1579,17 @@ case "${RCOW_LISTEN_PORT}" in
     ;;
 esac
 
+# Render /data/cubelet/s3.cfg from CUBE_S3_* before the s3lvol preflight
+# looks for it. Hand-written files without the one-click sentinel are kept.
+write_s3lvol_cfg
+
+# nvme-cli is not part of a minimal install; provide it before the
+# startup-deps validation below requires it.
+ensure_nvme_cli
+
 # CubeS3lvol runtime deps (nvme-cli, python3, truncate, and the shared
 # libraries s3lvol_tgt needs -- notably libssl.so.1.1) are validated once
-# here, fail-fast, before the installer touches the system.
+# here, fail-fast, before the installer replaces the install tree.
 validate_cubelet_s3lvol_startup_deps "${PKG_ROOT}/CubeS3lvol/bin/s3lvol_tgt"
 
 patch_cubelet_config_template \
@@ -1909,6 +1921,12 @@ fi
 # rcow_common.sh) so the systemd unit picks them up via EnvironmentFile
 # without re-deriving them, and so `down.sh` / upgrade knows the intent.
 upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_ENABLE_S3LVOL" "${ONE_CLICK_ENABLE_S3LVOL}"
+upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_S3LVOL_BUCKET" "${CUBE_S3LVOL_BUCKET}"
+if [[ -n "${CUBE_S3LVOL_PATH_STYLE}" ]]; then
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_S3LVOL_PATH_STYLE" "${CUBE_S3LVOL_PATH_STYLE}"
+else
+  remove_env_kv "${RUNTIME_ENV_FILE}" "CUBE_S3LVOL_PATH_STYLE"
+fi
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_WAL_MB" "${RCOW_WAL_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_JOURNAL_MB" "${RCOW_JOURNAL_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_CACHE_MB" "${RCOW_CACHE_MB}"

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -299,6 +299,80 @@ one_click_s3lvol_required_commands() {
     truncate
 }
 
+s3lvol_nvme_present() {
+  command -v nvme >/dev/null 2>&1
+}
+
+# Prefer apt, then dnf, then yum (detect_pkg_manager knows only apt/yum).
+s3lvol_nvme_pkg_manager() {
+  if command -v apt-get >/dev/null 2>&1; then
+    printf 'apt'
+    return 0
+  fi
+  if command -v dnf >/dev/null 2>&1; then
+    printf 'dnf'
+    return 0
+  fi
+  if command -v yum >/dev/null 2>&1; then
+    printf 'yum'
+    return 0
+  fi
+  return 1
+}
+
+# Install nvme-cli when s3lvol is enabled and `nvme` is missing.
+ensure_nvme_cli() {
+  [[ "${ONE_CLICK_ENABLE_S3LVOL:-0}" == "1" ]] || return 0
+  if s3lvol_nvme_present; then
+    return 0
+  fi
+
+  local pm
+  if ! pm="$(s3lvol_nvme_pkg_manager)"; then
+    die "CubeS3lvol needs nvme-cli (the nvme command) but no apt-get/dnf/yum was found. Install nvme-cli by hand and re-run install.sh"
+  fi
+  log "installing nvme-cli via ${pm}..."
+  if [[ -n "${ONE_CLICK_NVME_CLI_INSTALLER:-}" ]]; then
+    "${ONE_CLICK_NVME_CLI_INSTALLER}" "${pm}"
+  else
+    case "${pm}" in
+      apt)
+        apt-get update -qq
+        apt-get install -y -qq nvme-cli
+        ;;
+      dnf)
+        dnf install -y nvme-cli
+        ;;
+      yum)
+        yum install -y nvme-cli
+        ;;
+    esac
+  fi
+  if ! s3lvol_nvme_present; then
+    die "installed nvme-cli via ${pm} but nvme is still not in PATH. Install nvme-cli by hand (apt: apt-get install -y nvme-cli; dnf/yum: dnf install -y nvme-cli || yum install -y nvme-cli) and re-run install.sh"
+  fi
+}
+
+# validate_s3lvol_rpc_client: prove the packaged rpc.py launcher can start
+# under the *system* python3. SPDK's unmodified rpc.py needs
+# argparse.BooleanOptionalAction (Python 3.9+); Ubuntu 20.04 is 3.8, and
+# without the launcher shim rcow_start.sh loops on "target not answering".
+# A failure here is a client/interpreter mismatch, not a dead target.
+validate_s3lvol_rpc_client() {
+  local rpc_py="$1"
+  local rpc_dir python_dir out
+  [[ -n "${rpc_py}" && -f "${rpc_py}" ]] \
+    || die "CubeS3lvol RPC client is missing (${rpc_py:-unset}). The release package must ship scripts/rpc.py"
+  rpc_dir="$(cd "$(dirname "${rpc_py}")" && pwd)"
+  python_dir="${rpc_dir}/python"
+  if ! out="$(
+    env PYTHONPATH="${python_dir}${PYTHONPATH:+:${PYTHONPATH}}" \
+      python3 "${rpc_py}" --help 2>&1
+  )"; then
+    die "CubeS3lvol RPC client cannot run under $(python3 --version 2>&1) (${rpc_py}): ${out}. This is a Python/rpc.py incompatibility, not a failure of s3lvol_tgt"
+  fi
+}
+
 # validate_cubelet_s3lvol_startup_deps: check the runtime deps of the
 # installed s3lvol_tgt binary. The binary statically links SPDK/DPDK/AWS
 # CRT, so `ldd` on it is the authoritative probe for exactly the system
@@ -337,12 +411,19 @@ validate_cubelet_s3lvol_startup_deps() {
     die "CubeS3lvol startup dependency check failed for ${s3lvol_bin}; missing shared libraries: ${missing_libs[*]} (the binary links against OpenSSL 1.1 -- on distros shipping OpenSSL 3 install the compat package, e.g. compat-openssl11 on RHEL/CentOS/OpenCloudOS)"
   fi
 
-  # A missing COS config makes the target fail on first connect, the unit
+  # Release s3lvol_tgt is built for Haswell/AVX2, not the packager's native
+  # CPU. Fail here with that wording instead of DPDK's RTE_MACHINE dump.
+  if [[ "$(uname -m)" == "x86_64" ]] && ! grep -qw avx2 /proc/cpuinfo; then
+    die "CubeS3lvol release binaries require AVX2 (Haswell baseline). This CPU does not advertise avx2 in /proc/cpuinfo; s3lvol_tgt will not start"
+  fi
+
+  # A missing S3 config makes the target fail on first connect, the unit
   # hits StartLimitBurst and the role target gives up. Fail here instead,
-  # with the fix spelled out.
-  local cos_cfg="${RCOW_COS_CFG:-/data/cubelet/cos.cfg}"
-  if [[ ! -f "${cos_cfg}" ]]; then
-    die "CubeS3lvol is enabled but its COS config is missing: ${cos_cfg}. Create it from the template in deploy/one-click/env.example (or point RCOW_COS_CFG at an existing file) and re-run install.sh"
+  # with the fix spelled out. install.sh writes this file from CUBE_S3_*
+  # when ONE_CLICK_ENABLE_S3LVOL=1; a hand-written file is also accepted.
+  local s3_cfg="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
+  if [[ ! -f "${s3_cfg}" ]]; then
+    die "CubeS3lvol is enabled but ${s3_cfg} is missing and there is no CUBE_S3_ENDPOINT to generate it from. Set CUBE_S3_* (or enable bundled MinIO) or write ${s3_cfg} by hand (or point RCOW_S3_CFG at an existing file) and re-run install.sh"
   fi
 
   # The subsystem grid is exported with -a (allow_any_host), so the listener
@@ -356,7 +437,12 @@ validate_cubelet_s3lvol_startup_deps() {
       ;;
   esac
 
-  log "CubeS3lvol startup dependencies OK: ${cmds[*]} + $(ldd "${s3lvol_bin}" 2>/dev/null | awk '/=> \//{n++} END{print n+0}') shared libs resolved; COS config at ${cos_cfg}"
+  local scripts_dir
+  scripts_dir="$(cd "$(dirname "${s3lvol_bin}")/../scripts" 2>/dev/null && pwd)" \
+    || die "CubeS3lvol scripts directory is missing next to ${s3lvol_bin}"
+  validate_s3lvol_rpc_client "${scripts_dir}/rpc.py"
+
+  log "CubeS3lvol startup dependencies OK: ${cmds[*]} + $(ldd "${s3lvol_bin}" 2>/dev/null | awk '/=> \//{n++} END{print n+0}') shared libs resolved; S3 config at ${s3_cfg}"
 }
 
 require_root() {
@@ -1767,6 +1853,125 @@ write_volume_s3_conf() {
       "${CUBE_S3_S3FS_EXTRA_OPTS:-}"
     log "wrote ${plugin_dir}/volume-s3.conf endpoint=${CUBE_S3_ENDPOINT} bucket=${CUBE_S3_BUCKET:-cube-volumes}"
   done
+}
+
+# Sentinel that marks an installer-generated s3.cfg. A file without this line
+# is treated as operator-owned and is never overwritten.
+S3LVOL_CFG_SENTINEL="generated by cube-sandbox one-click; do not edit"
+
+# Print KEY="value" for s3.cfg. rcow_cfg_get's sed requires double quotes and
+# cannot unescape, so a literal quote in the value is rejected.
+toml_assign() {
+  local key="$1"
+  local value="$2"
+  if [[ "${value}" == *\"* ]]; then
+    die "s3.cfg value for ${key} must not contain double quotes"
+  fi
+  printf '%s="%s"\n' "${key}" "${value}"
+}
+
+# Strip http(s):// and any path from CUBE_S3_ENDPOINT. s3lvol uses the host
+# as the HTTP Host header; the scheme becomes no_tls instead.
+s3lvol_host_from_endpoint() {
+  local url="$1"
+  url="${url#http://}"
+  url="${url#https://}"
+  url="${url%%/*}"
+  printf '%s' "${url}"
+}
+
+s3lvol_no_tls_from_endpoint() {
+  [[ "${1:-}" == http://* ]]
+}
+
+# Whether s3.cfg should set path_style="true".
+# CUBE_S3LVOL_PATH_STYLE=1/0 wins; otherwise local MinIO or s3fs path-style opts.
+s3lvol_path_style() {
+  case "${CUBE_S3LVOL_PATH_STYLE:-}" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    0|false|FALSE|no|NO) return 1 ;;
+  esac
+  if s3_config_is_local_minio_fill; then
+    return 0
+  fi
+  [[ "${CUBE_S3_S3FS_EXTRA_OPTS:-}" == *use_path_request_style* ]]
+}
+
+# write_s3lvol_cfg_file: render one s3.cfg. path_style/no_tls are 0/1.
+write_s3lvol_cfg_file() {
+  local conf="$1"
+  local access_key="$2"
+  local secret_key="$3"
+  local bucket="$4"
+  local host="$5"
+  local region="$6"
+  local path_style="$7"
+  local no_tls="$8"
+  local tmp_file old_umask
+
+  if [[ "${bucket}" == *\"* ]]; then
+    die "s3.cfg value for buckets must not contain double quotes"
+  fi
+
+  mkdir -p "$(dirname "${conf}")"
+  old_umask="$(umask)"
+  umask 077
+  tmp_file="$(mktemp "${conf}.XXXXXX")"
+  chmod 600 "${tmp_file}"
+  {
+    printf '# %s\n' "${S3LVOL_CFG_SENTINEL}"
+    toml_assign access_key_id "${access_key}"
+    toml_assign secret_access_key "${secret_key}"
+    toml_assign endpoint "${host}"
+    toml_assign region "${region}"
+    printf 'buckets=["%s"]\n' "${bucket}"
+    if [[ "${path_style}" == "1" ]]; then
+      toml_assign path_style "true"
+    fi
+    if [[ "${no_tls}" == "1" ]]; then
+      toml_assign no_tls "true"
+    fi
+  } > "${tmp_file}"
+  mv -f "${tmp_file}" "${conf}"
+  umask "${old_umask}"
+  chmod 600 "${conf}"
+}
+
+# write_s3lvol_cfg: generate /data/cubelet/s3.cfg from CUBE_S3_* when
+# s3lvol is enabled. Leaves a hand-written file (no sentinel) alone.
+write_s3lvol_cfg() {
+  local conf host no_tls=0 path_style=0
+
+  [[ "${ONE_CLICK_ENABLE_S3LVOL:-0}" == "1" ]] || return 0
+
+  conf="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
+  if [[ -z "${CUBE_S3_ENDPOINT:-}" ]]; then
+    return 0
+  fi
+  if [[ -f "${conf}" ]] && ! grep -Fq "${S3LVOL_CFG_SENTINEL}" "${conf}"; then
+    log "keeping hand-written ${conf} (no one-click sentinel)"
+    return 0
+  fi
+
+  host="$(s3lvol_host_from_endpoint "${CUBE_S3_ENDPOINT}")"
+  [[ -n "${host}" ]] || die "CUBE_S3_ENDPOINT=${CUBE_S3_ENDPOINT} has no host; cannot write ${conf}"
+  if s3lvol_no_tls_from_endpoint "${CUBE_S3_ENDPOINT}"; then
+    no_tls=1
+  fi
+  if s3lvol_path_style; then
+    path_style=1
+  fi
+
+  write_s3lvol_cfg_file \
+    "${conf}" \
+    "${CUBE_S3_ACCESS_KEY_ID:-}" \
+    "${CUBE_S3_SECRET_ACCESS_KEY:-}" \
+    "${CUBE_S3LVOL_BUCKET:-cube-s3lvol}" \
+    "${host}" \
+    "${CUBE_S3_REGION:-us-east-1}" \
+    "${path_style}" \
+    "${no_tls}"
+  log "wrote ${conf} endpoint=${host} bucket=${CUBE_S3LVOL_BUCKET:-cube-s3lvol}"
 }
 
 # install_s3_volume_host_deps: install s3fs for the S3 volume plugin.

--- a/deploy/one-click/scripts/systemd/cube-s3lvol-supervise.sh
+++ b/deploy/one-click/scripts/systemd/cube-s3lvol-supervise.sh
@@ -43,9 +43,46 @@ source "${RCOW_COMMON}" # provides rcow_target_alive + RCOW_PIDFILE default
 # treat the deliberate stop as a failure.
 trap 'exit 0' TERM INT
 
+# Ensure the bucket exists before the target attaches. s3lvol will not
+# create it; a missing bucket fails create/attach with -EACCES. Failure
+# here is only a warning: HEAD 403 can mean "exists but HeadBucket is
+# denied", and MinIO may still be coming up (Restart=on-failure retries).
+S3_BUCKET_PY="${S3LVOL_ROOT}/scripts/s3_bucket.py"
+if [[ ! -f "${S3_BUCKET_PY}" ]]; then
+  S3_BUCKET_PY="${S3LVOL_ROOT}/test/tools/s3_bucket.py"
+fi
+if [[ -f "${S3_BUCKET_PY}" ]]; then
+  if rcow_load_credentials; then
+    s3_host="$(rcow_cfg_get endpoint)"
+    s3_region="$(rcow_cfg_get region)"
+    s3_bucket="$(rcow_s3_buckets | head -1)"
+    [[ -n "${s3_region}" ]] || s3_region="us-east-1"
+    s3_flags=()
+    rcow_s3_addr_flags s3_flags
+    if [[ -n "${s3_host}" && -n "${s3_bucket}" ]]; then
+      if python3 "${S3_BUCKET_PY}" ensure \
+          -e "${s3_host}" -b "${s3_bucket}" -r "${s3_region}" \
+          "${s3_flags[@]+"${s3_flags[@]}"}"; then
+        log "CubeS3lvol: bucket ${s3_bucket} is ready"
+      else
+        log "WARN: could not ensure S3 bucket ${s3_bucket} at ${s3_host}; rcow_start.sh will report the precise error if the bucket is actually missing"
+      fi
+    else
+      log "WARN: ${RCOW_S3_CFG} has no endpoint/buckets; skipping bucket ensure"
+    fi
+  else
+    log "WARN: could not read credentials from ${RCOW_S3_CFG}; skipping bucket ensure"
+  fi
+else
+  log "WARN: s3_bucket.py not found; skipping bucket ensure"
+fi
+
 log "CubeS3lvol: running rcow_start.sh"
-if ! "${RCOW_START}"; then
-  rc=$?
+# Do not use `if ! cmd; then rc=$?`: the `!` inverts success, so rc becomes 0
+# and Restart=on-failure never retries (MinIO still coming up).
+rc=0
+"${RCOW_START}" || rc=$?
+if [[ "${rc}" -ne 0 ]]; then
   log "CubeS3lvol: rcow_start.sh failed (rc=${rc})"
   exit "${rc}"
 fi

--- a/deploy/one-click/tests/test_minio_s3_guard.sh
+++ b/deploy/one-click/tests/test_minio_s3_guard.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ONE_CLICK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${ONE_CLICK_DIR}/../.." && pwd)"
+RCOW_COMMON="${ROOT_DIR}/CubeS3lvol/scripts/rcow_common.sh"
+RCOW_PURGE="${ROOT_DIR}/CubeS3lvol/scripts/rcow_purge.sh"
+S3LVOL_SUPERVISE="${ONE_CLICK_DIR}/scripts/systemd/cube-s3lvol-supervise.sh"
 
 TMP_DIR="$(mktemp -d)"
 cleanup() {
@@ -198,6 +202,281 @@ test_minio_disabled_external_endpoint_ok
 test_compute_empty_s3_endpoint_dies
 test_compute_set_s3_endpoint_ok
 test_control_empty_s3_endpoint_ok
+s3cfg_get() {
+  local conf="$1" key="$2"
+  sed -n "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*/\1/p" \
+    "${conf}" | head -1 | tr -d '\r'
+}
+
+s3cfg_buckets() {
+  local conf="$1"
+  sed -n 's/^[[:space:]]*buckets[[:space:]]*=[[:space:]]*\[\(.*\)\].*/\1/p' \
+    "${conf}" | head -1 | tr ',' '\n' |
+    sed -n 's/^[[:space:]]*"\([^"]*\)".*/\1/p' | tr -d '\r'
+}
+
+test_s3lvol_host_from_endpoint() {
+  local got
+  got="$(s3lvol_host_from_endpoint "http://10.0.0.11:9000")"
+  [[ "${got}" == "10.0.0.11:9000" ]] || fail "strip http:// (got ${got})"
+  got="$(s3lvol_host_from_endpoint "https://s3.example.com")"
+  [[ "${got}" == "s3.example.com" ]] || fail "strip https:// (got ${got})"
+  got="$(s3lvol_host_from_endpoint "https://s3.example.com/path")"
+  [[ "${got}" == "s3.example.com" ]] || fail "strip path (got ${got})"
+  s3lvol_no_tls_from_endpoint "http://10.0.0.11:9000" \
+    || fail "http:// must be no_tls"
+  if s3lvol_no_tls_from_endpoint "https://s3.example.com"; then
+    fail "https:// must not be no_tls"
+  fi
+}
+
+test_write_s3lvol_cfg_file_roundtrip() {
+  local conf="${TMP_DIR}/s3.cfg"
+  write_s3lvol_cfg_file \
+    "${conf}" "ak-id" "sk-secret" "cube-s3lvol" \
+    "10.0.0.11:9000" "us-east-1" "1" "1"
+  grep -Fq "${S3LVOL_CFG_SENTINEL}" "${conf}" \
+    || fail "generated s3.cfg must carry the one-click sentinel"
+  [[ "$(s3cfg_get "${conf}" access_key_id)" == "ak-id" ]] \
+    || fail "access_key_id roundtrip"
+  [[ "$(s3cfg_get "${conf}" secret_access_key)" == "sk-secret" ]] \
+    || fail "secret_access_key roundtrip"
+  [[ "$(s3cfg_get "${conf}" endpoint)" == "10.0.0.11:9000" ]] \
+    || fail "endpoint must have no scheme (got $(s3cfg_get "${conf}" endpoint))"
+  [[ "$(s3cfg_get "${conf}" region)" == "us-east-1" ]] || fail "region roundtrip"
+  [[ "$(s3cfg_buckets "${conf}")" == "cube-s3lvol" ]] || fail "buckets roundtrip"
+  [[ "$(s3cfg_get "${conf}" path_style)" == "true" ]] || fail "path_style=true"
+  [[ "$(s3cfg_get "${conf}" no_tls)" == "true" ]] || fail "no_tls=true"
+}
+
+test_write_s3lvol_cfg_minio_vs_volume_bucket() {
+  reset_minio_s3_vars
+  ONE_CLICK_ENABLE_S3LVOL=1
+  CUBE_S3_ENDPOINT="http://10.0.0.11:9000"
+  CUBE_S3_ACCESS_KEY_ID="cubeminio"
+  CUBE_S3_SECRET_ACCESS_KEY="minio-root-password-1"
+  CUBE_S3_BUCKET="cube-volumes"
+  CUBE_S3LVOL_BUCKET="cube-s3lvol"
+  CUBE_S3_REGION="us-east-1"
+  CUBE_S3_S3FS_EXTRA_OPTS="-ouse_path_request_style"
+  RCOW_S3_CFG="${TMP_DIR}/generated-s3.cfg"
+  rm -f "${RCOW_S3_CFG}"
+  write_s3lvol_cfg
+  [[ -f "${RCOW_S3_CFG}" ]] || fail "write_s3lvol_cfg must create ${RCOW_S3_CFG}"
+  [[ "$(s3cfg_get "${RCOW_S3_CFG}" endpoint)" == "10.0.0.11:9000" ]] \
+    || fail "minio endpoint must drop scheme"
+  [[ "$(s3cfg_get "${RCOW_S3_CFG}" no_tls)" == "true" ]] || fail "minio no_tls"
+  [[ "$(s3cfg_get "${RCOW_S3_CFG}" path_style)" == "true" ]] || fail "minio path_style"
+  local bucket
+  bucket="$(s3cfg_buckets "${RCOW_S3_CFG}")"
+  [[ "${bucket}" == "cube-s3lvol" ]] || fail "s3lvol bucket (got ${bucket})"
+  [[ "${bucket}" != "${CUBE_S3_BUCKET}" ]] \
+    || fail "s3lvol bucket must differ from volume plugin bucket"
+  unset RCOW_S3_CFG ONE_CLICK_ENABLE_S3LVOL CUBE_S3LVOL_BUCKET
+}
+
+test_write_s3lvol_cfg_external_https() {
+  reset_minio_s3_vars
+  CUBE_SANDBOX_MINIO_ENABLED=0
+  ONE_CLICK_ENABLE_S3LVOL=1
+  CUBE_S3_ENDPOINT="https://s3.example.com"
+  CUBE_S3_ACCESS_KEY_ID="external-ak"
+  CUBE_S3_SECRET_ACCESS_KEY="external-sk"
+  CUBE_S3_REGION="ap-guangzhou"
+  CUBE_S3_S3FS_EXTRA_OPTS=""
+  CUBE_S3LVOL_PATH_STYLE=""
+  RCOW_S3_CFG="${TMP_DIR}/external-s3.cfg"
+  rm -f "${RCOW_S3_CFG}"
+  write_s3lvol_cfg
+  [[ "$(s3cfg_get "${RCOW_S3_CFG}" endpoint)" == "s3.example.com" ]] \
+    || fail "external endpoint host"
+  [[ -z "$(s3cfg_get "${RCOW_S3_CFG}" no_tls)" ]] \
+    || fail "https must omit no_tls (got $(s3cfg_get "${RCOW_S3_CFG}" no_tls))"
+  [[ -z "$(s3cfg_get "${RCOW_S3_CFG}" path_style)" ]] \
+    || fail "external https must omit path_style by default"
+  unset RCOW_S3_CFG ONE_CLICK_ENABLE_S3LVOL CUBE_S3LVOL_PATH_STYLE
+}
+
+test_write_s3lvol_cfg_quote_dies() {
+  local err="${TMP_DIR}/quote.err"
+  if ( write_s3lvol_cfg_file \
+        "${TMP_DIR}/bad.cfg" 'ak"id' "sk" "b" "host" "us-east-1" "0" "0" ) \
+      >"${err}" 2>&1; then
+    fail "quoted access key must die"
+  fi
+  grep -Fq "must not contain double quotes" "${err}" \
+    || fail "quote die message (got $(cat "${err}"))"
+}
+
+test_write_s3lvol_cfg_keeps_handwritten() {
+  reset_minio_s3_vars
+  ONE_CLICK_ENABLE_S3LVOL=1
+  CUBE_S3_ENDPOINT="http://10.0.0.11:9000"
+  CUBE_S3_ACCESS_KEY_ID="cubeminio"
+  CUBE_S3_SECRET_ACCESS_KEY="minio-root-password-1"
+  RCOW_S3_CFG="${TMP_DIR}/handwritten-s3.cfg"
+  printf 'access_key_id="keep-me"\nendpoint="manual.host"\nbuckets=["keep"]\n' \
+    >"${RCOW_S3_CFG}"
+  write_s3lvol_cfg
+  grep -Fq 'access_key_id="keep-me"' "${RCOW_S3_CFG}" \
+    || fail "hand-written s3.cfg without sentinel must be kept"
+  unset RCOW_S3_CFG ONE_CLICK_ENABLE_S3LVOL
+}
+
+test_supervise_preserves_rcow_start_exit_code() {
+  [[ -f "${S3LVOL_SUPERVISE}" ]] || fail "missing ${S3LVOL_SUPERVISE}"
+  if grep -F -q 'if ! "${RCOW_START}"' "${S3LVOL_SUPERVISE}"; then
+    fail "supervise must not use if ! RCOW_START (washes rc to 0)"
+  fi
+  grep -F -q '"${RCOW_START}" || rc=$?' "${S3LVOL_SUPERVISE}" \
+    || fail "supervise must capture rcow_start status with || rc=\$?"
+  local rc=0
+  false || rc=$?
+  [[ "${rc}" -eq 1 ]] || fail "rc=0; false || rc=\$? must yield 1 (got ${rc})"
+}
+
+test_rcow_s3_addr_flags_roundtrip() {
+  [[ -f "${RCOW_COMMON}" ]] || fail "missing ${RCOW_COMMON}"
+  RCOW_S3_CFG="${TMP_DIR}/addr-unused.cfg"
+  RCOW_ACTIVE_FILE="${TMP_DIR}/rcow/active_lvols"
+  RCOW_BSTORE_FILE="${TMP_DIR}/rcow/bstore.json"
+  RCOW_WAL_IMG="${TMP_DIR}/rcow/wal_bdev.img"
+  RCOW_RUN_DIR="${TMP_DIR}/rcow-run"
+  # Pin RCOW_LVS_NAME so sourcing does not depend on hostname -s
+  # (empty in some builder containers; rcow_common.sh then exits 1).
+  RCOW_LVS_NAME="${RCOW_LVS_NAME:-minio-guard-test}"
+  # shellcheck source=/dev/null
+  source "${RCOW_COMMON}"
+
+  RCOW_S3_CFG="${TMP_DIR}/addr-minio.cfg"
+  printf '%s\n' \
+    'path_style="true"' \
+    'no_tls="true"' \
+    >"${RCOW_S3_CFG}"
+  local s3_flags=()
+  rcow_s3_addr_flags s3_flags
+  [[ "${#s3_flags[@]}" -eq 2 ]] || fail "minio flags count (got ${#s3_flags[@]})"
+  [[ "${s3_flags[0]}" == "--path-style" ]] || fail "minio path-style (got ${s3_flags[0]})"
+  [[ "${s3_flags[1]}" == "--no-tls" ]] || fail "minio no-tls (got ${s3_flags[1]})"
+
+  RCOW_S3_CFG="${TMP_DIR}/addr-https.cfg"
+  printf '%s\n' \
+    'endpoint="s3.example.com"' \
+    'region="ap-guangzhou"' \
+    >"${RCOW_S3_CFG}"
+  s3_flags=()
+  rcow_s3_addr_flags s3_flags
+  [[ "${#s3_flags[@]}" -eq 0 ]] || fail "https flags must be empty (got ${s3_flags[*]})"
+}
+
+test_rcow_purge_expands_s3_addr_flags() {
+  [[ -f "${RCOW_PURGE}" ]] || fail "missing ${RCOW_PURGE}"
+  local n
+  n="$(grep -c 'S3_ADDR_FLAGS\[@\]' "${RCOW_PURGE}" || true)"
+  [[ "${n}" -eq 3 ]] \
+    || fail "rcow_purge.sh must expand S3_ADDR_FLAGS at 3 PREFIX_RM sites (got ${n})"
+  grep -q 'rcow_s3_addr_flags S3_ADDR_FLAGS' "${RCOW_PURGE}" \
+    || fail "rcow_purge.sh must call rcow_s3_addr_flags S3_ADDR_FLAGS"
+}
+
+test_ensure_nvme_cli_skips_when_disabled() {
+  local marker="${TMP_DIR}/nvme-off.marker"
+  rm -f "${marker}"
+  (
+    record_nvme_install() { printf '%s\n' "$1" >"${marker}"; }
+    ONE_CLICK_ENABLE_S3LVOL=0
+    ONE_CLICK_NVME_CLI_INSTALLER=record_nvme_install
+    s3lvol_nvme_present() { return 1; }
+    s3lvol_nvme_pkg_manager() { printf 'dnf'; }
+    ensure_nvme_cli
+  ) || fail "ensure_nvme_cli must succeed when s3lvol is off"
+  [[ ! -f "${marker}" ]] \
+    || fail "ensure_nvme_cli must not invoke the installer when ONE_CLICK_ENABLE_S3LVOL!=1"
+}
+
+test_ensure_nvme_cli_skips_when_present() {
+  local marker="${TMP_DIR}/nvme-present.marker"
+  rm -f "${marker}"
+  (
+    record_nvme_install() { printf '%s\n' "$1" >"${marker}"; }
+    ONE_CLICK_ENABLE_S3LVOL=1
+    ONE_CLICK_NVME_CLI_INSTALLER=record_nvme_install
+    s3lvol_nvme_present() { return 0; }
+    s3lvol_nvme_pkg_manager() { printf 'apt'; }
+    ensure_nvme_cli
+  ) || fail "ensure_nvme_cli must succeed when nvme is already in PATH"
+  [[ ! -f "${marker}" ]] \
+    || fail "ensure_nvme_cli must not invoke the installer when nvme is already present"
+}
+
+test_validate_s3lvol_rpc_client_accepts_help() {
+  local rpc_py="${TMP_DIR}/rpc-ok.py"
+  cat >"${rpc_py}" <<'PY'
+#!/usr/bin/env python3
+print("usage: rpc.py [options]")
+PY
+  validate_s3lvol_rpc_client "${rpc_py}" \
+    || fail "validate_s3lvol_rpc_client must accept a rpc.py that prints --help"
+}
+
+test_validate_s3lvol_rpc_client_dies_on_incompat() {
+  local rpc_py="${TMP_DIR}/rpc-bad.py"
+  local err="${TMP_DIR}/rpc-bad.err"
+  cat >"${rpc_py}" <<'PY'
+#!/usr/bin/env python3
+import sys
+sys.stderr.write("AttributeError: module 'argparse' has no attribute 'BooleanOptionalAction'\n")
+sys.exit(1)
+PY
+  if ( validate_s3lvol_rpc_client "${rpc_py}" ) >"${err}" 2>&1; then
+    fail "validate_s3lvol_rpc_client must die when rpc.py --help fails"
+  fi
+  grep -Fq "Python/rpc.py incompatibility" "${err}" \
+    || fail "die message must name the client/interpreter mismatch (got $(cat "${err}"))"
+}
+
+test_validate_cubelet_s3lvol_startup_deps_runs_rpc_help() {
+  grep -q 'validate_s3lvol_rpc_client' "${ONE_CLICK_DIR}/lib/common.sh" \
+    || fail "validate_cubelet_s3lvol_startup_deps must call validate_s3lvol_rpc_client"
+  grep -q '"${rpc_py}" --help' "${ONE_CLICK_DIR}/lib/common.sh" \
+    || fail "validate_s3lvol_rpc_client must invoke rpc.py --help"
+}
+
+test_ensure_nvme_cli_installs_when_missing() {
+  local marker="${TMP_DIR}/nvme-missing.marker"
+  rm -f "${marker}"
+  (
+    installed=0
+    record_nvme_install() {
+      printf '%s\n' "$1" >"${marker}"
+      installed=1
+    }
+    ONE_CLICK_ENABLE_S3LVOL=1
+    ONE_CLICK_NVME_CLI_INSTALLER=record_nvme_install
+    s3lvol_nvme_present() { [[ "${installed}" -eq 1 ]]; }
+    s3lvol_nvme_pkg_manager() { printf 'dnf'; }
+    ensure_nvme_cli
+  ) || fail "ensure_nvme_cli must succeed after the mock installer records one call"
+  [[ -f "${marker}" ]] || fail "ensure_nvme_cli must invoke the installer when nvme is missing"
+  [[ "$(cat "${marker}")" == "dnf" ]] \
+    || fail "ensure_nvme_cli must pass the detected pm to the installer (got $(cat "${marker}"))"
+}
+
 test_write_volume_s3_conf_file_source_roundtrip
+test_s3lvol_host_from_endpoint
+test_write_s3lvol_cfg_file_roundtrip
+test_write_s3lvol_cfg_minio_vs_volume_bucket
+test_write_s3lvol_cfg_external_https
+test_write_s3lvol_cfg_quote_dies
+test_write_s3lvol_cfg_keeps_handwritten
+test_supervise_preserves_rcow_start_exit_code
+test_rcow_s3_addr_flags_roundtrip
+test_rcow_purge_expands_s3_addr_flags
+test_ensure_nvme_cli_skips_when_disabled
+test_ensure_nvme_cli_skips_when_present
+test_ensure_nvme_cli_installs_when_missing
+test_validate_s3lvol_rpc_client_accepts_help
+test_validate_s3lvol_rpc_client_dies_on_incompat
+test_validate_cubelet_s3lvol_startup_deps_runs_rpc_help
 
 echo "minio s3 guard tests OK"

--- a/deploy/one-click/tests/test_package_layout.sh
+++ b/deploy/one-click/tests/test_package_layout.sh
@@ -364,6 +364,28 @@ test_env_templates_are_split() {
 # 4) The build entrypoints AND every shipped Terraform deployer script must at
 #    least be syntactically valid — a cheap, cloud-free guard so a broken script
 #    fails here instead of only when a user runs it from the bundle.
+test_s3lvol_bucket_tool_is_packaged() {
+  require_file "${ROOT_DIR}/CubeS3lvol/test/tools/s3_bucket.py" \
+    "s3lvol ensure-bucket tool"
+  require_file "${ROOT_DIR}/CubeS3lvol/make_release.sh" "s3lvol make_release.sh"
+  if ! grep -q -F 's3_bucket.py' "${ROOT_DIR}/CubeS3lvol/make_release.sh"; then
+    fail "make_release.sh must install test/tools/s3_bucket.py into scripts/"
+  fi
+}
+
+test_s3lvol_rpc_launcher_is_packaged() {
+  require_file "${ROOT_DIR}/CubeS3lvol/scripts/rpc.py" "s3lvol rpc.py launcher"
+  require_file "${ROOT_DIR}/CubeS3lvol/scripts/rpc_compat.py" \
+    "s3lvol rpc.py 3.8 compat shim"
+  require_file "${ROOT_DIR}/CubeS3lvol/make_release.sh" "s3lvol make_release.sh"
+  if ! grep -q -F 'scripts/spdk_rpc.py' "${ROOT_DIR}/CubeS3lvol/make_release.sh"; then
+    fail "make_release.sh must install SPDK rpc.py as scripts/spdk_rpc.py"
+  fi
+  if ! grep -q -F '${REPO_ROOT}/scripts/rpc.py' "${ROOT_DIR}/CubeS3lvol/make_release.sh"; then
+    fail "make_release.sh must install this repo's scripts/rpc.py launcher"
+  fi
+}
+
 test_build_scripts_parse() {
   local f
   for f in "${BUNDLE_SH}" "${BUILD_IMAGES_SH}" \
@@ -383,6 +405,8 @@ test_tke_addons_network_config_key
 test_reinstall_cleanup_tracks_packaged_components
 test_terraform_deployer_files_present
 test_env_templates_are_split
+test_s3lvol_bucket_tool_is_packaged
+test_s3lvol_rpc_launcher_is_packaged
 test_build_scripts_parse
 
 if [[ "${failures}" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Rename the s3lvol backend from Tencent COS to generic S3 and add first-class MinIO support, across the target, scripts, tests and deploy tooling.

### Highlights

- **COS → S3 config**: the per-node config moves from `cos.cfg` to `s3.cfg` with S3-style field names (`access_key_id`, `secret_access_key`, `endpoint`, `buckets`, `path_style`, `no_tls`). There is no fallback from the old file or the old keys. The `rcow_add_cos_config` RPC is renamed to `rcow_add_s3_config`.
- **MinIO support**: `path_style` / `no_tls` flags are threaded through the startup scripts, the purge path and an address-flags helper, so a path-style plain-HTTP backend works out of the box.
- **Ensure-bucket tool**: a stdlib SigV4 `s3_bucket.py` creates/confirms the dedicated s3lvol bucket (kept separate from the volume plugin's) before `rcow_start.sh`; no awscli or boto3 needed.
- **CPU-portable releases**: SPDK is built with `--target-arch=haswell` (x86_64) / `armv8.2-a+crypto` (aarch64) instead of `native`; `make_release.sh` refuses to package a native tree, and the one-click preflight checks for AVX2.
- **Python 3.8 RPC client**: a `rpc.py` launcher plus `rpc_compat.py` backfills `argparse.BooleanOptionalAction` so SPDK's unmodified client runs on Ubuntu 20.04; SPDK's own `rpc.py` ships as `spdk_rpc.py`.
- **One-click deploy**: `install.sh` renders `s3.cfg` from `CUBE_S3_*`, installs `nvme-cli` when missing, validates the packaged RPC client, and the supervisor preserves `rcow_start`'s exit status so systemd `Restart=on-failure` retries.

## Tests

- New offline suites: ISA baseline (`test_isa_baseline.sh`) and rpc.py py3.8 compat (`test_rpc_py38_compat.sh`), plus the `s3_bucket.py` self-test, all wired into `run_all.sh`.
- Extended `test_minio_s3_guard.sh` (s3.cfg rendering, bucket separation, nvme-cli installer, RPC client validation, supervisor exit code) and `test_package_layout.sh` (packaged bucket tool and RPC launcher).
