### PR TITLE
fix(CubeAPI): include backend in snapshot list tracing

### DIFF
--- a/CubeAPI/src/handlers/snapshots.rs
+++ b/CubeAPI/src/handlers/snapshots.rs
@@ -71,6 +71,7 @@ pub async fn list_snapshots(
         sandbox_id = ?params.sandbox_id,
         limit = ?params.limit,
         next_token = ?params.next_token,
+        backend = ?params.backend,
         "list_snapshots"
     );
 


### PR DESCRIPTION
Rust emitted `warning: field backend is never read` because deserializing
ListSnapshotsParams does not count as reading the field. The request trace
already records every other query parameter, so backend belongs in the same
instrumentation and the warning indicates a real observability omission.

Assisted-by: Claude Code:claude-opus-4.7
Signed-off-by: Like Xu <likexu@tencent.com>