### PR TITLE
fix(sdk): honour e2b files.read formats across Node/Python/Go

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -131,6 +131,7 @@ Consume output via **either** `Output()` **or** `Wait(onData)`, not both — the
 ```go
 // Read & write
 content, err := sb.Files().Read(ctx, "/etc/hosts")
+png, err := sb.Files().ReadBytes(ctx, "/tmp/chart.png")
 err = sb.Files().Write(ctx, "/tmp/hello.txt", []byte("hi"))
 
 // Execute all filesystem operations as a specific sandbox user.
@@ -166,7 +167,9 @@ for ev := range watcher.Events {
 | Method | Description |
 |---|---|
 | `ForUser(user)` | Return an immutable view that runs all filesystem operations as `user` |
-| `Read(ctx, path)` | Download file content via `GET /files` |
+| `Read(ctx, path)` | Download file content as text via `GET /files` (e2b `format=text`) |
+| `ReadBytes(ctx, path)` | Download raw bytes (e2b `format=bytes`) |
+| `ReadStream(ctx, path)` | Stream download; caller must `Close` (e2b `format=stream`) |
 | `Write(ctx, path, data)` | Upload via `POST /files` (octet-stream, multipart fallback) |
 | `WriteFiles(ctx, entries)` | Batch write, stops on first error, returns count |
 | `List(ctx, path)` | List directory entries via `ListDir` RPC |

--- a/sdk/go/envd.go
+++ b/sdk/go/envd.go
@@ -115,19 +115,17 @@ func (s *Sandbox) startProcess(ctx context.Context, payload processStartRequest,
 }
 
 func (s *Sandbox) readFile(ctx context.Context, path string, options ...fileRequestOption) (string, error) {
-	if err := s.ensureClient(); err != nil {
-		return "", err
-	}
-
-	query := newEnvdFileQuery(path, options...)
-	req, err := s.newEnvdRequest(ctx, http.MethodGet, "/files", query, nil)
+	raw, err := s.readFileBytes(ctx, path, options...)
 	if err != nil {
 		return "", err
 	}
+	return string(raw), nil
+}
 
-	resp, err := s.client.dataHTTP.Do(req)
+func (s *Sandbox) readFileBytes(ctx context.Context, path string, options ...fileRequestOption) ([]byte, error) {
+	resp, err := s.doEnvdFileGet(ctx, path, options...)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
@@ -136,14 +134,44 @@ func (s *Sandbox) readFile(ctx context.Context, path string, options ...fileRequ
 		if message == "" {
 			message = fmt.Sprintf("HTTP %d", resp.StatusCode)
 		}
-		return "", fmt.Errorf("failed to read %s: %s", path, message)
+		return nil, fmt.Errorf("failed to read %s: %s", path, message)
 	}
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return string(raw), nil
+	return raw, nil
+}
+
+func (s *Sandbox) openFileStream(ctx context.Context, path string, options ...fileRequestOption) (io.ReadCloser, error) {
+	resp, err := s.doEnvdFileGet(ctx, path, options...)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		message := readErrorMessage(resp)
+		resp.Body.Close()
+		if message == "" {
+			message = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("failed to read %s: %s", path, message)
+	}
+	return resp.Body, nil
+}
+
+func (s *Sandbox) doEnvdFileGet(ctx context.Context, path string, options ...fileRequestOption) (*http.Response, error) {
+	if err := s.ensureClient(); err != nil {
+		return nil, err
+	}
+
+	query := newEnvdFileQuery(path, options...)
+	req, err := s.newEnvdRequest(ctx, http.MethodGet, "/files", query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.dataHTTP.Do(req)
 }
 
 // writeFile uploads data through envd's POST /files API. It first tries a raw

--- a/sdk/go/files.go
+++ b/sdk/go/files.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 )
 
 type Files struct {
@@ -40,6 +41,8 @@ func resolveFileRequestOptions(options ...fileRequestOption) fileRequestOptions 
 
 type fileReader interface {
 	readFile(context.Context, string, ...fileRequestOption) (string, error)
+	readFileBytes(context.Context, string, ...fileRequestOption) ([]byte, error)
+	openFileStream(context.Context, string, ...fileRequestOption) (io.ReadCloser, error)
 }
 
 type fileWriter interface {
@@ -67,11 +70,31 @@ func (f *Files) ForUser(user string) *Files {
 	return &scoped
 }
 
+// Read downloads file content as text (UTF-8 string), matching the e2b
+// files.read(..., format="text") default. Binary files should use ReadBytes.
 func (f *Files) Read(ctx context.Context, path string) (string, error) {
 	if f == nil || f.reader == nil {
 		return "", fmt.Errorf("files is not attached to a sandbox")
 	}
 	return f.reader.readFile(ctx, path, withUser(f.user))
+}
+
+// ReadBytes downloads file content as raw bytes, matching e2b
+// files.read(..., format="bytes"). Prefer this for any non-UTF-8 payload.
+func (f *Files) ReadBytes(ctx context.Context, path string) ([]byte, error) {
+	if f == nil || f.reader == nil {
+		return nil, fmt.Errorf("files is not attached to a sandbox")
+	}
+	return f.reader.readFileBytes(ctx, path, withUser(f.user))
+}
+
+// ReadStream opens a streaming download of path, matching e2b
+// files.read(..., format="stream"). The caller must Close the reader.
+func (f *Files) ReadStream(ctx context.Context, path string) (io.ReadCloser, error) {
+	if f == nil || f.reader == nil {
+		return nil, fmt.Errorf("files is not attached to a sandbox")
+	}
+	return f.reader.openFileStream(ctx, path, withUser(f.user))
 }
 
 // Write uploads data to path through envd's HTTP file API.

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -4,6 +4,7 @@
 package cubesandbox
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -820,6 +821,58 @@ func TestFilesReadUsesEnvdHTTPFileAPI(t *testing.T) {
 	}
 }
 
+func TestFilesReadBytesPreservesBinary(t *testing.T) {
+	png := []byte{0x89, 0x50, 0x4e, 0x47}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/files" {
+			t.Fatalf("request=%s %s", r.Method, r.URL.Path)
+		}
+		w.Write(png)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{
+		ProxyNodeIP:    host,
+		ProxyPortHTTP:  port,
+		SandboxDomain:  "cube.test",
+		RequestTimeout: time.Second,
+	})
+	sb := &Sandbox{client: client, SandboxID: "sb-bin", TemplateID: "tpl-test"}
+
+	got, err := sb.Files().ReadBytes(context.Background(), "/tmp/x.png")
+	if err != nil {
+		t.Fatalf("ReadBytes: %v", err)
+	}
+	if !bytes.Equal(got, png) {
+		t.Fatalf("got=%x want=%x", got, png)
+	}
+
+	stream, err := sb.Files().ReadStream(context.Background(), "/tmp/x.png")
+	if err != nil {
+		t.Fatalf("ReadStream: %v", err)
+	}
+	defer stream.Close()
+	streamed, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(streamed, png) {
+		t.Fatalf("streamed=%x want=%x", streamed, png)
+	}
+
+	// Go strings hold arbitrary bytes (unlike JS/Python UTF-8 text paths), so
+	// Read still round-trips binary. ReadBytes is the e2b format=bytes surface
+	// for callers that want an explicit []byte API.
+	textContent, err := sb.Files().Read(context.Background(), "/tmp/x.png")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal([]byte(textContent), png) {
+		t.Fatalf("Read round-trip=%x want=%x", []byte(textContent), png)
+	}
+}
+
 func TestFilesReadReturnsEnvdFileError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message":"file not found"}`, http.StatusNotFound)
