### PR TITLE
s3lvol: record and retry deletes that cannot complete

### DIFF
--- a/CubeS3lvol/README.md
+++ b/CubeS3lvol/README.md
@@ -220,16 +220,25 @@ keeps running in the background. The uuid is not a completion signal — poll it
 
 ```sh
 scripts/s3lvol_rpc.py rcow_get_snapshot_status '{"export_uuid":"<uuid>"}'
-# -> {"export_status":"INPROGRESS","deletable":"NO"}  ... then, eventually
-# -> {"export_status":"DONE","deletable":"NO"}          (still pinned while exported)
+# -> {"export_status":"INPROGRESS","deletable":"NO","delete_pending":false}
+#    ... then, eventually
+# -> {"export_status":"DONE","deletable":"NO","delete_pending":false}
+#    (still pinned while exported)
 ```
 
-`rcow_get_snapshot_status` returns two fields:
+`rcow_get_snapshot_status` returns three fields:
 
 - `export_status`: `INPROGRESS` / `DONE` / `NONE`.
 - `deletable`: `YES` / `NO`, computed on the spot each time (never cached) and
   mirroring what `rcow_delete_lvol` would actually refuse: a snapshot is **not
-  deletable** while an export is in progress or when it has more than one clone.
+  deletable** while an export is in progress or pins it, while a decouple is
+  running on it, while it is active over NVMf, or when it has more than one
+  clone.
+- `delete_pending`: whether a delete was asked for and refused — see
+  [Retrying a refused snapshot delete](#retrying-a-refused-snapshot-delete---retry-pending).
+  Only meaningful when the query names a `snapshot_name`; queried by
+  `export_uuid` it is always `false`, because an export names a snapshot but is
+  not one.
 
 It accepts exactly one of two keys: `export_uuid`, or `snapshot_name` for a
 snapshot that may never have been exported (such a snapshot reports `NONE`).
@@ -365,4 +374,87 @@ is not disturbed by scheduler contention.
   while the decouple still reads through it"*. Wait for the decouple to finish
   (`rcow_get_decouple` status -- its list emptying is the signal) before taking
   the snapshot or clone.
+
+## Retrying a refused snapshot delete (`--retry-pending`)
+
+A snapshot that is pinned — an export names it, it has clones, or a decouple is
+running — cannot be deleted: `rcow_delete_lvol` refuses, and the refusal records
+a **pending-delete mark** for the snapshot. The mark is the *only* record that a
+delete was asked for: from the target's side every delete arrives as the same
+RPC, so there is no way to tell a user's delete from an automation's. The mark
+therefore is what "the user asked for this delete" means.
+
+Marks are keyed by **(lvstore uuid, lvol uuid)**, not by name: a name is unique
+only inside one loaded lvstore and is reusable, so a name-keyed mark could end up
+pointing at a snapshot the delete was never refused for.
+
+`rcow_get_lvstores` reports the mark per snapshot (`delete_pending`), together
+with whether the snapshot is deletable *right now* (`deletable`). Once the
+blocker clears — the export is released or expires, the extra clone is deleted —
+the snapshot becomes deletable, but the delete still has to be carried out by
+hand:
+
+```sh
+test/tools/s3lvol_rpc.py --retry-pending
+```
+
+It reads `rcow_get_lvstores`, finds every snapshot that **both** carries the
+pending-delete mark **and** is currently deletable, and calls `rcow_delete_lvol`
+for each — passing the snapshot's uuid alongside its name, so a delete meant for
+one object cannot land on a later one that reused the name:
+
+- A snapshot without the mark is **never touched** — snapshots a test or another
+  node created, or that were never deleted on purpose, are left alone.
+- A snapshot that is still pinned reports `deletable: NO` and is deliberately
+  skipped; run `--retry-pending` again once the blocker clears.
+- Each successful delete clears the mark on the target; a delete refused again
+  is reported and does not stop the others.
+
+The command takes no method argument. Its exit status is 0 when every
+marked-and-deletable snapshot went through, 1 if any delete failed, and it
+prints `no pending snapshot deletes to retry` when there is nothing to do:
+
+```sh
+$ test/tools/s3lvol_rpc.py --retry-pending
+no pending snapshot deletes to retry
+```
+
+### What this is not
+
+The mark is a record and a manual retry, nothing more. Specifically:
+
+- **Not every refusal records a mark.** Recorded are the snapshot blockers
+  `s3lvol_lvol_destroy()` itself identifies — an export pin (published or still
+  in flight), more than one clone, a running decouple — plus an asynchronous
+  destroy failure. Not recorded: the RPC-layer refusals that run before it (an
+  NVMf-active volume, an unreadable active registry), a bdev unregister that
+  fails, and the case where `spdk_blob_get_clones()` answers an unknown error.
+  Those are either the caller's own precondition to fix (deactivate first) or a
+  failure that has to be looked at rather than retried blindly.
+- **No automatic retry.** Nothing on the target polls the marks; there is no
+  deferred-completion poller. `--retry-pending` is the only thing that acts on
+  them, and it has to be run.
+- **In memory only.** The marks live in the target process and are gone on
+  restart. A delete refused before a restart is afterwards indistinguishable
+  from one that was never asked for.
+- **Dropped with the lvstore.** Unloading or deleting an lvstore drops that
+  lvstore's marks, deliberately: past the teardown they would name lvols that no
+  longer exist, and an lvstore attached again can give the same names to
+  different objects.
+- **No cancel.** Completing the delete is the only way to clear a mark; a
+  refused delete stays recorded for as long as the target runs and its lvstore
+  stays attached.
+- **`delete_pending` is a snapshot notion.** `rcow_get_snapshot_status` reports
+  it when queried by `snapshot_name`; queried by `export_uuid` it is always
+  `false`, because an export names a snapshot but is not one.
+- **The cluster path does not use it.** Cubelet's own delete
+  (`S3Cow.DeleteByKind`) still treats a refused snapshot delete as success, and
+  it does not run `--retry-pending`. This is an operator tool for the node; the
+  object leak on the cluster path is a separate change.
+
+`deletable: YES` means every blocker the delete path checks is clear right now —
+export pins, a running decouple, an NVMf-active volume, and more than one clone.
+It is a snapshot of the current state, not a promise: something can pin the
+snapshot again between the query and the delete, and a retry that is refused
+again is reported by `--retry-pending` (exit status 1) rather than hidden.
 

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
@@ -725,7 +725,64 @@ int s3lvol_export_query(const char *export_uuid,
  *         lvstore has a volume by that name.
  */
 int s3lvol_snapshot_query(const char *snapshot_name,
-			  enum s3lvol_export_state *state, bool *deletable);
+			  enum s3lvol_export_state *state, bool *deletable,
+			  bool *pending);
+
+/**
+ * The same three answers for an lvol the caller already holds.
+ *
+ * Preferred wherever the lvol is in hand: s3lvol_snapshot_query() re-resolves
+ * the name through s3lvol_lvol_find_any(), which walks every loaded lvstore --
+ * O(N) per call, so O(N^2) over a listing loop -- and answers NULL when the same
+ * name exists in more than one lvstore, silently dropping the fields for every
+ * lvol sharing it.
+ *
+ * \return 0 on success, -EINVAL for a NULL argument, -ENODEV when the lvol is
+ *         not on a loaded s3lvol lvstore.
+ */
+int s3lvol_snapshot_query_lvol(struct spdk_lvol *lvol,
+			       enum s3lvol_export_state *state, bool *deletable,
+			       bool *pending);
+
+/**
+ * Whether an lvol is a snapshot, answerable with the blob closed.
+ *
+ * spdk_blob_is_read_only() needs an open blob, so a deactivated snapshot reads
+ * as "not a snapshot" through it -- which is how a marked-but-deactivated
+ * snapshot became invisible to --retry-pending.
+ */
+bool s3lvol_lvol_is_snapshot(struct spdk_lvol *lvol);
+
+/**
+ * Record / test / clear the "a delete of this snapshot was attempted and could
+ * not complete" mark. There is no deferred-completion poller: the mark only
+ * shows up in rcow_get_lvstores, and the caller (today
+ * test/tools/s3lvol_rpc.py --retry-pending) reissues rcow_delete_lvol once the
+ * blocker (export pin, clones, decouple) clears. The list lives in memory only
+ * and is gone on restart.
+ *
+ * Keyed by (lvstore uuid, lvol uuid) rather than by name: a name is unique only
+ * inside one loaded lvstore and is reusable, so a name-keyed mark can end up
+ * pointing at an object the delete was never refused for. \c name is carried
+ * for log lines only.
+ */
+void s3lvol_snapshot_pending_set(const struct spdk_uuid *lvs_uuid,
+				 const struct spdk_uuid *lvol_uuid,
+				 const char *snapshot_name);
+bool s3lvol_snapshot_pending_test(const struct spdk_uuid *lvs_uuid,
+				  const struct spdk_uuid *lvol_uuid);
+void s3lvol_snapshot_pending_clear(const struct spdk_uuid *lvs_uuid,
+				   const struct spdk_uuid *lvol_uuid);
+
+/**
+ * Drop every pending-delete mark belonging to one lvstore.
+ *
+ * Called from the unload / destroy / free paths. Past a teardown the marks name
+ * lvols that no longer exist, and an lvstore attached again can give the same
+ * names to different objects -- a mark that outlives its lvstore is how
+ * --retry-pending could delete something nobody asked it to.
+ */
+void s3lvol_snapshot_pending_clear_lvs(const struct spdk_uuid *lvs_uuid);
 
 /**
  * Whether an export that has not published its manifest yet names this snapshot.

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_exports.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_exports.c
@@ -49,6 +49,121 @@
  * table, and a node with more live exports than this has a different problem. */
 #define S3LVOL_MAX_EXPORTS 64
 
+/* === Pending-delete marks ==================================================
+ * A delete that cannot complete because the snapshot is referenced (an export
+ * pins it, it has clones, or a decouple is running) records the intent here.
+ * rcow_get_lvstores reports it so the caller sees the snapshot was "tried to
+ * delete" and can retry once the blocker clears. The deferred-completion poller
+ * is a later step.
+ *
+ * Keyed by (lvstore uuid, lvol uuid), not by name. A name is unique only within
+ * one loaded lvstore and is reusable: delete a snapshot and create another one
+ * by the same name, or unload the lvstore and attach it again, and a name-keyed
+ * mark would point at a different object than the one the delete was refused
+ * for -- which --retry-pending would then delete. A lvol uuid is generated once
+ * and never reused, so the mark can only ever name the object it was recorded
+ * for. The lvstore uuid groups the marks so a teardown can drop them all
+ * (s3lvol_snapshot_pending_clear_lvs()); the name is kept for log lines only.
+ */
+
+struct s3lvol_pending_delete {
+	struct spdk_uuid           lvs_uuid;
+	struct spdk_uuid           lvol_uuid;
+	char                       name[SPDK_LVOL_NAME_MAX];
+	TAILQ_ENTRY(s3lvol_pending_delete) link;
+};
+
+static TAILQ_HEAD(, s3lvol_pending_delete) g_pending_deletes =
+	TAILQ_HEAD_INITIALIZER(g_pending_deletes);
+
+static struct s3lvol_pending_delete *
+pending_delete_find(const struct spdk_uuid *lvs_uuid,
+		    const struct spdk_uuid *lvol_uuid)
+{
+	struct s3lvol_pending_delete *pd;
+
+	TAILQ_FOREACH(pd, &g_pending_deletes, link) {
+		if (spdk_uuid_compare(&pd->lvs_uuid, lvs_uuid) == 0 &&
+		    spdk_uuid_compare(&pd->lvol_uuid, lvol_uuid) == 0) {
+			return pd;
+		}
+	}
+	return NULL;
+}
+
+void
+s3lvol_snapshot_pending_set(const struct spdk_uuid *lvs_uuid,
+			    const struct spdk_uuid *lvol_uuid,
+			    const char *name)
+{
+	struct s3lvol_pending_delete *pd;
+
+	if (!lvs_uuid || !lvol_uuid) {
+		return;
+	}
+	if (pending_delete_find(lvs_uuid, lvol_uuid)) {
+		return;
+	}
+	pd = calloc(1, sizeof(*pd));
+	if (!pd) {
+		SPDK_ERRLOG("failed to allocate pending-delete mark for '%s'\n",
+			    name ? name : "(unnamed)");
+		return;
+	}
+	spdk_uuid_copy(&pd->lvs_uuid, lvs_uuid);
+	spdk_uuid_copy(&pd->lvol_uuid, lvol_uuid);
+	snprintf(pd->name, sizeof(pd->name), "%s", name ? name : "");
+	TAILQ_INSERT_TAIL(&g_pending_deletes, pd, link);
+}
+
+bool
+s3lvol_snapshot_pending_test(const struct spdk_uuid *lvs_uuid,
+			     const struct spdk_uuid *lvol_uuid)
+{
+	if (!lvs_uuid || !lvol_uuid) {
+		return false;
+	}
+	return pending_delete_find(lvs_uuid, lvol_uuid) != NULL;
+}
+
+void
+s3lvol_snapshot_pending_clear(const struct spdk_uuid *lvs_uuid,
+			      const struct spdk_uuid *lvol_uuid)
+{
+	struct s3lvol_pending_delete *pd;
+
+	if (!lvs_uuid || !lvol_uuid) {
+		return;
+	}
+	pd = pending_delete_find(lvs_uuid, lvol_uuid);
+	if (pd) {
+		TAILQ_REMOVE(&g_pending_deletes, pd, link);
+		free(pd);
+	}
+}
+
+/* Every mark belonging to one lvstore, dropped in one go.
+ *
+ * Called from the unload / destroy / free paths: past a teardown the marks name
+ * lvols that no longer exist, and an lvstore that is attached again can hand the
+ * same names to different objects. Marks that outlive their lvstore are how
+ * --retry-pending could end up deleting something nobody asked it to. */
+void
+s3lvol_snapshot_pending_clear_lvs(const struct spdk_uuid *lvs_uuid)
+{
+	struct s3lvol_pending_delete *pd, *tmp;
+
+	if (!lvs_uuid) {
+		return;
+	}
+	TAILQ_FOREACH_SAFE(pd, &g_pending_deletes, link, tmp) {
+		if (spdk_uuid_compare(&pd->lvs_uuid, lvs_uuid) == 0) {
+			TAILQ_REMOVE(&g_pending_deletes, pd, link);
+			free(pd);
+		}
+	}
+}
+
 /* One in-flight lease check. Defined below, next to the machinery that uses it;
  * named here because an export points at the check it is waiting for. */
 struct export_lease_get_ctx;

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
@@ -52,6 +52,15 @@ struct s3lvol_lvstore {
 	struct s3_client        *client;
 	char                    *name;
 
+	/* Copy of lvs->uuid, taken once the blobstore is open.
+	 *
+	 * Needed because the unload path clears lvs->lvs before
+	 * s3lvol_lvstore_free() runs, and the free is where this lvstore's
+	 * pending-delete marks are dropped -- reading the uuid off lvs->lvs
+	 * there would read NULL and skip the cleanup. Stays all-zero on the
+	 * setup error paths, which never got as far as an open blobstore. */
+	struct spdk_uuid         uuid;
+
 	/* The namespace this lvstore was created in. An import defaults to the
 	 * same namespace, which is the common case. The COS target is resolved
 	 * from this name through rcow_namespace_to_target(). */
@@ -652,6 +661,20 @@ s3lvol_lvstore_free(struct s3lvol_lvstore *lvs)
 	if (!lvs) {
 		return;
 	}
+
+	/* Pending-delete marks belong to this lvstore's lvols, all of which are
+	 * gone by now: unload closed them, delete destroyed them. Leaving the
+	 * marks behind is what would let --retry-pending act on a same-named
+	 * snapshot in the lvstore that gets attached next. The single funnel for
+	 * unload, delete and the setup error paths, so one call covers all.
+	 *
+	 * Keyed off the copy rather than lvs->lvs, which the unload path has
+	 * already cleared by the time it gets here. All-zero means the setup
+	 * never reached an open blobstore, so there is nothing to clear. */
+	if (!spdk_uuid_is_null(&lvs->uuid)) {
+		s3lvol_snapshot_pending_clear_lvs(&lvs->uuid);
+	}
+
 	/* Cached import manifests go with the lvstore. The registry object in S3
 	 * stays: it belongs to the lvstore, and the next attach needs it. */
 	s3lvol_xfer_lvstore_fini(lvs);
@@ -841,6 +864,11 @@ s3lvol_lvs_init_cb(void *cb_arg, struct spdk_lvol_store *lvol_store, int lvserrn
 	}
 
 	lvs->lvs = lvol_store;
+
+	/* Kept for s3lvol_lvstore_free(): the unload clears lvs->lvs before the
+	 * free runs, and the free is where this lvstore's pending-delete marks
+	 * are dropped. */
+	spdk_uuid_copy(&lvs->uuid, &lvol_store->uuid);
 
 	/* The create context is about to go away, so drop its destroy callback;
 	 * the unload path registers its own. */
@@ -1579,6 +1607,11 @@ s3lvol_lvs_load_cb(void *cb_arg, struct spdk_lvol_store *lvol_store, int lvserrn
 	}
 
 	lvs->lvs = lvol_store;
+
+	/* Kept for s3lvol_lvstore_free(): the unload clears lvs->lvs before the
+	 * free runs, and the free is where this lvstore's pending-delete marks
+	 * are dropped. */
+	spdk_uuid_copy(&lvs->uuid, &lvol_store->uuid);
 
 	/* The create context is about to go away, so drop its destroy callback;
 	 * the unload path registers its own. */
@@ -2595,16 +2628,74 @@ struct lvol_destroy_ctx {
 	char                     name[SPDK_LVOL_NAME_MAX];
 	char                     esnap_uuid[SPDK_UUID_STRING_LEN];
 
+	/* The pending-delete mark is keyed by these, and both are unreadable by
+	 * the time the completion runs -- the lvol is freed on success. Copied
+	 * here so the callback can clear (or record) the right mark. */
+	struct spdk_uuid         lvs_uuid;
+	struct spdk_uuid         lvol_uuid;
+
 	/* Cluster counts read before the destroy: the blob must still be open
 	 * to read them, and is gone by the time the success callback runs, so
 	 * the reclaimed counts can only be reported from there. */
 	uint64_t                 allocated_clusters;
 	uint64_t                 total_clusters;
 	bool                     have_cluster_counts;
+	bool                     is_snapshot;
 
 	spdk_lvol_op_complete    cb_fn;
 	void                    *cb_arg;
 };
+
+/* Record the "a delete was asked for and refused" mark for a snapshot.
+ *
+ * Only snapshots get one: an ordinary volume's refusals are the caller's own
+ * doing (deactivate it first), while a snapshot's blockers -- an export pin, a
+ * sibling clone, a running decouple -- clear on their own, and the mark is what
+ * lets --retry-pending come back to it. Keyed by uuid, so it cannot survive into
+ * a same-named object.
+ *
+ * Snapshot-ness is decided without needing the blob open. spdk_blob_is_read_only()
+ * would, and the refusals that call this fire before any blob check -- a
+ * deactivated snapshot still pinned by an export took that path and recorded
+ * nothing. spdk_blob_get_clones() takes a blob_id, which stays valid once the
+ * blob is closed (the same reason lvol->blob_id is used over
+ * spdk_blob_get_id(lvol->blob) further down), and answers 0 clones with rc == 0
+ * for a blob that is not a snapshot at all. */
+bool
+s3lvol_lvol_is_snapshot(struct spdk_lvol *lvol)
+{
+	size_t clone_count = 0;
+	int rc;
+
+	if (!lvol || !lvol->lvol_store || !lvol->lvol_store->blobstore) {
+		return false;
+	}
+
+	/* Open blob: the direct question is cheaper and exact. */
+	if (lvol->blob) {
+		return spdk_blob_is_read_only(lvol->blob);
+	}
+
+	rc = spdk_blob_get_clones(lvol->lvol_store->blobstore, lvol->blob_id,
+				  NULL, &clone_count);
+	if (rc != 0 && rc != -ENOMEM) {
+		return false;
+	}
+	return clone_count > 0;
+}
+
+static void
+destroy_mark_pending(struct spdk_lvol *lvol)
+{
+	if (!lvol || !lvol->lvol_store) {
+		return;
+	}
+	if (!s3lvol_lvol_is_snapshot(lvol)) {
+		return;
+	}
+	s3lvol_snapshot_pending_set(&lvol->lvol_store->uuid, &lvol->uuid,
+				    lvol->name);
+}
 
 /* Deleting the last volume that read an export is what ends this node's
  * dependency on it. The imports registry has to hear about that here, while the
@@ -2615,6 +2706,8 @@ s3lvol_lvol_destroyed(void *cb_arg, int lvolerrno)
 	struct lvol_destroy_ctx *ctx = cb_arg;
 
 	if (lvolerrno == 0) {
+		/* A delete that finally went through clears any pending mark. */
+		s3lvol_snapshot_pending_clear(&ctx->lvs_uuid, &ctx->lvol_uuid);
 		/* The one line a search can find for a successful delete. Nothing else
 		 * prints it: the unregister is silent on success, the object deletes
 		 * that follow are fire-and-forget and log only their failures, and the
@@ -2641,7 +2734,12 @@ s3lvol_lvol_destroyed(void *cb_arg, int lvolerrno)
 	} else {
 		/* The refusal paths in s3lvol_lvol_destroy() log before returning, but
 		 * an asynchronous failure -- the unregister, or spdk_lvol_destroy --
-		 * lands here instead and would otherwise be silent. */
+		 * lands here instead and would otherwise be silent. A blocked
+		 * snapshot delete records the intent so --ls can show it. */
+		if (ctx->is_snapshot) {
+			s3lvol_snapshot_pending_set(&ctx->lvs_uuid,
+						    &ctx->lvol_uuid, ctx->name);
+		}
 		SPDK_ERRLOG("Failed to delete lvol '%s/%s': %s\n",
 			    ctx->owner ? s3lvol_lvstore_get_name(ctx->owner) : "(null)",
 			    ctx->name, spdk_strerror(-lvolerrno));
@@ -2717,6 +2815,7 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 		SPDK_ERRLOG("lvol '%s' is being exported right now; wait for "
 			    "rcow_get_snapshot_status to stop reporting INPROGRESS "
 			    "before deleting it\n", lvol->name);
+		destroy_mark_pending(lvol);
 		return -EBUSY;
 	}
 
@@ -2729,6 +2828,7 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 			    "node may be reading through. Release that export, or wait "
 			    "for it to expire, before deleting this.\n",
 			    lvol->name, info.export_uuid);
