### PR TITLE
feat(cubemastercli): support deleting multiple templates

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -610,7 +610,7 @@ var TemplateRenderCommand = cli.Command{
 var TemplateDeleteCommand = cli.Command{
 	Name:      "delete",
 	Usage:     "delete template metadata and node replicas",
-	ArgsUsage: "<template-id>",
+	ArgsUsage: "<template-id> [template-id ...]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "template-id",
@@ -618,8 +618,8 @@ var TemplateDeleteCommand = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		templateID := resolveTemplateID(c)
-		if templateID == "" {
+		templateIDs := resolveTemplateIDs(c)
+		if len(templateIDs) == 0 {
 			return errors.New("template-id is required")
 		}
 
@@ -628,34 +628,52 @@ var TemplateDeleteCommand = cli.Command{
 			return errors.New("no server addr")
 		}
 		port = c.GlobalString("port")
-		requestID := uuid.New().String()
 		host := serverList[rand.Int()%len(serverList)]
 		url := fmt.Sprintf("http://%s/cube/template", net.JoinHostPort(host, port))
 
-		req := &templateDeleteRequest{
-			RequestID:  requestID,
-			TemplateID: templateID,
+		var deleteErr error
+		for _, templateID := range templateIDs {
+			if err := deleteTemplate(c, url, templateID); err != nil {
+				deleteErr = errors.Join(deleteErr, fmt.Errorf("%s: %w", templateID, err))
+				continue
+			}
+			log.Printf("template deleted: %s\n", templateID)
 		}
-		body, err := jsoniter.Marshal(req)
-		if err != nil {
-			return err
-		}
-
-		rsp := &templateResponse{}
-		if err := doHttpReq(c, url, http.MethodDelete, requestID, bytes.NewBuffer(body), rsp); err != nil {
-			log.Printf("template delete request err. %s. RequestId: %s\n", err.Error(), requestID)
-			return err
-		}
-		if rsp.Ret == nil {
-			return errors.New("empty response")
-		}
-		if rsp.Ret.RetCode != 200 {
-			log.Printf("template delete failed. %s. RequestId: %s\n", rsp.Ret.RetMsg, requestID)
-			return errors.New(rsp.Ret.RetMsg)
-		}
-		log.Printf("template deleted: %s\n", templateID)
-		return nil
+		return deleteErr
 	},
+}
+
+func resolveTemplateIDs(c *cli.Context) []string {
+	if id := c.String("template-id"); id != "" {
+		return []string{id}
+	}
+	return c.Args()
+}
+
+func deleteTemplate(c *cli.Context, url, templateID string) error {
+	requestID := uuid.New().String()
+	req := &templateDeleteRequest{
+		RequestID:  requestID,
+		TemplateID: templateID,
+	}
+	body, err := jsoniter.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	rsp := &templateResponse{}
+	if err := doHttpReq(c, url, http.MethodDelete, requestID, bytes.NewBuffer(body), rsp); err != nil {
+		log.Printf("template delete request err. %s. TemplateId: %s. RequestId: %s\n", err.Error(), templateID, requestID)
+		return err
+	}
+	if rsp.Ret == nil {
+		return errors.New("empty response")
+	}
+	if rsp.Ret.RetCode != 200 {
+		log.Printf("template delete failed. %s. TemplateId: %s. RequestId: %s\n", rsp.Ret.RetMsg, templateID, requestID)
+		return errors.New(rsp.Ret.RetMsg)
+	}
+	return nil
 }
 
 // templateSetAliasRequest is the JSON body for PUT /cube/template/:id/alias.

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -84,6 +85,25 @@ func newCommitContext(t *testing.T, args []string) *cli.Context {
 
 	ctx := cli.NewContext(nil, set, nil)
 	ctx.Command = TemplateCommitCommand
+	return ctx
+}
+
+func newDeleteContext(t *testing.T, args []string) *cli.Context {
+	t.Helper()
+
+	set := flag.NewFlagSet("delete", flag.ContinueOnError)
+	set.String("address", "", "cubemaster address")
+	set.String("port", "", "cubemaster port")
+	set.Duration("timeout", 0, "request timeout")
+	for _, cliFlag := range TemplateDeleteCommand.Flags {
+		cliFlag.Apply(set)
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatalf("parse args %v: %v", args, err)
+	}
+
+	ctx := cli.NewContext(nil, set, nil)
+	ctx.Command = TemplateDeleteCommand
 	return ctx
 }
 
@@ -816,5 +836,111 @@ func TestResolveTemplateIDFromAllTemplateCommands(t *testing.T) {
 				t.Fatalf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveTemplateIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "multiple positional ids",
+			args: []string{"tpl-1", "tpl-2", "tpl-3"},
+			want: []string{"tpl-1", "tpl-2", "tpl-3"},
+		},
+		{
+			name: "flag preserves existing override behavior",
+			args: []string{"--template-id", "tpl-flag", "tpl-positional"},
+			want: []string{"tpl-flag"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newDeleteContext(t, tt.args)
+			if got := resolveTemplateIDs(ctx); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTemplateDeleteCommandDeletesAllTemplateIDs(t *testing.T) {
+	var deleted []string
+	origHTTPClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var body templateDeleteRequest
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Fatalf("decode delete request: %v", err)
+		}
+		deleted = append(deleted, body.TemplateID)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ret":{"ret_code":200,"ret_msg":"success"}}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+	defer func() { http.DefaultClient = origHTTPClient }()
+
+	ctx := newDeleteContext(t, []string{
+		"--address", "127.0.0.1",
+		"--port", "8089",
+		"tpl-1", "tpl-2", "tpl-3",
+	})
+	action := TemplateDeleteCommand.Action.(func(*cli.Context) error)
+	if err := action(ctx); err != nil {
+		t.Fatalf("delete returned error: %v", err)
+	}
+	if want := []string{"tpl-1", "tpl-2", "tpl-3"}; !reflect.DeepEqual(deleted, want) {
+		t.Fatalf("deleted %v, want %v", deleted, want)
+	}
+}
+
+func TestTemplateDeleteCommandContinuesAfterFailure(t *testing.T) {
+	var deleted []string
+	var logBuf bytes.Buffer
+	oldWriter := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() {
+		log.SetOutput(oldWriter)
+	})
+
+	origHTTPClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var body templateDeleteRequest
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Fatalf("decode delete request: %v", err)
+		}
+		deleted = append(deleted, body.TemplateID)
+		response := `{"ret":{"ret_code":200,"ret_msg":"success"}}`
+		if body.TemplateID == "tpl-fail" {
+			response = `{"ret":{"ret_code":500,"ret_msg":"delete failed"}}`
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(response)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+	defer func() { http.DefaultClient = origHTTPClient }()
+
+	ctx := newDeleteContext(t, []string{
+		"--address", "127.0.0.1",
+		"--port", "8089",
+		"tpl-first", "tpl-fail", "tpl-last",
+	})
+	action := TemplateDeleteCommand.Action.(func(*cli.Context) error)
+	err := action(ctx)
+	if err == nil || !strings.Contains(err.Error(), "tpl-fail: delete failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := []string{"tpl-first", "tpl-fail", "tpl-last"}; !reflect.DeepEqual(deleted, want) {
+		t.Fatalf("deleted %v, want %v", deleted, want)
+	}
+	if got := logBuf.String(); !strings.Contains(got, "template delete failed. delete failed. TemplateId: tpl-fail. RequestId:") {
+		t.Fatalf("failure log %q does not identify failed template", got)
 	}
 }

--- a/docs/guide/tutorials/template-from-image.md
+++ b/docs/guide/tutorials/template-from-image.md
@@ -279,7 +279,12 @@ For a user-oriented walkthrough of what each output means and how to preview the
 
 ```bash
 cubemastercli tpl delete tpl-748094d2f2374b0a8a37e6ec
+
+# Delete multiple templates in one command
+cubemastercli tpl delete tpl-first tpl-second tpl-third
 ```
+
+When multiple template IDs are provided, the CLI attempts every deletion even if one fails, then returns a combined error for the failed templates.
 
 On success:
 

--- a/docs/zh/guide/tutorials/template-from-image.md
+++ b/docs/zh/guide/tutorials/template-from-image.md
@@ -251,7 +251,12 @@ cubemastercli tpl render --template-id tpl-748094d2f2374b0a8a37e6ec --json
 
 ```bash
 cubemastercli tpl delete tpl-748094d2f2374b0a8a37e6ec
+
+# 一次删除多个模板
+cubemastercli tpl delete tpl-first tpl-second tpl-third
 ```
+
+传入多个模板 ID 时，即使其中某个模板删除失败，CLI 也会继续尝试删除其余模板，最后汇总返回失败项。
 
 成功后输出：
 


### PR DESCRIPTION
allow tpl delete to accept multiple positional template IDs. Continue deleting the remaining templates after an individual failure and return the combined errors afterward.

```bash
cubemastercli tpl delete <tpl-1> <tpl-2> ...
```
