### PR TITLE
fix(cubelet): do not export template disks on AppSnapshot

### DIFF
--- a/Cubelet/services/cubebox/appsnapshot.go
+++ b/Cubelet/services/cubebox/appsnapshot.go
@@ -449,19 +449,8 @@ func (s *service) AppSnapshot(ctx context.Context, req *cubebox.AppSnapshotReque
 		stepLog.Warnf("s3 finalize package snapshots %s failed: %v", templateID, err)
 	}
 
-	// Export the rootfs snapshot only. Every sandbox rootfs is a child of
-	// it, and a child's export references only chunks that already have a
-	// committed S3 object — the parent's are silently skipped, so without
-	// this a cross-node restore imports a rootfs with no ext4 metadata at
-	// all (measured: 17 objects／7.2MB instead of 80／74.9MB; the imported
-	// disk has no root inode). Memory and metadata of a template are not in
-	// that chain and stay node-local. Best-effort: a template that fails to
-	// export still works on this node.
-	if uuid, err := storage.UploadTemplateRootfs(ctx, backend, templateID); err != nil {
-		stepLog.Warnf("s3 export template rootfs %s failed: %v", templateID, err)
-	} else if uuid != "" {
-		stepLog.Infof("s3 exported template rootfs %s uuid=%s", templateID, uuid)
-	}
+	// Template disks stay node-local. Pause / CommitSandbox export the
+	// sandbox snapshot package, not the template.
 
 	stepLog.Infof("AppSnapshot completed successfully: snapshotPath=%s", snapshotPath)
 	rsp.Ret.RetMsg = "success"

--- a/Cubelet/storage/cow_store_ops.go
+++ b/Cubelet/storage/cow_store_ops.go
@@ -70,28 +70,6 @@ func UploadSnapshot(ctx context.Context, backend, snapshotID string) (*cow.Remot
 	return uploader.Upload(ctx, snapshotID)
 }
 