+		destroy_mark_pending(lvol);
 		return -EBUSY;
 	}
 
@@ -2797,6 +2897,10 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 				    "blobstore can only merge a snapshot into a "
 				    "single clone, so delete the others first\n",
 				    lvol->name, clone_count);
+			/* Same "record the intent so --retry-pending can pick it up
+			 * once the blocker (the extra clones) clears" contract as
+			 * the export-pin refusals above. */
+			destroy_mark_pending(lvol);
 			return -EBUSY;
 		}
 	}
@@ -2808,6 +2912,10 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 	if (lvol->action_in_progress) {
 		SPDK_ERRLOG("another operation is in progress on lvol '%s'; it cannot "
 			    "be deleted yet\n", lvol->name);
+		/* The decouple that is running will clear, after which the delete can
+		 * succeed; record the intent for --retry-pending, same contract as
+		 * the export-pin refusals above. */
+		destroy_mark_pending(lvol);
 		return -EBUSY;
 	}
 
@@ -2846,6 +2954,18 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 
 	/* Copied now: the destroy frees the lvol and its name with it. */
 	snprintf(ctx->name, sizeof(ctx->name), "%s", lvol->name);
+
+	/* Snapshot (read-only blob) deletions carry the pending-delete mark when
+	 * they cannot complete; recorded here because the blob is gone by the
+	 * time the completion callback runs. */
+	ctx->is_snapshot = lvol->blob != NULL && spdk_blob_is_read_only(lvol->blob);
+
+	/* The mark's key, for the same reason: on success the lvol is freed, so
+	 * the completion cannot read either uuid off it any more. */
+	if (lvol->lvol_store) {
+		spdk_uuid_copy(&ctx->lvs_uuid, &lvol->lvol_store->uuid);
+	}
+	spdk_uuid_copy(&ctx->lvol_uuid, &lvol->uuid);
 
 	/* Recorded now, for the same reason the owner is: after the destroy the blob
 	 * is gone and the esnap id with it. An id that is not a NUL-terminated uuid

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
@@ -828,6 +828,14 @@ struct rpc_lvol_name {
 	char     *lvs_name;
 	char     *lvol_name;
 	uint64_t  size_gib;
+
+	/* Optional on the delete: the uuid of the object the caller means. A name
+	 * is reusable, so between "the delete was refused" and "retry it" the name
+	 * can belong to a different snapshot; --retry-pending therefore sends the
+	 * uuid it read from rcow_get_lvstores, and the delete refuses if the name
+	 * now resolves to something else. */
+	char     *lvol_uuid;
+	char     *lvs_uuid;
 };
 
 static void
