### PR TITLE
docs: document per-node WAL storage requirements for cross-node restore

### DIFF
--- a/docs/guide/cross-node-snapshot.md
+++ b/docs/guide/cross-node-snapshot.md
@@ -39,7 +39,7 @@ cubemastercli tpl create-from-image \
   --probe-path /health
 ```
 
-Confirm `BACKEND` is `s3` with `cubemastercli cubebox template list`. Sandboxes and snapshots created from that template inherit `s3` (see [CLI fields](#3-cli-fields-for-cross-node-restore)).
+Confirm `BACKEND` is `s3` with `cubemastercli cubebox template list`. Sandboxes and snapshots created from that template inherit `s3` (see [CLI fields](#4-cli-fields-for-cross-node-restore)).
 
 ### 1.2 Origin first; cross-node only when the origin cannot schedule
 
@@ -120,11 +120,39 @@ To point at your own S3 store, follow the [CubeS3lvol README](https://github.com
 
 ---
 
-## 3. CLI fields for cross-node restore
+## 3. Storage requirements on every node
+
+Snapshot objects live in shared S3, but **every node that runs the s3lvol target also needs a local WAL image**. Cross-node restore depends on it: writes to the snapshot are staged on local disk first and flushed to S3 asynchronously, and a node without the image can neither take snapshots nor restore them.
+
+### 3.1 The WAL image
+
+- Path: `/data/cubelet/rcow/wal_bdev.img`
+- Logical size: **512 GiB** by default, created as a **sparse** file by `install.sh`
+- Created once; the journal / WAL / cache split is fixed at creation and cannot be resized afterwards (only by re-creating the image)
+
+The default 512 GiB is three regions:
+
+| Region | Default size | Purpose |
+|--------|-------------|---------|
+| Journal | 1024 MiB | records of in-flight writes, replayed when the lvstore is attached |
+| WAL | 32768 MiB (32 GiB) | locally staged writes before they are flushed to S3 |
+| Chunk cache | 490496 MiB (≈479 GiB) | local cache of recently written chunks |
+
+> The image is **sparse**: provisioning 512 GiB of logical space does not consume 512 GiB of disk up front. Plan physical disk usage around the write working set, not the logical size.
+
+### 3.2 Cluster planning
+
+- **Every node that may restore cross-node needs its own WAL image on local disk** — compute nodes running sandboxes, and control nodes that run the s3lvol target, included.
+- The region sizes are set at install time via `RCOW_JOURNAL_MB` / `RCOW_WAL_MB` / `RCOW_CACHE_MB` (one-click install), or the equivalent runtime env in the CubeS3lvol config. Tuning them only matters **before the first start** — the layout is frozen once the image exists.
+- The image does not hold snapshot data permanently: it is a write buffer plus a cache. The durable copy is in S3.
+
+---
+
+## 4. CLI fields for cross-node restore
 
 `cubemastercli` adds `backend` / `remote_status` / `origin_node` columns, and `--backend` on template create. Node list and isolate live on `cubeopscli` (CubeOps, default port `3010`); see [Node Operations](./node-operations.md) and [CLI Tools](./cli-tools.md).
 
-### 3.1 `cubebox list`
+### 4.1 `cubebox list`
 
 Two extra columns show whether a sandbox uses S3 and whether its pause package has synced:
 
@@ -139,7 +167,7 @@ cubemastercli cubebox list --all
 
 Non-paused rows sort by create time descending; paused rows come last and include `pause_snap`. After a successful Resume those columns return to `-`.
 
-### 3.2 `cubebox snapshot list` / `snapshot info`
+### 4.2 `cubebox snapshot list` / `snapshot info`
 
 | Field | Meaning |
 |-------|---------|
@@ -153,7 +181,7 @@ cubemastercli cubebox snapshot list
 cubemastercli cubebox snapshot info --snapshot-id <snapshot-id>
 ```
 
-### 3.3 `cubebox template list` / `template info`
+### 4.3 `cubebox template list` / `template info`
 
 The template list adds a `BACKEND` column; `template info` prints `backend: <xfs|s3>`. That value is the default CoW backend for sandboxes and snapshots created from the template.
 
@@ -162,7 +190,7 @@ cubemastercli cubebox template list
 cubemastercli cubebox template info <template-id>
 ```
 
-### 3.4 `tpl create-from-image --backend xfs|s3`
+### 4.4 `tpl create-from-image --backend xfs|s3`
 
 ```bash
 # Declare the backend at template create; omit to keep historical xfs
