### PR TITLE
fix(cubelet): name sandbox TAPs after IPv4 and reject oversize names

### DIFF
--- a/Cubelet/network/plugin_tap_create_test.go
+++ b/Cubelet/network/plugin_tap_create_test.go
@@ -54,7 +54,7 @@ func (c *fakeNetworkRuntime) EnsureNetwork(_ context.Context, req *networkruntim
 		NetworkHandle: "sandbox-1",
 		Interfaces: []networkruntime.Interface{
 			{
-				Name:    "z192.168.0.40",
+				Name:    "192.168.0.40",
 				MAC:     "20:90:6f:fc:fc:fc",
 				MTU:     1500,
 				IPs:     []string{"169.254.68.6/30"},
@@ -170,7 +170,7 @@ func TestTapCreateWithNetworkRuntimeCallsEnsureNetwork(t *testing.T) {
 		t.Fatal("network runtime ReleaseNetwork was called despite successful Create")
 	}
 	shimInfo, ok := opts.NetworkInfo.(*networktypes.ShimNetReq)
-	if !ok || shimInfo == nil || len(shimInfo.Interfaces) != 1 || shimInfo.Interfaces[0].Name != "z192.168.0.40" {
+	if !ok || shimInfo == nil || len(shimInfo.Interfaces) != 1 || shimInfo.Interfaces[0].Name != "192.168.0.40" {
 		t.Fatalf("NetworkInfo not populated from runtime response: %+v", opts.NetworkInfo)
 	}
 }

--- a/Cubelet/network/runtime/controller.go
+++ b/Cubelet/network/runtime/controller.go
@@ -221,7 +221,7 @@ func newProductionControllerDeps(cfg Config) (networkControllerDeps, error) {
 		device:            device,
 		cubeDev:           cubeDev,
 		cubeRouter:        cubeRouter,
-		tapAdapter:        newRealTapDeviceAdapter(),
+		tapAdapter:        newRealTapDeviceAdapter(cfg.CIDR),
 		cubevsAdapter:     newRealCubeVSAdapter(),
 		cubeEgressAdapter: newCubeEgressAdapterFromConfig(cfg),
 	}, nil

--- a/Cubelet/network/runtime/startup_recover.go
+++ b/Cubelet/network/runtime/startup_recover.go
@@ -777,16 +777,24 @@ func (s *NetworkController) claimRecoveredSuccessResources(state *managedState) 
 // uniquely from the IP, so no other goroutine can re-reference this tap between
 // the check and the destroy.
 //
-// Lookup is by deterministic tap name (RTM_GETLINK), not LinkList. A full dump
-// of every host interface on every pool-miss create races with concurrent TAP
-// churn and surfaces as netlink ErrDumpInterrupted under density load.
+// Lookup is by the current TAP name then the legacy z-prefixed name
+// (RTM_GETLINK), not LinkList. A full dump of every host interface on every
+// pool-miss create races with concurrent TAP churn and surfaces as netlink
+// ErrDumpInterrupted under density load.
 func (s *NetworkController) cleanupConflictingTap(ip net.IP) error {
-	tap, err := s.tapAdapter.GetByName(tapName(ip.String()))
-	if err != nil {
-		if isTapNotFound(err) {
-			return nil
+	var tap *tapDevice
+	for _, name := range candidateTapNames(ip.String()) {
+		found, err := s.tapAdapter.GetByName(name)
+		if err != nil {
+			if isTapNotFound(err) {
+				continue
+			}
+			return err
 		}
-		return err
+		if found != nil {
+			tap = found
+			break
+		}
 	}
 	if tap == nil {
 		return nil

--- a/Cubelet/network/runtime/tap_device.go
+++ b/Cubelet/network/runtime/tap_device.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/tencentcloud/CubeSandbox/CubeNet/cubevs"
@@ -52,8 +53,9 @@ var unixIoctlSetTunOffload = func(fd int, features uintptr) error {
 var enableTapTXTCPMangleIDSegmentation = enableTXTCPMangleIDSegmentation
 
 const (
-	// TAP names are derived from sandbox IPs so recovery can match live devices
-	// back to allocator addresses without a separate registry.
+	// TAP names are the sandbox IPv4 so recovery can match live devices back to
+	// allocator addresses without a separate registry. Older runtimes prefixed
+	// the same IP with tapNamePrefix; recover still accepts those names.
 	tapNamePrefix    = "z"
 	virtioNetHdrSize = 12
 	tunDevicePath    = "/dev/net/tun"
@@ -87,11 +89,20 @@ type TapDeviceAdapter interface {
 }
 
 // realTapDeviceAdapter forwards calls to the Linux TAP implementation below.
-type realTapDeviceAdapter struct{}
+type realTapDeviceAdapter struct {
+	sandboxCIDR *net.IPNet
+}
 
-// newRealTapDeviceAdapter returns the production TAP adapter.
-func newRealTapDeviceAdapter() TapDeviceAdapter {
-	return realTapDeviceAdapter{}
+// newRealTapDeviceAdapter returns the production TAP adapter. sandboxCIDR
+// limits recover/list to TAP names whose decoded IPv4 sits in the configured
+// sandbox network; devices outside that prefix are treated as unrelated host
+// TAPs. If cidr does not parse, listCubeTaps claims no devices.
+func newRealTapDeviceAdapter(cidr string) TapDeviceAdapter {
+	var sandboxCIDR *net.IPNet
+	if _, n, err := net.ParseCIDR(cidr); err == nil {
+		sandboxCIDR = n
+	}
+	return realTapDeviceAdapter{sandboxCIDR: sandboxCIDR}
 }
 
 func (realTapDeviceAdapter) Create(ip net.IP, mvmMacAddr string, mtu, cubeDevIdx int) (*tapDevice, error) {
@@ -110,12 +121,12 @@ func (realTapDeviceAdapter) Close(file *os.File) {
 	closeTapFile(file)
 }
 
-func (realTapDeviceAdapter) List() (map[string]*tapDevice, error) {
-	return listCubeTaps()
+func (a realTapDeviceAdapter) List() (map[string]*tapDevice, error) {
+	return listCubeTaps(a.sandboxCIDR)
 }
 
-func (realTapDeviceAdapter) GetByName(name string) (*tapDevice, error) {
-	return getTapByName(name)
+func (a realTapDeviceAdapter) GetByName(name string) (*tapDevice, error) {
+	return getTapByName(name, a.sandboxCIDR)
 }
 
 func (realTapDeviceAdapter) Destroy(ifIdx int) error {
@@ -301,8 +312,10 @@ func restoreTap(tap *tapDevice, mtu int, mvmMacAddr string, cubeDevIdx int) (*ta
 }
 
 // listCubeTaps returns live TAP devices whose names follow the runtime's
-// IP-derived naming convention, keyed by sandbox IP string.
-func listCubeTaps() (map[string]*tapDevice, error) {
+// IP-derived naming convention (bare IPv4 or legacy z+IPv4), keyed by sandbox
+// IP string. When sandboxCIDR is set, names that decode to an address outside
+// that prefix are ignored.
+func listCubeTaps(sandboxCIDR *net.IPNet) (map[string]*tapDevice, error) {
 	links, err := netlinkLinkList()
 	if err != nil {
 		return nil, err
@@ -313,12 +326,11 @@ func listCubeTaps() (map[string]*tapDevice, error) {
 		if !ok || tap.Mode != netlink.TUNTAP_MODE_TAP {
 			continue
 		}
-		ipStr, err := extractIP(tap.Name)
+		ip, err := parseCubeTapIP(tap.Name)
 		if err != nil {
 			continue
 		}
-		ip := net.ParseIP(ipStr).To4()
-		if ip == nil {
+		if sandboxCIDR == nil || !sandboxCIDR.Contains(ip) {
 			continue
 		}
 		ipToTap[ip.String()] = &tapDevice{
@@ -341,7 +353,7 @@ func isTapNotFound(err error) bool {
 }
 
 // getTapByName returns identity for one runtime-managed TAP by name.
-func getTapByName(name string) (*tapDevice, error) {
+func getTapByName(name string, sandboxCIDR *net.IPNet) (*tapDevice, error) {
 	link, err := netlinkLinkByName(name)
 	if err != nil {
 		return nil, err
@@ -350,13 +362,12 @@ func getTapByName(name string) (*tapDevice, error) {
 	if !ok {
 		return nil, fmt.Errorf("%s is not tap", name)
 	}
-	ipStr, err := extractIP(tap.Name)
+	ip, err := parseCubeTapIP(tap.Name)
 	if err != nil {
 		return nil, err
 	}
-	ip := net.ParseIP(ipStr).To4()
-	if ip == nil {
-		return nil, fmt.Errorf("invalid tap ip for %s", name)
+	if sandboxCIDR != nil && !sandboxCIDR.Contains(ip) {
+		return nil, fmt.Errorf("not cube tap: %s", name)
 	}
 	return &tapDevice{
 		Name:  tap.Name,
@@ -444,14 +455,30 @@ func deletePersistentTapByName(name string) error {
 }
 
 // tapName derives the deterministic host TAP name for a sandbox IP.
+// New devices use the dotted IPv4; that string is at most 15 bytes and always
+// fits in kernel IFNAMSIZ (16 including the trailing NUL).
 func tapName(ip string) string {
+	return ip
+}
+
+// legacyTapName is the pre-rename host TAP name (z + IPv4). Recover and
+// conflict cleanup still look this up; new creates never use it.
+func legacyTapName(ip string) string {
 	return tapNamePrefix + ip
 }
 
-// extractIP reverses tapName and rejects unrelated host TAP devices.
-func extractIP(name string) (string, error) {
-	if len(name) <= len(tapNamePrefix) || name[:len(tapNamePrefix)] != tapNamePrefix {
-		return "", fmt.Errorf("not cube tap: %s", name)
+// candidateTapNames is the lookup order for an allocated sandbox IP: the
+// current name first, then the leftover z-prefixed device after upgrade.
+func candidateTapNames(ip string) []string {
+	return []string{tapName(ip), legacyTapName(ip)}
+}
+
+// parseCubeTapIP reverses tapName / legacyTapName. A leftover z prefix is
+// stripped and the remainder is parsed as IPv4.
+func parseCubeTapIP(name string) (net.IP, error) {
+	ip := net.ParseIP(strings.TrimPrefix(name, tapNamePrefix)).To4()
+	if ip == nil {
+		return nil, fmt.Errorf("not cube tap: %s", name)
 	}
-	return name[len(tapNamePrefix):], nil
+	return ip, nil
 }

--- a/Cubelet/network/runtime/tap_device_test.go
+++ b/Cubelet/network/runtime/tap_device_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"errors"
+	"net"
 	"testing"
 
 	"github.com/vishvananda/netlink"
@@ -156,5 +157,97 @@ func TestDestroyTapPolicyCleanupFailureDoesNotFailDestroy(t *testing.T) {
 
 	if err := destroyTap(99); err != nil {
 		t.Fatalf("destroyTap error=%v, want nil when only policy cleanup fails", err)
+	}
+}
+
+func TestTapNameIsBareIPv4(t *testing.T) {
+	if got := tapName("192.168.195.183"); got != "192.168.195.183" {
+		t.Fatalf("tapName=%q, want bare IPv4", got)
+	}
+}
+
+func TestParseCubeTapIPAcceptsCurrentAndLegacyNames(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "192.168.0.10", want: "192.168.0.10"},
+		{name: "z192.168.0.10", want: "192.168.0.10"},
+		{name: "10.1.2.3", want: "10.1.2.3"},
+		{name: "z10.1.2.3", want: "10.1.2.3"},
+	}
+	for _, tc := range cases {
+		got, err := parseCubeTapIP(tc.name)
+		if err != nil {
+			t.Fatalf("parseCubeTapIP(%q): %v", tc.name, err)
+		}
+		if got.String() != tc.want {
+			t.Fatalf("parseCubeTapIP(%q)=%s, want %s", tc.name, got, tc.want)
+		}
+	}
+	for _, name := range []string{"eth0", "zeth0", "cube-dev", "zz192.168.0.1", "2001:db8::1"} {
+		if _, err := parseCubeTapIP(name); err == nil {
+			t.Fatalf("parseCubeTapIP(%q) succeeded, want error", name)
+		}
+	}
+}
+
+func TestCandidateTapNamesCurrentThenLegacy(t *testing.T) {
+	got := candidateTapNames("192.168.0.10")
+	want := []string{"192.168.0.10", "z192.168.0.10"}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("candidateTapNames=%v, want %v", got, want)
+	}
+}
+
+func TestListCubeTapsAcceptsBothNamesAndFiltersCIDR(t *testing.T) {
+	origList := netlinkLinkList
+	t.Cleanup(func() { netlinkLinkList = origList })
+	netlinkLinkList = func() ([]netlink.Link, error) {
+		return []netlink.Link{
+			&netlink.Tuntap{
+				LinkAttrs: netlink.LinkAttrs{Name: "z192.168.0.10", Index: 10},
+				Mode:      netlink.TUNTAP_MODE_TAP,
+			},
+			&netlink.Tuntap{
+				LinkAttrs: netlink.LinkAttrs{Name: "192.168.0.11", Index: 11},
+				Mode:      netlink.TUNTAP_MODE_TAP,
+			},
+			&netlink.Tuntap{
+				LinkAttrs: netlink.LinkAttrs{Name: "10.0.0.1", Index: 12},
+				Mode:      netlink.TUNTAP_MODE_TAP,
+			},
+			&netlink.Tuntap{
+				LinkAttrs: netlink.LinkAttrs{Name: "eth0", Index: 13},
+				Mode:      netlink.TUNTAP_MODE_TAP,
+			},
+			&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "192.168.0.12", Index: 14}},
+		}, nil
+	}
+
+	_, cidr, err := net.ParseCIDR("192.168.0.0/18")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := listCubeTaps(cidr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("listCubeTaps got %d devices: %+v", len(got), got)
+	}
+	if tap := got["192.168.0.10"]; tap == nil || tap.Name != "z192.168.0.10" || tap.Index != 10 {
+		t.Fatalf("legacy z+IP tap: %+v", tap)
+	}
+	if tap := got["192.168.0.11"]; tap == nil || tap.Name != "192.168.0.11" || tap.Index != 11 {
+		t.Fatalf("current IP tap: %+v", tap)
+	}
+
+	empty, err := listCubeTaps(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("nil CIDR must not claim host TAPs, got %+v", empty)
 	}
 }

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -2293,7 +2293,9 @@ ip_int_to_dot() {
 is_cube_tap_netdev() {
   local iface="$1"
   iface="${iface%%@*}"
-  [[ "${iface}" =~ ^z[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]
+  # Current: dotted IPv4. Legacy: z + IPv4 (names that still fit IFNAMSIZ).
+  [[ "${iface}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || [[ "${iface}" =~ ^z[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]
 }
 
 is_cube_managed_netdev() {
@@ -2363,7 +2365,8 @@ _check_cidr_conflict() {
       continue
     fi
     # Other cube-managed devices, including the optional cube-router and
-    # persistent TAP devices named "z<ipv4>", are also deployment residue.
+    # persistent TAP devices named "<ipv4>" (legacy "z<ipv4>"), are also
+    # deployment residue.
     if is_cube_managed_netdev "${iface_name}"; then
       continue
     fi
@@ -2517,7 +2520,7 @@ _check_cidr_conflict() {
       die "${cidr_label} '${cidr}' overlaps an existing cube-dev network (${cd_network}/${cd_mask}).
 
   Changing the sandbox CIDR on a host that already has a cube network is
-  disruptive: the old cube-dev and the persistent z* TAP devices are left
+  disruptive: the old cube-dev and the persistent TAP devices are left
   stale. A reboot alone is NOT enough -- the systemd target is enabled and
   cubelet's embedded network runtime rebuilds the old network from config.toml on boot.
 
@@ -2525,7 +2528,9 @@ _check_cidr_conflict() {
     sudo systemctl stop 'cube-sandbox-*.target'
     sudo ip link delete cube-dev 2>/dev/null || true
     sudo ip link delete cube-router 2>/dev/null || true
-    ip tuntap show | awk -F: '/^z[0-9]+\\./{print \$1}' \\
+    ip tuntap show | awk -F: '
+      \$1 ~ /^(z)?[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\$/ { print \$1 }
+    ' \\
       | xargs -r -n1 -I{} sudo ip tuntap del dev {} mode tap
   then re-run install with the new CIDR.
 


### PR DESCRIPTION
The z+IPv4 scheme produced 16-byte names (e.g. z192.168.195.183). vishvananda/netlink LinkAdd copies into ifr_name[:15] and truncates silently, so create could succeed while later open/query used a different string than the kernel device.

New creates use the dotted IPv4. Recover still accepts leftover z-prefixed names when the decoded address is in the configured sandbox CIDR. Create fails before LinkAdd if the name is >= IFNAMSIZ.