### PR TITLE
fix(cubemaster): use ADC for Artifact Registry

### DIFF
--- a/CubeMaster/go.mod
+++ b/CubeMaster/go.mod
@@ -1,10 +1,5 @@
 module github.com/tencentcloud/CubeSandbox/CubeMaster
 
-// Older grpc go.mod entries pull the pre-split cloud.google.com/go module,
-// whose compute/metadata package conflicts with the modern split module used
-// by Workload Identity ADC.
-exclude cloud.google.com/go v0.26.0
-
 go 1.25.7
 
 // toolchain go1.22.9

--- a/CubeMaster/go.mod
+++ b/CubeMaster/go.mod
@@ -1,5 +1,10 @@
 module github.com/tencentcloud/CubeSandbox/CubeMaster
 
+// Older grpc go.mod entries pull the pre-split cloud.google.com/go module,
+// whose compute/metadata package conflicts with the modern split module used
+// by Workload Identity ADC.
+exclude cloud.google.com/go v0.26.0
+
 go 1.25.7
 
 // toolchain go1.22.9
@@ -36,6 +41,7 @@ require (
 	github.com/tencentcloud/CubeSandbox/cubelog v0.1.1-0.20260113105508-a996703fa42f
 	github.com/urfave/cli v1.22.15
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.44.0
 	golang.org/x/time v0.14.0
@@ -51,6 +57,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect

--- a/CubeMaster/go.sum
+++ b/CubeMaster/go.sum
@@ -1,3 +1,4 @@
+cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=

--- a/CubeMaster/go.sum
+++ b/CubeMaster/go.sum
@@ -1,4 +1,5 @@
-cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -407,6 +408,8 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
 golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/CubeMaster/pkg/templatecenter/image/native.go
+++ b/CubeMaster/pkg/templatecenter/image/native.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -19,8 +20,10 @@ import (
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"golang.org/x/oauth2/google"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -39,6 +42,8 @@ var nativeCopyBufferPool = sync.Pool{
 	},
 }
 
+var googleDefaultTokenSource = google.DefaultTokenSource
+
 // nativeRootfsExportEnabled checks if CUBEMASTER_NATIVE_ROOTFS_EXPORT_ENABLED is enabled.
 // By default, it is enabled, which avoids using external CLI tools (docker, skopeo, umoci).
 func nativeRootfsExportEnabled() bool {
@@ -47,15 +52,39 @@ func nativeRootfsExportEnabled() bool {
 }
 
 // registryAuthOption converts PreparedSource credentials into a remote.Option.
-// Falls back to the DefaultKeychain if explicit credentials are not provided.
-func registryAuthOption(auth *RegistryAuthConfig) remote.Option {
+// Explicit credentials always win. For Google Artifact Registry, use
+// Application Default Credentials when available; this includes GKE Workload
+// Identity. Other registries retain the DefaultKeychain fallback.
+func registryAuthOption(ctx context.Context, ref name.Reference, auth *RegistryAuthConfig) remote.Option {
+	return remote.WithAuth(registryAuthenticator(ctx, ref, auth))
+}
+
+func registryAuthenticator(ctx context.Context, ref name.Reference, auth *RegistryAuthConfig) authn.Authenticator {
 	if auth != nil && (auth.Username != "" || auth.Password != "") {
-		return remote.WithAuth(authn.FromConfig(authn.AuthConfig{
+		return authn.FromConfig(authn.AuthConfig{
 			Username: auth.Username,
 			Password: auth.Password,
-		}))
+		})
 	}
-	return remote.WithAuthFromKeychain(authn.DefaultKeychain)
+	if isGoogleArtifactRegistry(ref.Context().RegistryStr()) {
+		if source, err := googleDefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform"); err == nil {
+			if token, err := source.Token(); err == nil && token.AccessToken != "" {
+				return authn.FromConfig(authn.AuthConfig{
+					Username: "oauth2accesstoken",
+					Password: token.AccessToken,
+				})
+			}
+		}
+	}
+	resolved, err := authn.DefaultKeychain.Resolve(ref.Context())
+	if err != nil {
+		return authn.Anonymous
+	}
+	return resolved
+}
+
+func isGoogleArtifactRegistry(registry string) bool {
+	return strings.HasSuffix(strings.ToLower(strings.TrimSpace(registry)), ".pkg.dev")
 }
 
 type progressReader struct {

--- a/CubeMaster/pkg/templatecenter/image/native.go
+++ b/CubeMaster/pkg/templatecenter/image/native.go
@@ -6,6 +6,7 @@ package image
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -22,7 +23,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/sync/errgroup"
 )
@@ -42,7 +44,10 @@ var nativeCopyBufferPool = sync.Pool{
 	},
 }
 
-var googleDefaultTokenSource = google.DefaultTokenSource
+var (
+	googleDefaultTokenSource                = google.DefaultTokenSource
+	defaultKeychain          authn.Keychain = authn.DefaultKeychain // seam for tests
+)
 
 // nativeRootfsExportEnabled checks if CUBEMASTER_NATIVE_ROOTFS_EXPORT_ENABLED is enabled.
 // By default, it is enabled, which avoids using external CLI tools (docker, skopeo, umoci).
@@ -51,40 +56,66 @@ func nativeRootfsExportEnabled() bool {
 	return err != nil || v
 }
 
-// registryAuthOption converts PreparedSource credentials into a remote.Option.
-// Explicit credentials always win. For Google Artifact Registry, use
-// Application Default Credentials when available; this includes GKE Workload
-// Identity. Other registries retain the DefaultKeychain fallback.
-func registryAuthOption(ctx context.Context, ref name.Reference, auth *RegistryAuthConfig) remote.Option {
-	return remote.WithAuth(registryAuthenticator(ctx, ref, auth))
-}
+const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
 
-func registryAuthenticator(ctx context.Context, ref name.Reference, auth *RegistryAuthConfig) authn.Authenticator {
+// registryAuthenticator resolves registry auth for a pull. Explicit credentials
+// always win. For Google Artifact Registry, the docker keychain wins when it
+// has credentials; otherwise Application Default Credentials (including GKE
+// Workload Identity) are used. Other registries retain the DefaultKeychain
+// fallback.
+func registryAuthenticator(ctx context.Context, ref name.Reference, auth *RegistryAuthConfig) (authn.Authenticator, error) {
 	if auth != nil && (auth.Username != "" || auth.Password != "") {
 		return authn.FromConfig(authn.AuthConfig{
 			Username: auth.Username,
 			Password: auth.Password,
-		})
+		}), nil
 	}
-	if isGoogleArtifactRegistry(ref.Context().RegistryStr()) {
-		if source, err := googleDefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform"); err == nil {
-			if token, err := source.Token(); err == nil && token.AccessToken != "" {
-				return authn.FromConfig(authn.AuthConfig{
-					Username: "oauth2accesstoken",
-					Password: token.AccessToken,
-				})
-			}
-		}
-	}
-	resolved, err := authn.DefaultKeychain.Resolve(ref.Context())
+	registry := ref.Context()
+	// Docker-config credentials win over ADC; keychain errors propagate.
+	resolved, err := defaultKeychain.Resolve(registry)
 	if err != nil {
-		return authn.Anonymous
+		return nil, err
 	}