@@ -174,7 +202,7 @@ cubemastercli tpl create-from-image \
 
 > The backend is fixed at **template / sandbox create**. Snapshot create does **not** take a backend flag; it always uses the persisted backend.
 
-### 3.5 `cubeopscli node list`
+### 4.5 `cubeopscli node list`
 
 The default table shows health and isolation. HostFacts are in JSON:
 
@@ -187,13 +215,13 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
 
 ---
 
-## 4. Benchmarks
+## 5. Benchmarks
 
 Times are **milliseconds**. **avg** / **p95** are **per-sandbox** create latency (when that sandbox became `running`), not batch wall time divided by concurrency.
 
 Figures below were measured on 2026-08-25. Numbers depend on hardware, image, and dirty-page load; treat them as a same-cluster xfs vs s3 comparison, not a SLA.
 
-### 4.1 Environment
+### 5.1 Environment
 
 Two identical Tencent Cloud CVM nodes (nested KVM), one control+compute and one compute-only.
 
@@ -205,7 +233,7 @@ Two identical Tencent Cloud CVM nodes (nested KVM), one control+compute and one 
 | Memory | 30 GiB |
 | Data disk | ~1 TB virtio, XFS on `/data` |
 
-### 4.2 Template
+### 5.2 Template
 
 Both backends use the **same** image and sandbox spec. Each template has a replica on **one** compute node (the origin). Local runs isolate the peer so jobs stay on the origin; cross-node FromSnap isolates the origin.
 
@@ -217,7 +245,7 @@ Both backends use the **same** image and sandbox spec. Each template has a repli
 | Probe | port `49983`, path `/health` |
 | Backends | `xfs` and `s3`, created with `tpl create-from-image --backend …` |
 
-### 4.3 Method
+### 5.3 Method
 
 Keep this method if you re-measure. Do not change table columns or round semantics.
 
@@ -228,7 +256,7 @@ Keep this method if you re-measure. Do not change table columns or round semanti
 5. **Create from snapshot (S3 local):** isolate the peer; origin still has the replica. **S3 cross-node:** wait until the snapshot is `ready`, isolate the origin, create on the peer.
 6. XFS has no share step and cannot restore cross-node.
 
-### 4.4 Cold start
+### 5.4 Cold start
 
 Create from the **template** (`Sandbox.create(template=tpl-…)`).
 
@@ -237,7 +265,7 @@ Create from the **template** (`Sandbox.create(template=tpl-…)`).
 | 1           | 50.9    | 57.2    | 430.6  | 471.4  |
 | 5           | 59.5    | 81.2    | 747.4  | 885.8  |
 
-### 4.5 Snapshot / Pause / Resume
+### 5.5 Snapshot / Pause / Resume
 
 | Operation | xfs avg | xfs p95 | s3 local avg | s3 local p95 | s3 cross-node avg | s3 cross-node p95 |
 |-----------|---------|---------|--------------|--------------|-------------------|-------------------|
@@ -248,7 +276,7 @@ Create from the **template** (`Sandbox.create(template=tpl-…)`).
 
 ---
 
-## 5. Known limitations
+## 6. Known limitations
 
 1. **S3lvol deletes snapshot objects asynchronously, and referenced snapshots are refused.** After you delete an S3 snapshot, CubeS3lvol finishes removing the objects in the background. The delete RPC returning does not mean the objects are gone from S3 immediately.
 
@@ -272,7 +300,7 @@ Create from the **template** (`Sandbox.create(template=tpl-…)`).
 
 ---
 
-## 6. See also
+## 7. See also
 
 - [Snapshot, Rollback & Clone](./snapshot-rollback-clone.md)
 - [Sandbox Lifecycle](./lifecycle.md)

