### PR TITLE
chore(one-click): make compute-node S3 config non-blocking

### DIFF
--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -278,10 +278,18 @@ ONE_CLICK_DEPLOY_ROLE=compute
 ONE_CLICK_CONTROL_PLANE_IP=10.0.0.11
 ```
 
-If the control node runs bundled MinIO (or any S3 backend), also copy `CUBE_S3_*`
-from that node's `.one-click.env` so the volume plugin can reach the same store.
-Compute nodes never deploy MinIO; they only consume `CUBE_S3_*`. Allow TCP 9000
-from compute to the control node when using bundled MinIO.
+If the control node runs bundled MinIO (or any S3 backend), copy `CUBE_S3_*` from
+that node's runtime env file so the volume plugin reaches the same store:
+
+```bash
+# Run on the control node; paste the output into the compute node's .env
+grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+```
+
+Compute nodes never deploy MinIO; they only consume `CUBE_S3_*`. These values are
+optional but strongly recommended: if missing, the installer prints a prominent
+warning and continues; the S3 volume plugin stays disabled until configured. Allow
+TCP 9000 from compute to the control node when using bundled MinIO.
 
 If you need to explicitly specify the compute node IP, or if the default NIC on the target machine is not `eth0`, also set:
 
@@ -403,8 +411,16 @@ CUBE_S3_BUCKET=cube-volumes
 ```
 
 Compute nodes never run MinIO. Copy the filled `CUBE_S3_*` values from the
-control node's `.one-click.env` into the compute `.env` (and allow TCP 9000
-from compute to the control node if you are using bundled MinIO):
+control node's runtime env file into the compute `.env`:
+
+```bash
+# Run on the control node; paste the output into the compute node's .env
+grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+```
+
+These values are optional but strongly recommended — if missing, the installer
+warns and continues; the S3 volume plugin stays disabled until configured. Allow
+TCP 9000 from compute to the control node if using bundled MinIO:
 
 ```bash
 ONE_CLICK_DEPLOY_ROLE=compute

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -246,9 +246,14 @@ ONE_CLICK_DEPLOY_ROLE=compute
 ONE_CLICK_CONTROL_PLANE_IP=10.0.0.11
 ```
 
-若控制节点用了内置 MinIO（或任何 S3 后端），再把该节点 `.one-click.env` 里的
-`CUBE_S3_*` 拷过来。计算节点不部署 MinIO，只消费 `CUBE_S3_*`。用内置 MinIO 时
-还需放行计算节点到控制面的 TCP 9000。
+若控制节点用了内置 MinIO（或任何 S3 后端），建议把该节点回填的 `CUBE_S3_*` 拷过来：
+
+```bash
+# 在控制节点执行，把输出拷贝到计算节点 .env
+grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+```
+
+计算节点不部署 MinIO，只消费 `CUBE_S3_*`。该项可选但强烈建议——缺失时仅打印黄色警告并继续安装，S3 卷插件在补上配置并重装前不可用。用内置 MinIO 时还需放行计算节点到控制面的 TCP 9000。
 
 如需显式指定计算节点 IP，或目标机默认网卡不是 `eth0`，再额外设置：
 
@@ -358,8 +363,14 @@ CUBE_S3_BUCKET=cube-volumes
 # CUBE_S3_S3FS_EXTRA_OPTS=-ouse_path_request_style
 ```
 
-计算节点从不部署 MinIO。把控制节点 `.one-click.env` 里填好的 `CUBE_S3_*` 拷到
-计算节点 `.env`（若用内置 MinIO，还需放行控制面 TCP 9000）：
+计算节点从不部署 MinIO。建议把控制节点回填的 `CUBE_S3_*` 拷到计算节点 `.env`：
+
+```bash
+# 在控制节点执行，把输出拷贝到计算节点 .env
+grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+```
+
+该项可选但强烈建议——缺失时仅打印黄色警告并继续安装，S3 卷插件在补上配置并重装前不可用。用内置 MinIO 时还需放行控制面 TCP 9000。
 
 ```bash
 ONE_CLICK_DEPLOY_ROLE=compute

