### PR TITLE
test(sdk_compat): default volume plugin e2e to S3 + MinIO

### DIFF
--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -107,8 +107,8 @@ SDK_E2E_BACKENDS=e2b,cubesandbox pytest --run-e2e -m "p0 or p1"
 # Platform lifecycle regression (cube-proxy + lifecycle manager)
 SDK_E2E_PLATFORM_LIFECYCLE=true pytest --run-e2e -k lifecycle -m "p1 and slow"
 
-# Volume plugin regression (manual plugin deploy/config; cubesandbox >= 0.6.0)
-SDK_E2E_VOLUME_PLUGIN=true pytest --run-e2e -m volume --sdk-e2e-backends=cubesandbox
+# Volume plugin regression (default S3 + MinIO; cubesandbox >= 0.6.0)
+pytest --run-e2e -m volume --sdk-e2e-backends=cubesandbox
 
 # Broader regression
 SDK_E2E_BACKENDS=e2b,cubesandbox pytest --run-e2e -m "p0 or p1 or p2"
@@ -380,9 +380,9 @@ Optional:
   initial wait. Defaults to `45`.
 - `CUBE_PROXY_ADMIN_PORT`: CubeProxy admin port used by the lifecycle probe.
   Defaults to `8082`.
-- `SDK_E2E_VOLUME_PLUGIN`: enable Volume Plugin cases (CRUD and sandbox
-  `volumeMounts` bind/unbind). Defaults to `false`.
-- `SDK_E2E_VOLUME_DRIVER`: driver name for `POST /volumes`. Defaults to `cos`.
+- `SDK_E2E_VOLUME_PLUGIN`: run Volume Plugin cases (CRUD and sandbox
+  `volumeMounts` bind/unbind). Defaults to `true`; set `false` to skip.
+- `SDK_E2E_VOLUME_DRIVER`: driver name for `POST /volumes`. Defaults to `s3`.
 - `SDK_E2E_VOLUME_REFCOUNT_WAIT`: seconds to wait for delete-while-bound `409`
   and post-unbind `204`. Defaults to `60`.
 
@@ -484,7 +484,7 @@ Current capability domains:
 - `cases/concurrency/`: simultaneous multi-sandbox isolation.
 - `cases/host-mount/`: host-directory mount extension — happy path plus create-time
   validation, runtime bind-mount failures, and cross-sandbox sharing boundary cases.
-- `cases/volume/`: Volume Plugin CRUD plus sandbox `volumeMounts` bind/unbind and per-sandbox read-only attachment enforcement (opt-in via `SDK_E2E_VOLUME_PLUGIN=true`; CubeSandbox only). Requires a manually deployed/configured Volume Plugin and `cubesandbox` >= 0.6.0.
+- `cases/volume/`: Volume Plugin CRUD plus sandbox `volumeMounts` bind/unbind and per-sandbox read-only attachment enforcement (CubeSandbox only; default driver `s3`). Runs with `--run-e2e` unless `SDK_E2E_VOLUME_PLUGIN=false`. Requires the default-install S3 plugin + MinIO and `cubesandbox` >= 0.6.0.
 - `cases/auth/`: `CUBE_API_KEY` simple-key authentication against the CubeAPI
   control plane — `X-API-Key`/`Bearer` accept, wrong/missing 401, `/health`
   exempt (CubeSandbox only). Skipped unless the server was started with
@@ -510,7 +510,7 @@ Capability markers:
 - `@pytest.mark.requires_capability("<name>")`: skip or deselect unsupported backends.
 - `@pytest.mark.sandbox_create_options(...)`: pass SDK create-time options such as `network`, `env_vars`, or `lifecycle`.
 - `@pytest.mark.requires_cubeproxy`: platform lifecycle cases that depend on cube-proxy and lifecycle-manager coordination. Skipped unless `SDK_E2E_PLATFORM_LIFECYCLE=true`.
