### PR TITLE
test(network): stabilize L7 egress retries

### DIFF
--- a/tests/e2e/sdk_compat/cases/framework/test_l7_egress_retry.py
+++ b/tests/e2e/sdk_compat/cases/framework/test_l7_egress_retry.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hermetic coverage for L7 HTTP command retry behavior."""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from framework.l7_egress import (
+    L7_ATTEMPTS,
+    http_json_command,
+    l7_command_timeout,
+)
+
+pytestmark = pytest.mark.framework
+
+
+@contextmanager
+def _scripted_server(
+    responses: list[tuple[int | None, str]],
+) -> Iterator[tuple[str, list[int]]]:
+    request_count = [0]
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            index = min(request_count[0], len(responses) - 1)
+            status, body = responses[index]
+            request_count[0] += 1
+            if status is None:
+                self.close_connection = True
+                self.connection.shutdown(socket.SHUT_RDWR)
+                self.connection.close()
+                return
+            payload = body.encode()
+            self.send_response(status)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args: object) -> None:
+            pass
+
+    class Server(ThreadingHTTPServer):
+        def handle_error(self, *_args: object) -> None:
+            pass
+
+    server = Server(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/headers", request_count
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def _run_http_command(
+    url: str, *, attempts: int = L7_ATTEMPTS
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        http_json_command(url, timeout=2, attempts=attempts, backoff_enabled=False),
+        shell=True,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@pytest.mark.parametrize("gateway_status", [502, 504])
+def test_http_command_retries_gateway_failure(gateway_status: int) -> None:
+    with _scripted_server([(gateway_status, "temporary"), (200, "recovered")]) as (
+        url,
+        request_count,
+    ):
+        result = _run_http_command(url)
+
+    assert result.returncode == 0
+    assert result.stdout == "STATUS:200\nrecovered\n"
+    assert request_count == [2]
+
+
+def test_http_command_retries_transport_failure() -> None:
+    with _scripted_server([(None, ""), (200, "recovered")]) as (url, request_count):
+        result = _run_http_command(url)
+
+    assert result.returncode == 0
+    assert result.stdout == "STATUS:200\nrecovered\n"
+    assert request_count == [2]
+
+
+def test_http_command_returns_last_gateway_failure_after_attempt_limit() -> None:
+    with _scripted_server([(504, "first"), (502, "second"), (504, "last")]) as (
+        url,
+        request_count,
+    ):
+        result = _run_http_command(url)
+
+    assert result.returncode == 0
+    assert result.stdout == "STATUS:504\nlast\n"
+    assert request_count == [3]
+
+
+def test_http_command_does_not_retry_policy_denial() -> None:
+    with _scripted_server([(403, "denied"), (200, "should not run")]) as (
+        url,
+        request_count,
+    ):
+        result = _run_http_command(url)
+
+    assert result.returncode == 0
+    assert result.stdout == "STATUS:403\ndenied\n"
+    assert request_count == [1]
+
+
+def test_l7_command_timeout_uses_requested_retry_budget() -> None:
+    assert l7_command_timeout(10, request_timeout=2, attempts=4) == 44
+    assert l7_command_timeout(10, request_timeout=10, attempts=2) == 91
+    assert l7_command_timeout(100, request_timeout=10, attempts=2) == 100
+
+
+def test_http_command_does_not_retry_successful_response() -> None:
+    with _scripted_server([(200, "missing header"), (200, "should not run")]) as (
+        url,
+        request_count,
+    ):
+        result = _run_http_command(url)
+
+    assert result.returncode == 0
+    assert result.stdout == "STATUS:200\nmissing header\n"
+    assert request_count == [1]

--- a/tests/e2e/sdk_compat/cases/network/test_l7_egress.py
+++ b/tests/e2e/sdk_compat/cases/network/test_l7_egress.py
@@ -10,24 +10,27 @@ import os
 import re
 
 import pytest
-
 from framework.assertions import assert_command_ok
 from framework.capabilities import NETWORK_L7_EGRESS
+from framework.l7_egress import (
+    L7_ATTEMPTS,
+    L7_HTTP_TIMEOUT,
+    http_json_command,
+    l7_command_timeout,
+)
 
 HTTPBUN_HOST = os.environ.get("SDK_E2E_L7_ECHO_HOST", "httpbun.com")
 OTHER_HOST = os.environ.get("SDK_E2E_L7_OTHER_HOST", "example.com")
 INJECT_HEADER = os.environ.get("SDK_E2E_L7_INJECT_HEADER", "X-Cube-E2E-Inject")
-INJECT_SECRET = os.environ.get("SDK_E2E_L7_INJECT_SECRET", "e2e-inject-secret-not-a-real-key")
+INJECT_SECRET = os.environ.get(
+    "SDK_E2E_L7_INJECT_SECRET", "e2e-inject-secret-not-a-real-key"
+)
 # CubeEgress MITM CA CN. The authoritative value (one-click prepare and the
 # k8s chart, deploy/.../cube-egress-prepare.sh + chart values caCommonName) is
 # "CubeSandbox Egress MITM CA". Override with SDK_E2E_L7_MITM_CA_CN if a
 # deployment customized it. A regex fallback in the test also tolerates
 # "Cube Sandbox Egress"-style spacing variants.
 MITM_CA_CN = os.environ.get("SDK_E2E_L7_MITM_CA_CN", "CubeSandbox Egress MITM CA")
-# Cold MITM path (DNS learn + TLS + upstream) needs more headroom than the
-# shared TCP network_probe_timeout default (5s).
-L7_HTTP_TIMEOUT = int(os.environ.get("SDK_E2E_L7_HTTP_TIMEOUT", "15"))
-
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.sdk_compat,
@@ -58,45 +61,6 @@ def _https_rule(
     return {"name": name, "match": match, "action": action}
 
 
-def _http_json_command(url: str, *, method: str = "GET", timeout: int = 15, attempts: int = 3) -> str:
-    """Fetch URL without TLS verify; print STATUS + body (or error).
-
-    Retries transient transport failures (timeout / connection reset / temporary
-    DNS) with backoff, since the public echo endpoints can be slow or rate-limit.
-    An HTTP 4xx/5xx is a real policy verdict and is returned as-is, never retried.
-    """
-    return (
-        "python3 - <<'PY'\n"
-        "import ssl, time, urllib.error, urllib.request\n"
-        f"url = {url!r}\n"
-        f"method = {method!r}\n"
-        f"timeout = {timeout!r}\n"
-        f"attempts = {attempts!r}\n"
-        "ctx = ssl._create_unverified_context()\n"
-        "last = None\n"
-        "for attempt in range(attempts):\n"
-        "    try:\n"
-        "        req = urllib.request.Request(url, method=method)\n"
-        "        with urllib.request.urlopen(req, context=ctx, timeout=timeout) as resp:\n"
-        "            body = resp.read().decode('utf-8', errors='replace')\n"
-        "            print(f'STATUS:{resp.status}')\n"
-        "            print(body)\n"
-        "        break\n"
-        "    except urllib.error.HTTPError as exc:\n"
-        "        body = exc.read().decode('utf-8', errors='replace')\n"
-        "        print(f'STATUS:{exc.code}')\n"
-        "        print(body)\n"
-        "        break\n"
-        "    except Exception as exc:\n"
-        "        last = exc\n"
-        "        if attempt + 1 < attempts:\n"
-        "            time.sleep(min(2 ** attempt, 5))\n"
-        "else:\n"
-        "    print(f'ERROR:{type(last).__name__}:{last}')\n"
-        "PY"
-    )
-
-
 def _parse_status_and_body(result) -> tuple[int | None, str]:
     assert_command_ok(result)
     text = result.stdout
@@ -116,8 +80,7 @@ def _headers_from_httpbun(body: str, *, status: int | None = None) -> dict[str, 
         data = json.loads(body)
     except json.JSONDecodeError as exc:
         raise AssertionError(
-            f"httpbun response was not JSON; status={status} "
-            f"body={body[:200]!r}: {exc}"
+            f"httpbun response was not JSON; status={status} body={body[:200]!r}: {exc}"
         ) from exc
     raw = data.get("headers") or data
     if not isinstance(raw, dict):
@@ -135,7 +98,9 @@ def _header_ci(headers: dict[str, str], name: str) -> str | None:
     return None
 
 
-def _tls_issuer_command(host: str, timeout: int = 15, attempts: int = 3) -> str:
+def _tls_issuer_command(
+    host: str, timeout: int = 15, attempts: int = L7_ATTEMPTS
+) -> str:
     return (
         "python3 - <<'PY'\n"
         "import shutil, socket, ssl, subprocess, tempfile, time\n"
@@ -213,14 +178,16 @@ def test_l7_credential_inject_visible_on_httpbun(sdk_sandbox, sdk_e2e_config):
     )
 
     result = sdk_sandbox.run_command(
-        _http_json_command(
+        http_json_command(
             f"https://{HTTPBUN_HOST}/headers",
             timeout=L7_HTTP_TIMEOUT,
         ),
-        timeout=sdk_e2e_config.command_timeout,
+        timeout=l7_command_timeout(sdk_e2e_config.command_timeout),
     )
     status, body = _parse_status_and_body(result)
-    assert status == 200, f"expected 200 from httpbun; status={status} body={body[:200]!r}"
+    assert status == 200, (
+        f"expected 200 from httpbun; status={status} body={body[:200]!r}"
+    )
     headers = _headers_from_httpbun(body, status=status)
     assert _header_ci(headers, INJECT_HEADER) == INJECT_SECRET, (
         f"injected header {INJECT_HEADER!r} missing or wrong; headers={headers!r}"
@@ -267,11 +234,11 @@ def test_l7_credential_inject_visible_on_httpbun(sdk_sandbox, sdk_e2e_config):
 def test_l7_first_match_wins(sdk_sandbox, sdk_e2e_config):
     """CubeEgress walks rules in order; first match decides allow/deny."""
     allowed = sdk_sandbox.run_command(
-        _http_json_command(
+        http_json_command(
             f"https://{HTTPBUN_HOST}/headers",
             timeout=L7_HTTP_TIMEOUT,
         ),
-        timeout=sdk_e2e_config.command_timeout,
+        timeout=l7_command_timeout(sdk_e2e_config.command_timeout),
     )
     status, body = _parse_status_and_body(allowed)
     assert status == 200, (
@@ -279,11 +246,11 @@ def test_l7_first_match_wins(sdk_sandbox, sdk_e2e_config):
     )
 
     denied = sdk_sandbox.run_command(
-        _http_json_command(
+        http_json_command(
             f"https://{HTTPBUN_HOST}/get",
             timeout=L7_HTTP_TIMEOUT,
         ),
-        timeout=sdk_e2e_config.command_timeout,
+        timeout=l7_command_timeout(sdk_e2e_config.command_timeout),
     )
     status, body = _parse_status_and_body(denied)
     assert status == 403, (
@@ -315,21 +282,21 @@ def test_l7_first_match_wins(sdk_sandbox, sdk_e2e_config):
 def test_l7_deny_and_unmatched_are_blocked(sdk_sandbox, sdk_e2e_config):
     """Explicit deny and no-rule-match both return HTTP 403."""
     ok = sdk_sandbox.run_command(
-        _http_json_command(
+        http_json_command(
             f"https://{HTTPBUN_HOST}/headers",
             timeout=L7_HTTP_TIMEOUT,
         ),
-        timeout=sdk_e2e_config.command_timeout,
+        timeout=l7_command_timeout(sdk_e2e_config.command_timeout),
     )
     status, _ = _parse_status_and_body(ok)
     assert status == 200
 
     explicit_deny = sdk_sandbox.run_command(
-        _http_json_command(
+        http_json_command(
             f"https://{HTTPBUN_HOST}/anything",
             timeout=L7_HTTP_TIMEOUT,
         ),
-        timeout=sdk_e2e_config.command_timeout,
+        timeout=l7_command_timeout(sdk_e2e_config.command_timeout),
     )
     status, body = _parse_status_and_body(explicit_deny)
     assert status == 403, (
@@ -337,11 +304,11 @@ def test_l7_deny_and_unmatched_are_blocked(sdk_sandbox, sdk_e2e_config):
     )
 
     unmatched = sdk_sandbox.run_command(
-        _http_json_command(
+        http_json_command(
             f"https://{HTTPBUN_HOST}/get",
             timeout=L7_HTTP_TIMEOUT,
         ),
-        timeout=sdk_e2e_config.command_timeout,
+        timeout=l7_command_timeout(sdk_e2e_config.command_timeout),
     )
     status, body = _parse_status_and_body(unmatched)
     assert status == 403, (
@@ -369,7 +336,7 @@ def test_l7_tls_mitm_issuer_is_cube_egress_ca(sdk_sandbox, sdk_e2e_config):
     """Peer cert issuer is CubeEgress CA after SNI-layer MITM (needs openssl)."""
     result = sdk_sandbox.run_command(
         _tls_issuer_command(HTTPBUN_HOST, timeout=L7_HTTP_TIMEOUT),
-        timeout=sdk_e2e_config.command_timeout,
+        timeout=l7_command_timeout(sdk_e2e_config.command_timeout),
     )
     assert_command_ok(result)
     line = result.stdout.strip()
@@ -384,7 +351,7 @@ def test_l7_tls_mitm_issuer_is_cube_egress_ca(sdk_sandbox, sdk_e2e_config):
     )
     # Accept the configured CN, or any CubeEgress-style CA subject.
     mitm_ok = MITM_CA_CN in issuer or bool(
-        re.search(r"Cube\s*Sandbox\s+Egress", issuer, re.I)
+        re.search(r"Cube\s*Sandbox\s+Egress", issuer, re.IGNORECASE)
     )
     assert mitm_ok, (
         f"peer certificate issuer should be CubeEgress MITM CA "
@@ -415,11 +382,11 @@ def test_l7_tls_mitm_issuer_is_cube_egress_ca(sdk_sandbox, sdk_e2e_config):
 def test_l7_sni_host_match_allow_and_deny(sdk_sandbox, sdk_e2e_config):
     """match.sni/host allow one destination and deny another."""
     allowed = sdk_sandbox.run_command(
-        _http_json_command(
+        http_json_command(
             f"https://{HTTPBUN_HOST}/headers",
             timeout=L7_HTTP_TIMEOUT,
         ),
-        timeout=sdk_e2e_config.command_timeout,
+        timeout=l7_command_timeout(sdk_e2e_config.command_timeout),
     )
     status, body = _parse_status_and_body(allowed)
     assert status == 200, (
@@ -427,11 +394,11 @@ def test_l7_sni_host_match_allow_and_deny(sdk_sandbox, sdk_e2e_config):
     )
 
     denied = sdk_sandbox.run_command(
-        _http_json_command(
+        http_json_command(
             f"https://{OTHER_HOST}/",
             timeout=L7_HTTP_TIMEOUT,
         ),
-        timeout=sdk_e2e_config.command_timeout,
+        timeout=l7_command_timeout(sdk_e2e_config.command_timeout),
     )
     status, body = _parse_status_and_body(denied)
     assert status == 403, (

--- a/tests/e2e/sdk_compat/framework/l7_egress.py
+++ b/tests/e2e/sdk_compat/framework/l7_egress.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared L7 egress command helpers."""
+
+from __future__ import annotations
+
+import os
+
+L7_HTTP_TIMEOUT = int(os.environ.get("SDK_E2E_L7_HTTP_TIMEOUT", "15"))
+L7_ATTEMPTS = 3
+L7_BLOCKING_PHASES_PER_ATTEMPT = 4
+L7_COMMAND_MARGIN = 5
+
+
+def l7_command_timeout(
+    configured_timeout: int,
+    *,
+    request_timeout: int = L7_HTTP_TIMEOUT,
+    attempts: int = L7_ATTEMPTS,
+) -> int:
+    backoff_budget = sum(min(2**attempt, 5) for attempt in range(attempts - 1))
+    request_budget = request_timeout * L7_BLOCKING_PHASES_PER_ATTEMPT * attempts
+    margin = max(L7_COMMAND_MARGIN, request_timeout)
+    retry_budget = request_budget + backoff_budget + margin
+    return max(configured_timeout, retry_budget)
+
+
+def http_json_command(
+    url: str,
+    *,
+    method: str = "GET",
+    timeout: int = L7_HTTP_TIMEOUT,
+    attempts: int = L7_ATTEMPTS,
+    backoff_enabled: bool = True,
+) -> str:
+    """Fetch a URL, retrying transport failures and non-policy 502/504 responses."""
+    return (
+        "python3 - <<'PY'\n"
+        "import ssl, time, urllib.error, urllib.request\n"
+        f"url = {url!r}\n"
+        f"method = {method!r}\n"
+        f"timeout = {timeout!r}\n"
+        f"attempts = {attempts!r}\n"
+        f"backoff_enabled = {backoff_enabled!r}\n"
+        "ctx = ssl._create_unverified_context()\n"
+        "last = None\n"
+        "for attempt in range(attempts):\n"
+        "    try:\n"
+        "        req = urllib.request.Request(url, method=method)\n"
+        "        with urllib.request.urlopen(req, context=ctx, timeout=timeout) as resp:\n"
+        "            body = resp.read().decode('utf-8', errors='replace')\n"
+        "            print(f'STATUS:{resp.status}')\n"
+        "            print(body)\n"
+        "        break\n"
+        "    except urllib.error.HTTPError as exc:\n"
+        "        if exc.code in (502, 504) and attempt + 1 < attempts:\n"
+        "            exc.close()\n"
+        "            if backoff_enabled:\n"
+        "                time.sleep(min(2 ** attempt, 5))\n"
+        "            continue\n"
+        "        try:\n"
+        "            body = exc.read().decode('utf-8', errors='replace')\n"
+        "        except Exception as body_exc:\n"
+        "            body = f'<failed to read response body: {body_exc}>'\n"
+        "        print(f'STATUS:{exc.code}')\n"
+        "        print(body)\n"
+        "        break\n"
+        "    except Exception as exc:\n"
+        "        last = exc\n"
+        "        if attempt + 1 < attempts and backoff_enabled:\n"
+        "            time.sleep(min(2 ** attempt, 5))\n"
+        "else:\n"
+        "    print(f'ERROR:{type(last).__name__}:{last}')\n"
+        "PY"
+    )


### PR DESCRIPTION
## Summary

- retry transient L7 gateway responses (502/504) and transport failures with bounded backoff
- budget the outer command timeout for connect, TLS handshake, response headers, body reads, retry delays, and timeout-scaled headroom
- keep retry helpers in `framework.l7_egress` and cover retry bounds with hermetic framework tests
- keep simulated connection resets quiet so successful tests do not emit server tracebacks

## Test plan

- `PYTHONPATH=tests/e2e/sdk_compat python3 -m pytest -q tests/e2e/sdk_compat/cases/framework/test_l7_egress_retry.py`
- verify the pytest command emits no stderr for simulated transport failures
- `python3 -m ruff format --check tests/e2e/sdk_compat/framework/l7_egress.py tests/e2e/sdk_compat/cases/framework/test_l7_egress_retry.py tests/e2e/sdk_compat/cases/network/test_l7_egress.py`
- joint pytest collection of framework and network L7 modules

## CI notes

`Format Check` / `Code Format Check` is path-filtered to Go, Rust, Makefile, web, and workflow changes, so this Python-only PR does not trigger that workflow.