--- a/deploy/one-click/USER_GUIDE_zh.md
+++ b/deploy/one-click/USER_GUIDE_zh.md
@@ -69,7 +69,14 @@ ONE_CLICK_DEPLOY_ROLE=compute
 ONE_CLICK_CONTROL_PLANE_IP=10.0.0.11
 ```
 
-若要使用 S3 Volume，再从控制节点 `.one-click.env` 拷贝 `CUBE_S3_*`（计算节点不部署 MinIO）。
+可选但强烈建议：若要使用 S3 Volume，把控制节点回填的 `CUBE_S3_*` 拷到计算节点 `.env`：
+
+```bash
+# 在控制节点执行，把输出拷贝到计算节点 .env
+grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+```
+
+计算节点不部署 MinIO。缺失时仅打印黄色警告并继续安装，S3 卷插件在配置前不可用。
 
 如果要显式指定当前计算节点 IP，再补充：
 

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -99,10 +99,16 @@ WEB_UI_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1
 # CUBE_EXTERNAL_REDIS_SENTINEL_PASSWORD=
 
 # ---- Bundled MinIO (default on for control nodes) ----
-# These variables only deploy the MinIO container; the S3 volume plugin reads
-# CUBE_S3_* below. When MinIO is enabled, install.sh fills CUBE_S3_* from this
-# MinIO automatically. Compute nodes do not deploy MinIO; copy CUBE_S3_* from
-# the control node's .one-click.env.
+# CUBE_SANDBOX_MINIO_* only deploys the MinIO container. The S3 volume plugin
+# always reads CUBE_S3_* below.
+#   - Control node: when MinIO is enabled, install.sh fills CUBE_S3_* from it
+#     and persists them to /usr/local/services/cubetoolbox/.one-click.env.
+#     Leave CUBE_S3_* empty here.
+#   - Compute node: does not deploy MinIO. Copy CUBE_S3_* from the control
+#     node's file above:
+#       grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+#     Missing CUBE_S3_* only warns — the installer continues, and the S3
+#     volume plugin stays disabled until configured.
 CUBE_SANDBOX_MINIO_ENABLED=1
 # Optional init for the bundled MinIO. Empty password → install.sh generates
 # a 24-character secret and writes it to .one-click.env.
@@ -111,9 +117,11 @@ CUBE_SANDBOX_MINIO_ROOT_USER=cubeminio
 CUBE_SANDBOX_MINIO_BUCKET=cube-volumes
 
 # ---- S3 volume plugin (CUBE_S3_*; source of truth for volume-s3.conf) ----
-# Control node with MinIO: leave empty; install.sh fills these from MinIO.
-# Compute node or external S3 store: set all of them.
-# Control node that should not run MinIO: also set CUBE_SANDBOX_MINIO_ENABLED=0.
+#   - Control node with MinIO: leave empty (filled automatically).
+#   - Compute node or external S3 store: set all of them.
+#   - Control node that should not run MinIO: also set CUBE_SANDBOX_MINIO_ENABLED=0.
+# On a compute node these are optional but strongly recommended; if empty the
+# S3 volume plugin is unavailable (install warns and continues).
 # CUBE_S3_ENDPOINT=https://s3.example.com
 # CUBE_S3_ACCESS_KEY_ID=
 # CUBE_S3_SECRET_ACCESS_KEY=

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -1489,7 +1489,7 @@ check_cgroup_cpu_preflight
 check_bpf_fs_preflight
 check_glibc_preflight
 check_compute_control_plane_preflight
-check_compute_s3_required
+warn_compute_s3_missing
 
 CUBE_SANDBOX_NODE_IP="$(detect_node_ip)"
 export CUBE_SANDBOX_NODE_IP
@@ -1940,3 +1940,6 @@ fi
 
 log "install complete (role=${DEPLOY_ROLE})"
 print_path_hint
+# Re-print the missing-S3 warning last so an unconfigured compute node ends on
+# the remediation path (no-op for control role and for compute nodes with S3).
+warn_compute_s3_missing

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -20,6 +20,38 @@ die() {
   exit 1
 }
 
+# warn: print a prominent warning to stderr. Bold-yellow when stderr is a
+# terminal and color is not disabled (NO_COLOR unset/empty, TERM != dumb);
+# plain text otherwise, so log captures and CI/test `grep` stay clean. The
+# first line carries the [one-click] WARNING: prefix; continuation lines are
+# indented so commands (e.g. the S3 grep hint) stay copyable.
+warn() {
+  local color=0
+  if [[ -t 2 ]] && [[ -z "${NO_COLOR:-}" ]] && [[ "${TERM:-}" != "dumb" ]]; then
+    color=1
+  fi
+  local line first=1
+  while IFS= read -r line; do
+    # Blank separator lines stay blank (no continuation indent).
+    if [[ -z "${line}" ]]; then
+      printf '\n' >&2
+      continue
+    fi
+    if [[ "${first}" -eq 1 ]]; then
+      if [[ "${color}" -eq 1 ]]; then
+        printf '\033[1;33m[one-click] WARNING: %s\033[0m\n' "${line}" >&2
+      else
+        printf '%s\n' "[one-click] WARNING: ${line}" >&2
+      fi
+      first=0
+    elif [[ "${color}" -eq 1 ]]; then
+      printf '\033[1;33m  %s\033[0m\n' "${line}" >&2
+    else
+      printf '  %s\n' "${line}" >&2
+    fi
+  done <<<"$*"
+}
+
 # shellcheck source=../scripts/common/validation.sh
 source "${ONE_CLICK_DIR}/scripts/common/validation.sh"
 
@@ -1838,16 +1870,24 @@ check_minio_not_combined_with_user_s3() {
   die "CUBE_SANDBOX_MINIO_ENABLED=1 cannot be combined with CUBE_S3_ENDPOINT; set CUBE_SANDBOX_MINIO_ENABLED=0 to use an external S3 backend"
 }
 
-# check_compute_s3_required: fail fast when a compute node has no S3 backend
-# configured. Compute nodes never deploy MinIO (install.sh forces
+# warn_compute_s3_missing: warn (do not abort) when a compute node has no S3
+# backend configured. Compute nodes never deploy MinIO (install.sh forces
 # CUBE_SANDBOX_MINIO_ENABLED=0), so the volume plugin resolves the S3 store
-# solely from CUBE_S3_*. Those values must be copied verbatim from the control
-# node's .one-click.env (or point at an operator-managed S3-compatible store);
-# an empty endpoint leaves the volume plugin with no backend at runtime.
-check_compute_s3_required() {
-  [[ "$(one_click_deploy_role)" == "compute" ]] || return 0
+# solely from CUBE_S3_*. Installing without it is allowed, but the volume
+# plugin stays disabled until the values are provided and install is re-run.
+warn_compute_s3_missing() {
+  is_compute_role || return 0
   [[ -n "${CUBE_S3_ENDPOINT:-}" ]] && return 0
-  die "compute node requires CUBE_S3_ENDPOINT (the volume plugin hard-depends on S3): copy CUBE_S3_* from the control node's .one-click.env, or set CUBE_S3_ENDPOINT to an S3-compatible store"
+  warn "compute node has no CUBE_S3_* backend configured; the S3 volume
+plugin will stay disabled until you set one. To fix this:
+
+  1. On the control node, run: grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+     (empty output means the control node itself has no S3 backend)
+  2. Paste the output into this node's .env
+  3. Re-run: sudo ./install-compute.sh
+
+With bundled MinIO, also allow TCP 9000 from this node to the control node."
+  return 0
 }
 
 # Print KEY='value' so bash `source` of volume-s3.conf is safe. Apostrophes in

--- a/deploy/one-click/tests/test_minio_s3_guard.sh
+++ b/deploy/one-click/tests/test_minio_s3_guard.sh
@@ -4,7 +4,9 @@
 #
 # Unit tests for the MinIO / CUBE_S3_* mutex: a previous local-MinIO fill
 # must be allowed on upgrade; an operator-supplied external store must not
-# be combined with CUBE_SANDBOX_MINIO_ENABLED=1.
+# be combined with CUBE_SANDBOX_MINIO_ENABLED=1. Also covers the compute-node
+# missing-S3 warning (warn_compute_s3_missing warns instead of aborting) and
+# warn()'s plain-text output when stderr is not a TTY.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -47,19 +49,19 @@ expect_die() {
 
 expect_s3_ok() {
   local label="$1"
-  if ! check_compute_s3_required; then
+  if ! warn_compute_s3_missing; then
     fail "${label}: expected check to pass"
   fi
 }
 
-expect_s3_die() {
+expect_s3_warn() {
   local label="$1"
-  local err="${TMP_DIR}/s3.err"
-  if ( check_compute_s3_required ) >"${err}" 2>&1; then
-    fail "${label}: expected check to die"
+  local err="${TMP_DIR}/s3-warn.err"
+  if ! ( warn_compute_s3_missing ) >"${err}" 2>&1; then
+    fail "${label}: expected check to warn and return 0"
   fi
-  grep -Fq "CUBE_S3_ENDPOINT" "${err}" \
-    || fail "${label}: die message missing (got $(cat "${err}"))"
+  grep -Fq "no CUBE_S3_* backend configured" "${err}" \
+    || fail "${label}: warning message missing (got $(cat "${err}"))"
 }
 
 reset_minio_s3_vars() {
@@ -130,12 +132,22 @@ test_minio_disabled_external_endpoint_ok() {
   expect_ok "minio off + external endpoint"
 }
 
-test_compute_empty_s3_endpoint_dies() {
+test_compute_empty_s3_endpoint_warns() {
   reset_minio_s3_vars
   ONE_CLICK_DEPLOY_ROLE=compute
   CUBE_S3_ENDPOINT=""
-  expect_s3_die "compute + empty endpoint"
+  expect_s3_warn "compute + empty endpoint"
   unset ONE_CLICK_DEPLOY_ROLE
+}
+
+test_warn_plain_when_not_tty() {
+  local out
+  out="$(warn "hello" 2>&1 || true)"
+  grep -Fq "[one-click] WARNING: hello" <<<"${out}" \
+    || fail "warn must print plain text when stderr is not a TTY (got ${out})"
+  if grep -Fq $'\033' <<<"${out}"; then
+    fail "warn must not emit ANSI escapes when stderr is not a TTY (got ${out})"
+  fi
 }
 
 test_compute_set_s3_endpoint_ok() {
@@ -199,9 +211,10 @@ test_minio_enabled_local_endpoint_ok
 test_minio_enabled_old_ip_matching_credentials_ok
 test_minio_enabled_external_endpoint_dies
 test_minio_disabled_external_endpoint_ok
-test_compute_empty_s3_endpoint_dies
+test_compute_empty_s3_endpoint_warns
 test_compute_set_s3_endpoint_ok
 test_control_empty_s3_endpoint_ok
+test_warn_plain_when_not_tty
 s3cfg_get() {
   local conf="$1" key="$2"
   sed -n "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*/\1/p" \

--- a/docs/guide/multi-node-deploy.md
+++ b/docs/guide/multi-node-deploy.md
@@ -65,13 +65,12 @@ ONE_CLICK_DEPLOY_ROLE=compute
 CUBE_SANDBOX_NODE_IP=<current-node-ip>
 ONE_CLICK_CONTROL_PLANE_IP=<control-plane-ip>
 
-# CUBE_S3_* is required — the volume plugin hard-depends on S3. Compute nodes
-# never deploy MinIO, so copy these values from the control node's .one-click.env
-# (they must match exactly so the plugin resolves the same store). With the
-# bundled MinIO the block looks like:
+# CUBE_S3_*: optional but strongly recommended. If missing, install proceeds
+# with a warning and the S3 volume plugin stays disabled. See the tip below
+# for how to fetch the values. With the bundled MinIO this looks like:
 CUBE_S3_ENDPOINT=http://<control-plane-ip>:9000
-CUBE_S3_ACCESS_KEY_ID=<from control .one-click.env>
-CUBE_S3_SECRET_ACCESS_KEY=<from control .one-click.env>
+CUBE_S3_ACCESS_KEY_ID=<from control node>
+CUBE_S3_SECRET_ACCESS_KEY=<from control node>
 CUBE_S3_BUCKET=cube-volumes
 CUBE_S3_S3FS_EXTRA_OPTS=-ouse_path_request_style
 ```