-	return resolved
+	if resolved != authn.Anonymous {
+		return resolved, nil
+	}
+	if isGoogleArtifactRegistry(registry.RegistryStr()) {
+		source, err := googleDefaultTokenSource(ctx, cloudPlatformScope)
+		if err == nil {
+			return &tokenSourceAuthenticator{source: source}, nil
+		}
+		// ADC is unavailable (e.g. not on GCP, Workload Identity misconfigured).
+		// Fall through to anonymous, but log so this is distinguishable from a
+		// permission problem at the registry.
+		log.G(ctx).Debugf("Artifact Registry ADC unavailable for %s: %v", registry.RegistryStr(), err)
+	}
+	return authn.Anonymous, nil
+}
+
+// tokenSourceAuthenticator presents an OAuth2 access token as the
+// `oauth2accesstoken` username that Artifact Registry expects. Token() is
+// invoked on every Authorization() so the underlying ReuseTokenSource can
+// refresh the token if a pull outlives its ~1h lifetime.
+type tokenSourceAuthenticator struct {
+	source oauth2.TokenSource
+}
+
+func (a *tokenSourceAuthenticator) Authorization() (*authn.AuthConfig, error) {
+	token, err := a.source.Token()
+	if err != nil {
+		return nil, err
+	}
+	if token.AccessToken == "" {
+		return nil, errors.New("ADC returned empty access token for Artifact Registry")
+	}
+	return &authn.AuthConfig{
+		Username: "oauth2accesstoken",
+		Password: token.AccessToken,
+	}, nil
 }
 
 func isGoogleArtifactRegistry(registry string) bool {
-	return strings.HasSuffix(strings.ToLower(strings.TrimSpace(registry)), ".pkg.dev")
+	return strings.HasSuffix(strings.ToLower(registry), ".pkg.dev")
 }
 
 type progressReader struct {

--- a/CubeMaster/pkg/templatecenter/image/native_test.go
+++ b/CubeMaster/pkg/templatecenter/image/native_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"golang.org/x/oauth2"
 )
 
 func TestNativeRootfsExportEnabledParsesEnv(t *testing.T) {
@@ -40,6 +41,47 @@ func TestNativeRootfsExportEnabledParsesEnv(t *testing.T) {
 	t.Setenv("CUBEMASTER_NATIVE_ROOTFS_EXPORT_ENABLED", "not-a-bool")
 	if !nativeRootfsExportEnabled() {
 		t.Fatal("expected invalid native export env value to fallback to enabled")
+	}
+}
+
+func TestRegistryAuthenticatorUsesGoogleADCForArtifactRegistry(t *testing.T) {
+	old := googleDefaultTokenSource
+	defer func() { googleDefaultTokenSource = old }()
+	googleDefaultTokenSource = func(context.Context, ...string) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "wi-access-token"}), nil
+	}
+
+	ref, err := name.ParseReference("us-west1-docker.pkg.dev/project/repository/image:tag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := registryAuthenticator(context.Background(), ref, nil).Authorization()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth.Username != "oauth2accesstoken" || auth.Password != "wi-access-token" {
+		t.Fatalf("unexpected ADC auth: %#v", auth)
+	}
+}
+
+func TestRegistryAuthenticatorPrefersExplicitCredentials(t *testing.T) {
+	old := googleDefaultTokenSource
+	defer func() { googleDefaultTokenSource = old }()
+	googleDefaultTokenSource = func(context.Context, ...string) (oauth2.TokenSource, error) {
+		t.Fatal("ADC must not be consulted when explicit credentials are supplied")
+		return nil, nil
+	}
+
+	ref, err := name.ParseReference("us-west1-docker.pkg.dev/project/repository/image:tag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := registryAuthenticator(context.Background(), ref, &RegistryAuthConfig{Username: "user", Password: "password"}).Authorization()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth.Username != "user" || auth.Password != "password" {
+		t.Fatalf("unexpected explicit auth: %#v", auth)
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/image/native_test.go
+++ b/CubeMaster/pkg/templatecenter/image/native_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http/httptest"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"testing/synctest"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -44,45 +46,202 @@ func TestNativeRootfsExportEnabledParsesEnv(t *testing.T) {
 	}
 }
 
