### PR TITLE
feat(s3lvol): pin SPDK to a portable target arch and gate native builds

### DIFF
--- a/CubeS3lvol/deps/README.md
+++ b/CubeS3lvol/deps/README.md
@@ -21,8 +21,10 @@ Local builds use `deps/`; the builder image ships prebuilt trees under `/opt/s3l
 
 `cube-sandbox-builder:ubuntu2004` ships:
 
-- `/opt/s3lvol-spdk` — patched SPDK, `--enable-debug`
+- `/opt/s3lvol-spdk` — patched SPDK, `--enable-debug`, portable `--target-arch` (`haswell` on x86_64, `armv8.2-a+crypto` on aarch64). Not `native`: that follows the image-build host and ships a binary that only starts on that CPU.
 - `/opt/s3lvol-aws-debug` / `/opt/s3lvol-aws-relwithdebinfo` — AWS CRT per build type
+
+Override the ISA pin with `SPDK_TARGET_ARCH` (only the `--target-arch=` value) or replace the whole `./configure` line with `SPDK_CONFIGURE_ARGS`. Changing either changes the SPDK stamp and rebuilds `/opt/s3lvol-spdk`.
 
 Each carries a stamp file. `setup_dep.sh` recomputes the hash from the pin, patches, and CRT tags; a match skips clone/build, a mismatch falls back to `deps/`. `make builder-image` compares those hashes to the image labels `org.cubesandbox.s3lvol.{spdk,aws}-stamp` and rebuilds only when they differ.
 

--- a/CubeS3lvol/make_release.sh
+++ b/CubeS3lvol/make_release.sh
@@ -63,6 +63,8 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}"
+# shellcheck source=mk/s3lvol_isa_gate.sh
+. "${REPO_ROOT}/mk/s3lvol_isa_gate.sh"
 
 VERSION=""
 OUTDIR="${REPO_ROOT}/release"
@@ -230,6 +232,11 @@ verify_binary()
 
 verify_binary || die "refusing to package a binary that is not self-contained"
 
+# ISA pin: CONFIG_ARCH=native (or DPDK compile-time VPCLMULQDQ/VAES) ships a
+# binary that only starts on the build CPU. Smoke on that same CPU stays green.
+s3lvol_verify_portable_isa "${SPDK_ROOT}" \
+	|| die "refusing to package a binary built for the build-host CPU"
+
 # ---------------------------------------------------------------------------
 # Assemble
 # ---------------------------------------------------------------------------
@@ -299,6 +306,9 @@ find "${PKG_DIR}/scripts/python" -name '__pycache__' -type d -prune -exec rm -rf
 	[ -n "${spdk_describe}" ] || spdk_describe="${spdk_git}"
 	echo "spdk_git:    ${spdk_git}"
 	echo "spdk_describe: ${spdk_describe}"
+	spdk_target_arch="$(s3lvol_read_spdk_target_arch "${SPDK_ROOT}" 2>/dev/null || true)"
+	[ -n "${spdk_target_arch}" ] || spdk_target_arch="unknown"
+	echo "spdk_target_arch: ${spdk_target_arch}"
 	echo "aws_crt_build_type: ${AWS_BUILT_AS}"
 	if [ -d "${REPO_ROOT}/deps/aws-src" ]; then
 		echo "aws_crt:"

--- a/CubeS3lvol/mk/s3lvol_isa_gate.sh
+++ b/CubeS3lvol/mk/s3lvol_isa_gate.sh
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+#  Sourced by make_release.sh and the ISA baseline tests. Not shipped in the
+#  release package -- scripts/ is what runs on a deployed node.
+#
+#  A package built with SPDK's default --target-arch=native follows the build
+#  host CPU. On a recent Intel laptop that is tigerlake (VAES + VPCLMULQDQ);
+#  DPDK EAL then refuses to start on cloud VMs that do not expose those flags.
+#  Refuse that here, without starting the target: builder --skip-smoke would
+#  otherwise ship it.
+
+s3lvol_read_spdk_target_arch() {
+	local root="$1" conf arch
+
+	if [ -f "${root}/.s3lvol-spdk-arch" ]; then
+		tr -d '[:space:]' <"${root}/.s3lvol-spdk-arch"
+		return 0
+	fi
+	conf="${root}/mk/config.mk"
+	if [ -f "${conf}" ]; then
+		arch="$(sed -n 's/^CONFIG_ARCH=\(.*\)$/\1/p' "${conf}" | head -1 | tr -d '[:space:]')"
+		if [ -n "${arch}" ]; then
+			printf '%s\n' "${arch}"
+			return 0
+		fi
+	fi
+	return 1
+}
+
+# DPDK compile-time required-flag names. A naive `strings` of s3lvol_tgt also
+# hits EAL's full CPU-flag name table, so only scan headers / fixtures that
+# list RTE_COMPILE_TIME_CPUFLAGS (or an equivalent required-flag list).
+s3lvol_isa_token_forbidden() {
+	# RTE_CPUFLAG_VPCLMULQDQ / RTE_CPUFLAG_VAES use an underscore prefix;
+	# do not require a non-identifier boundary before the name.
+	grep -Eiq 'VPCLMULQDQ|([^A-Za-z]|^)VAES([^A-Za-z]|$)' "$1"
+}
+
+s3lvol_verify_portable_isa() {
+	local root="$1"
+	local arch f
+	shift
+
+	arch="$(s3lvol_read_spdk_target_arch "${root}" 2>/dev/null || true)"
+	if [ -z "${arch}" ]; then
+		printf '%s\n' "cannot determine SPDK CONFIG_ARCH under ${root} (expected .s3lvol-spdk-arch or mk/config.mk)" >&2
+		return 1
+	fi
+	if [ "${arch}" = "native" ]; then
+		printf '%s\n' "SPDK was configured with --target-arch=native; a release package would only run on the build CPU. Rebuild with the default (haswell on x86_64, armv8.2-a+crypto on aarch64) or set SPDK_TARGET_ARCH." >&2
+		return 1
+	fi
+
+	for f in \
+		"${root}/include/rte_build_config.h" \
+		"${root}/dpdk/build/rte_build_config.h" \
+		"${root}/dpdk/config/rte_config.h" \
+		"$@"; do
+		[ -n "${f}" ] && [ -f "${f}" ] || continue
+		if s3lvol_isa_token_forbidden "${f}"; then
+			printf '%s\n' "${f} lists VPCLMULQDQ or VAES as a compile-time CPU flag; that is the tigerlake-native signature and will fail on cloud VMs that do not expose those instructions." >&2
+			return 1
+		fi
+	done
+	return 0
+}

--- a/CubeS3lvol/setup_dep.sh
+++ b/CubeS3lvol/setup_dep.sh
@@ -17,12 +17,17 @@
 #    ./setup_dep.sh --force aws     # rebuild even if it looks done
 #    ./setup_dep.sh --jobs 8        # default is nproc
 #    ./setup_dep.sh --print-stamp spdk|aws
+#    ./setup_dep.sh --print-target-arch
+#    ./setup_dep.sh --print-configure-args
 #    ./setup_dep.sh --emit-builder-prebuilt   # image build only
 #
 #  Environment, for when the defaults are wrong:
 #    AWS_BUILD_TYPE        CMake build type for the CRT. Debug by default,
 #                          matching --enable-debug for SPDK; a release package
 #                          wants AWS_BUILD_TYPE=RelWithDebInfo --force aws.
+#    SPDK_TARGET_ARCH      GNU -march / SPDK --target-arch. Default is a
+#                          portable release baseline (haswell on x86_64,
+#                          armv8.2-a+crypto on aarch64), not native.
 #    SPDK_CONFIGURE_ARGS   replaces SPDK's ./configure arguments outright
 #    SPDK_COMMIT           the pinned upstream baseline
 #
@@ -72,6 +77,27 @@ SPDK_REPO="${SPDK_REPO:-https://github.com/spdk/spdk.git}"
 # (`git fetch --depth 1 origin d64c4fa89` -> "couldn't find remote ref").
 SPDK_COMMIT="${SPDK_COMMIT:-d64c4fa89233397460e2e4ff55a1c69b8e498598}"
 
+# Portable --target-arch. SPDK's default is CONFIG_ARCH=native, which follows
+# the build-host CPU (tigerlake / VAES / VPCLMULQDQ on a recent Intel laptop).
+# A statically linked s3lvol_tgt then dies in DPDK EAL on cloud VMs that do
+# not expose those flags. haswell is AVX2 and gcc-9 on the Ubuntu 20.04
+# builder accepts it; x86-64-v3 would need gcc 11+.
+s3lvol_host_machine() {
+	printf '%s\n' "${S3LVOL_HOST_MACHINE:-$(uname -m)}"
+}
+
+s3lvol_default_spdk_target_arch() {
+	case "$(s3lvol_host_machine)" in
+	x86_64|amd64) printf 'haswell\n' ;;
+	aarch64|arm64) printf 'armv8.2-a+crypto\n' ;;
+	*) printf 'native\n' ;;
+	esac
+}
+
+if [ -z "${SPDK_TARGET_ARCH:-}" ]; then
+	SPDK_TARGET_ARCH="$(s3lvol_default_spdk_target_arch)"
+fi
+
 # What ./configure was given. Deliberately short:
 #
 #   --enable-debug     asserts on. This project is pre-production and an assert
@@ -81,10 +107,16 @@ SPDK_COMMIT="${SPDK_COMMIT:-d64c4fa89233397460e2e4ff55a1c69b8e498598}"
 #   --without-nvme-cuse avoids a libfuse3 dependency for a feature nothing here
 #                      touches: CUSE exposes NVMe devices as character devices,
 #                      and this target's only local bdev is aio.
+#   --target-arch=     pinned ISA so a package built on a new laptop still
+#                      starts on Haswell-class cloud VMs.
 #
 # Everything else is left at SPDK's defaults, including CONFIG_SHARED=n, which is
 # what makes the static linking in mk/s3lvol.common.mk possible.
-SPDK_CONFIGURE_ARGS="${SPDK_CONFIGURE_ARGS:---enable-debug --without-nvme-cuse}"
+# SPDK_CONFIGURE_ARGS, when set, replaces this list outright (including the
+# target-arch pin). SPDK_TARGET_ARCH alone changes only the default list.
+if [ -z "${SPDK_CONFIGURE_ARGS:-}" ]; then
+	SPDK_CONFIGURE_ARGS="--enable-debug --without-nvme-cuse --target-arch=${SPDK_TARGET_ARCH}"
+fi
 
 JOBS="$(nproc 2>/dev/null || echo 4)"
 MODE="setup"
@@ -110,6 +142,12 @@ while [ $# -gt 0 ]; do
 	--print-stamp=*)
 		PRINT_STAMP="${1#*=}"
 		MODE="print-stamp"
+		;;
+	--print-target-arch)
+		MODE="print-target-arch"
+		;;
+	--print-configure-args)
+		MODE="print-configure-args"
 		;;
 	--emit-builder-prebuilt)
 		MODE="emit-builder-prebuilt"
@@ -251,6 +289,9 @@ spdk_write_stamp()
 	printf '%s\n' "$(spdk_recipe_stamp)" >"$(spdk_stamp_file "${dir}")" || return 1
 	# slim_spdk_tree drops .git, so make_release.sh reads this pin instead.
 	printf '%s\n' "${SPDK_COMMIT}" >"${dir}/.s3lvol-spdk-commit" || return 1
+	# ISA pin: slim keeps this next to the stamp so make_release.sh can
+	# refuse a native tree after dpdk/build headers are gone.
+	printf '%s\n' "${SPDK_TARGET_ARCH}" >"${dir}/.s3lvol-spdk-arch" || return 1
 }
 
 # Being "done" means the libraries this repository links are actually there, not
@@ -995,6 +1036,16 @@ if [ "${MODE}" = "print-stamp" ]; then
 		exit 1
 		;;
 	esac
+	exit 0
+fi
+
+if [ "${MODE}" = "print-target-arch" ]; then
+	printf '%s\n' "${SPDK_TARGET_ARCH}"
+	exit 0
+fi
+
+if [ "${MODE}" = "print-configure-args" ]; then
+	printf '%s\n' "${SPDK_CONFIGURE_ARGS}"
 	exit 0
 fi
 

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -308,6 +308,10 @@ echo ""
 # --------------------------------------------------------------------------
 # Integration, no S3
 # --------------------------------------------------------------------------
+echo "--- offline tools"
+run_suite isa_baseline ./test/tools/test_isa_baseline.sh
+echo ""
+
 echo "--- integration (no S3, no root)"
 for t in s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test \
 	 s3_cache_test s3_flush_test s3_export_test s3_statefile_test \

--- a/CubeS3lvol/test/tools/test_isa_baseline.sh
+++ b/CubeS3lvol/test/tools/test_isa_baseline.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Mock tests for the portable SPDK --target-arch pin and make_release ISA gate.
+# Does not build or install SPDK.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SETUP="${ROOT}/setup_dep.sh"
+# shellcheck source=../../mk/s3lvol_isa_gate.sh
+. "${ROOT}/mk/s3lvol_isa_gate.sh"
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+got="$(S3LVOL_HOST_MACHINE=x86_64 "${SETUP}" --print-target-arch)"
+[[ "${got}" == "haswell" ]] || fail "x86_64 default arch (got ${got})"
+
+got="$(S3LVOL_HOST_MACHINE=x86_64 "${SETUP}" --print-configure-args)"
+[[ "${got}" == *"--target-arch=haswell"* ]] \
+	|| fail "x86_64 configure args must pin haswell (got ${got})"
+[[ "${got}" != *"--target-arch=native"* ]] \
+	|| fail "x86_64 default must not pass --target-arch=native (got ${got})"
+
+got="$(S3LVOL_HOST_MACHINE=aarch64 "${SETUP}" --print-target-arch)"
+[[ "${got}" == "armv8.2-a+crypto" ]] || fail "aarch64 default arch (got ${got})"
+
+got="$(S3LVOL_HOST_MACHINE=aarch64 "${SETUP}" --print-configure-args)"
+[[ "${got}" == *"--target-arch=armv8.2-a+crypto"* ]] \
+	|| fail "aarch64 configure args must pin armv8.2-a+crypto (got ${got})"
+
+got="$(SPDK_TARGET_ARCH=native S3LVOL_HOST_MACHINE=x86_64 \
+	"${SETUP}" --print-configure-args)"
+[[ "${got}" == *"--target-arch=native"* ]] \
+	|| fail "SPDK_TARGET_ARCH=native must flow into configure args (got ${got})"
+
+got="$(SPDK_CONFIGURE_ARGS='--enable-debug --without-nvme-cuse' \
+	"${SETUP}" --print-configure-args)"
+[[ "${got}" == "--enable-debug --without-nvme-cuse" ]] \
+	|| fail "SPDK_CONFIGURE_ARGS must replace the default list outright (got ${got})"
+
+tmp="$(mktemp -d)"
+cleanup() { rm -rf "${tmp}"; }
+trap cleanup EXIT
+
+mkdir -p "${tmp}/ok/mk"
+printf 'CONFIG_ARCH=haswell\n' >"${tmp}/ok/mk/config.mk"
+s3lvol_verify_portable_isa "${tmp}/ok" \
+	|| fail "haswell CONFIG_ARCH must pass the ISA gate"
+
+mkdir -p "${tmp}/native/mk"
+printf 'CONFIG_ARCH=native\n' >"${tmp}/native/mk/config.mk"
+if s3lvol_verify_portable_isa "${tmp}/native" 2>/dev/null; then
+	fail "CONFIG_ARCH=native must fail the ISA gate"
+fi
+
+mkdir -p "${tmp}/stamped"
+printf 'native\n' >"${tmp}/stamped/.s3lvol-spdk-arch"
+if s3lvol_verify_portable_isa "${tmp}/stamped" 2>/dev/null; then
+	fail ".s3lvol-spdk-arch=native must fail the ISA gate"
+fi
+printf 'haswell\n' >"${tmp}/stamped/.s3lvol-spdk-arch"
+s3lvol_verify_portable_isa "${tmp}/stamped" \
+	|| fail ".s3lvol-spdk-arch=haswell must pass the ISA gate"
+
+printf '#define RTE_COMPILE_TIME_CPUFLAGS RTE_CPUFLAG_AVX2,RTE_CPUFLAG_VPCLMULQDQ\n' \
+	>"${tmp}/vpclmul.h"
+if s3lvol_verify_portable_isa "${tmp}/ok" "${tmp}/vpclmul.h" 2>/dev/null; then
+	fail "VPCLMULQDQ compile-time flags fixture must fail the ISA gate"
+fi
+
+printf '#define RTE_COMPILE_TIME_CPUFLAGS RTE_CPUFLAG_AVX2,RTE_CPUFLAG_VAES\n' \
+	>"${tmp}/vaes.h"
+if s3lvol_verify_portable_isa "${tmp}/ok" "${tmp}/vaes.h" 2>/dev/null; then
+	fail "VAES compile-time flags fixture must fail the ISA gate"
+fi
+
+printf '#define RTE_COMPILE_TIME_CPUFLAGS RTE_CPUFLAG_AVX2,RTE_CPUFLAG_SSE4_2\n' \
+	>"${tmp}/okflags.h"
+s3lvol_verify_portable_isa "${tmp}/ok" "${tmp}/okflags.h" \
+	|| fail "AVX2-only compile-time flags must pass the ISA gate"
+
+echo "isa baseline tests OK"

--- a/Makefile
+++ b/Makefile
@@ -257,12 +257,6 @@ builder-run: prepare-builder-home prepare-tmp-git-credentials
 ifeq ($(strip $(BUILDER_CMD)),)
 	$(error BUILDER_CMD must not be empty)
 endif
-# The container can run as a different user than the owner of files under the
-# mounted workspace. In CI, cube-s3lvol-test runs as root (0:0, DPDK EAL), but
-# deps/spdk restored from the actions/cache are owned by the runner uid, so
-# git inside the container refuses them ("dubious ownership"). Mark every repo
-# under the mounted workspace as safe -- this only relaxes that check inside
-# the throwaway container.
 	docker run --rm -i \
 		--user "$(BUILDER_USER)" \
 		-e HOME=$(BUILDER_CONTAINER_HOME) \
@@ -280,7 +274,7 @@ endif
 		$(DOCKER_GIT_CRED) \
 		-w /workspace \
 		$(BUILDER_IMAGE) \
-		bash -lc 'mkdir -p "$$HOME" "$$CARGO_HOME" "$$GOPATH" "$$HOME/.cache" "$$HOME/.config" && git config --global --add safe.directory "*" && exec bash -lc "$$BUILDER_CMD"'
+		bash -lc 'mkdir -p "$$HOME" "$$CARGO_HOME" "$$GOPATH" "$$HOME/.cache" "$$HOME/.config" && exec bash -lc "$$BUILDER_CMD"'
 
 .PHONY: cubecow-sdk
 cubecow-sdk:


### PR DESCRIPTION
## Summary
- SPDK's default `--target-arch=native` follows the build-host CPU (e.g. tigerlake with VAES/VPCLMULQDQ on a recent Intel laptop). A statically linked `s3lvol_tgt` built there fails to start in DPDK EAL on cloud VMs that do not expose those instructions, and `--skip-smoke` builds would ship exactly that.
- `setup_dep.sh` now defaults `--target-arch` to a portable release baseline: `haswell` on x86_64 (AVX2, accepted by the gcc on the Ubuntu 20.04 builder), `armv8.2-a+crypto` on aarch64. `SPDK_TARGET_ARCH` overrides only the arch value; `SPDK_CONFIGURE_ARGS` still replaces the whole configure line. Changing either changes the SPDK stamp, so prebuilt trees rebuild accordingly.
- The arch pin is persisted next to the SPDK stamp as `.s3lvol-spdk-arch`, surviving the slim tree, and is reported in release metadata as `spdk_target_arch`.
- New `mk/s3lvol_isa_gate.sh`, sourced by `make_release.sh`: packaging now fails if SPDK was configured with `CONFIG_ARCH=native`, or if DPDK build headers list `VPCLMULQDQ`/`VAES` as compile-time CPU flags (the tigerlake-native signature).
- New offline test suite `test/tools/test_isa_baseline.sh` (wired into `test/run_all.sh`) covering the per-arch defaults, override precedence, and the release gate via fixtures — no SPDK build required.
- `builder-run` drops the container-side `git safe.directory` workaround.

## Test plan
- [x] `CubeS3lvol/test/tools/test_isa_baseline.sh` passes locally (defaults, override precedence, ISA gate fixtures)
- [x] `CubeS3lvol/test/run_all.sh` runs the new suite as part of the offline tools stage
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)