### PR TITLE
docs: add downloads page and simplify PVM kernel download steps

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -148,7 +148,8 @@ export default withMermaid(defineConfig({
                   ]
                 },
                 { text: 'Tencent Cloud Cluster (Terraform)', link: '/guide/tencentcloud-terraform-deploy' },
-                { text: 'Development Environment (QEMU VM)', link: '/guide/dev-environment' }
+                { text: 'Development Environment (QEMU VM)', link: '/guide/dev-environment' },
+                { text: 'Downloads & Releases', link: '/guide/downloads' }
               ]
             },
             {
@@ -353,7 +354,8 @@ export default withMermaid(defineConfig({
                   ]
                 },
                 { text: '腾讯云集群（Terraform）', link: '/zh/guide/tencentcloud-terraform-deploy' },
-                { text: '开发环境（QEMU 虚机）', link: '/zh/guide/dev-environment' }
+                { text: '开发环境（QEMU 虚机）', link: '/zh/guide/dev-environment' },
+                { text: '下载与 Release 说明', link: '/zh/guide/downloads' }
               ]
             },
             {

--- a/docs/guide/downloads.md
+++ b/docs/guide/downloads.md
@@ -1,0 +1,89 @@
+# Downloads & Releases
+
+All CubeSandbox release artifacts live on one [Releases page](https://github.com/TencentCloud/CubeSandbox/releases). Find your scenario below and jump to the matching section:
+
+| Your scenario | What you download manually | Section |
+| --- | --- | --- |
+| Standard deployment ([Quick Start](./quickstart.md), [bare-metal](./bare-metal-deploy.md)) | Nothing | [Standard deployment](#standard-deployment-nothing-to-download) |
+| PVM deployment (cloud server without `/dev/kvm`) | The PVM host kernel package (rpm/deb) | [PVM deployment](#pvm-deployment-download-the-host-kernel-package) |
+| Building the bundle yourself / swapping kernel or image | Guest kernels, guest image | [Self-build](#self-build-downloading-guest-kernels-and-image) |
+
+::: tip Just following the Quick Start?
+You don't need this page — the [online installer](./quickstart.md) downloads the one-click bundle and resolves all artifacts automatically.
+:::
+
+## Standard deployment: nothing to download
+
+Install online with one command (see [Quick Start](./quickstart.md)):
+
+```bash
+curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh | bash
+```
+
+To download the full bundle manually (`cube-sandbox-one-click-<version>-<arch>.tar.gz`, arch is `amd64` / `arm64`):
+
+```bash
+wget https://github.com/TencentCloud/CubeSandbox/releases/download/v0.6.0/cube-sandbox-one-click-v0.6.0-amd64.tar.gz
+```
+
+## PVM deployment: download the host kernel package
+
+The host kernel package is the only artifact you download by hand for a PVM deployment — install it, reboot into the PVM kernel, and the machine gains KVM capability. The PVM *guest* kernel (`vmlinux-pvm`) already ships inside the one-click bundle and is activated by `CUBE_PVM_ENABLE=1` at install time. For the install, GRUB, and reboot steps see [PVM Deployment — Step 1](./pvm-deploy.md#step-1-install-the-pvm-host-kernel); this section only covers getting the package.
+
+The kernel package is published on dedicated `kernel-release-*` Releases — download it from the release page:
+
+1. Open the [GitHub Releases page](https://github.com/TencentCloud/CubeSandbox/releases?q=kernel-release-&expanded=true) (or the [CNB mirror](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases) for mainland China — filter by `kernel-release` there), and open the newest `kernel-release-*` release
+2. Download the **main package** for your distribution:
+   - RPM-based (OpenCloudOS, RHEL, CentOS, TencentOS, Fedora): `kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`
+   - DEB-based (Ubuntu, Debian): `linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`
+
+<small>Optional assets like `kernel-headers-*` and `-dbg` are not needed.</small>
+
+If you have the GitHub CLI installed, you can download by glob without hunting for the exact filename — see the [appendix](#appendix-url-patterns-latest-tags-and-version-pinning).
+
+> 📌 **Shortcut for OpenCloudOS 9 users**
+> The kernel package is also on the official OpenCloudOS yum repository — `dnf install` installs it directly, no manual rpm download needed, and the whole deployment takes about 5 commands.
+> 👉 [One-command CubeSandbox deployment on OpenCloudOS 9 — walkthrough (Chinese)](https://mp.weixin.qq.com/s/oGAaUpze_uB_uzyvuYJSIg)
+
+## Self-build: downloading guest kernels and image
+
+You only need these when [building the release bundle yourself](./self-build-deploy.md) or replacing components (the one-click bundle already ships both):
+
+```bash
+# Guest kernels (published under kernel-release-*, filenames are stable)
+wget "https://github.com/TencentCloud/CubeSandbox/releases/download/kernel-release-260812-1/vmlinux-amd64"    # bare-metal/KVM; use vmlinux-arm64 on aarch64
+wget "https://github.com/TencentCloud/CubeSandbox/releases/download/kernel-release-260812-1/vmlinux-pvm-amd64" # PVM guest kernel (x86_64 only)
+
+# Guest image (published under guest-image-*, contains cube-guest-image-cpu.img)
+wget https://github.com/TencentCloud/CubeSandbox/releases/download/guest-image-260820-1/cube-guest-image-amd64.tar.gz
+tar -xzf cube-guest-image-amd64.tar.gz
+```
+
+<small>The tags in these URLs advance with each release (filenames are stable — just swap the tag); find the newest ones on the Releases page filtered by [`kernel-release`](https://github.com/TencentCloud/CubeSandbox/releases?q=kernel-release-&expanded=true) or [`guest-image`](https://github.com/TencentCloud/CubeSandbox/releases?q=guest-image-&expanded=true).</small>
+
+For a self-build, place `vmlinux` into `deploy/one-click/assets/kernel-artifacts/` — see [Self-Build Deployment — 1.1 Prepare the Kernel](./self-build-deploy.md#_1-1-prepare-the-kernel).
+
+## Appendix: URL patterns, latest tags, and version pinning
+
+**URL patterns** — every asset is identical on both channels; swap the hostname to switch:
+
+| Channel | URL pattern |
+| --- | --- |
+| GitHub (canonical) | `https://github.com/TencentCloud/CubeSandbox/releases/download/<tag>/<asset>` |
+| CNB mirror (mainland China) | `https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/<tag>/<asset>` |
+
+**Using `gh` so you don't have to hunt for filenames** — download by pattern, or list the kernel-release tags:
+
+```bash
+# List the newest kernel-release tags
+gh release list --repo TencentCloud/CubeSandbox --limit 30 | grep kernel-release
+
+# Download by glob (replace <tag> with the newest tag found above; no exact
+# filename needed)
+gh release download <tag> --repo TencentCloud/CubeSandbox \
+  --pattern 'kernel-6*.x86_64.rpm'   # or: --pattern 'linux-image-6*_amd64.deb'
+```
+
+**Version pinning** — every `v*` product release records the kernel / guest-image tags it was built with in [`deploy/release-assets.yaml`](https://github.com/TencentCloud/CubeSandbox/blob/master/deploy/release-assets.yaml) (also recorded in the bundle's `release-manifest.json`), which answers "which kernel is inside my bundle". Dedicated tags are released on their own cadence, so the pin may lag behind the newest tag — for the **PVM host kernel, always take the newest `kernel-release-*`** (it carries kernel security fixes); there is no need to match a product version.
+
+(Product releases up to `v0.6.0` also attached kernel/image assets directly to the `v*` release — a legacy layout that no longer applies.)

--- a/docs/guide/pvm-deploy.md
+++ b/docs/guide/pvm-deploy.md
@@ -46,6 +46,10 @@ Purchase an **x86_64** cloud server from any cloud provider — no special requi
 
 **OpenCloudOS 9 (RPM-based) is the recommended OS.** The Cube Sandbox PVM host kernel is built on the OpenCloudOS kernel, so choosing OpenCloudOS 9 gives the best compatibility with the fewest distribution-specific differences to handle. Other mainstream distributions — Ubuntu, Debian, CentOS, etc. — are equally supported; just follow the corresponding section below.
 
+> 📌 **Shortcut for OpenCloudOS 9 users**
+> The Cube PVM host kernel package is also available on the official OpenCloudOS yum repository — `dnf install` installs it directly, no manual rpm download needed, and the whole deployment takes about 5 commands.
+> 👉 [One-command CubeSandbox deployment on OpenCloudOS 9 — walkthrough (Chinese)](https://mp.weixin.qq.com/s/oGAaUpze_uB_uzyvuYJSIg)
+
 ::: tip Recommended specifications
 - CPU: ≥ 4 cores
 - RAM: ≥ 8 GB
@@ -54,18 +58,22 @@ Purchase an **x86_64** cloud server from any cloud provider — no special requi
 
 ## Step 1: Install the PVM Host Kernel
 
-Go to the [CubeSandbox GitHub Releases](https://github.com/TencentCloud/CubeSandbox/releases) page, open the latest release that includes PVM kernel assets, then **right-click each asset → Copy link address** and paste the URL into the `wget` commands below.
+### Download the kernel package
 
-Choose the package format that matches your Linux distribution:
+The PVM host kernel package is published on dedicated `kernel-release-*` Releases — download the latest main package from the release page:
+
+1. Open the [GitHub Releases page](https://github.com/TencentCloud/CubeSandbox/releases?q=kernel-release-&expanded=true) (or the [CNB mirror](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases) for mainland China — filter by `kernel-release` there), and open the newest `kernel-release-*` release
+2. Download the **main package** for your distribution:
+   - RPM-based (OpenCloudOS, RHEL, CentOS, TencentOS, Fedora): `kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`
+   - DEB-based (Ubuntu, Debian): `linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`
+
+<small>Optional assets like `kernel-headers-*` and `-dbg` are not needed.</small>
 
 ### RPM-based (OpenCloudOS, RHEL, CentOS, TencentOS, Fedora)
 
-Go to the [Releases page](https://github.com/TencentCloud/CubeSandbox/releases), find `kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`, right-click and copy the download link:
+Install the downloaded package:
 
 ```bash
-# Replace the URLs below with the actual download links copied from the Releases page
-wget "<kernel rpm download URL>"
-
 # --oldpackage skips the version check if a newer kernel is already installed
 rpm -ivh --oldpackage kernel-*.rpm
 ```
@@ -92,12 +100,9 @@ bash <(curl -fsSL \
 
 ### DEB-based (Ubuntu, Debian)
 
-Go to the [Releases page](https://github.com/TencentCloud/CubeSandbox/releases), find `linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`, right-click and copy the download link:
+Install the downloaded package:
 
 ```bash
-# Replace the URLs below with the actual download links copied from the Releases page
-wget "<linux-image deb download URL>"
-
 dpkg -i linux-image-*opencloudos9.cubesandbox.pvm.host*.deb
 ```
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -68,18 +68,22 @@ sudo su root
 
 ### Install the PVM Host Kernel
 
-Go to the [CubeSandbox GitHub Releases](https://github.com/TencentCloud/CubeSandbox/releases) page, open the latest release that includes PVM kernel attachments, **right-click the matching attachment → Copy Link Address**, then download with `wget`.
+#### Download the kernel package
 
-Choose the format for your Linux distribution:
+The PVM host kernel package is published on dedicated `kernel-release-*` Releases — download the latest main package from the release page:
+
+1. Open the [GitHub Releases page](https://github.com/TencentCloud/CubeSandbox/releases?q=kernel-release-&expanded=true) (or the [CNB mirror](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases) for mainland China — filter by `kernel-release` there), and open the newest `kernel-release-*` release
+2. Download the **main package** for your distribution:
+   - RPM-based: `kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`
+   - DEB-based: `linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`
+
+<small>Optional assets like `kernel-headers-*` and `-dbg` are not needed.</small>
 
 #### RPM-based (OpenCloudOS, RHEL, CentOS, TencentOS, Fedora)
 
-Go to the [Releases page](https://github.com/TencentCloud/CubeSandbox/releases), find `kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`, right-click and copy the download link:
+Install the downloaded package:
 
 ```bash
-# Replace the URL below with the actual download link you copied from the Releases page
-wget "<kernel rpm download link>"
-
 # Use --oldpackage if the host already has a newer kernel version
 rpm -ivh --oldpackage kernel-*.rpm
 ```
@@ -105,12 +109,9 @@ curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/pvm/grub/
 
 #### DEB-based (Ubuntu, Debian)
 
-Go to the [Releases page](https://github.com/TencentCloud/CubeSandbox/releases), find `linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`, right-click and copy the download link:
+Install the downloaded package:
 
 ```bash
-# Replace the URL below with the actual download link you copied from the Releases page
-wget "<linux-image deb download link>"
-
 dpkg -i linux-image-*opencloudos9.cubesandbox.pvm.host*.deb
 ```
 

--- a/docs/guide/self-build-deploy.md
+++ b/docs/guide/self-build-deploy.md
@@ -57,7 +57,26 @@ These steps are performed on the **build machine**.
 
 ### 1.1 Prepare the Kernel
 
-Obtain a compiled `vmlinux` kernel file (either compile it yourself or use a prebuilt one) and place it in the designated directory:
+Get a compiled `vmlinux` kernel file into the designated directory. Two options:
+
+**Option A — download a prebuilt kernel (recommended)**
+
+Guest kernels are published on dedicated `kernel-release-*` Releases, so you don't have to compile one yourself:
+
+```bash
+# Standard (bare-metal/KVM) guest kernel — pick the target architecture
+wget -O deploy/one-click/assets/kernel-artifacts/vmlinux \
+  "https://github.com/TencentCloud/CubeSandbox/releases/download/kernel-release-260812-1/vmlinux-amd64"
+# (use vmlinux-arm64 on aarch64)
+
+# If the target host deploys with PVM, also fetch the PVM guest kernel
+wget -O deploy/one-click/assets/kernel-artifacts/vmlinux-pvm \
+  "https://github.com/TencentCloud/CubeSandbox/releases/download/kernel-release-260812-1/vmlinux-pvm-amd64"
+```
+
+The tag above is an example — see [Downloads & Releases](./downloads.md) for the latest tag, the CNB mirror, and the full asset list.
+
+**Option B — compile your own `vmlinux`**
 
 ```bash
 cp /path/to/vmlinux deploy/one-click/assets/kernel-artifacts/

--- a/docs/zh/guide/downloads.md
+++ b/docs/zh/guide/downloads.md
@@ -1,0 +1,88 @@
+# 下载与 Release 说明
+
+CubeSandbox 的所有发布物都在同一个 [Releases 页面](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases)上。先按你的场景对号入座，再跳到对应小节照做：
+
+| 你的场景 | 需要手动下载什么 | 去哪一节 |
+| --- | --- | --- |
+| 标准部署（[快速开始](./quickstart.md)、[裸金属](./bare-metal-deploy.md)） | 什么都不用 | [标准部署](#标准部署-无需手动下载) |
+| PVM 部署（云服务器无 `/dev/kvm`） | 宿主机内核包（rpm/deb） | [PVM 部署](#pvm-部署-下载宿主机内核包) |
+| 自建发布包 / 替换内核或镜像 | guest 内核、guest 镜像 | [自建部署](#自建部署-下载-guest-内核与镜像) |
+
+::: tip 只是照着快速开始部署？
+那你不需要本页面 —— [在线安装脚本](./quickstart.md)会自动下载一键部署包并解析全部产物。
+:::
+
+## 标准部署：无需手动下载
+
+一行命令在线安装（详见[快速开始](./quickstart.md)）：
+
+```bash
+curl -sL https://cnb.cool/CubeSandbox/CubeSandbox/-/git/raw/master/deploy/one-click/online-install.sh | MIRROR=cn bash
+```
+
+需要手动下载整包（`cube-sandbox-one-click-<版本>-<架构>.tar.gz`，架构为 `amd64` / `arm64`）：
+
+```bash
+wget https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/v0.6.0/cube-sandbox-one-click-v0.6.0-amd64.tar.gz
+```
+
+## PVM 部署：下载宿主机内核包
+
+PVM 部署中，唯一需要手动下载的就是宿主机内核包 —— 装上它、重启进入 PVM 内核即可获得 KVM 能力。PVM 的 guest 内核（`vmlinux-pvm`）已内置于一键部署包，安装时设 `CUBE_PVM_ENABLE=1` 即自动激活。安装、GRUB 配置与重启的完整步骤见 [PVM 部署 — 第一步](./pvm-deploy.md#第一步安装-pvm-宿主机内核)，本节只讲怎么拿到包。
+
+内核包发布在专属的 `kernel-release-*` Release 上，直接到发布页下载：
+
+1. 打开 [CubeSandbox Releases 页面](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases)，在过滤框输入 `kernel-release`，打开最新的一个
+2. 按你的发行版下载**内核主包**：
+   - RPM 系（OpenCloudOS、RHEL、CentOS、TencentOS、Fedora）：`kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`
+   - DEB 系（Ubuntu、Debian）：`linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`
+
+<small>资产列表中的 `kernel-headers-*`、`-dbg` 等为可选包，无需下载。</small>
+
+已安装 GitHub CLI 的用户也可免找文件名、按通配直接下载，用法见[附录](#附录-url-规律-最新-tag-与版本-pin)。
+
+> 📌 **OpenCloudOS 9 用户专属快捷路径**
+> 内核包已上架 OpenCloudOS 官方 yum 仓库，无需手动下载 rpm，`dnf install` 一行命令可实现直装，整体部署只需 5 条命令。
+> 👉 [在 OpenCloudOS 9 上一键部署 CubeSandbox 实测](https://mp.weixin.qq.com/s/oGAaUpze_uB_uzyvuYJSIg)
+
+## 自建部署：下载 guest 内核与镜像
+
+只有在[自行构建发布包](./self-build-deploy.md)或替换组件时才需要下载这些（一键部署包已全部自带）：
+
+```bash
+# guest 内核（发布在 kernel-release-* 下，文件名固定）
+wget "https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/kernel-release-260812-1/vmlinux-amd64"       # 裸金属/KVM，aarch64 用 vmlinux-arm64
+wget "https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/kernel-release-260812-1/vmlinux-pvm-amd64"    # PVM guest 内核（仅 x86_64）
+
+# guest 镜像（发布在 guest-image-* 下，内含 cube-guest-image-cpu.img）
+wget https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/guest-image-260820-1/cube-guest-image-amd64.tar.gz
+tar -xzf cube-guest-image-amd64.tar.gz
+```
+
+<small>URL 中的 tag 会随发布递增（文件名固定，换 tag 即可）；最新 tag 可在 [Releases 页面](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases) 过滤 `kernel-release` / `guest-image` 查看。</small>
+
+自建时把 `vmlinux` 放入 `deploy/one-click/assets/kernel-artifacts/` 即可，详见[本地构建部署 — 1.1 准备内核文件](./self-build-deploy.md#_1-1-准备内核文件)。
+
+## 附录：URL 规律、最新 tag 与版本 pin
+
+**URL 规律** —— 所有资产两个渠道完全一致，把域名换掉即可切换：
+
+| 渠道 | URL 规律 |
+| --- | --- |
+| CNB 镜像（国内推荐） | `https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/<tag>/<资产名>` |
+| GitHub（权威源，境外推荐） | `https://github.com/TencentCloud/CubeSandbox/releases/download/<tag>/<资产名>` |
+
+**用 gh 免找文件名** —— 按通配直接下载，或列出所有 kernel-release tag：
+
+```bash
+# 列出最新的 kernel-release tag
+gh release list --repo TencentCloud/CubeSandbox --limit 30 | grep kernel-release
+
+# 按通配下载（<tag> 替换为上面查到的最新 tag，无需知道精确文件名）
+gh release download <tag> --repo TencentCloud/CubeSandbox \
+  --pattern 'kernel-6*.x86_64.rpm'   # 或：--pattern 'linux-image-6*_amd64.deb'
+```
+
+**版本 pin** —— 每个 `v*` 产品版本在 [`deploy/release-assets.yaml`](https://github.com/TencentCloud/CubeSandbox/blob/master/deploy/release-assets.yaml) 中记录打包所用的 kernel / guest-image tag（也写在包内 `release-manifest.json`），据此可查"我手里的包用的是哪个内核"。专属 tag 的发布节奏独立于产品版本，pin 可能落后于最新 tag —— **PVM 宿主机内核建议始终用最新 `kernel-release-*`**（含内核安全修复），无需与产品版本对齐。
+
+（v0.6.0 及之前的产品 Release 上还直接附有内核/镜像资产，属历史布局，之后不再如此。）

--- a/docs/zh/guide/pvm-deploy.md
+++ b/docs/zh/guide/pvm-deploy.md
@@ -60,20 +60,22 @@ Ubuntu / Debian / CentOS 等其他主流发行版同样支持，按对应章节�
 
 ## 第一步：安装 PVM 宿主机内核
 
-前往 [CubeSandbox Releases](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases) 页面，打开最新包含 PVM 内核附件的 Release，**在对应附件上右键 → 复制链接地址**，然后用 `wget` 下载。
+### 下载内核包
 
-根据你的 Linux 发行版选择对应格式：
+PVM 宿主机内核包发布在专属的 `kernel-release-*` Release 上，请到发布页下载最新的内核主包：
+
+1. 打开 [CubeSandbox Releases 页面](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases)，在过滤框输入 `kernel-release`，打开最新的一个
+2. 按你的 Linux 发行版下载**内核主包**：
+   - RPM 系（OpenCloudOS、RHEL、CentOS、TencentOS、Fedora）：`kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`
+   - DEB 系（Ubuntu、Debian）：`linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`
+
+<small>资产列表中的 `kernel-headers-*`、`-dbg` 等为可选包，无需下载。</small>
 
 ### RPM 系（OpenCloudOS、RHEL、CentOS、TencentOS、Fedora）
 
-在 [Release 附件列表](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/) 中找到以下文件，右键复制下载链接：
-
-- `kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`（内核主包）
+安装下载好的内核包：
 
 ```bash
-# 将下面的 URL 替换为你从 Releases 页面右键复制的实际下载链接
-wget "<kernel rpm 下载链接>"
-
 # 若宿主机已有更高版本内核，--oldpackage 跳过版本号比较
 rpm -ivh --oldpackage kernel-*.rpm
 ```
@@ -99,14 +101,9 @@ curl -sL https://cnb.cool/CubeSandbox/CubeSandbox/-/git/raw/master/deploy/pvm/gr
 
 ### DEB 系（Ubuntu、Debian）
 
-在 [Release 附件列表](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/) 中找到以下文件，右键复制下载链接：
-
-- `linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`（内核主包）
+安装下载好的内核包：
 
 ```bash
-# 将下面的 URL 替换为你从 Releases 页面右键复制的实际下载链接
-wget "<linux-image deb 下载链接>"
-
 dpkg -i linux-image-*opencloudos9.cubesandbox.pvm.host*.deb
 ```
 

--- a/docs/zh/guide/quickstart.md
+++ b/docs/zh/guide/quickstart.md
@@ -68,18 +68,22 @@ sudo su root
 
 ### 安装 PVM 宿主机内核
 
-前往 [CubeSandbox Releases](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases) 页面，打开最新包含 PVM 内核附件的 Release，**在对应附件上右键 → 复制链接地址**，然后用 `wget` 下载。
+#### 下载内核包
 
-根据你的 Linux 发行版选择对应格式：
+PVM 宿主机内核包发布在专属的 `kernel-release-*` Release 上，请到发布页下载最新的内核主包：
+
+1. 打开 [CubeSandbox Releases 页面](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases)，在过滤框输入 `kernel-release`，打开最新的一个
+2. 按你的 Linux 发行版下载**内核主包**：
+   - RPM 系：`kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`
+   - DEB 系：`linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`
+
+<small>`kernel-headers-*`、`-dbg` 等为可选包，无需下载。</small>
 
 #### RPM 系（OpenCloudOS、RHEL、CentOS、TencentOS、Fedora）
 
-在 [Release 附件列表](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/) 中找到 `kernel-*opencloudos9.cubesandbox.pvm.host*.x86_64.rpm`，右键复制下载链接：
+安装下载好的内核包：
 
 ```bash
-# 将下面的 URL 替换为你从 Releases 页面右键复制的实际下载链接
-wget "<kernel rpm 下载链接>"
-
 # 若宿主机已有更高版本内核，--oldpackage 跳过版本号比较
 rpm -ivh --oldpackage kernel-*.rpm
 ```
@@ -105,12 +109,9 @@ curl -sL https://cnb.cool/CubeSandbox/CubeSandbox/-/git/raw/master/deploy/pvm/gr
 
 #### DEB 系（Ubuntu、Debian）
 
-在 [Release 附件列表](https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/) 中找到 `linux-image-*opencloudos9.cubesandbox.pvm.host*_amd64.deb`，右键复制下载链接：
+安装下载好的内核包：
 
 ```bash
-# 将下面的 URL 替换为你从 Releases 页面右键复制的实际下载链接
-wget "<linux-image deb 下载链接>"
-
 dpkg -i linux-image-*opencloudos9.cubesandbox.pvm.host*.deb
 ```
 

--- a/docs/zh/guide/self-build-deploy.md
+++ b/docs/zh/guide/self-build-deploy.md
@@ -57,7 +57,26 @@
 
 ### 1.1 准备内核文件
 
-获取编译好的 `vmlinux` 内核文件（自行编译或使用预编译版本），放置到指定目录：
+将编译好的 `vmlinux` 内核文件放入指定目录，两种方式：
+
+**方式 A —— 下载预编译内核（推荐）**
+
+Guest 内核已发布在专属的 `kernel-release-*` Release 上，无需自行编译：
+
+```bash
+# 普通（裸金属/KVM）guest 内核 —— 按目标架构选择
+wget -O deploy/one-click/assets/kernel-artifacts/vmlinux \
+  "https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/kernel-release-260812-1/vmlinux-amd64"
+# （aarch64 使用 vmlinux-arm64）
+
+# 若目标主机以 PVM 方式部署，另需下载 PVM guest 内核
+wget -O deploy/one-click/assets/kernel-artifacts/vmlinux-pvm \
+  "https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/kernel-release-260812-1/vmlinux-pvm-amd64"
+```
+
+上面的 tag 仅为示例 —— 最新 tag、CNB 镜像及完整资产列表见[下载与 Release 说明](./downloads.md)。
+
+**方式 B —— 自行编译 `vmlinux`**
 
 ```bash
 cp /path/to/vmlinux deploy/one-click/assets/kernel-artifacts/


### PR DESCRIPTION
## Summary

Add a bilingual (English / Chinese) **Downloads & Releases** guide that maps each deployment scenario to the release artifacts to fetch, and register it in the documentation navigation.

## Changes

- **New pages** — `docs/guide/downloads.md` and `docs/zh/guide/downloads.md`: one place that tells users what (if anything) they need to download for standard, PVM, and self-build deployments, including URL patterns, `gh` glob-download examples, and version-pinning notes.
- **Navigation** — `docs/.vitepress/config.mjs`: register the new page in both the English and Chinese sidebars.
- **Quick-start & PVM deployment guides (en/zh)** — replace the "right-click to copy an attachment link" instructions with direct download from the dedicated `kernel-release-*` Releases (with a CNB mirror for mainland China).
- **Self-build deployment guides (en/zh)** — add an option to fetch a prebuilt guest kernel from `kernel-release-*` releases instead of compiling one locally.

## Notes

Docs-only change; no code, build, or test files affected.