-- `@pytest.mark.volume`: Volume Plugin cases. Skipped unless `SDK_E2E_VOLUME_PLUGIN=true`.
+- `@pytest.mark.volume`: Volume Plugin cases. Run with `--run-e2e`; skipped when `SDK_E2E_VOLUME_PLUGIN=false`.
 - `@pytest.mark.auth`: `CUBE_API_KEY` simple-key auth cases. Skipped unless `CUBE_API_KEY` is set for the runner and the backend supports `auth_simple_key` (CubeSandbox only).
 - Common capabilities include `lifecycle`, `commands`, `filesystem`,
   `filesystem_extended`, and `run_code`.

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -98,8 +98,8 @@ pytest --run-e2e -m "smoke or p0" --sdk-e2e-backends=cubesandbox
 # 每日双 SDK 兼容性回归
 SDK_E2E_BACKENDS=e2b,cubesandbox pytest --run-e2e -m "p0 or p1"
 
-# Volume Plugin 回归（需手动部署并配置插件；cubesandbox >= 0.6.0）
-SDK_E2E_VOLUME_PLUGIN=true pytest --run-e2e -m volume --sdk-e2e-backends=cubesandbox
+# Volume Plugin 回归（默认 S3 + MinIO；cubesandbox >= 0.6.0）
+pytest --run-e2e -m volume --sdk-e2e-backends=cubesandbox
 
 # 更广泛的回归
 SDK_E2E_BACKENDS=e2b,cubesandbox \
@@ -321,9 +321,9 @@ cp env.example .env
 - `SDK_E2E_PLATFORM_LIFECYCLE_WAIT_MARGIN`：额外等待时间，默认 `20` 秒；
 - `SDK_E2E_PLATFORM_LIFECYCLE_POLL_TIMEOUT`：轮询窗口，默认 `45` 秒；
 - `CUBE_PROXY_ADMIN_PORT`：CubeProxy admin 端口，默认 `8082`；
-- `SDK_E2E_VOLUME_PLUGIN`：启用 Volume Plugin 用例（CRUD 与 sandbox
-  `volumeMounts` 绑定/解绑），默认 `false`；
-- `SDK_E2E_VOLUME_DRIVER`：`POST /volumes` 使用的 driver，默认 `cos`；
+- `SDK_E2E_VOLUME_PLUGIN`：运行 Volume Plugin 用例（CRUD 与 sandbox
+  `volumeMounts` 绑定/解绑），默认 `true`；设为 `false` 可跳过；
+- `SDK_E2E_VOLUME_DRIVER`：`POST /volumes` 使用的 driver，默认 `s3`；
 - `SDK_E2E_VOLUME_REFCOUNT_WAIT`：等待绑定中删除 `409` / 解绑后 `204`
   的秒数，默认 `60`。
 
@@ -449,7 +449,7 @@ tests/e2e/sdk_compat/
 - `cases/concurrency/`：同时运行多个 sandbox 时的数据隔离；
 - `cases/host-mount/`：宿主目录挂载扩展——happy path，以及创建时校验、
   运行期 bind-mount 失败和跨 sandbox 共享等边界用例。
-- `cases/volume/`：Volume Plugin CRUD、sandbox `volumeMounts` 绑定/解绑，以及每个沙箱挂载点的只读约束（需 `SDK_E2E_VOLUME_PLUGIN=true`；仅 CubeSandbox）。插件需手动部署并配置，且要求 `cubesandbox` >= 0.6.0。
+- `cases/volume/`：Volume Plugin CRUD、sandbox `volumeMounts` 绑定/解绑，以及每个沙箱挂载点的只读约束（仅 CubeSandbox；默认 driver `s3`）。随 `--run-e2e` 执行，除非设置 `SDK_E2E_VOLUME_PLUGIN=false`。依赖默认安装的 S3 插件 + MinIO，且要求 `cubesandbox` >= 0.6.0。
 - `cases/auth/`：`CUBE_API_KEY` 简单密钥鉴权，针对 CubeAPI 控制面——
   `X-API-Key`/`Bearer` 通过、错误/缺失返回 401、`/health` 豁免（仅 CubeSandbox）。
   仅当服务端以 `CUBE_API_KEY` 启动且 runner 导出相同 key 时才运行，否则跳过。