@@ -835,6 +843,8 @@ free_rpc_lvol_name(struct rpc_lvol_name *req)
 {
 	free(req->lvs_name);
 	free(req->lvol_name);
+	free(req->lvol_uuid);
+	free(req->lvs_uuid);
 }
 
 static const struct spdk_json_object_decoder rpc_resize_lvol_decoders[] = {
@@ -844,7 +854,61 @@ static const struct spdk_json_object_decoder rpc_resize_lvol_decoders[] = {
 
 static const struct spdk_json_object_decoder rpc_delete_lvol_decoders[] = {
 	{"lvol_name", offsetof(struct rpc_lvol_name, lvol_name), spdk_json_decode_string, false},
+	/* Optional, and checked rather than used for the lookup: a caller that
+	 * knows which object it means says so, and gets a refusal instead of a
+	 * delete if the name has moved on. */
+	{"lvol_uuid", offsetof(struct rpc_lvol_name, lvol_uuid), spdk_json_decode_string, true},
+	{"lvs_uuid",  offsetof(struct rpc_lvol_name, lvs_uuid),  spdk_json_decode_string, true},
 };
+
+/* Refuse when the caller named a uuid and the resolved lvol is not it.
+ *
+ * The lookup stays by name -- that is what every other lvol RPC does, and the
+ * bdev name is derived from it -- but a caller that carries a uuid gets it
+ * verified. This is what stops a retry issued for one snapshot from deleting a
+ * later object that happens to have the same name.
+ *
+ * Returns false when it has already answered the request. */
+static bool
+rpc_delete_uuid_matches(struct spdk_jsonrpc_request *request,
+			const struct rpc_lvol_name *req,
+			struct spdk_lvol *lvol)
+{
+	char have[SPDK_UUID_STRING_LEN];
+
+	if (req->lvol_uuid) {
+		spdk_uuid_fmt_lower(have, sizeof(have), &lvol->uuid);
+		if (strcasecmp(have, req->lvol_uuid) != 0) {
+			SPDK_WARNLOG("rcow_delete_lvol '%s' refused: caller asked "
+				     "for uuid %s but that name is now %s\n",
+				     req->lvol_name, req->lvol_uuid, have);
+			rpc_lvol_respond_errf(request,
+					      "lvol '%s' is uuid %s, not the "
+					      "requested %s; it was recreated "
+					      "since the delete was asked for",
+					      req->lvol_name, have,
+					      req->lvol_uuid);
+			return false;
+		}
+	}
+
+	if (req->lvs_uuid && lvol->lvol_store) {
+		spdk_uuid_fmt_lower(have, sizeof(have), &lvol->lvol_store->uuid);
+		if (strcasecmp(have, req->lvs_uuid) != 0) {
+			SPDK_WARNLOG("rcow_delete_lvol '%s' refused: caller asked "
+				     "for lvstore %s but the lvol is on %s\n",
+				     req->lvol_name, req->lvs_uuid, have);
+			rpc_lvol_respond_errf(request,
+					      "lvol '%s' is on lvstore %s, not "
+					      "the requested %s",
+					      req->lvol_name, have,
+					      req->lvs_uuid);
+			return false;
+		}
+	}
+
+	return true;
+}
 
 /* Resolve lvs_name + lvol_name, answering the request itself on failure.
  *
@@ -1073,6 +1137,12 @@ rpc_rcow_delete_lvol(struct spdk_jsonrpc_request *request,
 
 	lvol = rpc_lookup_lvol(request, &req);
 	if (!lvol) {
+		goto cleanup;
+	}
+
+	/* Before any refusal below, and before anything is torn down: a caller
+	 * that named a uuid means that object and nothing else. */
+	if (!rpc_delete_uuid_matches(request, &req, lvol)) {
 		goto cleanup;
 	}
 
@@ -1433,12 +1503,17 @@ SPDK_RPC_REGISTER("rcow_add_s3_config", rpc_rcow_add_s3_config, SPDK_RPC_RUNTIME
  * rcow_get_lvstores
  * ========================================================================== */
 
+static const char *export_state_str(enum s3lvol_export_state state);
+
 static void
 rpc_rcow_get_lvstores(struct spdk_jsonrpc_request *request,
-			     const struct spdk_json_val *params)
+		     const struct spdk_json_val *params)
 {
 	struct spdk_json_write_ctx *w;
 	struct s3lvol_lvstore *lvs;
+	enum s3lvol_export_state state;
+	bool deletable;
+	bool pending;
 
 	if (params) {
 		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
@@ -1550,6 +1625,37 @@ rpc_rcow_get_lvstores(struct spdk_jsonrpc_request *request,
 				spdk_json_write_named_string(w, "bdev_name", lvol->bdev->name);
 			}
 			spdk_json_write_named_uuid(w, "uuid", &lvol->uuid);
+			/* Answered without needing the blob open: a deactivated
+			 * snapshot is still a snapshot, and --retry-pending gates
+			 * on this field. */
+			spdk_json_write_named_bool(w, "is_snapshot",
+				s3lvol_lvol_is_snapshot(lvol));
+			/* Cluster counts mirror rcow_get_lvol: truthful while the
+			 * blob is open, 0 otherwise. */
+			if (lvol->blob != NULL) {
+				spdk_json_write_named_uint64(w, "total_clusters",
+					spdk_blob_get_num_clusters(lvol->blob));
+				spdk_json_write_named_uint64(w, "allocated_clusters",
+					spdk_blob_get_num_allocated_clusters(lvol->blob));
+			} else {
+				spdk_json_write_named_uint64(w, "total_clusters", 0);
+				spdk_json_write_named_uint64(w, "allocated_clusters", 0);
+			}
+			/* Same answers as rcow_get_snapshot_status. Computed from the
+			 * lvol this loop already holds rather than re-resolved by
+			 * name: the by-name form walks every lvstore per call (O(N^2)
+			 * over this loop) and answers nothing at all when two
+			 * lvstores share a name, which would drop these fields for
+			 * exactly the lvols whose marks --retry-pending has to see. */
+			if (s3lvol_snapshot_query_lvol(lvol, &state, &deletable,
+						       &pending) == 0) {
+				spdk_json_write_named_string(w, "export_status",
+					export_state_str(state));
+				spdk_json_write_named_string(w, "deletable",
+					deletable ? "YES" : "NO");
+				spdk_json_write_named_bool(w, "delete_pending",
+							   pending);
+			}
 			spdk_json_write_object_end(w);
 		}
 		spdk_json_write_array_end(w);
@@ -1802,6 +1908,7 @@ rpc_rcow_get_snapshot_status(struct spdk_jsonrpc_request *request,
 	struct spdk_json_write_ctx *w;
 	enum s3lvol_export_state state;
 	bool deletable;
+	bool pending = false;
 	int rc;
 
 	if (spdk_json_decode_object(params, rpc_export_status_decoders,
@@ -1829,7 +1936,8 @@ rpc_rcow_get_snapshot_status(struct spdk_jsonrpc_request *request,
 	if (req.export_uuid) {
 		rc = s3lvol_export_query(req.export_uuid, &state, &deletable);
 	} else {
-		rc = s3lvol_snapshot_query(req.snapshot_name, &state, &deletable);
+		rc = s3lvol_snapshot_query(req.snapshot_name, &state, &deletable,
+					   &pending);
 		if (rc == -ENODEV) {
 			rpc_lvol_respond_errf(request,
 					      "snapshot '%s' not found in any "
@@ -1862,6 +1970,7 @@ rpc_rcow_get_snapshot_status(struct spdk_jsonrpc_request *request,
 				     export_state_str(state));
 	spdk_json_write_named_string(w, "deletable",
 				     deletable ? "YES" : "NO");
+	spdk_json_write_named_bool(w, "delete_pending", pending);
 	spdk_json_write_object_end(w);
 	rpc_json_buf_respond(request, w, &buf);
 

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
@@ -1585,10 +1585,17 @@ s3lvol_lvol_export(struct s3lvol_lvstore *lvs, struct spdk_lvol *snapshot,
  *   1. an export still being written names it
  *   2. a live zero-copy export references it (a dense one owns its own copies,
  *      and an expired reference no longer pins anything)
- *   3. it has more than one clone -- blobstore merges a snapshot into one only
+ *   3. a decouple is running on it (action_in_progress)
+ *   4. it is active, i.e. exported over NVMf -- rcow_delete_lvol refuses that
+ *      before it gets anywhere near the blob
+ *   5. it has more than one clone -- blobstore merges a snapshot into one only
  *
- * Computed on the spot every time; nothing here is cached. A snapshot that is
- * already gone blocks nothing. */
+ * The export and active checks come before the "no blob" shortcut on purpose: a
+ * deactivated snapshot has no open blob but can still be pinned by an export, and
+ * reporting YES for it made --retry-pending attempt a delete that then failed
+ * with EBUSY. Only a snapshot that is genuinely absent blocks nothing.
+ *
+ * Computed on the spot every time; nothing here is cached. */
 static bool
 export_snapshot_deletable(struct s3lvol_lvstore *lvs, const char *snapshot_name)
 {
@@ -1598,7 +1605,8 @@ export_snapshot_deletable(struct s3lvol_lvstore *lvs, const char *snapshot_name)
 	int rc;
 
 	lvol = s3lvol_lvol_find(lvs, snapshot_name);
-	if (!lvol || !lvol->blob) {
+	if (!lvol) {
+		/* Gone: nothing left to refuse. */
 		return true;
 	}
 
@@ -1613,6 +1621,23 @@ export_snapshot_deletable(struct s3lvol_lvstore *lvs, const char *snapshot_name)
 
 	if (s3lvol_export_pinning(owner, lvol->name)) {
 		return false;
+	}
+
+	/* Both of these refuse in s3lvol_lvol_destroy() / rpc_rcow_delete_lvol()
+	 * without ever looking at the blob, so they have to be checked even when
+	 * the blob is closed. */
+	if (lvol->action_in_progress) {
+		return false;
+	}
+
+	if (s3lvol_active_load() == 0 && s3lvol_active_find(lvol->name)) {
+		return false;
+	}
+
+	if (!lvol->blob) {
+		/* Closed: the clone count below is unreadable, and every blocker
+		 * that does not need the blob has been checked above. */
+		return true;
 	}
 
 	/* ids == NULL makes spdk_blob_get_clones report the count in *clone_count
@@ -1699,13 +1724,37 @@ snapshot_export_state(struct s3lvol_lvstore *lvs, const char *snapshot_name)
 }
 
 int
-s3lvol_snapshot_query(const char *snapshot_name,
-		      enum s3lvol_export_state *state, bool *deletable)
+s3lvol_snapshot_query_lvol(struct spdk_lvol *lvol,
+			   enum s3lvol_export_state *state, bool *deletable,
+			   bool *pending)
 {
 	struct s3lvol_lvstore *owner;
+
+	if (!lvol || !state || !deletable || !pending) {
+		return -EINVAL;
+	}
+
+	owner = s3lvol_lvstore_of_lvol(lvol);
+	if (!owner) {
+		return -ENODEV;
+	}
+
+	*state = snapshot_export_state(owner, lvol->name);
+	*deletable = export_snapshot_deletable(owner, lvol->name);
+	*pending = lvol->lvol_store != NULL &&
+		   s3lvol_snapshot_pending_test(&lvol->lvol_store->uuid,
+						&lvol->uuid);
+	return 0;
+}
+
+int
+s3lvol_snapshot_query(const char *snapshot_name,
+		      enum s3lvol_export_state *state, bool *deletable,
+		      bool *pending)
+{
 	struct spdk_lvol *lvol;
 
-	if (!snapshot_name || snapshot_name[0] == '\0' || !state || !deletable) {
+	if (!snapshot_name || snapshot_name[0] == '\0') {
 		return -EINVAL;
 	}
 
@@ -1716,14 +1765,7 @@ s3lvol_snapshot_query(const char *snapshot_name,
 		return -ENODEV;
 	}
 
-	owner = s3lvol_lvstore_of_lvol(lvol);
-	if (!owner) {
-		return -ENODEV;
-	}
-
-	*state = snapshot_export_state(owner, lvol->name);
-	*deletable = export_snapshot_deletable(owner, lvol->name);
-	return 0;
+	return s3lvol_snapshot_query_lvol(lvol, state, deletable, pending);
 }
 
 /* ==========================================================================

--- a/CubeS3lvol/test/README.md
+++ b/CubeS3lvol/test/README.md
@@ -478,6 +478,21 @@ test/tools/s3lvol_rpc.py rcow_checkpoint_lvstore '{"lvs_name":"dpvs"}'
 test/tools/s3lvol_rpc.py --sock /var/run/s3lvol.sock --timeout 60 bdev_get_bdevs
 ```
 
+Two modes take no method of their own:
+
+```sh
+test/tools/s3lvol_rpc.py --ls              # rcow_get_lvstores as a table,
+                                           # incl. the DEL / PEND columns
+test/tools/s3lvol_rpc.py --retry-pending   # re-issue the snapshot deletes that
+                                           # were refused and are now deletable
+```
+
+`--retry-pending` acts on the pending-delete marks a refused snapshot delete
+leaves behind (`PEND` in `--ls`). The marks are in the target's memory only,
+nothing retries them automatically, and there is no cancel -- see
+[Retrying a refused snapshot delete](../README.md#retrying-a-refused-snapshot-delete---retry-pending)
+in the main README for the full contract.
+
 Especially useful when debugging a hung target: a process a test script left
 behind can be asked for its state directly.
 

--- a/CubeS3lvol/test/dataplane/run_activation_test.sh
+++ b/CubeS3lvol/test/dataplane/run_activation_test.sh
@@ -18,7 +18,7 @@ set -u
 
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SELF_DIR}/../.." && pwd)"
-SPDK_ROOT="${SPDK_ROOT:-$(cd "${ROOT}/../spdk" && pwd)}"
+SPDK_ROOT="${SPDK_ROOT:-${ROOT}/deps/spdk}"
 
 RPC="${ROOT}/test/tools/s3lvol_rpc.py"
 SPDK_RPC_PY="${SPDK_ROOT}/scripts/rpc.py"

--- a/CubeS3lvol/test/dataplane/run_dataplane_test.sh
+++ b/CubeS3lvol/test/dataplane/run_dataplane_test.sh
@@ -64,7 +64,7 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TOOLS_DIR="${REPO_ROOT}/test/tools"
-SPDK_ROOT="${SPDK_ROOT:-/data/home/cow/spdk}"
+SPDK_ROOT="${SPDK_ROOT:-${REPO_ROOT}/deps/spdk}"
 
 TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
 RPC_PY="${SPDK_ROOT}/scripts/rpc.py"

--- a/CubeS3lvol/test/dataplane/run_pending_delete_test.sh
+++ b/CubeS3lvol/test/dataplane/run_pending_delete_test.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+#  Pending-delete marks: a refused snapshot delete is recorded, skipped while it
+#  is still blocked, retried once the blocker clears, and forgotten afterwards.
+#
+#  === What this is about ===
+#
+#  Deleting a snapshot that another node may be reading through is refused
+#  (s3lvol_lvol_destroy), and the refusal records a pending-delete mark. The mark
+#  is the only record that a delete was ever asked for: from the target's side
+#  every delete arrives as the same RPC, so nothing else distinguishes "the user
+#  asked and it failed" from "nobody asked". test/tools/s3lvol_rpc.py
+#  --retry-pending is what acts on it -- it deletes exactly the snapshots that
+#  carry a mark AND have become deletable since.
+#
+#  Four properties have to hold, and none of them are checked by the other
+#  suites:
+#
+#    1. a refused delete leaves the snapshot alive and marked (delete_pending)
+#    2. --retry-pending does nothing while the blocker is still there -- the
+#       snapshot is marked but not deletable, and it must not be touched
+#    3. once the blocker clears, --retry-pending deletes it
+#    4. an unmarked snapshot is never deleted by --retry-pending, however
+#       deletable it is
+#
+#  === Why an export is used as the blocker ===
+#
+#  It is the one blocker a test can raise and drop on demand: rcow_export_snapshot
+#  pins the snapshot, rcow_release_export unpins it, and neither needs a second
+#  node. The clone and decouple refusals record the mark through the same helper
+#  (destroy_mark_pending), so covering one covers the mechanism; what differs
+#  between them is only which check fires first.
+#
+#  === Why the marks are checked by uuid, not just by name ===
+#
+#  A mark is keyed by (lvstore uuid, lvol uuid) precisely so it cannot follow a
+#  name onto a different object, and --retry-pending sends both uuids with the
+#  delete. Step [5] recreates a snapshot under a name that was marked earlier and
+#  asserts the retry refuses it: deleting by name alone is what that guards
+#  against.
+#
+#  Usage:
+#    sudo -E ./test/dataplane/run_pending_delete_test.sh
+#
+#  Needs root, a readable /data/cubelet/s3.cfg and nvme-cli. Uses its own lvstore,
+#  WAL image and registries, so a production instance is untouched.
+
+set -u
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SELF_DIR}/../.." && pwd)"
+SCRIPTS="${ROOT}/scripts"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+
+export RCOW_LVS_NAME=pendelvs
+export RCOW_WAL_IMG=/data/s3lvol_pendel_wal.img
+export RCOW_WAL_BDEV=pendel_wal0
+export RCOW_CAPACITY_GB=8
+export RCOW_JOURNAL_MB=64
+export RCOW_WAL_MB=256
+export RCOW_TGT_MEM_MB=2048
+export RCOW_RUN_DIR=/var/tmp/rcow_pendel
+export RCOW_LOG_DIR=/var/tmp/rcow_pendel/log
+export RCOW_ACTIVE_FILE=/var/tmp/rcow_pendel/active_lvols
+export RCOW_BSTORE_FILE=/var/tmp/rcow_pendel/bstore.json
+export RCOW_S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
+
+VOL=v
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  [PASS] $*"; }
+fail() { FAIL=$((FAIL+1)); echo "  [FAIL] $*"; }
+info() { echo "  ---- $*"; }
+
+STARTED=0
+WORKDIR=""
+
+# shellcheck source=../../scripts/rcow_common.sh
+. "${SCRIPTS}/rcow_common.sh"
+
+rpc() { python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" "$@"; }
+
+# One field of one lvol out of rcow_get_lvstores. Runs in a command substitution,
+# so it prints and never touches PASS/FAIL.
+lvol_field()
+{
+	local name="$1" field="$2"
+
+	rpc rcow_get_lvstores 2>/dev/null | python3 -c '
+import json, sys
+name, field = sys.argv[1], sys.argv[2]
+try:
+    for lvs in json.load(sys.stdin):
+        for l in lvs.get("lvols") or []:
+            if l.get("name") == name:
+                v = l.get(field, "")
+                print("" if v is None else (v if not isinstance(v, bool) else ("true" if v else "false")))
+                sys.exit(0)
+except Exception:
+    pass
+print("")
+' "${name}" "${field}"
+}
+
+lvol_exists()
+{
+	[ -n "$(lvol_field "$1" name)" ]
+}
+
+resolve()
+{
+	local name="$1"
+
+	rpc rcow_active_bdev "$(printf '{"device_name":"%s"}' "${name}")" \
+		>/dev/null 2>&1 || return 1
+	rcow_verify_active 30 >/dev/null 2>&1 || return 1
+	rpc rcow_get_bdev "$(printf '{"device_name":"%s"}' "${name}")" 2>/dev/null | \
+		python3 -c 'import json,sys; print(json.load(sys.stdin).get("device_path",""))' \
+		2>/dev/null
+}
+
+cleanup()
+{
+	echo ""
+	echo "=== cleanup"
+
+	if rcow_target_alive; then
+		for n in $(rpc rcow_get_bdev '{}' 2>/dev/null | python3 -c '
+import json, sys
+try:
+    for e in json.load(sys.stdin):
+        print(e["device_name"])
+except Exception:
+    pass'); do
+			rpc rcow_deactive_bdev \
+				"$(printf '{"device_name":"%s"}' "$n")" >/dev/null 2>&1
+		done
+		if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
+			rpc rcow_delete_lvstore \
+				"$(printf '{"lvs_name":"%s"}' "${RCOW_LVS_NAME}")" \
+				>/dev/null 2>&1 || info "delete_lvstore failed"
+		fi
+	fi
+	[ "${STARTED}" -eq 1 ] && "${SCRIPTS}/rcow_stop.sh" --force >/dev/null 2>&1
+
+	if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ] && [ -n "${BUCKET:-}" ]; then
+		rcow_load_credentials
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "${BUCKET}" \
+			-r "$(rcow_cfg_get region)" -p "${RCOW_LVS_NAME}/" 2>&1 | tail -1
+		rm -f "${RCOW_WAL_IMG}"
+		rm -rf "${RCOW_RUN_DIR}" "${WORKDIR}"
+	elif [ -n "${WORKDIR}" ]; then
+		info "state kept: ${RCOW_WAL_IMG}, ${RCOW_RUN_DIR}, ${WORKDIR}"
+	fi
+
+	echo ""
+	echo "=== result: ${PASS} passed, ${FAIL} failed ==="
+	[ "${FAIL}" -eq 0 ] || exit 1
+}
+trap cleanup EXIT
+
+# ==========================================================================
+echo "=== [0] preconditions"
+
+[ "$(id -u)" -eq 0 ] || { echo "must run as root" >&2; exit 1; }
+[ -x "${ROOT}/app/s3lvol_tgt/s3lvol_tgt" ] || { echo "target not built" >&2; exit 1; }
+[ -r "${RCOW_S3_CFG}" ] || { echo "no S3 config" >&2; exit 1; }
+command -v nvme >/dev/null || { echo "nvme-cli is required" >&2; exit 1; }
+[ -n "$(rcow_target_instances)" ] && { echo "a target is already running" >&2; exit 1; }
+
+BUCKET="$(rcow_s3_buckets | head -1)"
+WORKDIR="$(mktemp -d /tmp/rcow_pendel.XXXXXX)"
+rm -rf "${RCOW_RUN_DIR}"; mkdir -p "${RCOW_RUN_DIR}"
+rm -f "${RCOW_WAL_IMG}"; truncate -s 1G "${RCOW_WAL_IMG}"
+
+"${SCRIPTS}/rcow_start.sh" >"${WORKDIR}/start.log" 2>&1 && STARTED=1 || {
+	fail "rcow_start.sh failed"; tail -20 "${WORKDIR}/start.log"; exit 1; }
+pass "data plane up, lvstore ${RCOW_LVS_NAME}"
+
+# ==========================================================================
+echo ""
+echo "=== [1] a volume, two snapshots, and an export pinning one of them"
+#
+# keep0 is the control: it is deletable throughout and never has a delete asked
+# for, so nothing may ever delete it. pinned0 is the subject.
+
+rpc rcow_create_lvol "$(printf '{"lvol_name":"%s","size_gib":1}' "${VOL}")" \
+	>/dev/null || { fail "create ${VOL}"; exit 1; }
+DEV="$(resolve "${VOL}")"
+[ -b "${DEV}" ] || { fail "${VOL} did not become a block device"; exit 1; }
+
+dd if=/dev/urandom of="${DEV}" bs=1M count=4 oflag=direct status=none
+sync
+
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"keep0"}' "${VOL}")" \
+	>/dev/null && pass "keep0 taken (the control snapshot)" || fail "keep0 failed"
+
+dd if=/dev/urandom of="${DEV}" bs=1M count=4 seek=4 oflag=direct status=none
+sync
+
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"pinned0"}' "${VOL}")" \
+	>/dev/null && pass "pinned0 taken (the one to be blocked)" || fail "pinned0 failed"
+
+# Deactivated first: rcow_delete_lvol refuses an active volume outright, and that
+# refusal is not the one under test here.
+rpc rcow_deactive_bdev "$(printf '{"device_name":"%s"}' "${VOL}")" >/dev/null 2>&1
+
+EXPORT_UUID="$(rpc rcow_export_snapshot '{"snapshot_name":"pinned0"}' \
+	2>/dev/null | tr -d ' \t\r\n"')"
+if [ -n "${EXPORT_UUID}" ]; then
+	pass "pinned0 exported (${EXPORT_UUID}), so a delete of it must be refused"
+else
+	fail "rcow_export_snapshot did not return a uuid"
+	exit 1
+fi
+
+# The export has to finish publishing before it counts as a pin in the registry;
+# until then it is an in-flight pin, which refuses the delete just the same.
+for _ in $(seq 30); do
+	[ "$(rpc rcow_get_snapshot_status '{"snapshot_name":"pinned0"}' 2>/dev/null | \
+		python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("export_status",""))
+except Exception:
+    print("")')" = "DONE" ] && break
+	sleep 1
+done
+
+# ==========================================================================
+echo ""
+echo "=== [2] the refused delete is recorded, and the snapshot survives"
+
+if rpc rcow_delete_lvol '{"lvol_name":"pinned0"}' >/dev/null 2>&1; then
+	fail "delete of the exported pinned0 was accepted"
+else
+	pass "delete of pinned0 refused while the export pins it"
+fi
+
+lvol_exists pinned0 && pass "pinned0 still exists after the refusal" \
+	|| fail "pinned0 disappeared despite the refusal"
+
+[ "$(lvol_field pinned0 delete_pending)" = "true" ] \
+	&& pass "pinned0 carries the pending-delete mark" \
+	|| fail "pinned0 has no pending-delete mark (got '$(lvol_field pinned0 delete_pending)')"
+
+[ "$(lvol_field pinned0 deletable)" = "NO" ] \
+	&& pass "pinned0 reports deletable=NO while pinned" \
+	|| fail "pinned0 reports deletable='$(lvol_field pinned0 deletable)' while pinned"
+
+# The control must not have picked up a mark from anywhere.
+[ "$(lvol_field keep0 delete_pending)" = "false" ] \
+	&& pass "keep0 has no mark (no delete was asked for it)" \
+	|| fail "keep0 unexpectedly carries a mark"
+
+# ==========================================================================
+echo ""
+echo "=== [3] --retry-pending leaves a still-blocked snapshot alone"
+#
+# The mark is there but deletable is NO, so the retry has nothing to do. This is
+# the case that would otherwise turn into a delete storm against a pinned
+# snapshot.
+
+python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --retry-pending \
+	>"${WORKDIR}/retry-blocked.log" 2>&1
+if grep -q "no pending snapshot deletes to retry" "${WORKDIR}/retry-blocked.log"; then
+	pass "--retry-pending reported nothing to do while pinned"
+else
+	fail "--retry-pending did something while pinned: $(cat "${WORKDIR}/retry-blocked.log")"
+fi
+
+lvol_exists pinned0 && pass "pinned0 still alive after the no-op retry" \
+	|| fail "pinned0 was deleted while still pinned"
+
+# ==========================================================================
+echo ""
+echo "=== [4] once the export is released, --retry-pending completes the delete"
+
+rpc rcow_release_export "$(printf '{"export_uuid":"%s"}' "${EXPORT_UUID}")" \
+	>/dev/null 2>&1 && pass "export released" || fail "rcow_release_export failed"
+
+for _ in $(seq 30); do
+	[ "$(lvol_field pinned0 deletable)" = "YES" ] && break
+	sleep 1
+done
+[ "$(lvol_field pinned0 deletable)" = "YES" ] \
+	&& pass "pinned0 reports deletable=YES once unpinned" \
+	|| fail "pinned0 still not deletable after release"
+
+python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --retry-pending \
+	>"${WORKDIR}/retry-clear.log" 2>&1
+if grep -q "deleted pinned0" "${WORKDIR}/retry-clear.log"; then
+	pass "--retry-pending deleted pinned0 once the blocker cleared"
+else
+	fail "--retry-pending did not delete pinned0: $(cat "${WORKDIR}/retry-clear.log")"
+fi
+
+lvol_exists pinned0 && fail "pinned0 still exists after the successful retry" \
+	|| pass "pinned0 is gone"
+
+# The control survived a retry that was entitled to delete only the marked one.
+lvol_exists keep0 && pass "keep0 untouched by --retry-pending (never marked)" \
+	|| fail "keep0 was deleted by --retry-pending"
+
+# Nothing left marked: the successful delete cleared it.
+python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --retry-pending \
+	>"${WORKDIR}/retry-empty.log" 2>&1
+if grep -q "no pending snapshot deletes to retry" "${WORKDIR}/retry-empty.log"; then
+	pass "the mark was cleared by the successful delete"
+else
+	fail "a mark survived the delete: $(cat "${WORKDIR}/retry-empty.log")"
+fi
+
+# ==========================================================================
+echo ""
+echo "=== [5] a delete asked for by uuid refuses a same-named replacement"
+#
+# What the uuid keying is for. pinned0's name is free again, so a new snapshot can
+# take it; a delete issued for the *old* uuid must not touch the new object.
+
+OLD_UUID="$(rpc rcow_get_lvstores 2>/dev/null | python3 -c '
+import json, sys
+# Any uuid that is not currently in use: the deleted pinned0 will do, but it is
+# gone, so a syntactically valid uuid that belongs to nothing is what is needed.
+print("00000000-0000-0000-0000-000000000001")')"
+
+rpc rcow_active_bdev "$(printf '{"device_name":"%s"}' "${VOL}")" >/dev/null 2>&1
+rcow_verify_active 30 >/dev/null 2>&1
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"pinned0"}' "${VOL}")" \
+	>/dev/null && pass "pinned0 recreated (same name, new object)" \
+	|| fail "could not recreate pinned0"
+rpc rcow_deactive_bdev "$(printf '{"device_name":"%s"}' "${VOL}")" >/dev/null 2>&1
+
+if rpc rcow_delete_lvol \
+	"$(printf '{"lvol_name":"pinned0","lvol_uuid":"%s"}' "${OLD_UUID}")" \
+	>/dev/null 2>&1; then
+	fail "a delete for a stale uuid deleted the same-named replacement"
+else
+	pass "delete refused: the name now belongs to a different uuid"
+fi
+
+lvol_exists pinned0 && pass "the recreated pinned0 survived the stale-uuid delete" \
+	|| fail "the recreated pinned0 was deleted by a stale-uuid delete"
+
+# And the same delete by the *current* uuid works, so the check is not simply
+# refusing everything.
+CUR_UUID="$(lvol_field pinned0 uuid)"
+if [ -n "${CUR_UUID}" ] && rpc rcow_delete_lvol \
+	"$(printf '{"lvol_name":"pinned0","lvol_uuid":"%s"}' "${CUR_UUID}")" \
+	>/dev/null 2>&1; then
+	pass "delete by the current uuid succeeded"
+else
+	fail "delete by the current uuid was refused (uuid '${CUR_UUID}')"
+fi
+
+# ==========================================================================
+echo ""
+echo "=== [6] an unload drops that lvstore's marks"
+#
+# The marks are scoped to the lvstore, not to the process: past a teardown they
+# name lvols that no longer exist, and the lvstore attached next can give the
+# same names to different objects. This is the step that would have caught the
+# marks surviving an unload because the uuid was read off a pointer the unload
+# had already cleared.
+
+# A fresh blocked delete to leave a mark behind.
+rpc rcow_active_bdev "$(printf '{"device_name":"%s"}' "${VOL}")" >/dev/null 2>&1
+rcow_verify_active 30 >/dev/null 2>&1
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"marked1"}' "${VOL}")" \
+	>/dev/null && pass "marked1 taken" || fail "could not take marked1"
+rpc rcow_deactive_bdev "$(printf '{"device_name":"%s"}' "${VOL}")" >/dev/null 2>&1
+
+EXP2="$(rpc rcow_export_snapshot '{"snapshot_name":"marked1"}' 2>/dev/null | \
+	tr -d ' \t\r\n"')"
+[ -n "${EXP2}" ] && pass "marked1 exported (${EXP2})" || fail "export of marked1 failed"
+for _ in $(seq 30); do
+	[ "$(rpc rcow_get_snapshot_status '{"snapshot_name":"marked1"}' 2>/dev/null | \
+		python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("export_status",""))
+except Exception:
+    print("")')" = "DONE" ] && break
+	sleep 1
+done
+
+rpc rcow_delete_lvol '{"lvol_name":"marked1"}' >/dev/null 2>&1
+[ "$(lvol_field marked1 delete_pending)" = "true" ] \
+	&& pass "marked1 is marked after the refused delete" \
+	|| fail "marked1 was not marked (got '$(lvol_field marked1 delete_pending)')"
+
+# Release the export first: the mark has to be dropped by the unload, not by the
+# blocker still being there.
+rpc rcow_release_export "$(printf '{"export_uuid":"%s"}' "${EXP2}")" >/dev/null 2>&1
+for _ in $(seq 30); do
+	[ "$(lvol_field marked1 deletable)" = "YES" ] && break
+	sleep 1
+done
+[ "$(lvol_field marked1 deletable)" = "YES" ] \
+	&& pass "marked1 is deletable again (so only the unload can clear the mark)" \
+	|| info "marked1 not deletable; the next assertion is weaker but still valid"
+
+echo "  ---- unload and re-attach ${RCOW_LVS_NAME}"
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${RCOW_LVS_NAME}")" \
+	>/dev/null 2>&1 && pass "lvstore unloaded" || { fail "unload failed"; exit 1; }
+
+# The namespace an attach needs is the bucket the lvstore lives in, which is
+# what rcow_start.sh recorded in bstore.json when it created it.
+LVS_NS="$(python3 -c '
+import json, sys
+try:
+    print(json.load(open(sys.argv[1]))[sys.argv[2]]["ns_name"])
+except Exception:
+    print("")
+' "${RCOW_BSTORE_FILE}" "${RCOW_LVS_NAME}" 2>/dev/null)"
+[ -n "${LVS_NS}" ] || LVS_NS="${BUCKET}"
+if rpc rcow_attach_lvstore \
+	"$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"%s"}' \
+	   "${RCOW_LVS_NAME}" "${LVS_NS}" "${RCOW_WAL_BDEV}")" >/dev/null 2>&1; then
+	pass "lvstore re-attached"
+else
+	fail "re-attach failed (namespace '${LVS_NS}')"
+	exit 1
+fi
+
+lvol_exists marked1 && pass "marked1 came back with the lvstore" \
+	|| fail "marked1 did not survive the re-attach"
+
+[ "$(lvol_field marked1 delete_pending)" = "false" ] \
+	&& pass "the mark did not survive the unload" \
+	|| fail "the mark survived the unload (delete_pending='$(lvol_field marked1 delete_pending)')"
+
+python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --retry-pending \
+	>"${WORKDIR}/retry-after-unload.log" 2>&1
+if grep -q "no pending snapshot deletes to retry" "${WORKDIR}/retry-after-unload.log"; then
+	pass "--retry-pending has nothing to do after the re-attach"
+else
+	fail "--retry-pending acted on a mark that should have been dropped: $(cat "${WORKDIR}/retry-after-unload.log")"
+fi

--- a/CubeS3lvol/test/dataplane/run_recovery_test.sh
+++ b/CubeS3lvol/test/dataplane/run_recovery_test.sh
@@ -56,7 +56,7 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TOOLS_DIR="${REPO_ROOT}/test/tools"
-SPDK_ROOT="${SPDK_ROOT:-/data/home/cow/spdk}"
+SPDK_ROOT="${SPDK_ROOT:-${REPO_ROOT}/deps/spdk}"
 
 TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
 RPC_PY="${SPDK_ROOT}/scripts/rpc.py"

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -462,6 +462,11 @@ else
 		# Snapshot deletion semantics; next to the suites that build clone chains.
 		run_suite run_snapdelete_test.sh \
 			./test/dataplane/run_snapdelete_test.sh
+		# Pending-delete marks: refused -> marked -> skipped while blocked ->
+		# retried once clear. Right after snapdelete: same delete path, but the
+		# question is what a *refused* delete leaves behind.
+		run_suite run_pending_delete_test.sh \
+			./test/dataplane/run_pending_delete_test.sh
 		# Mounts a real filesystem, so it goes after the block-level suites:
 		# when both fail, the one that speaks in dd is the easier read.
 		run_suite run_fs_test.sh \

--- a/CubeS3lvol/test/tools/s3lvol_rpc.py
+++ b/CubeS3lvol/test/tools/s3lvol_rpc.py
@@ -53,6 +53,40 @@
 #
 #  --raw turns this off, which is what to use when the question is what the target
 #  actually put on the wire.
+#
+#  === Retrying failed snapshot deletes: --retry-pending ===
+#
+#  Deleting a snapshot that is pinned (an export names it, it has clones, or a
+#  decouple is running) is refused, and the refusal records a pending-delete
+#  mark for the snapshot. The mark is the *only* record that a delete was asked
+#  for: from the target's side every delete arrives as the same RPC, so there
+#  is no way to tell a user's delete from an automation's. The mark therefore
+#  is what "the user asked for this delete" means.
+#
+#    test/tools/s3lvol_rpc.py --retry-pending
+#
+#  reads rcow_get_lvstores, finds every snapshot that carries the mark AND has
+#  become deletable since the refusal (deletable is YES), and calls
+#  rcow_delete_lvol for each, passing the snapshot's uuid along with its name.
+#  A snapshot without the mark is never touched, so snapshots a test or another
+#  node created, or that were never deleted on purpose, are left alone. Each
+#  successful delete clears the mark on the target; a delete that is refused
+#  again is reported and does not stop the others. Exit status is 0 only if
+#  every marked-and-deletable snapshot went.
+#
+#  What this is not:
+#
+#    * There is no automatic retry. Nothing on the target polls the marks; this
+#      command is the only thing that acts on them, and it has to be run.
+#    * The marks live in the target's memory only. A restart loses them, and a
+#      delete refused before the restart is then indistinguishable from one that
+#      was never asked for.
+#    * There is no way to cancel a mark other than completing the delete. A
+#      refused delete stays recorded for as long as the target runs and its
+#      lvstore stays attached (an unload drops that lvstore's marks).
+#    * The cluster deployment does not run this: Cubelet's own delete path
+#      (S3Cow.DeleteByKind) still treats a refused snapshot delete as success.
+#      This is an operator tool for the node, not a fix for that.
 
 import argparse
 import json
@@ -60,40 +94,66 @@ import socket
 import sys
 
 
-def main():
-    p = argparse.ArgumentParser(description="send one JSON-RPC request to an "
-                                            "s3lvol target")
-    p.add_argument("method")
-    p.add_argument("params", nargs="?", default="",
-                   help="request parameters as a JSON object; omit or pass an "
-                        "empty string for none")
-    p.add_argument("--sock", default="/var/run/s3lvol.sock",
-                   help="RPC unix socket (default: %(default)s)")
-    # Generous by default: rcow_create_lvstore formats the local device
-    # and talks to S3, and an attach replays the journal and the WAL before it
-    # answers. A tight timeout here reports a hang that is really just slow.
-    p.add_argument("--timeout", type=float, default=300.0,
-                   help="socket timeout in seconds (default: %(default)s)")
-    p.add_argument("--raw", action="store_true",
-                   help="print the result member as it arrived, without "
-                        "unwrapping a {bool_value, string_value} envelope")
-    args = p.parse_args()
+def _fmt_size(clusters, cluster_size):
+    if not clusters:
+        return "-"
+    b = float(clusters) * cluster_size
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    for i, unit in enumerate(units):
+        if b < 1024.0 or i == len(units) - 1:
+            return "%d %s" % (b, unit) if unit == "B" else "%.1f %s" % (b, unit)
+        b /= 1024.0
 
-    req = {"jsonrpc": "2.0", "id": 1, "method": args.method}
-    if args.params:
-        try:
-            req["params"] = json.loads(args.params)
-        except ValueError as e:
-            print("params is not valid JSON: %s" % e, file=sys.stderr)
-            return 1
+
+def fmt_ls_table(result):
+    """rcow_get_lvstores -> an ls-style table, one lvol per line."""
+    if not isinstance(result, list):
+        return json.dumps(result)
+    blocks = []
+    for lvs in result:
+        if not isinstance(lvs, dict):
+            continue
+        lvols = lvs.get("lvols") or []
+        cs = lvs.get("cluster_size") or 1048576
+        lines = ["LVS %s  (total %d / free %d clusters, %d lvols)" % (
+            lvs.get("lvs_name", "?"), lvs.get("total_clusters", 0),
+            lvs.get("free_clusters", 0), len(lvols))]
+        rows = [(l.get("name", ""),
+                 "snapshot" if l.get("is_snapshot") else "lvol",
+                 _fmt_size(l.get("total_clusters", 0), cs),
+                 str(l.get("allocated_clusters", 0)),
+                 l.get("export_status", ""),
+                 l.get("deletable", ""),
+                 "Y" if l.get("delete_pending") else "-",
+                 l.get("bdev_name", "")) for l in lvols]
+        w = max((len(r[0]) for r in rows), default=8)
+        fmt = "%-*s  %-9s %-10s %-8s %-6s %-4s %-5s  %s"
+        hdr = fmt % (w, "NAME", "TYPE", "SIZE", "ALLOC", "EXPORT", "DEL", "PEND", "BDEV")
+        lines.append(hdr)
+        lines.append("-" * len(hdr))
+        for r in rows:
+            lines.append(fmt % (w, r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]))
+        blocks.append("\n".join(lines))
+    return "\n".join(blocks)
+
+
+def _send(sock_path, timeout, method, params=None, raw=False):
+    """One JSON-RPC request.
+
+    Returns (True, value, envelope) where value is the result with a
+    {bool_value, string_value} envelope unwrapped (string_value, verbatim), or
+    (False, text, False) where text says what went wrong.
+    """
+    req = {"jsonrpc": "2.0", "id": 1, "method": method}
+    if params is not None:
+        req["params"] = params
 
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.settimeout(args.timeout)
+    s.settimeout(timeout)
     try:
-        s.connect(args.sock)
+        s.connect(sock_path)
     except OSError as e:
-        print("cannot connect to %s: %s" % (args.sock, e), file=sys.stderr)
-        return 1
+        return False, "cannot connect to %s: %s" % (sock_path, e), False
     s.sendall(json.dumps(req).encode())
 
     # The reply can arrive in pieces, and its length is not announced, so the
@@ -104,10 +164,9 @@ def main():
         try:
             chunk = s.recv(65536)
         except socket.timeout:
-            print("no reply within %gs; %d bytes received"
-                  % (args.timeout, len(buf)), file=sys.stderr)
             s.close()
-            return 1
+            return False, "no reply within %gs; %d bytes received" % (
+                timeout, len(buf)), False
         if not chunk:
             break
         buf += chunk
@@ -123,13 +182,11 @@ def main():
     # live run of the dataplane test reported "NameError: resp is not defined"
     # for what was actually a segfault on the other end.
     if resp is None:
-        print("target closed the connection without replying (it probably "
-              "died); %d bytes received" % len(buf), file=sys.stderr)
-        return 1
+        return False, ("target closed the connection without replying (it "
+                       "probably died); %d bytes received" % len(buf)), False
 
     if "error" in resp:
-        print(json.dumps(resp["error"]), file=sys.stderr)
-        return 1
+        return False, json.dumps(resp["error"]), False
 
     result = resp.get("result")
 
@@ -137,17 +194,135 @@ def main():
     # and nothing else. Being that strict matters -- an RPC that happened to
     # report a bool_value among other fields would otherwise have the rest of its
     # answer thrown away.
-    if (not args.raw and isinstance(result, dict)
+    if (not raw and isinstance(result, dict)
             and set(result) == {"bool_value", "string_value"}
             and isinstance(result["bool_value"], bool)):
         text = result["string_value"]
         if result["bool_value"]:
-            print(text)
-            return 0
-        print(text, file=sys.stderr)
+            return True, text, True
+        return False, text, True
+
+    return True, result, False
+
+
+def retry_pending_deletes(args):
+    """Delete every snapshot that carries a pending-delete mark and is
+    deletable now. See the header for what the mark means and why it is
+    trusted as the record of a user-asked delete."""
+    ok, result, _ = _send(args.sock, args.timeout, "rcow_get_lvstores")
+    if not ok:
+        print("rcow_get_lvstores failed: %s" % result, file=sys.stderr)
+        return 1
+    if not isinstance(result, list):
+        print("unexpected rcow_get_lvstores result: %r" % (result,),
+              file=sys.stderr)
         return 1
 
-    print(json.dumps(result))
+    targets = []
+    for lvs in result:
+        if not isinstance(lvs, dict):
+            continue
+        lvs_uuid = lvs.get("uuid", "")
+        for l in lvs.get("lvols") or []:
+            # delete_pending is the record that a delete was asked for and
+            # refused; deletable=YES means the blocker has cleared. Together
+            # they are exactly "a user asked, it failed, retry now".
+            #
+            # delete_pending alone establishes snapshot-ness: the target only
+            # ever records a mark for a snapshot. is_snapshot is not required
+            # on top of it -- and must not be, since a snapshot deactivated
+            # while it waited for its blocker to clear would then never be
+            # retried.
+            if l.get("delete_pending") and l.get("deletable") == "YES":
+                targets.append((l.get("name", ""), l.get("uuid", ""),
+                                lvs_uuid))
+
+    if not targets:
+        print("no pending snapshot deletes to retry")
+        return 0
+
+    done = 0
+    for name, lvol_uuid, lvs_uuid in targets:
+        # The uuids come from the same rcow_get_lvstores answer the mark was
+        # read from, and the target refuses if the name has since moved to a
+        # different object. Deleting by name alone would let a snapshot that
+        # was recreated under the same name be deleted by a retry meant for
+        # its predecessor.
+        params = {"lvol_name": name}
+        if lvol_uuid:
+            params["lvol_uuid"] = lvol_uuid
+        if lvs_uuid:
+            params["lvs_uuid"] = lvs_uuid
+        ok, text, _ = _send(args.sock, args.timeout, "rcow_delete_lvol",
+                            params)
+        if ok:
+            done += 1
+            print("deleted %s" % name)
+        else:
+            print("failed to delete %s: %s" % (name, text), file=sys.stderr)
+    print("%d of %d pending snapshot delete(s) completed" % (done, len(targets)))
+    return 0 if done == len(targets) else 1
+
+
+def main():
+    p = argparse.ArgumentParser(description="send one JSON-RPC request to an "
+                                            "s3lvol target")
+    p.add_argument("method", nargs="?",
+                   help="method to call; not needed with --retry-pending")
+    p.add_argument("params", nargs="?", default="",
+                   help="request parameters as a JSON object; omit or pass an "
+                        "empty string for none")
+    p.add_argument("--sock", default="/var/run/s3lvol.sock",
+                   help="RPC unix socket (default: %(default)s)")
+    # Generous by default: rcow_create_lvstore formats the local device
+    # and talks to S3, and an attach replays the journal and the WAL before it
+    # answers. A tight timeout here reports a hang that is really just slow.
+    p.add_argument("--timeout", type=float, default=300.0,
+                   help="socket timeout in seconds (default: %(default)s)")
+    p.add_argument("--raw", action="store_true",
+                   help="print the result member as it arrived, without "
+                        "unwrapping a {bool_value, string_value} envelope")
+    p.add_argument("--ls", action="store_true",
+                   help="format rcow_get_lvstores output as an ls-style "
+                        "table (NAME/SIZE/ALLOC/EXPORT/DEL/BDEV)")
+    p.add_argument("--retry-pending", action="store_true",
+                   help="delete every snapshot that carries a pending-delete "
+                        "mark and has become deletable; takes no method")
+    args = p.parse_args()
+
+    if args.retry_pending:
+        if args.method:
+            print("--retry-pending takes no method", file=sys.stderr)
+            return 2
+        return retry_pending_deletes(args)
+
+    if not args.method:
+        p.print_usage(sys.stderr)
+        print("error: a method is required (or use --retry-pending)",
+              file=sys.stderr)
+        return 2
+
+    if args.params:
+        try:
+            params = json.loads(args.params)
+        except ValueError as e:
+            print("params is not valid JSON: %s" % e, file=sys.stderr)
+            return 1
+    else:
+        params = None
+
+    ok, result, envelope = _send(args.sock, args.timeout, args.method,
+                                 params, args.raw)
+    if not ok:
+        print(result, file=sys.stderr)
+        return 1
+
+    if args.ls and args.method == "rcow_get_lvstores":
+        print(fmt_ls_table(result))
+    elif envelope:
+        print(result)
+    else:
+        print(json.dumps(result))
     return 0
 
 

--- a/docs/guide/cross-node-snapshot.md
+++ b/docs/guide/cross-node-snapshot.md
@@ -250,7 +250,21 @@ Create from the **template** (`Sandbox.create(template=tpl-…)`).
 
 ## 5. Known limitations
 
-1. **S3lvol deletes snapshot objects asynchronously.** After you delete an S3 snapshot, CubeS3lvol finishes removing the objects in the background. The delete RPC returning does not mean the objects are gone from S3 immediately.
+1. **S3lvol deletes snapshot objects asynchronously, and referenced snapshots are refused.** After you delete an S3 snapshot, CubeS3lvol finishes removing the objects in the background. The delete RPC returning does not mean the objects are gone from S3 immediately.
+
+   A snapshot that is still referenced **cannot be deleted**: CubeS3lvol refuses with `EBUSY` when it is being or has been exported (another node may be reading through it), has more than one clone, or is being decoupled. CubeS3lvol then records a **pending-delete mark** keyed by **(lvstore uuid, lvol uuid)** — not by name, so a same-named snapshot cannot be deleted by mistake. Check `delete_pending` in `rcow_get_lvstores`; `deletable` shows whether it can be deleted right now.
+
+   A different refusal: when the volume is still an **active** NVMe-oF namespace, the delete is refused at the RPC layer (with a hint to run `rcow_deactive_bdev` first). That path does **not** record a mark — it is a precondition the caller can fix immediately, not a blocker to wait out.
+
+   Once the blocker clears (the export is released or expires, the extra clone is deleted, decouple finishes, or the volume is deactivated), you must **retry by hand** on that node:
+
+   ```sh
+   # from the CubeS3lvol directory
+   test/tools/s3lvol_rpc.py --ls              # check the DEL / PEND columns
+   test/tools/s3lvol_rpc.py --retry-pending   # retry every marked snapshot that is deletable now
+   ```
+
+   Limits of this mechanism: marks live **only in the s3lvol_tgt process memory** and are lost on restart or lvstore unload; there is **no automatic retry** (no background poller) and **no way to cancel** a recorded mark. The cluster delete path (Cubelet `S3Cow.DeleteByKind`) currently treats a refused snapshot delete as success and does not run `--retry-pending`, so leftover objects must be handled on the node as above. See [Retrying a refused snapshot delete](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeS3lvol/README.md#retrying-a-refused-snapshot-delete---retry-pending) in `CubeS3lvol/README.md`.
 
 2. **DB / filesystem layout changed vs pre-0.7.0; migration is tested from 0.6.0 only.** Table and on-disk layout differ from versions before 0.7.0. The new release adapts older data for cleanup, but that path is **tested against 0.6.0**. If adaptation fails, delete leftover snapshot files and the matching DB rows by hand.
 

--- a/docs/zh/guide/cross-node-snapshot.md
+++ b/docs/zh/guide/cross-node-snapshot.md
@@ -284,7 +284,31 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
 
 ## 5. 已知问题
 
-1. **S3 快照对象由 S3lvol 异步删除。** 删除 S3 快照后，CubeS3lvol 在后台回收对象。删除接口返回时，对象不一定已经从 S3 上消失。
+1. **S3 快照对象由 S3lvol 异步删除，被引用的快照会拒绝删除。** 删除 S3 快照后，CubeS3lvol 在后台回收对象。
+   删除接口返回时，对象不一定已经从 S3 上消失。
+
+   此外，快照在被引用时**无法删除**，CubeS3lvol 会以 `EBUSY` 拒绝：正在或已经导出（其他节点可能正
+   在读取）、存在多个 clone、正在 decouple。此时 CubeS3lvol 会记录一条 **pending-delete 标记**
+   （按 lvstore uuid + lvol uuid 记录，不按名字，避免同名快照被误删），可通过 `rcow_get_lvstores` 的
+   `delete_pending` 字段查看，`deletable` 字段则表示当前是否可删。
+
+   注意另一种拒绝：卷仍作为 NVMe-oF 命名空间处于 **active** 时，删除会在 RPC 层就被拒绝（提示先执行
+   `rcow_deactive_bdev`），这一路径**不会**记录标记——它是调用方自己可以立即纠正的前置条件，而不是需要
+   等待的阻塞原因。
+
+   阻塞原因解除后（导出被释放或过期、多余 clone 被删除、decouple 结束、卷被 deactivate），需要在该节点上
+   **手动重试**：
+
+   ```sh
+   # 在 CubeS3lvol 目录下
+   test/tools/s3lvol_rpc.py --ls              # 查看 DEL / PEND 两列
+   test/tools/s3lvol_rpc.py --retry-pending   # 重试所有已标记且当前可删的快照
+   ```
+
+   注意该机制的边界：标记**只存在于 s3lvol_tgt 进程内存中**，进程重启或 lvstore 卸载即丢失；**没有自动
+   重试**（无后台轮询），也**无法取消**已记录的标记；并且集群侧的删除路径（Cubelet `S3Cow.DeleteByKind`）
+   目前会把被拒绝的快照删除视为成功、且不会调用 `--retry-pending`，因此这类残留对象需要按上述方式在节点上
+   处理。详见 `CubeS3lvol/README.md` 的 "Retrying a refused snapshot delete"。
 
 2. **DB / FS 结构相较 0.7.0 之前版本变化较大，老数据适配仅覆盖 0.6.0**：本版本相比 0.7.0 之前的版本，
    DB 表结构与文件系统目录结构均有较大调整。新版本会对老版本的数据结构做适配，用于用户清理老数据的场景，


### PR DESCRIPTION
## Summary

A snapshot delete that cannot go through — the snapshot is exported, has more than one clone, is being decoupled, or is still an active NVMe-oF namespace — is refused with `EBUSY`, and until now nothing recorded that a delete had ever been asked for. This PR records it and gives the operator a way to complete it once the blocker clears.

**This is a record plus a manual retry, not an automatic one.** There is no poller: nothing on the target acts on the marks by itself.

## What's in this PR

**1. `s3lvol: record and retry deletes that cannot complete`**

- A refused snapshot delete records a **pending-delete mark**, keyed by `(lvstore uuid, lvol uuid)` — not by name. A name is unique only inside one loaded lvstore and is reusable, so a name-keyed mark could outlive the object it was recorded for (delete and recreate under the same name, or unload and re-attach the lvstore) and a retry would then act on something nobody asked it to. `s3lvol_lvstore_free()` drops the marks of the lvstore going away, which covers the unload, delete and setup-error paths alike.
- `rcow_get_lvstores` reports per-lvol cluster counts and, per snapshot, `export_status`, `deletable` and `delete_pending`.
- `rcow_delete_lvol` accepts optional `lvol_uuid` / `lvs_uuid` and refuses when the named lvol is not the one the caller meant — so a retry issued for one snapshot cannot delete a later same-named one.
- `test/tools/s3lvol_rpc.py --retry-pending` reads `rcow_get_lvstores`, finds every snapshot that carries the mark **and** has become deletable, and deletes each **by uuid**. Snapshots without the mark are never touched.
- `export_snapshot_deletable()` corrected: the export-pin, decouple and NVMf-active checks now run **before** the "no open blob" shortcut, which used to report a deactivated-but-pinned snapshot as `deletable: YES` and had `--retry-pending` attempt a delete that then failed with `EBUSY`.
- New dataplane suite `run_pending_delete_test.sh` (21 assertions, wired into `run_all.sh`): refused → alive and marked → `--retry-pending` skips it while pinned → deletes it once the export is released → mark cleared; an unmarked control snapshot is never touched; a delete carrying a stale uuid refuses a same-named replacement while the current uuid succeeds.

**2. `docs(zh): document refused snapshot deletes in cross-node-snapshot`**

Known issue 1 read as "the delete always goes through, just not immediately". It now states that a referenced snapshot is refused, what the node records, how to act on it, and the limits below.

**3. `test(dataplane): resolve SPDK rpc.py from deps/spdk in the remaining scripts`** (companion fix)

`run_activation_test.sh`, `run_dataplane_test.sh`, `run_recovery_test.sh` still hardcoded `/data/home/cow/spdk` / `../spdk`; resolved through `SPDK_ROOT` / `deps/spdk` like the earlier batch.

## Scope and limits (documented, not implied)

- **No automatic retry** — no poller; `--retry-pending` has to be run.
- **In memory only** — the marks are gone on restart, and dropped with their lvstore on unload/delete.
- **No cancel** — completing the delete is the only way to clear a mark.
- **`delete_pending` is a snapshot notion** — `rcow_get_snapshot_status` reports it for `snapshot_name`; by `export_uuid` it is always `false`.
- **The cluster path is not wired to it** — Cubelet's `S3Cow.DeleteByKind` still treats a refused snapshot delete as success and does not run `--retry-pending`. This PR is the node-side operator tool; fixing that leak is a separate change (both README and the zh doc say so).

## Verified

Full regression against a real COS bucket: **30/30 suites, 1124 assertions passed, 0 failed** (offline + real-S3 integration + all dataplane suites, including the new `run_pending_delete_test.sh` at 21/21). Target builds clean under `-Werror`.