--- a/docs/zh/guide/cross-node-snapshot.md
+++ b/docs/zh/guide/cross-node-snapshot.md
@@ -50,7 +50,7 @@ cubemastercli tpl create-from-image \
 ```
 
 创建后可用 `cubemastercli cubebox template list` 确认 `BACKEND` 列显示为 `s3`，其下新建的沙箱与
-快照也会自动继承 `s3`（见 [CLI 字段](#3-cubemastercli-跨机相关的子命令与新显示字段)）。
+快照也会自动继承 `s3`（见 [CLI 字段](#4-cubemastercli-跨机相关的子命令与新显示字段)）。
 
 ### 1.2 本机优先调度，本机无法调度才跨机
 
@@ -146,14 +146,47 @@ Cube 安装时默认安装 MinIO 作为 S3 服务，方便开箱体验。
 
 ---
 
-## 3. cubemastercli 跨机相关的子命令与新显示字段
+## 3. 每台节点的存储需求（重点是 WAL）
+
+快照对象存放在共享 S3 上，但**每台运行 s3lvol 的节点还需要一块本地 WAL 镜像盘**。
+跨机恢复依赖它：对快照的写入会先落到本地盘，再异步刷写回 S3；没有这块盘的节点既无法制作快照，
+也无法恢复快照。
+
+### 3.1 WAL 镜像盘
+
+- 路径：`/data/cubelet/rcow/wal_bdev.img`
+- 逻辑大小：默认 **512 GiB**，由 `install.sh` 以**稀疏文件**方式创建
+- 只创建一次：journal / WAL / cache 三段的划分在创建时就固定，之后无法调整（只能重新创建镜像）
+
+默认 512 GiB 由三段组成：
+
+| 区域 | 默认大小 | 作用 |
+|------|---------|------|
+| Journal | 1024 MiB | 在途写操作记录，挂载 lvstore 时回放 |
+| WAL | 32768 MiB（32 GiB） | 刷写 S3 之前暂存的本地写数据 |
+| Chunk cache | 490496 MiB（≈479 GiB） | 最近写入 chunk 的本地缓存 |
+
+> 镜像是**稀疏文件**：预留 512 GiB 逻辑空间并不会立即占用 512 GiB 物理磁盘。
+> 物理占用按实际写入增长，容量规划应围绕写入工作集，而非逻辑大小。
+
+### 3.2 集群规划
+
+- **每台可能参与跨机恢复的节点都要在本地磁盘上准备自己的 WAL 镜像**——包括运行沙箱的计算节点，
+  以及运行 s3lvol 的控制节点。
+- 三段大小在安装时通过 `RCOW_JOURNAL_MB` / `RCOW_WAL_MB` / `RCOW_CACHE_MB`
+  （一键安装）或 CubeS3lvol 运行时环境配置设置。调整只在**首次启动前**有意义——镜像一旦创建，布局即固定。
+- 镜像不长期保存快照数据：它只是写缓冲加缓存，持久副本在 S3。
+
+---
+
+## 4. cubemastercli 跨机相关的子命令与新显示字段
 
 为支持跨机能力，`cubemastercli` 在多个子命令中新增了 `backend` / `remote_status` /
 `origin_node` 等显示列，并在模板创建时提供 `--backend` 标志。下面按子命令说明。
 
 节点列表与隔离已迁到 `cubeopscli`（CubeOps，默认端口 `3010`），见 [节点相关操作](./node-operations.md) 与 [命令行工具](./cli-tools.md)。
 
-### 3.1 `cubebox list`（沙箱列表）
+### 4.1 `cubebox list`（沙箱列表）
 
 沙箱列表新增两列，用于一眼看出某个沙箱是否走 S3、以及其暂停包在云端的同步状态：
 
@@ -168,7 +201,7 @@ cubemastercli cubebox list --all
 
 非 paused 行按创建时间倒序；paused 行排在最后，并带 `pause_snap`。Resume 成功后这两列恢复为 `-`。
 
-### 3.2 `cubebox snapshot list` / `snapshot info`（快照）
+### 4.2 `cubebox snapshot list` / `snapshot info`（快照）
 
 快照资源中的跨机相关字段：
 
@@ -184,7 +217,7 @@ cubemastercli cubebox snapshot list
 cubemastercli cubebox snapshot info --snapshot-id <snapshot-id>
 ```
 
-### 3.3 `cubebox template list` / `template info`（模板）
+### 4.3 `cubebox template list` / `template info`（模板）
 
 模板列表新增 `BACKEND` 列；`template info` 会打印 `backend: <xfs|s3>`。
 模板的 `backend` 决定其下沙箱与快照默认使用的 CoW 后端。
@@ -194,7 +227,7 @@ cubemastercli cubebox template list
 cubemastercli cubebox template info <template-id>
 ```
 
-### 3.4 `tpl create-from-image --backend xfs|s3`
+### 4.4 `tpl create-from-image --backend xfs|s3`
 
 ```bash
 # 创建模板时声明后端；省略则沿用历史 xfs 路径