@@ -476,8 +476,8 @@ Capability marker：
   覆盖模板 ID；未设置时使用 `CUBE_TEMPLATE_ID` 或 `--cube-template-id`；
 - `@pytest.mark.requires_cubeproxy`：依赖 CubeProxy/lifecycle-manager
   协调，未设置 `SDK_E2E_PLATFORM_LIFECYCLE=true` 时跳过；
-- `@pytest.mark.volume`：Volume Plugin 用例，未设置
-  `SDK_E2E_VOLUME_PLUGIN=true` 时跳过。
+- `@pytest.mark.volume`：Volume Plugin 用例，随 `--run-e2e` 执行；设置
+  `SDK_E2E_VOLUME_PLUGIN=false` 时跳过。
 - `@pytest.mark.auth`：`CUBE_API_KEY` 简单密钥鉴权用例，未为 runner 设置
   `CUBE_API_KEY` 或后端不支持 `auth_simple_key`（仅 CubeSandbox）时跳过。
 

--- a/tests/e2e/sdk_compat/cases/volume/__init__.py
+++ b/tests/e2e/sdk_compat/cases/volume/__init__.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """sdk_compat Volume Plugin cases.
 
-Requires a manually deployed and configured Volume Plugin on the cluster, and
-``cubesandbox`` >= 0.6.0. See module docstrings in ``test_*.py`` for details.
+Default install uses the S3 plugin plus MinIO. ``SDK_E2E_VOLUME_DRIVER``
+defaults to ``s3``; set ``SDK_E2E_VOLUME_PLUGIN=false`` to skip.
 
 Plugin guide:
-https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md
+https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.md
 """

--- a/tests/e2e/sdk_compat/cases/volume/test_bind_unbind.py
+++ b/tests/e2e/sdk_compat/cases/volume/test_bind_unbind.py
@@ -2,14 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Volume bind / unbind and delete-while-bound (HTTP 409) cases.
 
-Prerequisites (manual; not provisioned by this suite):
-- Deploy and configure a Volume Plugin on CubeMaster (Controller) and Cubelet
-  (Node), e.g. COS binary/rpc under ``volume_plugins``, with credentials.
-  Guide: https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md
-- Platform Volume API available (CubeAPI / CubeMaster / Cubelet >= 0.6.0).
-- Python SDK ``cubesandbox`` >= 0.6.0 (Volume / volume_mounts support).
+Prerequisites:
+- Default install S3 Volume plugin + MinIO (CubeMaster / Cubelet ``volume_plugins``).
+  Guide: https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.md
+- Platform Volume API and Python SDK ``cubesandbox`` >= 0.6.0.
 - A READY template (``CUBE_TEMPLATE_ID``) for sandbox create with mounts.
-- Opt-in: ``SDK_E2E_VOLUME_PLUGIN=true`` (and usually ``SDK_E2E_VOLUME_DRIVER``).
+- ``SDK_E2E_VOLUME_DRIVER`` defaults to ``s3``; set ``SDK_E2E_VOLUME_PLUGIN=false`` to skip.
 """
 
 from __future__ import annotations

--- a/tests/e2e/sdk_compat/cases/volume/test_crud.py
+++ b/tests/e2e/sdk_compat/cases/volume/test_crud.py
@@ -2,13 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Volume CRUD cases (create / list / get / delete).
 
-Prerequisites (manual; not provisioned by this suite):
-- Deploy and configure a Volume Plugin on CubeMaster (Controller) and Cubelet
-  (Node), e.g. COS binary/rpc under ``volume_plugins``, with credentials.
-  Guide: https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md
-- Platform Volume API available (CubeAPI / CubeMaster / Cubelet >= 0.6.0).
-- Python SDK ``cubesandbox`` >= 0.6.0 (Volume / volume_mounts support).
-- Opt-in: ``SDK_E2E_VOLUME_PLUGIN=true`` (and usually ``SDK_E2E_VOLUME_DRIVER``).
+Prerequisites:
+- Default install S3 Volume plugin + MinIO (CubeMaster / Cubelet ``volume_plugins``).
+  Guide: https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.md
+- Platform Volume API and Python SDK ``cubesandbox`` >= 0.6.0.
+- ``SDK_E2E_VOLUME_DRIVER`` defaults to ``s3``; set ``SDK_E2E_VOLUME_PLUGIN=false`` to skip.
 """
 
 from __future__ import annotations

