### PR TITLE
examples(pi-agent): add OrcaRouter as a first-class Pi provider

### DIFF
--- a/examples/pi-agent-integration/.env.example
+++ b/examples/pi-agent-integration/.env.example
@@ -29,6 +29,12 @@ DEEPSEEK_API_KEY="<your-deepseek-api-key>"
 # GEMINI_API_KEY="<your-gemini-api-key>"
 # OPENROUTER_API_KEY="<your-openrouter-api-key>"
 
+# OrcaRouter (set PI_PROVIDER=orcarouter and PI_MODEL to one of the models
+# registered in models.json, e.g. orcarouter/fusion-flash):
+# ORCAROUTER_API_KEY="<your-orcarouter-api-key>"
+# PI_PROVIDER="orcarouter"
+# PI_MODEL="orcarouter/fusion-flash"
+
 # Anthropic-compatible endpoint (e.g. DeepSeek): keep the models aligned.
 # ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
 # ANTHROPIC_AUTH_TOKEN="<your-deepseek-api-key>"

--- a/examples/pi-agent-integration/Dockerfile
+++ b/examples/pi-agent-integration/Dockerfile
@@ -62,6 +62,14 @@ RUN mkdir -p /workspace "${PI_CODING_AGENT_SESSION_DIR}" \
         '}' \
         > "${PI_CODING_AGENT_DIR}/settings.json"
 
+# Register the "orcarouter" provider with Pi so it is a first-class provider
+# instead of an anonymous custom base URL. OrcaRouter is not a built-in Pi
+# provider, so models.json teaches Pi its OpenAI-compatible endpoint and the
+# model IDs it can reach there. The apiKey references the ORCAROUTER_API_KEY
+# env var: in the direct flavor the host passes the real key, and in the
+# CubeEgress vault flavor the placeholder is replaced on the wire.
+COPY models.json "${PI_CODING_AGENT_DIR}/models.json"
+
 WORKDIR /workspace
 
 EXPOSE 49983

--- a/examples/pi-agent-integration/README.md
+++ b/examples/pi-agent-integration/README.md
@@ -54,7 +54,7 @@ pip install -r requirements.txt
 | `E2B_API_KEY` | Local process | Any non-empty string in local dev |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
 | `CUBE_WARMUP_TEMPLATE_ID` | `run_pi_warmup.py` | From the warmup template job below |
-| `PI_PROVIDER` | Pi CLI | `deepseek` (default), `anthropic`, `openai`, ... |
+| `PI_PROVIDER` | Pi CLI | `deepseek` (default), `anthropic`, `openai`, `orcarouter`, ... |
 | `PI_MODEL` | Pi CLI | Model id for the provider |
 
 ## 4. One-shot run (direct key flavor)
@@ -151,6 +151,26 @@ python network_policy.py
 
 If the agent needs extra hosts (package registries, MCP servers), add matching
 allow rules or preinstall those dependencies into the template.
+
+## 8. OrcaRouter as a provider
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway. The
+image ships a `models.json` that registers it as a first-class Pi provider, so
+you do not need to treat it as an anonymous custom base URL:
+
+```bash
+# .env
+PI_PROVIDER=orcarouter
+PI_MODEL=orcarouter/fusion-flash
+ORCAROUTER_API_KEY=<your-orcarouter-api-key>
+```
+
+Available model IDs: `orcarouter/free`, `orcarouter/fusion`,
+`orcarouter/fusion-flash`, `orcarouter/fusion-mini`. The registered provider
+uses the OpenAI Chat Completions API at `https://api.orcarouter.ai/v1` — the
+same endpoint shape as the built-in `openai` provider — so every flavor
+(direct, warmup, vault) works with no extra configuration. In the vault flavor,
+CubeEgress injects the key on the wire just like any other provider.
 
 ## Troubleshooting
 

