### PR TITLE
feat(kubernetes): render CubeProxy admin token into cube-master config

### DIFF
--- a/deploy/kubernetes/chart/files/cube-master/conf.yaml
+++ b/deploy/kubernetes/chart/files/cube-master/conf.yaml
@@ -34,6 +34,13 @@ cubelet_conf:
 auth:
   enable: false
 
+# CubeProxy admin cache invalidation on sandbox resume. admin_token must match
+# the release Secret key cube-admin-token (what CubeProxy validates as
+# X-Cube-Admin-Token). Rendered from the chart helper; see cube.adminToken.
+# admin_port/heartbeat_ttl_ms fall back to defaults (8082 / 15000).
+cube_proxy_conf:
+  admin_token: {{ include "cube.adminToken" . | quote }}
+
 req_template_conf:
   whitelist_req_tag:
     WorkingDir: true

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -429,6 +429,35 @@ http {
 {{- printf "%s-master-config" (include "cube.fullname" .) -}}
 {{- end -}}
 
+{{/*
+cube.adminToken resolves the shared CubeProxy admin token. CubeProxy reads it at
+runtime as CUBE_PROXY_ADMIN_TOKEN and the lifecycle manager as CUBE_LCM_ADMIN_TOKEN
+from the release Secret key cube-admin-token; CubeMaster needs the same value
+rendered into its conf.yaml as cube_proxy_conf.admin_token (sent as
+X-Cube-Admin-Token when invalidating a proxy routing cache on sandbox resume).
+Priority: explicit lifecycleManager.adminToken → persisted cube-admin-token key
+in the release Secret → freshly generated random.
+
+Fresh-install note: Helm renders every manifest in a single pass, so the
+randAlphaNum fallback below is evaluated separately per caller. On a brand-new
+install the value rendered into the master config Secret can therefore differ
+from the one persisted in the release Secret until the next `helm upgrade`
+aligns both via lookup. Set lifecycleManager.adminToken explicitly (>=16 chars,
+see validate.yaml) to avoid the double generation entirely.
+*/}}
+{{- define "cube.adminToken" -}}
+{{- if .Values.lifecycleManager.adminToken -}}
+{{- .Values.lifecycleManager.adminToken -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "cube.secretName" .) -}}
+{{- if and $existing $existing.data (index $existing.data "cube-admin-token") -}}
+{{- index $existing.data "cube-admin-token" | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "cube.masterStoragePVCName" -}}
 {{- if .Values.controlPlane.master.persistence.existingClaim -}}
 {{- .Values.controlPlane.master.persistence.existingClaim -}}

--- a/deploy/kubernetes/chart/templates/secret.yaml
+++ b/deploy/kubernetes/chart/templates/secret.yaml
@@ -1,13 +1,6 @@
 {{- if eq (include "cube.secretEnabled" .) "true" }}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "cube.secretName" .) -}}
-{{- $adminToken := "" -}}
-{{- if .Values.lifecycleManager.adminToken -}}
-{{- $adminToken = .Values.lifecycleManager.adminToken -}}
-{{- else if and $existing $existing.data (index $existing.data "cube-admin-token") -}}
-{{- $adminToken = index $existing.data "cube-admin-token" | b64dec -}}
-{{- else -}}
-{{- $adminToken = randAlphaNum 32 -}}
-{{- end -}}
+{{- $adminToken := include "cube.adminToken" . -}}
 {{- $minioUser := default "cubeminio" .Values.minio.rootUser -}}
 {{- $minioPassword := default "" .Values.minio.rootPassword -}}
 {{- if eq (include "cube.minioBuiltinEnabled" .) "true" }}


### PR DESCRIPTION
## Summary

Render the shared CubeProxy admin token into cube-master's `conf.yaml` so the lifecycle manager can invalidate CubeProxy's routing cache on sandbox resume.

Previously the admin token only lived in the release Secret; CubeMaster had no way to authenticate the admin request. This PR introduces a single `cube.adminToken` helper and uses it in both places, so the two values can never drift.

## Changes

- **`deploy/kubernetes/chart/templates/_helpers.tpl`**: add `cube.adminToken` helper that resolves the token with priority: explicit `lifecycleManager.adminToken` → persisted `cube-admin-token` key in the release Secret → freshly generated random token.
- **`deploy/kubernetes/chart/templates/secret.yaml`**: use the shared helper instead of inline resolution.
- **`deploy/kubernetes/chart/files/cube-master/conf.yaml`**: add `cube_proxy_conf.admin_token` rendered from the helper; `admin_port`/`heartbeat_ttl_ms` fall back to defaults.

## Notes

On a brand-new install Helm renders manifests in a single pass, so the random fallback may differ between the master config and the release Secret until the next `helm upgrade` aligns them via `lookup`. Set `lifecycleManager.adminToken` explicitly (>= 16 chars) to avoid double generation.