--- a/tests/e2e/sdk_compat/cases/volume/test_read_only.py
+++ b/tests/e2e/sdk_compat/cases/volume/test_read_only.py
@@ -1,13 +1,11 @@
 """Per-sandbox read-only Volume attachment cases.
 
-Prerequisites (manual; not provisioned by this suite):
-- Deploy and configure a Volume Plugin on CubeMaster (Controller) and Cubelet
-  (Node), e.g. COS binary/rpc under ``volume_plugins``, with credentials.
-  Guide: https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md
-- Platform Volume API available (CubeAPI / CubeMaster / Cubelet >= 0.6.0).
-- Python SDK ``cubesandbox`` with ``VolumeMount`` support.
+Prerequisites:
+- Default install S3 Volume plugin + MinIO (CubeMaster / Cubelet ``volume_plugins``).
+  Guide: https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.md
+- Platform Volume API and Python SDK ``cubesandbox`` with ``VolumeMount`` support.
 - A READY template (``CUBE_TEMPLATE_ID``) for sandbox create with mounts.
-- Opt-in: ``SDK_E2E_VOLUME_PLUGIN=true`` (and usually ``SDK_E2E_VOLUME_DRIVER``).
+- ``SDK_E2E_VOLUME_DRIVER`` defaults to ``s3``; set ``SDK_E2E_VOLUME_PLUGIN=false`` to skip.
 """
 
 from __future__ import annotations

--- a/tests/e2e/sdk_compat/conftest.py
+++ b/tests/e2e/sdk_compat/conftest.py
@@ -22,7 +22,7 @@ from framework.capabilities import (  # noqa: E402
     capabilities_for_backend,
 )
 from framework.cleanup import safe_kill  # noqa: E402
-from framework.config import SdkE2EConfig  # noqa: E402
+from framework.config import SdkE2EConfig, volume_plugin_enabled_from_env  # noqa: E402
 from framework.parallel import (  # noqa: E402
     apply_worker_count,
     current_worker_count,
@@ -205,7 +205,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         _template_id_for_node(item) is None for item in items
     )
     volume_skip = None
-    if not _env_true("SDK_E2E_VOLUME_PLUGIN"):
+    if not volume_plugin_enabled_from_env():
         from framework.volume import VOLUME_PLUGIN_SKIP_REASON  # noqa: E402
 
         volume_skip = pytest.mark.skip(reason=VOLUME_PLUGIN_SKIP_REASON)

--- a/tests/e2e/sdk_compat/docs/case-authoring.md
+++ b/tests/e2e/sdk_compat/docs/case-authoring.md
@@ -136,16 +136,15 @@ SDK_E2E_PLATFORM_LIFECYCLE=true \
 pytest --run-e2e --sdk-e2e-trace cases/lifecycle/test_auto_lifecycle.py
 ```
 
-Volume Plugin cases use the `volume` marker and stay skipped unless
-`SDK_E2E_VOLUME_PLUGIN=true`. Create the volume first, then pass dynamic
-`volumeMounts` through `create_adapter(..., create_options=...)` — do not
-hard-code a volume ID in `sandbox_create_options`. Deploy and configure the
-plugin manually first:
-https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md
+Volume Plugin cases use the `volume` marker and run with `--run-e2e` (default
+driver `s3`). Set `SDK_E2E_VOLUME_PLUGIN=false` to skip. Create the volume
+first, then pass dynamic `volumeMounts` through
+`create_adapter(..., create_options=...)` — do not hard-code a volume ID in
+`sandbox_create_options`. Default install wires the S3 plugin + MinIO:
+https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.md
 (`cubesandbox` >= 0.6.0).
 
 ```bash