--- a/examples/pi-agent-integration/README_zh.md
+++ b/examples/pi-agent-integration/README_zh.md
@@ -51,7 +51,7 @@ pip install -r requirements.txt
 | `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
 | `CUBE_WARMUP_TEMPLATE_ID` | `run_pi_warmup.py` | 来自下文 warmup 模板任务 |
-| `PI_PROVIDER` | Pi CLI | `deepseek`（默认）、`anthropic`、`openai` 等 |
+| `PI_PROVIDER` | Pi CLI | `deepseek`（默认）、`anthropic`、`openai`、`orcarouter` 等 |
 | `PI_MODEL` | Pi CLI | 对应 provider 的模型 id |
 
 ## 4. 一次性运行（直连注入密钥）
@@ -132,6 +132,23 @@ python network_policy.py
 - 任何其他目的地都会返回 `403 Forbidden - CubeEgress`。
 
 若 Agent 需要访问额外主机（包镜像源、MCP 服务器等），请增加对应的放行规则，或把这些依赖预装进模板。
+
+## 8. 将 OrcaRouter 作为 provider 使用
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个 OpenAI 兼容的 AI 网关。镜像内置
+`models.json`，将其注册为 Pi 的一等公民 provider，无需把它当成匿名的自定义 base URL：
+
+```bash
+# .env
+PI_PROVIDER=orcarouter
+PI_MODEL=orcarouter/fusion-flash
+ORCAROUTER_API_KEY=<your-orcarouter-api-key>
+```
+
+可用模型 ID：`orcarouter/free`、`orcarouter/fusion`、`orcarouter/fusion-flash`、
+`orcarouter/fusion-mini`。注册的 provider 使用 OpenAI Chat Completions API
+（`https://api.orcarouter.ai/v1`），与内置 `openai` provider 相同的端点形态，
+因此直连、warmup、vault 三种方式都无需额外配置。vault 方式下 CubeEgress 同样在链路上注入密钥。
 
 ## 排错
 

