### PR TITLE
feat(kubernetes): add hostNetwork toggle for cube-node DaemonSet

### DIFF
--- a/deploy/kubernetes/chart/templates/node-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-daemonset.yaml
@@ -26,8 +26,11 @@ spec:
       serviceAccountName: {{ include "cube.nodeServiceAccountName" . }}
       automountServiceAccountToken: true
       hostPID: {{ .Values.security.hostPID }}
+      hostNetwork: {{ .Values.cubeNode.hostNetwork }}
       terminationGracePeriodSeconds: {{ .Values.cubeNode.terminationGracePeriodSeconds }}
-      dnsPolicy: ClusterFirst
+      # With hostNetwork the Pod shares the host netns; ClusterFirstWithHostNet
+      # keeps in-cluster DNS working from the host network namespace.
+      dnsPolicy: {{ if .Values.cubeNode.hostNetwork }}ClusterFirstWithHostNet{{ else }}ClusterFirst{{ end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -553,6 +553,13 @@ cubeNode:
   # cubelet pidfile; containerd-shim-cube-rs / microVMs are left alone.
   terminationGracePeriodSeconds: 30
 
+  # Run cube-node on the host network (hostNetwork: true, dnsPolicy becomes
+  # ClusterFirstWithHostNet). The Pod then shares the host netns, so sandbox
+  # network devices survive cube-node Pod recreation. Trade-offs: cube-node
+  # loses its CNI-assigned Pod identity (Kubernetes NetworkPolicy can no longer
+  # govern sandbox traffic) and cubelet ports (9998/9999/9966) bind on the host.
+  hostNetwork: false
+
   # Stable NodeID = Kubernetes node name (CUBE_SANDBOX_NODE_ID).
   # Endpoint = status.podIP (CUBE_SANDBOX_ENDPOINT_IP).
   nodeIDSource: specNodeName
@@ -988,7 +995,8 @@ bootstrap:
         size: 25G
 
 security:
-  # cube-node always uses the Pod network; no hostNetwork toggle.
+  # cube-node host network is controlled by cubeNode.hostNetwork (default
+  # false = Pod network).
   hostPID: true
   privileged: true
 


### PR DESCRIPTION
## What

Adds a `cubeNode.hostNetwork` toggle (default `false`) to the Helm chart for the cube-node DaemonSet.

## Why

When enabled, cube-node runs on the host network namespace so sandbox network devices survive cube-node Pod recreation. The `dnsPolicy` switches to `ClusterFirstWithHostNet` to keep in-cluster DNS working from the host network namespace.

## Trade-offs

- cube-node loses its CNI-assigned Pod identity — Kubernetes NetworkPolicy can no longer govern sandbox traffic.
- cubelet ports (9998/9999/9966) bind directly on the host.

## Changes

- `deploy/kubernetes/chart/templates/node-daemonset.yaml`: add `hostNetwork` field and conditional `dnsPolicy`.
- `deploy/kubernetes/chart/values.yaml`: add `cubeNode.hostNetwork` config with usage notes.

## Behavior

Default behavior is unchanged (`hostNetwork: false`, `dnsPolicy: ClusterFirst`).