@@ -886,14 +939,37 @@ type fakeFileReader struct {
 	path    string
 	user    string
 	content string
+	raw     []byte
 	err     error
 }
 
-func (r *fakeFileReader) readFile(_ context.Context, path string, options ...fileRequestOption) (string, error) {
+func (r *fakeFileReader) readFile(ctx context.Context, path string, options ...fileRequestOption) (string, error) {
+	raw, err := r.readFileBytes(ctx, path, options...)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func (r *fakeFileReader) readFileBytes(_ context.Context, path string, options ...fileRequestOption) ([]byte, error) {
 	r.path = path
 	opts := resolveFileRequestOptions(options...)
 	r.user = opts.user
-	return r.content, r.err
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.raw != nil {
+		return append([]byte(nil), r.raw...), nil
+	}
+	return []byte(r.content), nil
+}
+
+func (r *fakeFileReader) openFileStream(ctx context.Context, path string, options ...fileRequestOption) (io.ReadCloser, error) {
+	raw, err := r.readFileBytes(ctx, path, options...)
+	if err != nil {
+		return nil, err
+	}
+	return io.NopCloser(bytes.NewReader(raw)), nil
 }
 
 func connectEnvelope(flags byte, payload string) []byte {

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -224,6 +224,7 @@ on a single `create` call — not both.
 // Read & write
 await sb.files.write("/tmp/hello.txt", "Hello, world!");
 console.log(await sb.files.read("/tmp/hello.txt")); // "Hello, world!"
+const png = await sb.files.read("/tmp/chart.png", { format: "bytes" }); // Uint8Array
 
 // Batch write
 await sb.files.writeFiles([
@@ -456,7 +457,7 @@ var**. Inline fields accepted by `create`: `apiUrl`, `proxyNodeIp`,
 
 | Method | Description |
 |---|---|
-| `read(path, options?)` | Download file content via `GET /files` |
+| `read(path, options?)` | Download file content via `GET /files`; `options.format` is `text` (default) / `bytes` / `blob` / `stream` (e2b-compatible) |
 | `write(path, data, options?)` | Upload via `POST /files` (octet-stream, multipart fallback) |
 | `writeFiles(files, options?)` | Batch write, stops on first error, returns count |
 | `list(path)` | List directory entries |

--- a/sdk/node/src/filesystem.ts
+++ b/sdk/node/src/filesystem.ts
@@ -90,8 +90,27 @@ export class Filesystem {
     return JSON.parse(text);
   }
 
-  /** Read a file's contents through envd's HTTP file API. */
-  async read(path: string, options: { user?: string } = {}): Promise<string> {
+  /**
+   * Read a file through envd's HTTP file API.
+   *
+   * Matches the e2b Node SDK surface: pass `text` (default), `bytes`, `blob`,
+   * or `stream` as `options.format` (an options object — the same shape as
+   * e2b's `files.read(path, { format })`, not a positional string). Without
+   * this, a binary file is always UTF-8-decoded — a PNG's `0x89` magic becomes
+   * the three-byte replacement character before the caller sees it.
+   */
+  async read(path: string, options?: { user?: string; format?: "text" }): Promise<string>;
+  async read(path: string, options: { user?: string; format: "bytes" }): Promise<Uint8Array>;
+  async read(path: string, options: { user?: string; format: "blob" }): Promise<Blob>;
+  async read(
+    path: string,
+    options: { user?: string; format: "stream" },
+  ): Promise<ReadableStream<Uint8Array>>;
+  async read(
+    path: string,
+    options: { user?: string; format?: "text" | "bytes" | "blob" | "stream" } = {},
+  ): Promise<string | Uint8Array | Blob | ReadableStream<Uint8Array>> {
+    const format = options.format ?? "text";
     const user = options.user || DEFAULT_ENVD_USER;
     const params = new URLSearchParams({ path, username: user });
     const resp = await fetch(this.sandbox.dataUrl(ENVD_PORT, `/files?${params.toString()}`), {
@@ -99,8 +118,8 @@ export class Filesystem {
       headers: this.baseHeaders(),
       dispatcher: this.sandbox.dataDispatcher,
     });
-    const text = await resp.text();
     if (resp.status !== 200) {
+      const text = await resp.text();
       let message = text || `HTTP ${resp.status}`;
       try {
         const body = JSON.parse(text);
@@ -110,7 +129,31 @@ export class Filesystem {
       }
       throw new Error(`Failed to read ${path}: ${message}`);
     }
-    return text;
+
+    // Mirror e2b: an explicit zero-length response short-circuits before the
+    // body parsers, so each format gets the empty value callers expect.
+    if (resp.headers.get("content-length") === "0") {
+      if (format === "bytes") return new Uint8Array(0);
+      if (format === "blob") return new Blob([]);
+      if (format === "stream") {
+        return new ReadableStream<Uint8Array>({ start(controller) { controller.close(); } });
+      }
+      return "";
+    }
+
+    if (format === "stream") {
+      if (!resp.body) {
+        return new ReadableStream<Uint8Array>({ start(controller) { controller.close(); } });
+      }
+      return resp.body as ReadableStream<Uint8Array>;
+    }
+    if (format === "bytes") {
+      return new Uint8Array(await resp.arrayBuffer());
+    }
+    if (format === "blob") {
+      return await resp.blob();
+    }
+    return await resp.text();
   }
 
   /** Write a file through envd's HTTP file API (octet-stream, multipart fallback). */

--- a/sdk/node/test/filesystem.test.ts
+++ b/sdk/node/test/filesystem.test.ts
@@ -31,6 +31,8 @@ interface MockResponse {
   status?: number;
   json?: unknown;
   text?: string;
+  /** Raw body bytes (for binary /files responses). */
+  bytes?: Buffer;
   headers?: Record<string, string>;
 }
 
@@ -74,12 +76,17 @@ beforeAll(async () => {
       requests.push(record);
       const out = handler(record);
       const headers: Record<string, string> = { ...(out.headers ?? {}) };
-      let payload = "";
-      if (out.text !== undefined) {
+      let payload: string | Buffer = "";
+      if (out.bytes !== undefined) {
+        payload = out.bytes;
+      } else if (out.text !== undefined) {
         payload = out.text;
       } else if (out.json !== undefined) {
         payload = JSON.stringify(out.json);
         headers["content-type"] ??= "application/json";
+      }
+      if (typeof payload !== "string" && headers["content-length"] === undefined) {
+        headers["content-length"] = String(payload.length);
       }
       res.writeHead(out.status ?? 200, headers);
       res.end(payload);
@@ -109,6 +116,77 @@ describe("Filesystem.read", () => {
       return { status: 200, text: "file content" };
     };
     expect(await sb.files.read("/tmp/foo.txt")).toBe("file content");
+    sb.close();
+  });
+
+  it("returns untouched bytes when format is bytes (e2b-compatible)", async () => {
+    // PNG magic: e2b's format:'bytes' path keeps 0x89; UTF-8 text decode would
+    // turn it into EF BF BD and inflate a 4-byte payload to 6.
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const sb = await createSandbox();
+    handler = () => ({ status: 200, bytes: png });
+    const got = await sb.files.read("/tmp/x.png", { format: "bytes" });
+    expect(got).toBeInstanceOf(Uint8Array);
+    expect(Buffer.from(got)).toEqual(png);
+    sb.close();
+  });
+
+  it("returns a Blob when format is blob", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const sb = await createSandbox();
+    handler = () => ({ status: 200, bytes: png });
+    const got = await sb.files.read("/tmp/x.png", { format: "blob" });
+    expect(got).toBeInstanceOf(Blob);
+    expect(Buffer.from(await got.arrayBuffer())).toEqual(png);
+    sb.close();
+  });
+
+  it("returns a ReadableStream when format is stream", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const sb = await createSandbox();
+    handler = () => ({ status: 200, bytes: png });
+    const stream = await sb.files.read("/tmp/x.png", { format: "stream" });
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    expect(Buffer.concat(chunks.map((c) => Buffer.from(c)))).toEqual(png);
+    sb.close();
+  });
+
+  it("returns empty values for content-length 0 across formats", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 200, text: "", headers: { "content-length": "0" } });
+    expect(await sb.files.read("/tmp/empty", { format: "text" })).toBe("");
+    expect(await sb.files.read("/tmp/empty", { format: "bytes" })).toEqual(new Uint8Array(0));
+    const blob = await sb.files.read("/tmp/empty", { format: "blob" });
+    expect(blob.size).toBe(0);
+    const stream = await sb.files.read("/tmp/empty", { format: "stream" });
+    const { done } = await stream.getReader().read();
+    expect(done).toBe(true);
+    sb.close();
+  });
+
+  it("still UTF-8-decodes when format is omitted (text default)", async () => {
+    // Documents the default: callers that want binary must opt into bytes.
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const sb = await createSandbox();
+    handler = () => ({ status: 200, bytes: png });
+    const text = await sb.files.read("/tmp/x.png");
+    expect(typeof text).toBe("string");
+    expect(Buffer.from(text, "utf8")).not.toEqual(png);
+    sb.close();
+  });
+
+  it("surfaces JSON error bodies when the status is not 200", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 404, json: { message: "No such file or directory" } });
+    await expect(sb.files.read("/tmp/missing.txt")).rejects.toThrow(
+      /Failed to read \/tmp\/missing\.txt: No such file or directory/,
+    );
     sb.close();
   });
 });

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -212,6 +212,7 @@ with Sandbox.create() as sb:
     # Read & write
     sb.files.write("/tmp/hello.txt", "Hello, world!")
     print(sb.files.read("/tmp/hello.txt"))  # "Hello, world!"