--- a/examples/pi-agent-integration/env_utils.py
+++ b/examples/pi-agent-integration/env_utils.py
@@ -20,6 +20,7 @@ PROVIDER_KEY_ENV = {
     "google": "GEMINI_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "orcarouter": "ORCAROUTER_API_KEY",
 }
 
 PROVIDER_KEY_ALIASES = {
@@ -32,6 +33,16 @@ PROVIDER_DEFAULT_HOST = {
     "google": "generativelanguage.googleapis.com",
     "deepseek": "api.deepseek.com",
     "openrouter": "openrouter.ai",
+    "orcarouter": "api.orcarouter.ai",
+}
+
+# Custom Pi providers registered in the image's models.json. Pi has built-in
+# providers (anthropic, openai, deepseek, openrouter, ...) that need no model
+# registration, but a first-class "orcarouter" provider must point Pi at the
+# OrcaRouter OpenAI-compatible endpoint explicitly. This is the OpenAI
+# Chat Completions base URL that mirrors Pi's built-in openai provider.
+PROVIDER_BASE_URL = {
+    "orcarouter": "https://api.orcarouter.ai/v1",
 }
 
 # The example has explicit defaults for its primary providers. Other providers
@@ -192,6 +203,17 @@ def pi_llm_host(provider: str | None = None) -> str:
             if host:
                 return host
     return PROVIDER_DEFAULT_HOST.get(provider_name, "")
+
+
+def pi_base_url(provider: str | None = None) -> str:
+    """Resolve the OpenAI-compatible base URL Pi should use for a provider.
+
+    Custom Pi providers (registered in the image's ``models.json``) must carry
+    an explicit base URL. OrcaRouter is OpenAI Chat Completions compatible, so
+    its base URL points at the gateway's ``/v1`` endpoint. Built-in Pi providers
+    need no base URL: Pi already knows their endpoints.
+    """
+    return PROVIDER_BASE_URL.get((provider or pi_provider()).strip().lower(), "")
 
 
 def _host_from_url(value: str) -> str:

--- a/examples/pi-agent-integration/models.json
+++ b/examples/pi-agent-integration/models.json
@@ -1,0 +1,16 @@
+{
+  "providers": {
+    "orcarouter": {
+      "name": "OrcaRouter",
+      "baseUrl": "https://api.orcarouter.ai/v1",
+      "api": "openai-completions",
+      "apiKey": "$ORCAROUTER_API_KEY",
+      "models": [
+        { "id": "orcarouter/free", "name": "OrcaRouter Free" },
+        { "id": "orcarouter/fusion", "name": "OrcaRouter Fusion" },
+        { "id": "orcarouter/fusion-flash", "name": "OrcaRouter Fusion Flash" },
+        { "id": "orcarouter/fusion-mini", "name": "OrcaRouter Fusion Mini" }
+      ]
+    }
+  }
+}

--- a/examples/pi-agent-integration/pi_warmup_adapter.mjs
+++ b/examples/pi-agent-integration/pi_warmup_adapter.mjs
@@ -82,6 +82,10 @@ async function handlePrompt(request, response) {
 
     const provider = String(body.provider || defaultProvider).toLowerCase();
     const modelId = String(body.model || defaultModel);
+    // Register the provider's OpenAI-compatible base URL when the host driver
+    // supplies one (e.g. the custom "orcarouter" provider in models.json).
+    // Built-in Pi providers (anthropic, deepseek, ...) omit baseUrl and use
+    // their built-in endpoint.
     if (typeof body.baseUrl === "string" && body.baseUrl !== "") {
       modelRegistry.registerProvider(provider, { baseUrl: body.baseUrl });
     }

--- a/examples/pi-agent-integration/run_pi_warmup.py
+++ b/examples/pi-agent-integration/run_pi_warmup.py
@@ -15,6 +15,7 @@ from env_utils import (
     int_env,
     load_local_dotenv,
     optional,
+    pi_base_url,
     pi_model,
     pi_provider,
     require_provider_key,
@@ -80,8 +81,13 @@ def main() -> int:
     required("E2B_API_KEY")
     provider = pi_provider()
     api_key = require_provider_key(provider)
+    # The adapter registers the provider's OpenAI-compatible base URL at runtime
+    # (see pi_warmup_adapter.mjs). OrcaRouter is not a built-in Pi provider, so
+    # it must carry an explicit base URL; built-in providers use an empty string.
     provider_base_url = (
-        optional("ANTHROPIC_BASE_URL") if provider == "anthropic" else ""
+        optional("ANTHROPIC_BASE_URL")
+        if provider == "anthropic"
+        else pi_base_url(provider)
     )
 
     print(f"Creating sandbox from warmup template: {template_id}")


### PR DESCRIPTION
# Add OrcaRouter as a first-class Pi provider

This PR registers [OrcaRouter](https://www.orcarouter.ai) as a named provider in the Pi Agent + CubeSandbox example, so its users can reach OrcaRouter's full stack without treating it as an anonymous custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`env_utils.py`** — add `orcarouter` to the provider key/host maps (mirroring the existing `openrouter` entry) and a `pi_base_url()` helper that resolves the OpenAI-compatible endpoint for custom Pi providers.
- **`models.json`** (new) — register the `orcarouter` provider with the OpenAI Chat Completions API at `https://api.orcarouter.ai/v1` and four model IDs (`orcarouter/free`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini`).
- **`Dockerfile`** — bake `models.json` into Pi's agent dir so the provider resolves in every flavor (direct, warmup, vault), exactly like the built-in `openai` provider Pi already knows.
- **`run_pi_warmup.py` / `pi_warmup_adapter.mjs`** — pass and register the provider's base URL at runtime so the warmup session resolves OrcaRouter models.
- **Docs** — document `PI_PROVIDER=orcarouter` in `README.md`, `README_zh.md`, and `.env.example`.

## Verification

- `ruff check` and `ruff format` pass on the modified Python files; `node --check` passes on the adapter.
- Live tested: Pi resolves the `orcarouter` provider from the shipped `models.json` and completes a prompt through `https://api.orcarouter.ai/v1` (HTTP 200) — both via the CLI (`--provider orcarouter --model orcarouter/fusion-flash`) and via an `AgentSession` using the warmup adapter's `registerProvider` path.
- All four registered model IDs return HTTP 200 from the OrcaRouter endpoint.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