@@ -81,10 +80,22 @@ CUBE_S3_S3FS_EXTRA_OPTS=-ouse_path_request_style
 | `ONE_CLICK_DEPLOY_ROLE` | Must be set to `compute` for compute-only nodes |
 | `CUBE_SANDBOX_NODE_IP` | This node's primary network interface IP |
 | `ONE_CLICK_CONTROL_PLANE_IP` | The control node's IP; automatically expanded to `<ip>:3010` for CubeOps node registration |
-| `CUBE_S3_*` | **Required.** The volume plugin hard-depends on S3. Compute nodes never deploy MinIO, so copy these from the control node's `.one-click.env` (or point them at your own S3-compatible store). With the bundled MinIO, also allow TCP 9000 from compute to the control node. |
+| `CUBE_S3_*` | Optional but strongly recommended. The volume plugin depends on S3; if missing, install warns and the S3 volume plugin stays disabled. See the tip below for how to fetch these values. |
 
-::: tip Enforced at install time
-`install-compute.sh` validates `CUBE_S3_ENDPOINT` before touching any local configuration and aborts if it is missing, instructing you to copy `CUBE_S3_*` from the control node. Set these variables before running the installer.
+::: tip Warns when missing
+`install-compute.sh` checks `CUBE_S3_ENDPOINT`; if it is missing the installer prints a prominent yellow warning and continues. The node deploys normally, but the **S3 volume plugin stays disabled** until you set `CUBE_S3_*` and re-run the installer.
+
+To fetch the `CUBE_S3_*` values backfilled on the control node:
+
+1. On the control node, run:
+   ```bash
+   grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+   ```
+   Empty output means the control node itself has no S3 backend configured.
+2. Paste the output into this node's `.env`.
+3. Re-run `sudo ./install-compute.sh`.
+
+With the bundled MinIO, also allow TCP 9000 from this node to the control node.
 :::
 
 You can also specify the CubeOps endpoint explicitly if it uses a non-default port:
