### PR TITLE
fix: drop exposed-port count cap and classify L7 intercept as TCP-only

### DIFF
--- a/CubeMaster/pkg/templatecenter/request_validation.go
+++ b/CubeMaster/pkg/templatecenter/request_validation.go
@@ -259,26 +259,5 @@ func normalizeTemplateExposedPorts(ports []int32) ([]int32, error) {
 	sort.Slice(normalized, func(i, j int) bool {
 		return normalized[i] < normalized[j]
 	})
-	if countCustomTemplateExposedPorts(normalized) > 3 {
-		return nil, fmt.Errorf("at most 3 custom exposed ports are supported")
-	}
 	return normalized, nil
-}
-
-func countCustomTemplateExposedPorts(ports []int32) int {
-	reserved := defaultTemplateExposedPorts()
-	count := 0
-	for _, port := range ports {
-		if _, ok := reserved[port]; ok {
-			continue
-		}
-		count++
-	}
-	return count
-}
-
-func defaultTemplateExposedPorts() map[int32]struct{} {
-	return map[int32]struct{}{
-		49983: {},
-	}
 }

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -251,46 +251,19 @@ func TestNormalizeTemplateImageRequestAllowsCIDRAllowOutWithoutDenyAll(t *testin
 	}
 }
 
-func TestNormalizeTemplateImageRequestRejectsTooManyCustomExposedPorts(t *testing.T) {
-
-	_, err := normalizeTemplateImageRequest(&types.CreateTemplateFromImageReq{
+func TestNormalizeTemplateImageRequestAllowsMoreThanThreeCustomExposedPorts(t *testing.T) {
+	req, err := normalizeTemplateImageRequest(&types.CreateTemplateFromImageReq{
 		Request:           &types.Request{RequestID: "req-1"},
 		SourceImageRef:    "docker.io/library/nginx:latest",
 		WritableLayerSize: "20Gi",
-		ExposedPorts:      []int32{9000, 9001, 9002, 9003},
+		ExposedPorts:      []int32{9000, 9001, 9002, 9003, 80},
 	})
-	if err == nil || !strings.Contains(err.Error(), "at most 3 custom exposed ports") {
-		t.Fatalf("unexpected error: %v", err)
+	if err != nil {
+		t.Fatalf("normalizeTemplateImageRequest failed: %v", err)
 	}
-}
-
-func TestDefaultTemplateExposedPortsContainsOnly49983(t *testing.T) {
-	got := defaultTemplateExposedPorts()
-	want := map[int32]struct{}{49983: {}}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("defaultTemplateExposedPorts()=%v, want %v", got, want)
-	}
-}
-
-func TestCountCustomTemplateExposedPortsTreats49983AsReserved(t *testing.T) {
-	if count := countCustomTemplateExposedPorts([]int32{49983, 9000}); count != 1 {
-		t.Fatalf("countCustomTemplateExposedPorts([49983, 9000])=%d, want 1", count)
-	}
-	if count := countCustomTemplateExposedPorts([]int32{8080, 9000}); count != 2 {
-		t.Fatalf("countCustomTemplateExposedPorts([8080, 9000])=%d, want 2", count)
-	}
-}
-
-func TestNormalizeTemplateImageRequestTreatsOnlyCubeletDefaultsAsReserved(t *testing.T) {
-
-	_, err := normalizeTemplateImageRequest(&types.CreateTemplateFromImageReq{
-		Request:           &types.Request{RequestID: "req-1"},
-		SourceImageRef:    "docker.io/library/nginx:latest",
-		WritableLayerSize: "20Gi",
-		ExposedPorts:      []int32{80, 9000, 9001, 9002},
-	})
-	if err == nil || !strings.Contains(err.Error(), "at most 3 custom exposed ports") {
-		t.Fatalf("unexpected error: %v", err)
+	want := []int32{80, 9000, 9001, 9002, 9003}
+	if !reflect.DeepEqual(req.ExposedPorts, want) {
+		t.Fatalf("ExposedPorts=%v, want %v", req.ExposedPorts, want)
 	}
 }
 

--- a/CubeNet/cubevs/egress_policy_test.go
+++ b/CubeNet/cubevs/egress_policy_test.go
@@ -15,6 +15,9 @@ const (
 	flowVerdictSNAT         = uint8(1)
 	flowVerdictHTTP         = uint8(2)
 	flowVerdictHTTPS        = uint8(3)
+	ipprotoICMP             = uint8(1)
+	ipprotoTCP              = uint8(6)
+	ipprotoUDP              = uint8(17)
 )
 
 type egressPolicyTestEnv struct {
@@ -108,11 +111,19 @@ func runEgressPolicyCase(t *testing.T, prog *ebpf.Program, ifindex, daddr uint32
 	dport uint16,
 ) uint8 {
 	t.Helper()
+	return runEgressPolicyCaseProto(t, prog, ifindex, daddr, dport, ipprotoTCP)
+}
+
+func runEgressPolicyCaseProto(t *testing.T, prog *ebpf.Program, ifindex, daddr uint32,
+	dport uint16, protocol uint8,
+) uint8 {
+	t.Helper()
 
 	data := make([]byte, egressPolicyTestCaseLen)
 	binary.LittleEndian.PutUint32(data[0:4], ifindex)
 	binary.LittleEndian.PutUint32(data[4:8], daddr)
 	binary.LittleEndian.PutUint16(data[8:10], dport)
+	data[11] = protocol
 	ret, out, err := prog.Test(data)
 	if err != nil {
 		if bpfTestUnavailable(err) {
@@ -265,7 +276,42 @@ func TestClassifyEgressFlowL7UnknownSchemeFailsClosed(t *testing.T) {
 	}
 
 	if got := runEgressPolicyCase(t, env.program, ifindex, daddr, dport); got != flowVerdictReject {
-		t.Fatalf("verdict=%d, want FLOW_REJECT (fail closed on unknown scheme)", got)
+		t.Fatalf("TCP verdict=%d, want FLOW_REJECT (fail closed on unknown scheme)", got)
+	}
+	if got := runEgressPolicyCaseProto(t, env.program, ifindex, daddr, dport, ipprotoUDP); got != flowVerdictSNAT {
+		t.Fatalf("UDP verdict=%d, want FLOW_SNAT", got)
+	}
+}
+
+func TestClassifyEgressFlowUDPAndICMPOnL7PortAreSNAT(t *testing.T) {
+	env := loadEgressPolicyTestEnv(t)
+	ifindex := uint32(153)
+	allowInner, denyInner := env.attachInnerMaps(t, ifindex)
+	daddr := mustParseCIDRForTest(t, "192.0.2.23").IP
+	dport := htonsPort(443)
+	allowKey := lpmKeyV3{Prefixlen: 48, IP: daddr, Port: dport}
+	allowValue := netPolicyValueV3{
+		Flags:  uint8(netPolicyFlagL7Required),
+		Scheme: L7SchemeHTTPS,
+	}
+	if err := allowInner.Put(&allowKey, &allowValue); err != nil {
+		t.Fatalf("insert exact L7 HTTPS allow rule: %v", err)
+	}
+
+	denyAll := mustParseCIDRForTest(t, "0.0.0.0/0")
+	denyValue := uint32(1)
+	if err := denyInner.Put(&denyAll, &denyValue); err != nil {
+		t.Fatalf("insert deny-all rule: %v", err)
+	}
+
+	if got := runEgressPolicyCase(t, env.program, ifindex, daddr, dport); got != flowVerdictHTTPS {
+		t.Fatalf("TCP verdict=%d, want FLOW_HTTPS", got)
+	}
+	if got := runEgressPolicyCaseProto(t, env.program, ifindex, daddr, dport, ipprotoUDP); got != flowVerdictSNAT {
+		t.Fatalf("UDP verdict=%d, want FLOW_SNAT", got)
+	}
+	if got := runEgressPolicyCaseProto(t, env.program, ifindex, daddr, dport, ipprotoICMP); got != flowVerdictSNAT {
+		t.Fatalf("ICMP verdict=%d, want FLOW_SNAT", got)
 	}
 }
 
@@ -375,8 +421,9 @@ func TestSessionPolicyRevoked(t *testing.T) {
 		schemeNone  = uint8(0)
 		schemeHTTP  = uint8(1)
 		schemeHTTPS = uint8(2)
-		protoTCP    = uint8(6)  // IPPROTO_TCP
-		protoUDP    = uint8(17) // IPPROTO_UDP
+		protoTCP    = uint8(6)
+		protoUDP    = uint8(17)
+		protoICMP   = uint8(1)
 	)
 
 	env := loadEgressPolicyTestEnv(t)
@@ -443,7 +490,7 @@ func TestSessionPolicyRevoked(t *testing.T) {
 		},
 		{
 			// SNAT and L7 disagree on the reply tuple and on who terminates
-			// the connection, so a TCP flow cannot migrate between them.
+			// the connection, so a flow cannot migrate between them.
 			name: "verdict change SNAT to L7 is revoked",
 			tc: sessionRecheckCase{
 				ifindex: ifindex, daddr: l7Host.IP, dport: otherPort,
@@ -474,13 +521,20 @@ func TestSessionPolicyRevoked(t *testing.T) {
 			wantVersion: 6,
 		},
 		{
-			// UDP is always SNAT. classify_egress_flow has no protocol, so an
-			// L7 allow on :443 still returns FLOW_HTTPS for QUIC; that standing
-			// mismatch is not a policy change and must not kill the flow.
 			name: "UDP SNAT against an L7 dest is restamped",
 			tc: sessionRecheckCase{
 				ifindex: ifindex, daddr: l7Host.IP, dport: otherPort,
 				packetClass: packetSNAT, l7Scheme: schemeNone, protocol: protoUDP,
+				sessPolicyVersion: 5, metaPolicyVersion: 6,
+			},
+			wantRevoked: false,
+			wantVersion: 6,
+		},
+		{
+			name: "ICMP SNAT against an L7 dest is restamped",
+			tc: sessionRecheckCase{
+				ifindex: ifindex, daddr: l7Host.IP, dport: otherPort,
+				packetClass: packetSNAT, l7Scheme: schemeNone, protocol: protoICMP,
 				sessPolicyVersion: 5, metaPolicyVersion: 6,
 			},
 			wantRevoked: false,

--- a/CubeNet/src/egress_policy_test.bpf.c
+++ b/CubeNet/src/egress_policy_test.bpf.c
@@ -12,7 +12,8 @@ struct egress_policy_case {
 	__u32 daddr;
 	__u16 dport;
 	__u8 verdict;
-	__u8 reserved[5];
+	__u8 protocol;
+	__u8 reserved[4];
 };
 
 SEC("tc")
@@ -23,7 +24,8 @@ int test_classify_egress_flow(struct __sk_buff *skb)
 	if (bpf_skb_load_bytes(skb, 0, &tc, sizeof(tc)))
 		return TC_ACT_SHOT;
 
-	tc.verdict = classify_egress_flow(tc.ifindex, tc.daddr, tc.dport);
+	tc.verdict = classify_egress_flow(tc.ifindex, tc.daddr, tc.dport,
+					  tc.protocol);
 	if (bpf_skb_store_bytes(skb, 0, &tc, sizeof(tc), 0))
 		return TC_ACT_SHOT;
 
@@ -60,7 +62,7 @@ int test_session_policy_revoked(struct __sk_buff *skb)
 
 	tc.revoked = session_policy_revoked(&sess, tc.meta_policy_version,
 					    tc.ifindex, tc.daddr, tc.dport,
-					    tc.protocol);
+					    tc.protocol ? tc.protocol : IPPROTO_TCP);
 	tc.policy_version_out = sess.policy_version;
 
 	if (bpf_skb_store_bytes(skb, 0, &tc, sizeof(tc), 0))

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -390,7 +390,7 @@ static __always_inline __u32 do_icmp_nat(struct __sk_buff *skb, struct mvm_meta 
 
 	/* create new session */
 	if (classify_egress_flow(skb->ingress_ifindex, key.dst_ip,
-				 key.dst_port) == FLOW_REJECT)
+				 key.dst_port, key.protocol) == FLOW_REJECT)
 		return 0;
 	snat_ip = pick_snat_ip_port(mvm_meta->ip, &key, &snat_id);
 	if (!snat_ip || !snat_ip->ip || !snat_id)
@@ -499,7 +499,7 @@ static __always_inline __u32 do_udp_nat_inline(struct __sk_buff *skb,
 
 	/* create new session */
 	if (classify_egress_flow(skb->ingress_ifindex, key.dst_ip,
-				 key.dst_port) == FLOW_REJECT)
+				 key.dst_port, key.protocol) == FLOW_REJECT)
 		return 0;
 	snat_ip = pick_snat_ip_port(mvm_meta->ip, &key, &snat_port);
 	if (!snat_ip || !snat_ip->ip || !snat_port)
@@ -672,7 +672,7 @@ do_create:
 	 * cached in nat_session and reused for every later packet.
 	 */
 	verdict = classify_egress_flow(skb->ingress_ifindex, key.dst_ip,
-				       key.dst_port);
+				       key.dst_port, key.protocol);
 	switch (verdict) {
 	case FLOW_HTTP:
 	case FLOW_HTTPS:
@@ -1047,7 +1047,7 @@ int from_cube(struct __sk_buff *skb)
 		 * behavior of the do_tcp_nat() path; UDP/ICMP silently drop.
 		 * dport is 0 because the original check was port-agnostic.
 		 */
-		switch (classify_egress_flow(ifindex, daddr, 0)) {
+		switch (classify_egress_flow(ifindex, daddr, 0, proto)) {
 		case FLOW_REJECT:
 			if (proto == IPPROTO_TCP)
 				return tcp_send_reset(skb, skb->ingress_ifindex, mvm_inner_ip);

--- a/CubeNet/src/session.h
+++ b/CubeNet/src/session.h
@@ -156,16 +156,18 @@ enum flow_verdict {
 
 /**
  * classify_egress_flow - single egress policy decision for a candidate flow
- * @ifindex: TAP ifindex of the originating MVM (policy key)
- * @daddr:   destination IP address in network byte order
- * @dport:   destination port in network byte order (0 for port-agnostic)
+ * @ifindex:  TAP ifindex of the originating MVM (policy key)
+ * @daddr:    destination IP address in network byte order
+ * @dport:    destination port in network byte order (0 for port-agnostic)
+ * @protocol: IPPROTO_* of the candidate flow
  *
  * Priority: allow_out_v3 > deny_out > default allow.
  *
  *   1. Look up (daddr, dport)/48 in allow_out_v3. LPM automatically falls
  *      back to a matching /32 or subnet entry. A non-expired L7_REQUIRED
- *      entry returns FLOW_HTTP / FLOW_HTTPS; any other non-expired allow
- *      entry returns FLOW_SNAT.
+ *      entry returns FLOW_HTTP / FLOW_HTTPS only for TCP: L7 intercept is a
+ *      TCP TPROXY path. UDP and ICMP that hit the same allow entry return
+ *      FLOW_SNAT. Any other non-expired allow entry returns FLOW_SNAT.
  *   2. Else if deny_out matches a /32 (or wider) entry, the flow is
  *      rejected (FLOW_REJECT).
  *   3. Otherwise the flow is allowed via SNAT (default allow).
@@ -180,7 +182,7 @@ enum flow_verdict {
  * through to deny_out (e.g. 0.0.0.0/0) and was silently dropped.
  */
 static __always_inline __u8 classify_egress_flow(__u32 ifindex, __u32 daddr,
-						 __u16 dport)
+						 __u16 dport, __u8 protocol)
 {
 	struct lpm_key_v3 key = {};
 	struct net_policy_value_v3 *value;
@@ -202,7 +204,8 @@ static __always_inline __u8 classify_egress_flow(__u32 ifindex, __u32 daddr,
 		value = bpf_map_lookup_elem(inner_map, &key);
 		if (value && (value->expires_at_ns == 0 ||
 			      value->expires_at_ns > now)) {
-			if (value->flags & NET_POLICY_FLAG_L7_REQUIRED) {
+			if ((value->flags & NET_POLICY_FLAG_L7_REQUIRED) &&
+			    protocol == IPPROTO_TCP) {
 				if (value->scheme == L7_SCHEME_HTTP)
 					return FLOW_HTTP;
 				if (value->scheme == L7_SCHEME_HTTPS)
@@ -265,7 +268,7 @@ static __always_inline __u8 session_verdict(const struct nat_session *sess)
  * @ifindex:   TAP ifindex of the originating MVM
  * @daddr:     destination IP in network byte order
  * @dport:     destination port in network byte order (0 for ICMP)
- * @protocol:  IPPROTO_* of the flow, from the session key
+ * @protocol:  IPPROTO_* passed through to classify_egress_flow
  *
  * Returns true when this flow may no longer carry traffic. Callers retire the
  * session pair with del_session() and reject the packet: TCP answers with an RST
@@ -277,14 +280,10 @@ static __always_inline __u8 session_verdict(const struct nat_session *sess)
  * flow cannot resume even if a subsequent update re-allows the destination,
  * while a SYN legitimately opens a fresh connection under the current policy.
  *
- * A verdict *change* counts as revocation, not just FLOW_REJECT, but only for
- * TCP. Once a TCP flow must switch between plain SNAT and L7 interception there
- * is no way to migrate it -- the two paths disagree on both the reply tuple and
- * who terminates the connection -- so the flow is retired and the client
- * reconnects. UDP and ICMP are always SNAT; classify_egress_flow has no
- * protocol, so an L7 allow on the same (ip, port) returns FLOW_HTTP/HTTPS for
- * them too. That standing mismatch is not a policy change and must not kill
- * the flow. Non-TCP sessions are therefore revoked only on FLOW_REJECT.
+ * A verdict *change* counts as revocation, not just FLOW_REJECT. Once a flow
+ * must switch between plain SNAT and L7 interception there is no way to migrate
+ * it -- the two paths disagree on both the reply tuple and who terminates the
+ * TCP connection -- so the flow is retired and the client reconnects.
  *
  * Called before update_session(): there is no point advancing the conntrack
  * state of a flow that is about to be deleted.
@@ -307,10 +306,8 @@ static __always_inline bool session_policy_revoked(struct nat_session *sess,
 	if (sess->policy_version == policy_version)
 		return false;
 
-	verdict = classify_egress_flow(ifindex, daddr, dport);
-	if (verdict == FLOW_REJECT)
-		return true;
-	if (protocol == IPPROTO_TCP && verdict != session_verdict(sess))
+	verdict = classify_egress_flow(ifindex, daddr, dport, protocol);
+	if (verdict == FLOW_REJECT || verdict != session_verdict(sess))
 		return true;
 	sess->policy_version = policy_version;
 	return false;

--- a/Cubelet/services/cubebox/check.go
+++ b/Cubelet/services/cubebox/check.go
@@ -54,10 +54,6 @@ func checkParam(ctx context.Context, realReq *cubebox.RunCubeSandboxRequest) err
 			return ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "invalid exposed port %d", p)
 		}
 	}
-	if len(realReq.GetExposedPorts()) > 4 {
-		return ret.Errorf(errorcode.ErrorCode_InvalidParamFormat,
-			"exposed ports should be at most 4")
-	}
 
 	if err != nil {
 		return ret.Err(errorcode.ErrorCode_InvalidParamFormat, err.Error())

--- a/Cubelet/services/cubebox/check_test.go
+++ b/Cubelet/services/cubebox/check_test.go
@@ -281,7 +281,7 @@ func TestCheckParamExposedPorts(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("valid ports within limit", func(t *testing.T) {
+	t.Run("valid ports", func(t *testing.T) {
 		err := checkParam(ctx, &cubebox.RunCubeSandboxRequest{
 			ExposedPorts: []int64{49983, 80, 443, 8080},
 		})
@@ -304,11 +304,10 @@ func TestCheckParamExposedPorts(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid exposed port")
 	})
 
-	t.Run("rejects more than 4 ports", func(t *testing.T) {
+	t.Run("allows more than 4 ports", func(t *testing.T) {
 		err := checkParam(ctx, &cubebox.RunCubeSandboxRequest{
 			ExposedPorts: []int64{49983, 80, 443, 8080, 9000},
 		})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "at most 4")
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Summary

- Drop the exposed-port count caps. Template create used to allow at most 3 custom ports (envd `49983` excluded) and Cubelet rejected more than 4 total. Host port budget is already an operator concern; keep range and dedup checks only.
- Classify L7 intercept as TCP-only. `allow_out_v3` is keyed by `(ip, port)` with no protocol, so UDP/ICMP to an L7 port used to return `FLOW_HTTP`/`FLOW_HTTPS`. Sessions are always SNAT, and the first unrelated `policy_version` bump looked like a verdict change and killed QUIC. Pass `IPPROTO_*` into `classify_egress_flow` and take the `L7_REQUIRED` branch only for TCP; UDP/ICMP that hit the same allow entry stay SNAT. Re-check can compare verdicts uniformly again (`REJECT` or `verdict != session_verdict`).