@@ -207,7 +240,7 @@ cubemastercli tpl create-from-image \
 > 后端在**模板 / 沙箱创建**时确定；快照创建命令本身**不接受** backend 选择，
 > 永远使用沙箱 / 模板已持久化的后端。
 
-### 3.5 `cubeopscli node list`（校验跨机兼容性）
+### 4.5 `cubeopscli node list`（校验跨机兼容性）
 
 默认表格显示节点健康与隔离状态。HostFacts 在 JSON 里：
 
@@ -221,13 +254,13 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
 
 ---
 
-## 4. 基准性能测试
+## 5. 基准性能测试
 
 单位 **ms**。表中 **avg** / **p95** 是**单实例**从发起到进入 `running` 的耗时，不是整批 wall 再除以并发。
 
 下列数字测于 2026-08-25。结果随硬件、镜像和脏页负载变化，只适合作为同集群上 xfs 与 s3 的对照，不是 SLA。
 
-### 4.1 测试环境
+### 5.1 测试环境
 
 两台同规格腾讯云 CVM（嵌套 KVM）：一台控制面+计算，一台仅计算。
 
@@ -239,7 +272,7 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
 | 内存 | 30 GiB |
 | 数据盘 | 约 1 TB virtio，`/data` 为 XFS |
 
-### 4.2 模版
+### 5.2 模版
 
 两个后端用**同一镜像、同一规格**。每份模版只在**一台**计算节点有副本（源节点）。同机用例隔离对端，让任务落在源节点；跨机 FromSnap 隔离源节点。
 
@@ -251,7 +284,7 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
 | Probe | 端口 `49983`，路径 `/health` |
 | 后端 | `xfs` 与 `s3`，`tpl create-from-image --backend …` |
 
-### 4.3 测试方法
+### 5.3 测试方法
 
 复测时沿用此方法，不要改表格列或「一轮」语义。
 
@@ -262,7 +295,7 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
 5. **从快照创建（S3 本地）：** 隔离对端，源节点仍有副本。**S3 跨机：** 等快照 `ready` 后隔离源节点，在对端创建。
 6. XFS 没有共享步骤，也不能跨机恢复。
 
-### 4.4 冷启动（Cold Start）
+### 5.4 冷启动（Cold Start）
 
 从**模版**创建（`Sandbox.create(template=tpl-…)`）。
 
@@ -271,7 +304,7 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
 | 1    | 50.9    | 57.2    | 430.6  | 471.4  |
 | 5    | 59.5    | 81.2    | 747.4  | 885.8  |
 
-### 4.5 快照 / 暂停 / 恢复（Snapshot / Pause / Resume）
+### 5.5 快照 / 暂停 / 恢复（Snapshot / Pause / Resume）
 
 | 操作 | xfs avg | xfs p95 | s3 本地 avg | s3 本地 p95 | s3 跨机 avg | s3 跨机 p95 |
 |------|---------|---------|-------------|-------------|-------------|-------------|
@@ -282,7 +315,7 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
 
 ---
 
-## 5. 已知问题
+## 6. 已知问题
 
 1. **S3 快照对象由 S3lvol 异步删除，被引用的快照会拒绝删除。** 删除 S3 快照后，CubeS3lvol 在后台回收对象。
    删除接口返回时，对象不一定已经从 S3 上消失。
@@ -319,7 +352,7 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
 
 ---
 
-## 6. 参考
+## 7. 参考
 
 - [快照、回滚与克隆](./snapshot-rollback-clone.md)
 - [沙箱生命周期](./lifecycle.md)


### PR DESCRIPTION
Documents what every node running the s3lvol target costs in local disk, since the S3 backend keeps snapshot objects in shared S3 but the WAL image is per-node local storage.

**New section 3 (en + zh): Storage requirements on every node**

- WAL image at `/data/cubelet/rcow/wal_bdev.img`, 512 GiB logical (sparse file; physical usage grows with writes), split into journal 1024 MiB + WAL 32 GiB + chunk cache ~479 GiB;
- created once by `install.sh`, layout frozen at creation, tunable only before first start (`RCOW_JOURNAL_MB` / `RCOW_WAL_MB` / `RCOW_CACHE_MB`);
- every node that may restore cross-node needs its own image on local disk (compute nodes and s3lvol-running control nodes alike);
- the image is a write buffer plus cache, not durable storage — the durable copy is in S3.

Sections 3-6 renumbered to 4-7 in both guides; the two cross-references updated.