@@ -290,7 +301,7 @@ Compute nodes use the same `.env` file format. The following variables are speci
 | `CUBE_SANDBOX_NETWORK_CIDR` | `192.168.0.0/18` (from `config.toml`) | cubevs local network CIDR. Should match the control-plane value. IPv4 CIDR format (e.g., `10.100.0.0/18`), mask range /16–/24. Auto-detected for host network conflicts at install time. |
 | `CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK` | `0` | Set to `1` to skip CIDR conflict detection (not recommended). |
 | `ONE_CLICK_RUN_QUICKCHECK` | `1` | Run health check after installation |
-| `CUBE_S3_*` | empty / filled by control MinIO | **Required.** Volume plugin is an S3 hard dependency. Copy from the control node's `.one-click.env`; `ENDPOINT` / `ACCESS_KEY_ID` / `SECRET_ACCESS_KEY` / `BUCKET` have no usable default. |
+| `CUBE_S3_*` | empty / filled by control MinIO | Optional but strongly recommended. The volume plugin depends on S3; if missing, install warns and the S3 volume plugin stays disabled. Copy from the control node's `/usr/local/services/cubetoolbox/.one-click.env` (fetch steps in Step 2 above); `ENDPOINT` / `ACCESS_KEY_ID` / `SECRET_ACCESS_KEY` / `BUCKET` have no usable default. |
 
 For the full configuration reference (build-time options, database, proxy, etc.), see [Self-Build Deployment — Configuration Reference](./self-build-deploy.md#configuration-reference).
 

--- a/docs/guide/node-operations.md
+++ b/docs/guide/node-operations.md
@@ -42,7 +42,12 @@ Adding a compute node means installing the compute-plane components and register
    ONE_CLICK_CONTROL_PLANE_IP=<control-plane-ip>
    ```
 
-3. Copy the `CUBE_S3_*` settings from the control node's `.one-click.env`, or configure another shared S3-compatible store.
+3. (Optional but strongly recommended) Copy `CUBE_S3_*` from the control node to this node's `.env`:
+   ```bash
+   # Run on the control node; paste the output into the compute node's .env
+   grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+   ```
+   Or point at another shared S3-compatible store. If missing, the installer warns and continues, but the S3 volume plugin stays disabled; you'll be reminded again when install finishes.
 4. Install the compute node:
 
    ```bash

--- a/docs/guide/s3-volume.md
+++ b/docs/guide/s3-volume.md
@@ -101,7 +101,15 @@ CUBE_S3_BUCKET=cube-volumes
 # CUBE_S3_S3FS_EXTRA_OPTS=-ouse_path_request_style
 ```
 
-Compute nodes don't run MinIO; just copy the `CUBE_S3_*` from the control node's `.one-click.env`. See [one-click README · Bundled MinIO vs the S3 volume plugin](https://github.com/TencentCloud/CubeSandbox/blob/master/deploy/one-click/README.md#bundled-minio-vs-the-s3-volume-plugin).
+Compute nodes don't run MinIO; copy the `CUBE_S3_*` backfilled on the control node:
+
+```bash
+# Run on the control node; paste the output into the compute node's .env
+grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+```
+
+If missing, the installer warns and continues; the S3 volume plugin stays
+unavailable. See [one-click README · Bundled MinIO vs the S3 volume plugin](https://github.com/TencentCloud/CubeSandbox/blob/master/deploy/one-click/README.md#bundled-minio-vs-the-s3-volume-plugin).
 
 ### Helm deploy
 

--- a/docs/zh/guide/multi-node-deploy.md
+++ b/docs/zh/guide/multi-node-deploy.md
@@ -65,12 +65,11 @@ ONE_CLICK_DEPLOY_ROLE=compute
 CUBE_SANDBOX_NODE_IP=<当前节点IP>
 ONE_CLICK_CONTROL_PLANE_IP=<控制节点IP>
 
-# CUBE_S3_* 必填——Volume 插件强制依赖 S3。计算节点不部署 MinIO，
-# 请把控制节点 .one-click.env 中的 CUBE_S3_* 原样拷贝（必须与控制节点一致，
-# 插件才能解析到同一个存储）。内置 MinIO 时形如：
+# CUBE_S3_*：可选但强烈建议。缺失时仅告警并继续安装，S3 卷插件不可用。
+# 取值方式见下方提示。内置 MinIO 时形如：
 CUBE_S3_ENDPOINT=http://<控制节点IP>:9000
-CUBE_S3_ACCESS_KEY_ID=<取自控制节点 .one-click.env>
-CUBE_S3_SECRET_ACCESS_KEY=<取自控制节点 .one-click.env>
+CUBE_S3_ACCESS_KEY_ID=<取自控制节点>
+CUBE_S3_SECRET_ACCESS_KEY=<取自控制节点>
 CUBE_S3_BUCKET=cube-volumes
 CUBE_S3_S3FS_EXTRA_OPTS=-ouse_path_request_style
 ```
@@ -80,10 +79,22 @@ CUBE_S3_S3FS_EXTRA_OPTS=-ouse_path_request_style
 | `ONE_CLICK_DEPLOY_ROLE` | 计算节点必须设为 `compute` |
 | `CUBE_SANDBOX_NODE_IP` | 当前节点主网卡 IP |
 | `ONE_CLICK_CONTROL_PLANE_IP` | 控制节点 IP，自动拼接为 `<ip>:3010` 作为 CubeOps 节点注册地址 |
-| `CUBE_S3_*` | **必填。** Volume 插件强制依赖 S3。计算节点不部署 MinIO，从控制节点 `.one-click.env` 拷贝（或指向自有 S3）。内置 MinIO 还需放行计算节点到控制面 TCP 9000。 |
+| `CUBE_S3_*` | 可选但强烈建议。Volume 插件依赖 S3；缺失时仅告警并继续安装，但 S3 卷插件不可用。取值见下方提示。 |
 
-::: tip 安装时会校验
-`install-compute.sh` 会在修改任何本地配置之前校验 `CUBE_S3_ENDPOINT`；缺失时直接中止，并提示从控制节点拷贝 `CUBE_S3_*`。请先补齐上述变量再运行安装。
+::: tip 缺失时仅告警
+`install-compute.sh` 检查 `CUBE_S3_ENDPOINT`，缺失时打印醒目的黄色警告并继续安装。节点可正常部署，但 **S3 卷插件不可用**，补齐后重装即可。
+
+从控制节点取 `CUBE_S3_*` 回填值：
+
+1. 在控制节点执行：
+   ```bash
+   grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+   ```
+   输出为空说明控制节点自身未配 S3。
+2. 把输出逐行拷贝到计算节点 `.env`。
+3. 重新执行 `sudo ./install-compute.sh`。
+
+使用内置 MinIO 时，还需放行计算节点到控制面的 TCP 9000。
 :::
 
 如果 CubeOps 使用非默认端口，也可以显式指定：
@@ -289,7 +300,7 @@ sudo ./down.sh
 | `CUBE_SANDBOX_NETWORK_CIDR` | `192.168.0.0/18`（取自 `config.toml`） | cubevs 本地网络 CIDR。需与控制节点一致。格式为 IPv4 CIDR（如 `10.100.0.0/18`），掩码范围 /16~/24。安装时自动检测宿主机冲突。 |
 | `CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK` | `0` | 设为 `1` 跳过冲突检测（不推荐）。 |
 | `ONE_CLICK_RUN_QUICKCHECK` | `1` | 安装后是否执行健康检查 |
-| `CUBE_S3_*` | 空 / 由控制面 MinIO 填入 | **必填。** Volume 插件强制依赖 S3。从控制节点 `.one-click.env` 拷贝；`ENDPOINT` / `ACCESS_KEY_ID` / `SECRET_ACCESS_KEY` / `BUCKET` 无可用默认值。 |
+| `CUBE_S3_*` | 空 / 由控制面 MinIO 填入 | 可选但强烈建议。Volume 插件依赖 S3，缺失时仅告警、S3 卷插件不可用。从控制节点 `/usr/local/services/cubetoolbox/.one-click.env` 拷贝（取值方法见上文第二步）；`ENDPOINT` / `ACCESS_KEY_ID` / `SECRET_ACCESS_KEY` / `BUCKET` 无可用默认值。 |
 
 完整配置参考（构建选项、数据库、代理等）请参阅[本地构建部署 — 配置参考](./self-build-deploy.md#配置参考)。
 

--- a/docs/zh/guide/node-operations.md
+++ b/docs/zh/guide/node-operations.md
@@ -42,7 +42,12 @@ cubeopscli node list --hostid <node_id>
    ONE_CLICK_CONTROL_PLANE_IP=<控制面IP>
    ```
 
-3. 从控制节点的 `.one-click.env` 复制 `CUBE_S3_*` 配置，或者配置其他共享的 S3 兼容存储。
+3. （可选但强烈建议）从控制节点复制 `CUBE_S3_*` 到本机 `.env`：
+   ```bash
+   # 在控制节点执行，把输出拷贝到计算节点 .env
+   grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+   ```
+   也可指向其他共享的 S3 兼容存储。缺失时仅告警并继续安装，但 S3 卷插件不可用，安装结束时会再次提醒。
 4. 安装计算节点：
 
    ```bash

--- a/docs/zh/guide/s3-volume.md
+++ b/docs/zh/guide/s3-volume.md
@@ -101,7 +101,14 @@ CUBE_S3_BUCKET=cube-volumes
 # CUBE_S3_S3FS_EXTRA_OPTS=-ouse_path_request_style
 ```
 
-计算节点不部署 MinIO，把控制节点 `.one-click.env` 里的 `CUBE_S3_*` 拷过去即可。详见 [one-click README · 内置 MinIO 与 S3 Volume 插件](https://github.com/TencentCloud/CubeSandbox/blob/master/deploy/one-click/README_zh.md)。
+计算节点不部署 MinIO，把控制节点回填的 `CUBE_S3_*` 拷过去即可：
+
+```bash
+# 在控制节点执行，把输出拷贝到计算节点 .env
+grep '^CUBE_S3_' /usr/local/services/cubetoolbox/.one-click.env
+```
+
+缺失时仅告警并继续安装，S3 卷插件将不可用。详见 [one-click README · 内置 MinIO 与 S3 Volume 插件](https://github.com/TencentCloud/CubeSandbox/blob/master/deploy/one-click/README_zh.md)。
 
 ### Helm 部署
 


### PR DESCRIPTION
## What

Make a missing `CUBE_S3_*` backend on compute nodes non-blocking in the one-click installer. Instead of aborting the install, the installer now prints a prominent warning and continues; the S3 volume plugin stays disabled until the values are provided and the install is re-run.

## Changes

- Rename `check_compute_s3_required` to `warn_compute_s3_missing` so a compute node without an S3 backend warns instead of failing fast.
- Add a `warn()` helper in `lib/common.sh` that emits bold-yellow text on a TTY and plain text otherwise, keeping log captures and CI `grep` output clean.
- `install.sh` triggers the warning at preflight and re-prints it at the end, so an unconfigured compute node finishes on the remediation path.
- Update EN/ZH docs (one-click `README`, `USER_GUIDE`, `multi-node-deploy`, `node-operations`, `s3-volume`) with the fetch steps from the control node's runtime env file.
- Extend `test_minio_s3_guard.sh` to cover warn-and-continue and `warn()`'s plain-text output when stderr is not a TTY.

## Notes

- Compute nodes never deploy MinIO; they consume `CUBE_S3_*` copied from the control node (or an operator-managed S3-compatible store). Bundled MinIO setups should still allow TCP 9000 from compute to the control node.