-// UploadTemplateRootfs exports a template's rootfs snapshot, the parent
-// layer of every sandbox rootfs derived from it. See
-// [S3Cow.UploadTemplateRootfs]. XFS returns an empty uuid and no error.
-func UploadTemplateRootfs(ctx context.Context, backend, templateID string) (string, error) {
-	normalized, err := cow.NormalizeBackend(backend)
-	if err != nil {
-		return "", err
-	}
-	if normalized != cow.BackendS3 {
-		return "", nil
-	}
-	store, err := requireCowStoreFor(cow.BackendS3)
-	if err != nil {
-		return "", err
-	}
-	s3, ok := store.(*S3Cow)
-	if !ok || s3 == nil {
-		return "", fmt.Errorf("s3 cow store does not support template rootfs export")
-	}
-	return s3.UploadTemplateRootfs(ctx, templateID)
-}
-
 // SnapshotUploadStatus returns upload state from cubecow export_status
 // (NONE→pending, empty/INPROGRESS→running, DONE→ready). XFS is a no-op ready.
 func SnapshotUploadStatus(ctx context.Context, backend, snapshotID string) (*cow.RemoteStatus, error) {

--- a/Cubelet/storage/s3_metadata_test.go
+++ b/Cubelet/storage/s3_metadata_test.go
@@ -6,7 +6,6 @@ package storage
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -345,53 +344,6 @@ func TestUploadSkipsMetadataBaseAndUploadsDerived(t *testing.T) {
 	_, err = (&S3Cow{engine: engine}).uploadOne(S3MetadataBaseVolumeName)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "node-local s3 metadata base")
-}
-
-func TestUploadTemplateRootfsExportsOnlyRootfs(t *testing.T) {
-	stubS3MetadataMounts(t)
-	engine := &fakeCowEngine{
-		volumeInfos: map[string]*cubecow.Volume{
-			"tpl-tpl-1-rootfs":              {SizeBytes: 1 << 20},
-			"tpl-tpl-1-memory-snap":         {SizeBytes: 64 << 20},
-			S3MetadataSnapshotName("tpl-1"): {SizeBytes: 8 << 20},
-		},
-	}
-	useTestCowStorage(t, engine)
-	home := t.TempDir()
-	require.NoError(t, EnsureSnapshotPackage(cow.BackendS3, home))
-	require.NoError(t, WriteSnapshotCatalogFor(cow.BackendS3, &SnapshotCatalogEntry{
-		SnapshotID:   "tpl-1",
-		SnapshotPath: home,
-		MetaDir:      filepath.Join(home, SnapshotMetadataDir),
-		RootfsVol:    "tpl-tpl-1-rootfs",
-		RootfsKind:   cowKindSnapshot,
-		MemoryVol:    "tpl-tpl-1-memory-snap",
-		MemoryKind:   cowKindSnapshot,
-		MetadataVol:  S3MetadataSnapshotName("tpl-1"),
-		MetadataKind: cowKindSnapshot,
-		Kind:         CatalogKindTemplate,
-		Backend:      cow.BackendS3,
-	}))
-
-	uuid, err := UploadTemplateRootfs(context.Background(), cow.BackendS3, "tpl-1")
-	require.NoError(t, err)
-	require.NotEmpty(t, uuid)
-	require.Contains(t, engine.exportSnapshots, "tpl-tpl-1-rootfs")
-	require.NotContains(t, engine.exportSnapshots, "tpl-tpl-1-memory-snap")
-	require.NotContains(t, engine.exportSnapshots, S3MetadataSnapshotName("tpl-1"))
-
-	// The id belongs on the object, not in catalog.json: by export time the
-	// package is sealed and its catalog is read-only.
-	raw, err := os.ReadFile(filepath.Join(home, SnapshotMetadataDir, snapshotCatalogFileName))
-	require.NoError(t, err)
-	require.NotContains(t, string(raw), "remote_uuids")
-}
-
-func TestUploadTemplateRootfsIsNoOpOnXFS(t *testing.T) {
-	useTestCowStorage(t, &fakeCowEngine{})
-	uuid, err := UploadTemplateRootfs(context.Background(), cow.BackendXFS, "tpl-1")
-	require.NoError(t, err)
-	require.Empty(t, uuid)
 }
 
 func TestS3CowEmptyDevicePathAfterCreateFails(t *testing.T) {

--- a/Cubelet/storage/s3_upload.go
+++ b/Cubelet/storage/s3_upload.go
@@ -113,45 +113,6 @@ func (m *S3Cow) Upload(ctx context.Context, snapshotID string) (*cow.RemoteUUIDs
 	return uuids, nil
 }
 
-// UploadTemplateRootfs exports only the rootfs object of a template package.
-//
-// A sandbox rootfs is a child snapshot of the template's rootfs, and a
-// reference export names just the objects the exported layer owns: the
-// child's export carries its own delta and nothing of the parent. Without
-// the parent exported, importing that child on another node yields a hole
-// where the base layer should be — the ext4 superblock and root inode live
-// in the parent, so the volume does not even mount. Exporting the parent
-// here is what makes the child resolvable elsewhere.
-//
-// A template's memory and metadata are not part of that chain (sandbox
-// memory is a fresh single-layer volume; metadata derives from a node-local
-// base and exports as a merged copy), so they stay node-local.
-func (m *S3Cow) UploadTemplateRootfs(ctx context.Context, snapshotID string) (string, error) {
-	id := strings.TrimSpace(snapshotID)
-	if id == "" {
-		return "", fmt.Errorf("snapshot_id is required")
-	}
-	rootfs := ""
-	for _, ref := range activateObjectRefs(ctx, cow.BackendS3, id) {
-		if ref.Role == "rootfs" {
-			rootfs = strings.TrimSpace(ref.Name)
-			break
-		}
-	}
-	if rootfs == "" {
-		return "", fmt.Errorf("no rootfs object for %s", id)
-	}
-	uuid, err := m.uploadOne(rootfs)
-	if err != nil {
-		return "", fmt.Errorf("upload rootfs %s: %w", rootfs, err)
-	}
-	// Settle before returning: the template is only usable cross-node once
-	// its objects are committed, and nothing later in template creation
-	// waits on this.
-	m.waitExportSettled(ctx, rootfs, uuid, time.Now().Add(exportSettleBudget))
-	return uuid, nil
-}
-
 // exportSettleBudget caps the total time Upload spends spacing out a
 // package's exports. Pause runs Upload and then a Destroy inside one 120s
 // budget, so this leaves room for the Destroy even in the worst case. An


### PR DESCRIPTION
## Summary
- Stop exporting template packages from `AppSnapshot`. Template disks stay node-local; Pause / CommitSandbox still export the sandbox snapshot package.
- Remove `UploadTemplateRootfs` and the tests that required a template rootfs export. That export held the object (`deletable=NO`) so template delete reported busy and leaked the rootfs snapshot.

## Test plan
- [x] `gofmt` on the four changed Go files
- [x] Cubelet storage tests that previously covered `UploadTemplateRootfs` are gone; remaining upload tests still pass
- [x] Create an S3 template and delete it: template list empty, template lvols gone except the node-local metadata base; new template rootfs stays `EXPORT=NONE`
- [x] Same-node Pause → Resume: guest `echo ok`, marker, and `dd` pass
- [x] Same-node Snapshot → FromSnap: guest marker and `dd` pass
- [x] Cross-node Pause → Resume: guest marker and `dd` pass
- [x] Cross-node Snapshot → FromSnap: guest marker and `dd` pass

Signed-off-by: ls-ggg <335814617@qq.com>