-SDK_E2E_VOLUME_PLUGIN=true \
 pytest --run-e2e -m volume --sdk-e2e-backends=cubesandbox
 ```
 

--- a/tests/e2e/sdk_compat/docs/test-coverage.md
+++ b/tests/e2e/sdk_compat/docs/test-coverage.md
@@ -179,7 +179,7 @@ resource contention test or multi-worker safety validation.
 
 ### 2.8 Volume
 
-`cases/volume/` covers Volume Plugin CRUD, sandbox bind/unbind and delete-while-bound behavior. It also verifies that one Volume can remain writable in one sandbox while a concurrent attachment is read-only in another sandbox, including read access and rejected create, write, rename and delete operations. These cases are CubeSandbox-only and remain skipped unless `SDK_E2E_VOLUME_PLUGIN=true` explicitly confirms that the deployment has a configured Volume Plugin.
+`cases/volume/` covers Volume Plugin CRUD, sandbox bind/unbind and delete-while-bound behavior. It also verifies that one Volume can remain writable in one sandbox while a concurrent attachment is read-only in another sandbox, including read access and rejected create, write, rename and delete operations. These cases are CubeSandbox-only, default to the S3 driver, and run with `--run-e2e` unless `SDK_E2E_VOLUME_PLUGIN=false`.
 
 ## 3. Coverage Boundaries
 

--- a/tests/e2e/sdk_compat/docs/zh/case-authoring.md
+++ b/tests/e2e/sdk_compat/docs/zh/case-authoring.md
@@ -341,6 +341,20 @@ def test_isolation(sdk_sandbox, sdk_backend, sdk_e2e_config):
 真正并发的用例还应设置可控并发数、超时和资源上限，并确保异常路径回收所有
 future/peer sandbox。
 
+### 6.7 Volume
+
+Volume Plugin 用例使用 `volume` marker，随 `--run-e2e` 执行（默认 driver
+`s3`）。无插件的环境设置 `SDK_E2E_VOLUME_PLUGIN=false` 即可跳过。先创建
+volume，再通过 `create_adapter(..., create_options=...)` 传入动态
+`volumeMounts`，不要在 `sandbox_create_options` 里写死 volume ID。默认安装
+已接好 S3 插件 + MinIO：
+https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.md
+（`cubesandbox` >= 0.6.0）。
+
+```bash
+pytest --run-e2e -m volume --sdk-e2e-backends=cubesandbox
+```
+
 ## 7. 清理、保留和额外 adapter
 
 `sdk_sandbox` 默认负责主 sandbox 清理。不要在测试体中对它额外调用 `kill()`，

--- a/tests/e2e/sdk_compat/docs/zh/test-coverage.md
+++ b/tests/e2e/sdk_compat/docs/zh/test-coverage.md
@@ -157,7 +157,7 @@ pytest --run-e2e -m "lifecycle and slow"
 
 ### 2.8 Volume
 
-`cases/volume/` 覆盖 Volume Plugin CRUD、sandbox 绑定/解绑和绑定期间禁止删除。它还验证同一个 Volume 可以在一个沙箱中保持读写，同时在另一个沙箱中以只读方式挂载，包括正常读取，以及 create、write、rename、delete 均被拒绝。这些用例仅适用于 CubeSandbox，只有通过 `SDK_E2E_VOLUME_PLUGIN=true` 明确确认部署已配置 Volume Plugin 后才会执行，否则保持 skip。
+`cases/volume/` 覆盖 Volume Plugin CRUD、sandbox 绑定/解绑和绑定期间禁止删除。它还验证同一个 Volume 可以在一个沙箱中保持读写，同时在另一个沙箱中以只读方式挂载，包括正常读取，以及 create、write、rename、delete 均被拒绝。这些用例仅适用于 CubeSandbox，默认使用 S3 driver，随 `--run-e2e` 执行，除非设置 `SDK_E2E_VOLUME_PLUGIN=false`。
 
 ## 3. 覆盖边界
 

--- a/tests/e2e/sdk_compat/env.example
+++ b/tests/e2e/sdk_compat/env.example
@@ -114,13 +114,12 @@ SDK_E2E_REPORT_DIR=reports/sdk-dual
 # CUBE_PROXY_ADMIN_PORT=8082
 
 # Volume Plugin cases (CRUD + sandbox volumeMounts bind/unbind).
-# Prerequisites (manual): deploy/configure the Volume Plugin on CubeMaster and
-# Cubelet; platform >= 0.6.0; Python SDK cubesandbox >= 0.6.0.
-# Guide: https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md
-# Keep disabled for PR smoke; enable for volume regression environments.
-# SDK_E2E_VOLUME_PLUGIN=true
-# Driver/plugin name passed to POST /volumes (default cos).
-# SDK_E2E_VOLUME_DRIVER=cos
+# Default install S3 plugin + MinIO; platform >= 0.6.0; Python SDK cubesandbox >= 0.6.0.
+# Guide: https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.md
+# Runs with --run-e2e; set false to skip on clusters without the plugin.
+# SDK_E2E_VOLUME_PLUGIN=false
+# Driver/plugin name passed to POST /volumes (default s3).
+# SDK_E2E_VOLUME_DRIVER=s3
 # Max seconds to wait for delete-while-bound 409 / post-unbind 204.
 # SDK_E2E_VOLUME_REFCOUNT_WAIT=60
 

--- a/tests/e2e/sdk_compat/framework/config.py
+++ b/tests/e2e/sdk_compat/framework/config.py
@@ -19,6 +19,10 @@ def _bool_env(name: str, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def volume_plugin_enabled_from_env() -> bool:
+    return _bool_env("SDK_E2E_VOLUME_PLUGIN", default=True)
+
+
 @dataclass(frozen=True)
 class SdkE2EConfig:
     backends: tuple[str, ...]
@@ -92,8 +96,8 @@ class SdkE2EConfig:
                 os.environ.get("SDK_E2E_PLATFORM_LIFECYCLE_POLL_TIMEOUT", "45")
             ),
             cube_proxy_admin_port=int(os.environ.get("CUBE_PROXY_ADMIN_PORT", "8082")),
-            volume_plugin_enabled=_bool_env("SDK_E2E_VOLUME_PLUGIN"),
-            volume_driver=os.environ.get("SDK_E2E_VOLUME_DRIVER", "cos").strip() or "cos",
+            volume_plugin_enabled=volume_plugin_enabled_from_env(),
+            volume_driver=os.environ.get("SDK_E2E_VOLUME_DRIVER", "s3").strip() or "s3",
             volume_refcount_wait=int(os.environ.get("SDK_E2E_VOLUME_REFCOUNT_WAIT", "60")),
             create_capacity_retries=int(
                 os.environ.get("SDK_E2E_CREATE_CAPACITY_RETRIES", "5")

--- a/tests/e2e/sdk_compat/framework/volume_hints.py
+++ b/tests/e2e/sdk_compat/framework/volume_hints.py
@@ -6,13 +6,11 @@
 from __future__ import annotations
 
 VOLUME_MOUNT_PATH = "/mnt/vol-data"
-# COS reference plugin install / config guide (manual deploy).
 VOLUME_PLUGIN_GUIDE_URL = (
-    "https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md"
+    "https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/s3/README.md"
 )
 VOLUME_PLUGIN_SKIP_REASON = (
-    "volume plugin tests require SDK_E2E_VOLUME_PLUGIN=true "
-    "(CubeAPI + CubeMaster + Cubelet + a configured volume plugin). "
+    "volume plugin tests skipped because SDK_E2E_VOLUME_PLUGIN=false. "
     f"See {VOLUME_PLUGIN_GUIDE_URL}"
 )
 


### PR DESCRIPTION
### Summary

Switch the `sdk_compat` Volume Plugin e2e cases from a manually deployed COS plugin to the default S3 + MinIO install shipped with CubeSandbox.

### Changes

- `SDK_E2E_VOLUME_PLUGIN` now defaults to `true`; set to `false` to skip Volume Plugin cases
- `SDK_E2E_VOLUME_DRIVER` defaults to `s3` (previously `cos`)
- Plugin prerequisites now reference the default S3 plugin + MinIO install and the `examples/volume/s3` guide
- Updated README (EN/zh), case-authoring docs (EN/zh) and test-coverage docs (EN/zh) to match

### Testing

No new test logic is added; the behavior change is limited to the config defaults and documentation updates. Volume Plugin cases run with `--run-e2e` on clusters that have the plugin installed.