-func TestRegistryAuthenticatorUsesGoogleADCForArtifactRegistry(t *testing.T) {
-	old := googleDefaultTokenSource
-	defer func() { googleDefaultTokenSource = old }()
-	googleDefaultTokenSource = func(context.Context, ...string) (oauth2.TokenSource, error) {
+func TestRegistryAuthenticatorUsesADCForArtifactRegistryWhenKeychainAnonymous(t *testing.T) {
+	setAuthSeams(t, fakeKeychain{auth: authn.Anonymous}, func(context.Context, ...string) (oauth2.TokenSource, error) {
 		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "wi-access-token"}), nil
-	}
+	})
 
 	ref, err := name.ParseReference("us-west1-docker.pkg.dev/project/repository/image:tag")
 	if err != nil {
 		t.Fatal(err)
 	}
-	auth, err := registryAuthenticator(context.Background(), ref, nil).Authorization()
+	auth, err := registryAuthenticator(context.Background(), ref, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if auth.Username != "oauth2accesstoken" || auth.Password != "wi-access-token" {
-		t.Fatalf("unexpected ADC auth: %#v", auth)
+	cfg, err := auth.Authorization()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Username != "oauth2accesstoken" || cfg.Password != "wi-access-token" {
+		t.Fatalf("unexpected ADC auth: %#v", cfg)
+	}
+}
+
+func TestRegistryAuthenticatorPrefersKeychainCredsOverADC(t *testing.T) {
+	setAuthSeams(t, fakeKeychain{auth: authn.FromConfig(authn.AuthConfig{Username: "kc-user", Password: "kc-pass"})}, func(context.Context, ...string) (oauth2.TokenSource, error) {
+		t.Fatal("ADC must not be consulted when the keychain has credentials")
+		return nil, nil
+	})
+
+	ref, err := name.ParseReference("us-west1-docker.pkg.dev/project/repository/image:tag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := registryAuthenticator(context.Background(), ref, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := auth.Authorization()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Username != "kc-user" || cfg.Password != "kc-pass" {
+		t.Fatalf("unexpected keychain auth: %#v", cfg)
 	}
 }
 
 func TestRegistryAuthenticatorPrefersExplicitCredentials(t *testing.T) {
-	old := googleDefaultTokenSource
-	defer func() { googleDefaultTokenSource = old }()
-	googleDefaultTokenSource = func(context.Context, ...string) (oauth2.TokenSource, error) {
+	// Explicit credentials must win even when keychain and ADC would both supply creds.
+	setAuthSeams(t, fakeKeychain{auth: authn.FromConfig(authn.AuthConfig{Username: "kc-user", Password: "kc-pass"})}, func(context.Context, ...string) (oauth2.TokenSource, error) {
 		t.Fatal("ADC must not be consulted when explicit credentials are supplied")
 		return nil, nil
-	}
+	})
 
 	ref, err := name.ParseReference("us-west1-docker.pkg.dev/project/repository/image:tag")
 	if err != nil {
 		t.Fatal(err)
 	}
-	auth, err := registryAuthenticator(context.Background(), ref, &RegistryAuthConfig{Username: "user", Password: "password"}).Authorization()
+	auth, err := registryAuthenticator(context.Background(), ref, &RegistryAuthConfig{Username: "user", Password: "password"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if auth.Username != "user" || auth.Password != "password" {
-		t.Fatalf("unexpected explicit auth: %#v", auth)
+	cfg, err := auth.Authorization()
+	if err != nil {
+		t.Fatal(err)
 	}
+	if cfg.Username != "user" || cfg.Password != "password" {
+		t.Fatalf("unexpected explicit auth: %#v", cfg)
+	}
+}
+
+func TestRegistryAuthenticatorSkipsADCForNonGoogleRegistry(t *testing.T) {
+	setAuthSeams(t, fakeKeychain{auth: authn.Anonymous}, func(context.Context, ...string) (oauth2.TokenSource, error) {
+		t.Fatal("ADC must not be consulted for non-Artifact-Registry refs")
+		return nil, nil
+	})
+
+	for _, refStr := range []string{
+		"gcr.io/project/repo:tag",
+		"asia.gcr.io/project/repo:tag",
+		"registry.example.com/ns/repo:tag",
+		"docker.io/library/alpine:latest",
+	} {
+		ref, err := name.ParseReference(refStr)
+		if err != nil {
+			t.Fatalf("parse %q: %v", refStr, err)
+		}
+		auth, err := registryAuthenticator(context.Background(), ref, nil)
+		if err != nil {
+			t.Fatalf("ref %q: %v", refStr, err)
+		}
+		if auth != authn.Anonymous {
+			t.Fatalf("ref %q: expected anonymous, got %#v", refStr, auth)
+		}
+	}
+}
+
+func TestRegistryAuthenticatorFallsBackToAnonymousWhenADCUnavailable(t *testing.T) {
+	setAuthSeams(t, fakeKeychain{auth: authn.Anonymous}, func(context.Context, ...string) (oauth2.TokenSource, error) {
+		return nil, errors.New("no google creds found")
+	})
+
+	ref, err := name.ParseReference("us-west1-docker.pkg.dev/project/repository/image:tag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := registryAuthenticator(context.Background(), ref, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth != authn.Anonymous {
+		t.Fatalf("expected anonymous fallback, got %#v", auth)
+	}
+}
+
+func TestRegistryAuthenticatorPropagatesKeychainError(t *testing.T) {
+	// ADC is never reached because the keychain error propagates first.
+	setAuthSeams(t, fakeKeychain{err: errors.New("keychain boom")}, nil)
+
+	ref, err := name.ParseReference("us-west1-docker.pkg.dev/project/repository/image:tag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registryAuthenticator(context.Background(), ref, nil); err == nil {
+		t.Fatal("expected keychain error to propagate")
+	}
+}
+
+func TestTokenSourceAuthenticatorRefreshesPerRequest(t *testing.T) {
+	src := &countingTokenSource{}
+	a := &tokenSourceAuthenticator{source: src}
+
+	first, err := a.Authorization()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := a.Authorization()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Password != "token-1" || second.Password != "token-2" {
+		t.Fatalf("expected per-call token refresh, got %q then %q", first.Password, second.Password)
+	}
+}
+
+func TestIsGoogleArtifactRegistry(t *testing.T) {
+	cases := []struct {
+		registry string
+		want     bool
+	}{
+		{"us-west1-docker.pkg.dev", true},
+		{"us-east1.pkg.dev", true},
+		{"US-WEST1-DOCKER.PKG.DEV", true}, // case-insensitive
+		{"gcr.io", false},
+		{"asia.gcr.io", false},
+		{"pkg.dev", false},
+		{"docker.io", false},
+		{"registry.example.com", false},
+	}
+	for _, c := range cases {
+		if got := isGoogleArtifactRegistry(c.registry); got != c.want {
+			t.Errorf("isGoogleArtifactRegistry(%q)=%v, want %v", c.registry, got, c.want)
+		}
+	}
+}
+
+// setAuthSeams swaps the auth resolution seams for the duration of a test and
+// restores them via t.Cleanup. Pass nil for ts when ADC must never be consulted.
+func setAuthSeams(t *testing.T, kc authn.Keychain, ts func(context.Context, ...string) (oauth2.TokenSource, error)) {
+	t.Helper()
+	oldKC := defaultKeychain
+	oldTS := googleDefaultTokenSource
+	defaultKeychain = kc
+	googleDefaultTokenSource = ts
+	t.Cleanup(func() {
+		defaultKeychain = oldKC
+		googleDefaultTokenSource = oldTS
+	})
+}
+
+// fakeKeychain lets tests control what the default keychain resolves to.
+type fakeKeychain struct {
+	auth authn.Authenticator
+	err  error
+}
+
+func (k fakeKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	return k.auth, k.err
+}
+
+// countingTokenSource returns a fresh access token on every call.
+type countingTokenSource struct {
+	calls int
+}
+
+func (s *countingTokenSource) Token() (*oauth2.Token, error) {
+	s.calls++
+	return &oauth2.Token{AccessToken: fmt.Sprintf("token-%d", s.calls)}, nil
 }
 
 func TestNativeExportConcurrencyParsesEnv(t *testing.T) {

--- a/CubeMaster/pkg/templatecenter/image/source.go
+++ b/CubeMaster/pkg/templatecenter/image/source.go
@@ -85,7 +85,7 @@ func prepareNativeSource(ctx context.Context, spec SourceSpec) (*PreparedSource,
 	if spec.RegistryUsername != "" || spec.RegistryPassword != "" {
 		authCfg = &RegistryAuthConfig{Username: spec.RegistryUsername, Password: spec.RegistryPassword}
 	}
-	authOpt := registryAuthOption(authCfg)
+	authOpt := registryAuthOption(ctx, ref, authCfg)
 	jobs := nativeExportConcurrency()
 	platOpt := remote.WithPlatform(defaultPlatform())
 	jobsOpt := remote.WithJobs(jobs)

--- a/CubeMaster/pkg/templatecenter/image/source.go
+++ b/CubeMaster/pkg/templatecenter/image/source.go
@@ -85,12 +85,15 @@ func prepareNativeSource(ctx context.Context, spec SourceSpec) (*PreparedSource,
 	if spec.RegistryUsername != "" || spec.RegistryPassword != "" {
 		authCfg = &RegistryAuthConfig{Username: spec.RegistryUsername, Password: spec.RegistryPassword}
 	}
-	authOpt := registryAuthOption(ctx, ref, authCfg)
+	auth, err := registryAuthenticator(ctx, ref, authCfg)
+	if err != nil {
+		return nil, fmt.Errorf("native export failed to resolve registry auth for %q: %w", spec.ImageRef, err)
+	}
 	jobs := nativeExportConcurrency()
 	platOpt := remote.WithPlatform(defaultPlatform())
 	jobsOpt := remote.WithJobs(jobs)
 
-	img, err := remote.Image(ref, remote.WithContext(ctx), authOpt, platOpt, jobsOpt)
+	img, err := remote.Image(ref, remote.WithContext(ctx), remote.WithAuth(auth), platOpt, jobsOpt)
 	if err != nil {
 		return nil, fmt.Errorf("native export failed to resolve image %q (if this is a multi-arch index, verify the requested platform exists): %w", spec.ImageRef, err)
 	}


### PR DESCRIPTION
## Summary

When a template source is hosted in Google Artifact Registry (`*.pkg.dev`) and no explicit registry credentials are provided, use Application Default Credentials (ADC) to authenticate the image pull. This supports GKE Workload Identity without adding static registry credentials to CubeMaster.

Explicit source credentials still take precedence. Other registries retain the existing default-keychain fallback. If ADC is unavailable or returns no token, Artifact Registry also falls back to the default keychain / anonymous behavior.

## Root cause

The native template importer previously always used `authn.DefaultKeychain` when a source omitted explicit credentials. In a GKE Workload Identity Pod, the projected Google access token is available through ADC / the metadata server, but it is not automatically represented in Docker config keychains. Artifact Registry imports therefore failed with an unauthenticated manifest request.

## Validation

- Added a unit test proving that an Artifact Registry reference maps an ADC access token to the `oauth2accesstoken` registry authenticator.
- Added a unit test proving explicit credentials take precedence and ADC is not consulted.
- Ran on Linux/amd64 with the upstream Go 1.25 builder environment:

  `go test ./pkg/templatecenter/image -run "TestRegistryAuthenticator(UsesGoogleADCForArtifactRegistry|PrefersExplicitCredentials)$" -count=1`

  Result: `ok github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image 0.091s`

- Ran `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/cubemaster` successfully.
- Validated the same auth path in a GKE Workload Identity STG PoC: the previous unauthenticated Artifact Registry template import advanced from `PULLING` through `UNPACKING` and `DISTRIBUTING` after the change.

Assisted-by: Codex:GPT-5