+    png = sb.files.read("/tmp/chart.png", format="bytes")  # bytearray
 
     # Batch write
     sb.files.write_files([
@@ -354,7 +355,7 @@ with Sandbox.create(config=cfg) as sb:
 
 | Method | Description |
 |---|---|
-| `sb.files.read(path)` | Download file content via `GET /files` |
+| `sb.files.read(path, *, format=...)` | Download via `GET /files`; `format` is `text` (default) / `bytes` / `stream` (e2b-compatible) |
 | `sb.files.write(path, data)` | Upload via `POST /files` (octet-stream, multipart fallback) |
 | `sb.files.write_files(files)` | Batch write `[(path, data), ...]`, stops on first error |
 | `sb.files.list(path)` | List directory entries → `list[dict]` |

--- a/sdk/python/cubesandbox/_filesystem.py
+++ b/sdk/python/cubesandbox/_filesystem.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import struct
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator, Literal, Union, overload
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +65,47 @@ class Filesystem:
             return {}
         return resp.json()
 
-    def read(self, path: str, *, user: str | None = None) -> str:
-        """Read a file through envd's HTTP file API."""
+    @overload
+    def read(
+        self,
+        path: str,
+        *,
+        format: Literal["text"] = "text",
+        user: str | None = None,
+    ) -> str: ...
+
+    @overload
+    def read(
+        self,
+        path: str,
+        *,
+        format: Literal["bytes"],
+        user: str | None = None,
+    ) -> bytearray: ...
+
+    @overload
+    def read(
+        self,
+        path: str,
+        *,
+        format: Literal["stream"],
+        user: str | None = None,
+    ) -> Iterator[bytes]: ...
+
+    def read(
+        self,
+        path: str,
+        *,
+        format: Literal["text", "bytes", "stream"] = "text",
+        user: str | None = None,
+    ) -> Union[str, bytearray, Iterator[bytes]]:
+        """Read a file through envd's HTTP file API.
+
+        Matches the e2b Python SDK surface: ``format`` is ``text`` (default),
+        ``bytes`` (``bytearray``), or ``stream`` (``Iterator[bytes]``). Without
+        ``format="bytes"``, a binary file is UTF-8-decoded and corrupted — a
+        PNG's ``0x89`` magic becomes the U+FFFD replacement character.
+        """
         self._ensure_client()
         effective_user = user or DEFAULT_ENVD_USER
 
@@ -85,6 +124,25 @@ class Filesystem:
                 body = {}
             message = body.get("message") or body.get("detail") or message
             raise IOError(f"Failed to read {path}: {message}")
+
+        # Mirror e2b: an explicit zero-length response short-circuits.
+        if resp.headers.get("content-length") == "0":
+            if format == "bytes":
+                return bytearray()
+            if format == "stream":
+                return iter(())
+            return ""
+
+        if format == "bytes":
+            return bytearray(resp.content)
+        if format == "stream":
+            data = resp.content
+
+            def _chunks() -> Iterator[bytes]:
+                if data:
+                    yield bytes(data)
+
+            return _chunks()
         return resp.text
 
     def write(self, path: str, data: str | bytes, *, user: str | None = None) -> None:

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -1690,6 +1690,44 @@ class TestFilesystem:
             with pytest.raises(IOError, match="Failed to read"):
                 sb.files.read("/tmp/missing.txt")
 
+    def test_read_bytes_preserves_binary(self):
+        # PNG magic: format="bytes" keeps 0x89; text would turn it into U+FFFD.
+        png = bytes([0x89, 0x50, 0x4E, 0x47])
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=png)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            got = sb.files.read("/tmp/x.png", format="bytes")
+        assert isinstance(got, bytearray)
+        assert bytes(got) == png
+
+    def test_read_stream_yields_bytes(self):
+        png = bytes([0x89, 0x50, 0x4E, 0x47])
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=png)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            chunks = list(sb.files.read("/tmp/x.png", format="stream"))
+        assert b"".join(chunks) == png
+
+    def test_read_empty_content_length_zero(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"", headers={"content-length": "0"})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            assert sb.files.read("/tmp/empty", format="text") == ""
+            assert sb.files.read("/tmp/empty", format="bytes") == bytearray()
+            assert list(sb.files.read("/tmp/empty", format="stream")) == []
+
     def test_write_uses_envd_file_api(self):
         sb = make_sandbox()
         seen = {}


### PR DESCRIPTION
## Summary

`files.read` in the CubeSandbox SDKs always treated the response as text, so the e2b-compatible binary formats were missing or ignored. Binary payloads (e.g. PNG `0x89`) were corrupted on the Node/Python UTF-8 text paths.

This PR aligns all three official SDKs with the e2b surface:

| SDK | Surface |
| --- | --- |
| **Node** | `format: 'text' \| 'bytes' \| 'blob' \| 'stream'` |
| **Python** | `format="text" \| "bytes" \| "stream"` → `str` / `bytearray` / `Iterator[bytes]` |
| **Go** | `Read` (text) + `ReadBytes` + `ReadStream` (e2b has no Go SDK; these are the idiomatic equivalents) |

Also mirrors e2b's empty `content-length: 0` short-circuit where applicable.

Fixes #1570

## Test plan

- [x] `cd sdk/node && npm test -- --run` (221 passed)
- [x] `cd sdk/go && go test ./...`
- [x] `cd sdk/python && pytest tests/test_sandbox.py -k read_` (7 passed, via container)
- [ ] Reviewer: optional live check — write a PNG into a sandbox and read it back with the binary API unaltered