### PR TITLE
docs(integrations): add LangGraph integration guide

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -255,6 +255,7 @@ export default withMermaid(defineConfig({
                   items: [
                     { text: 'Claude Code', link: '/guide/integrations/claude-code' },
                     { text: 'LangChain', link: '/guide/integrations/langchain' },
+                    { text: 'LangGraph', link: '/guide/integrations/langgraph' },
                     { text: 'Pi Agent', link: '/guide/integrations/pi-agent' },
                     { text: 'OpenAI Agents SDK', link: '/guide/integrations/openai-agents-sdk' }
                   ]
@@ -464,6 +465,7 @@ export default withMermaid(defineConfig({
                   items: [
                     { text: 'Claude Code', link: '/zh/guide/integrations/claude-code' },
                     { text: 'LangChain', link: '/zh/guide/integrations/langchain' },
+                    { text: 'LangGraph', link: '/zh/guide/integrations/langgraph' },
                     { text: 'Pi Agent', link: '/zh/guide/integrations/pi-agent' },
                     { text: 'OpenAI Agents SDK', link: '/zh/guide/integrations/openai-agents-sdk' }
                   ]

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -8,7 +8,7 @@ This section collects integration guides for agent frameworks, developer tools, 
 
 ## What belongs here
 
-- Agent framework integrations such as LangChain, Dify, OpenClaw, or Claude Code
+- Agent framework integrations such as LangChain, LangGraph, Dify, OpenClaw, or Claude Code
 - SDK wiring guides and platform-specific setup notes
 - End-to-end integration patterns with example repositories
 - Compatibility notes, caveats, and recommended configuration defaults
@@ -51,3 +51,4 @@ lang: en-US
 | [Claude Code Integration Guide](./claude-code.md) | shsaihdsaiudh | 2026-07-06 | integration, claude-code, coding-agent |
 | [LangChain Integration Guide](./langchain.md) | peerless-hero | 2026-07-07 | integration, langchain, agent |
 | [OpenAI Agents SDK Integration Guide](./openai-agents-sdk.md) | ZedingZhang | 2026-08-19 | integration, openai-agents-sdk, agent |
+| [LangGraph Integration Guide](./langgraph.md) | Mikey1129 | 2026-08-29 | integration, langgraph, agent |

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -231,20 +231,24 @@ def strip_code_fence(text: str) -> str | None:
     first_nl = after.find("\n")
     if first_nl == -1:
         return None                      # opener with no body — treat as no code
+    # The opener's indentation is the leading whitespace on its own line. A closer
+    # sits at that same indent, so a fence nested in a markdown list still closes
+    # correctly, while a ``` line indented deeper (a markdown example inside a
+    # docstring or string literal) stays code.
+    opener_line = text[text.rfind("\n", 0, start) + 1:start]
+    opener_indent = len(opener_line) - len(opener_line.lstrip())
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # A closer is a column-0 line whose leading backtick run matches the
-        # opener's length and is followed by nothing but prose — models sometimes
-        # slip as `` ``` Done! ``. An indented fence inside a docstring or string
-        # literal, a shorter bare ``` line, or a 4-backtick fence when the opener
-        # was 3, all stay code.
-        if line.startswith("`"):
-            s = line.strip()
-            run = 0
-            while run < len(s) and s[run] == "`":
-                run += 1
-            if run == fence_len and (len(s) == run or s[run].isspace()):
-                break
+        # A closer is a line whose stripped leading backtick run matches the
+        # opener's length at the opener's indent and is followed by nothing but
+        # prose — models sometimes slip as `` ``` Done! ``. A shorter bare ``` line
+        # or a 4-backtick fence when the opener was 3 all stay code.
+        s = line.lstrip()
+        run = 0
+        while run < len(s) and s[run] == "`":
+            run += 1
+        if run == fence_len and (len(s) == run or s[run].isspace()) and len(line) - len(s) == opener_indent:
+            break
         inner.append(line)
     return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code
 
@@ -352,17 +356,16 @@ if __name__ == "__main__":
             "done": False,
         })
         # The last message is the reviewer's verdict; print the code output
-        # instead so the user actually sees the computed numbers.
+        # instead so the user actually sees the computed numbers. rfind anchors on
+        # the real marker (not a literal "[code output]" inside the generated
+        # script), and we print the last coder message verbatim — even a failed
+        # attempt's placeholder — so the numbers shown match the run's final state
+        # rather than an earlier attempt the reviewer already rejected.
         for msg in reversed(result["messages"]):
             content = str(msg.content)
             marker = "[code output]"
-            idx = content.find(marker)
+            idx = content.rfind(marker)
             if idx == -1:
-                continue
-            tail = content[idx + len(marker):].lstrip("\n")
-            # Skip placeholder outputs (a failed LLM call or an empty/invalid
-            # extraction) so a "llm error: ..." doesn't read like a real result.
-            if tail.startswith(("(llm error", "(no code block", "(extracted block")):
                 continue
             print(content[idx:])
             break
@@ -425,7 +428,9 @@ sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
 config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
+    # Stage 1 writes an intermediate artifact so stage 2 reads state that only
+    # survives because /workspace persists across pause() / connect().
+    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and write the month -> revenue table to /workspace/monthly_revenue.csv."}]), config=config)
     if not stage1["done"]:
         print("(stage 1 not verified: reviewer never returned DONE)")
 
@@ -435,7 +440,7 @@ try:
     # instance, keeping the same checkpointer so the same checkpoint thread resumes.
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "now compute average units per product"}]), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv (written by stage 1) and report which month had the highest revenue."}]), config=config)
 finally:
     sandbox.kill()
 ```

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -115,7 +115,7 @@ from dotenv import load_dotenv
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, START, END
-from langgraph.graph.message import add_messages
+from langgraph.graph import add_messages
 from cubesandbox import Sandbox
 
 load_dotenv()
@@ -356,11 +356,13 @@ if __name__ == "__main__":
             "done": False,
         })
         # The last message is the reviewer's verdict; print the code output
-        # instead so the user actually sees the computed numbers. rfind anchors on
-        # the real marker (not a literal "[code output]" inside the generated
-        # script), and we print the last coder message verbatim — even a failed
-        # attempt's placeholder — so the numbers shown match the run's final state
-        # rather than an earlier attempt the reviewer already rejected.
+        # instead so the user actually sees the computed numbers. rfind takes the
+        # last "[code output]" occurrence, so a literal inside the generated script
+        # (before the real marker) can't shift the excerpt — only stdout that itself
+        # prints that token would, which merely truncates the display. Print the
+        # last coder message verbatim, even a failed attempt's placeholder, so the
+        # numbers shown match the run's final state rather than an earlier attempt
+        # the reviewer already rejected.
         for msg in reversed(result["messages"]):
             content = str(msg.content)
             marker = "[code output]"

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -202,7 +202,7 @@ def extract_text(content) -> str:
             if isinstance(block, str):
                 parts.append(block)
             elif isinstance(block, dict) and block.get("type") == "text":
-                parts.append(block.get("text", ""))
+                parts.append(block.get("text") or "")
         return "\n".join(parts)
     return str(content)
 
@@ -211,17 +211,21 @@ def strip_code_fence(text: str) -> str | None:
     """Return the code inside the first markdown fence, or None when the reply
     has no fenced block — models often prefix the fenced block with prose."""
     fence = "`" * 3                      # three backticks, without a literal fence
-    text = text.strip()
-    lines = text.splitlines()
-    start = None
-    for i, line in enumerate(lines):
-        if line.strip().startswith(fence):
-            start = i
-            break
-    if start is None:
+    if not text:
         return None
+    # The opener may share a line with prose (`` The code is: ```python ``), so
+    # search for the first fence token anywhere rather than only at a line start.
+    start = text.find(fence)
+    if start == -1:
+        return None
+    # Code begins on the line after the opener; a language tag like ```python and
+    # any trailing prose on that line are dropped.
+    after = text[start + len(fence):]
+    first_nl = after.find("\n")
+    if first_nl == -1:
+        return None                      # opener with no body — treat as no code
     inner = []
-    for line in lines[start + 1:]:
+    for line in after[first_nl + 1:].splitlines():
         # A closer starts with a fence run of three-or-more backticks and is
         # otherwise empty (a bare ``` line) or followed only by prose on the same
         # line — models sometimes slip as `` ``` Done! ``. A language-tagged line
@@ -231,7 +235,7 @@ def strip_code_fence(text: str) -> str | None:
         if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
             break
         inner.append(line)
-    return "\n".join(inner).strip()
+    return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code
 
 
 def coder(state: AgentState, run_python) -> dict:

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -112,6 +112,7 @@ import sys
 from typing import Annotated, TypedDict
 
 from dotenv import load_dotenv
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, START, END
 from langgraph.graph.message import add_messages
@@ -257,22 +258,19 @@ def coder(state: AgentState, run_python) -> dict:
     except Exception as exc:
         # A transient LLM error (rate limit, 5xx, timeout) must not abort the
         # whole graph run; surface it as empty code so the reviewer retries.
-        return {"messages": [{"role": "assistant",
-                              "content": f"[code output]\n(llm error: {exc})"}]}
+        return {"messages": [AIMessage(content=f"[code output]\n(llm error: {exc})")]}
     code = strip_code_fence(extract_text(reply))
     if code is None:
         # The model returned no fenced code block; surface that instead of writing
         # prose to a .py file and wasting an attempt on a SyntaxError.
-        return {"messages": [{"role": "assistant",
-                              "content": "[code output]\n(no code block in model reply)"}]}
+        return {"messages": [AIMessage(content="[code output]\n(no code block in model reply)")]}
     try:
         ast.parse(code)
     except SyntaxError as exc:
         # The fenced block isn't valid Python (e.g. the model prefaced the real
         # script with a diff/example fence); surface it so the reviewer retries
         # instead of writing a .py that always fails.
-        return {"messages": [{"role": "assistant",
-                              "content": f"[code output]\n(extracted block is not valid Python: {exc})"}]}
+        return {"messages": [AIMessage(content=f"[code output]\n(extracted block is not valid Python: {exc})")]}
     output = run_python(code)
     # Cap both the code and the output so a huge result (e.g. a printed DataFrame)
     # or a large generated script cannot blow the model's context window across
@@ -284,8 +282,7 @@ def coder(state: AgentState, run_python) -> dict:
         output = "[earlier output truncated]\n" + output[-4000:]
     # Include the code alongside the output so that on a RETRY the coder can see
     # what it wrote last time instead of repeating the same mistake.
-    return {"messages": [{"role": "assistant",
-                          "content": f"[code]\n{code}\n[code output]\n{output}"}]}
+    return {"messages": [AIMessage(content=f"[code]\n{code}\n[code output]\n{output}")]}
 
 
 def reviewer(state: AgentState) -> dict:
@@ -298,7 +295,7 @@ def reviewer(state: AgentState) -> dict:
         # A transient LLM error in the reviewer degrades to a retry rather than
         # aborting the run.
         return {
-            "messages": [{"role": "user", "content": f"[reviewer] RETRY (llm error: {exc})"}],
+            "messages": [HumanMessage(content=f"[reviewer] RETRY (llm error: {exc})")],
             "attempts": state.get("attempts", 0) + 1,
             "done": False,
         }
@@ -311,7 +308,7 @@ def reviewer(state: AgentState) -> dict:
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {
-        "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
+        "messages": [HumanMessage(content=f"[reviewer] {verdict}")],
         "attempts": state.get("attempts", 0) + 1,
         "done": done,
     }

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -304,6 +304,8 @@ if __name__ == "__main__":
                 break
         else:
             print("(no code output)")
+        if not result["done"]:
+            print("\n(not verified: reviewer never returned DONE)")
 ```
 
 Save the code above as `langgraph_agent_demo.py`, then run it:
@@ -333,7 +335,7 @@ long-running, resumable agents:
 |---|---|
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
 | `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `sandbox.sandbox_id` |
-| resume with `invoke(..., config)` | `sandbox.pause()` then `Sandbox.connect(sandbox_id)` |
+| continue a new run on the same thread via `invoke(..., config)` | `sandbox.pause()` then `Sandbox.connect(sandbox_id)` |
 
 ```python
 from langgraph.checkpoint.memory import MemorySaver

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -181,17 +181,24 @@ def extract_text(content) -> str:
 
 
 def strip_code_fence(text: str) -> str:
-    """Strip optional markdown code fences the model may wrap code in."""
+    """Return the code inside the first markdown fence, or the whole text when
+    there is none — models often prefix the fenced block with prose."""
     fence = "`" * 3                      # three backticks, without a literal fence
     text = text.strip()
-    if text.startswith(fence):
-        lines = text.splitlines()
-        if lines and lines[0].startswith(fence):
-            lines = lines[1:]
-        if lines and lines[-1].strip() == fence:
-            lines = lines[:-1]
-        return "\n".join(lines).strip()
-    return text
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith(fence):
+            start = i
+            break
+    if start is None:
+        return text
+    inner = []
+    for line in lines[start + 1:]:
+        if line.strip().startswith(fence):
+            break
+        inner.append(line)
+    return "\n".join(inner).strip()
 
 
 def coder(state: AgentState, run_python) -> dict:
@@ -200,6 +207,9 @@ def coder(state: AgentState, run_python) -> dict:
         [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
     ).content))
     output = run_python(code)
+    # Cap the output so a huge result (e.g. a printed DataFrame) cannot blow the
+    # model's context window on the next llm.invoke.
+    output = output[:4000]
     return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
 
 
@@ -283,6 +293,10 @@ forever.
 LangGraph checkpoints the graph state; Cube snapshots the sandbox. The two pair naturally for
 long-running, resumable agents:
 
+> `MemorySaver` below keeps checkpoints in **process memory** — fine for a demo, but they are
+> gone when the process restarts. For cross-process resume, use a durable checkpointer such as
+> `SqliteSaver` / `PostgresSaver` from `langgraph-checkpoint-sqlite` / `-postgres`.
+
 | LangGraph | Cube Sandbox |
 |---|---|
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
@@ -292,7 +306,7 @@ long-running, resumable agents:
 ```python
 from langgraph.checkpoint.memory import MemorySaver
 
-checkpointer = MemorySaver()
+checkpointer = MemorySaver()  # in-process demo; use a durable checkpointer for real resume
 
 
 def stage_input(messages):
@@ -323,7 +337,9 @@ finally:
 ```
 
 Keep the LangGraph `thread_id` aligned with the Cube `sandbox_id` (e.g. store both in your
-orchestration layer) so a resumed graph reattaches to the same sandbox.
+orchestration layer) so a resumed graph reattaches to the same sandbox. Because `MemorySaver` only
+survives within the current process, pair that orchestration layer with a durable checkpointer
+(`SqliteSaver` / `PostgresSaver`) to resume across restarts.
 
 ## Caveats
 
@@ -338,6 +354,9 @@ orchestration layer) so a resumed graph reattaches to the same sandbox.
   fails; bake pandas / numpy / matplotlib into the template.
 - **Cap the retry loop.** Use the `attempts` counter (as above) or LangGraph's recursion limit, so a
   reviewer that keeps asking for retries cannot exhaust the sandbox `timeout`.
+- **`MemorySaver` is in-process only.** Checkpoints live in memory and are lost on restart; use
+  `SqliteSaver` / `PostgresSaver` (from `langgraph-checkpoint-sqlite` / `-postgres`) for
+  cross-process resume, even though the Cube sandbox survives `pause()` / `connect()`.
 
 ## References
 

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -104,7 +104,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_TEMPLATE_ID",):
+for v in ("CUBE_API_URL", "CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -180,9 +180,9 @@ def extract_text(content) -> str:
     return str(content)
 
 
-def strip_code_fence(text: str) -> str:
-    """Return the code inside the first markdown fence, or the whole text when
-    there is none — models often prefix the fenced block with prose."""
+def strip_code_fence(text: str) -> str | None:
+    """Return the code inside the first markdown fence, or None when the reply
+    has no fenced block — models often prefix the fenced block with prose."""
     fence = "`" * 3                      # three backticks, without a literal fence
     text = text.strip()
     lines = text.splitlines()
@@ -192,7 +192,7 @@ def strip_code_fence(text: str) -> str:
             start = i
             break
     if start is None:
-        return text
+        return None
     inner = []
     for line in lines[start + 1:]:
         if line.strip().startswith(fence):
@@ -206,10 +206,17 @@ def coder(state: AgentState, run_python) -> dict:
     code = strip_code_fence(extract_text(llm.invoke(
         [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
     ).content))
+    if code is None:
+        # The model returned no fenced code block; surface that instead of writing
+        # prose to a .py file and wasting an attempt on a SyntaxError.
+        return {"messages": [{"role": "assistant",
+                              "content": "[code output]\n(no code block in model reply)"}]}
     output = run_python(code)
     # Cap the output so a huge result (e.g. a printed DataFrame) cannot blow the
-    # model's context window on the next llm.invoke.
-    output = output[:4000]
+    # model's context window. Keep the tail: the printed numbers (and any
+    # stderr/traceback) land at the end, so they must survive the truncation.
+    if len(output) > 4000:
+        output = "[earlier output truncated]\n" + output[-4000:]
     return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
 
 

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -116,7 +116,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_API_URL", "CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+for v in ("CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -238,9 +238,12 @@ def coder(state: AgentState, run_python) -> dict:
         return {"messages": [{"role": "assistant",
                               "content": "[code output]\n(no code block in model reply)"}]}
     output = run_python(code)
-    # Cap the output so a huge result (e.g. a printed DataFrame) cannot blow the
-    # model's context window. Keep the tail: the printed numbers (and any
-    # stderr/traceback) land at the end, so they must survive the truncation.
+    # Cap both the code and the output so a huge result (e.g. a printed DataFrame)
+    # or a large generated script cannot blow the model's context window across
+    # retries. Keep the tail of each: the printed numbers (and any stderr/traceback)
+    # land at the end, and the script's tail still shows the logic that ran.
+    if len(code) > 4000:
+        code = "[earlier code truncated]\n" + code[-4000:]
     if len(output) > 4000:
         output = "[earlier output truncated]\n" + output[-4000:]
     # Include the code alongside the output so that on a RETRY the coder can see

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -105,6 +105,7 @@ run later via checkpointing.
 ```python
 from __future__ import annotations
 
+import ast
 import itertools
 import os
 import sys
@@ -171,12 +172,12 @@ def make_run_python(sandbox: Sandbox):
 
 CODER_PROMPT = (
     "You are a data analyst. Write a single self-contained Python script that answers "
-    "the latest user request using the dataset at /workspace/sales.csv "
+    "the user's task using the dataset at /workspace/sales.csv "
     "(columns month,product,units,price). The environment has pandas, numpy, "
     "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
     "network access. Wrap the script in a single markdown ```python ... ``` fenced "
-    "block. If a previous reviewer message said RETRY, fix the issues it "
-    "listed before re-running."
+    "block. Messages prefixed with [reviewer] are feedback on your last attempt, "
+    "not a new task: if one said RETRY, fix the issues it listed before re-running."
 )
 
 REVIEWER_PROMPT = (
@@ -255,6 +256,14 @@ def coder(state: AgentState, run_python) -> dict:
         # prose to a .py file and wasting an attempt on a SyntaxError.
         return {"messages": [{"role": "assistant",
                               "content": "[code output]\n(no code block in model reply)"}]}
+    try:
+        ast.parse(code)
+    except SyntaxError as exc:
+        # The fenced block isn't valid Python (e.g. the model prefaced the real
+        # script with a diff/example fence); surface it so the reviewer retries
+        # instead of writing a .py that always fails.
+        return {"messages": [{"role": "assistant",
+                              "content": f"[code output]\n(extracted block is not valid Python: {exc})"}]}
     output = run_python(code)
     # Cap both the code and the output so a huge result (e.g. a printed DataFrame)
     # or a large generated script cannot blow the model's context window across
@@ -395,7 +404,7 @@ sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
 config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "first task"}]), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
 
     sandbox.pause()                                   # snapshot VM + rootfs
     # Sandbox.connect() returns a NEW instance; the run_python closure captured
@@ -403,7 +412,7 @@ try:
     # instance, keeping the same checkpointer so the same checkpoint thread resumes.
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}]), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "now compute average units per product"}]), config=config)
 finally:
     sandbox.kill()
 ```

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -136,13 +136,14 @@ def make_run_python(sandbox: Sandbox):
 
     def run_python(code: str) -> str:
         script = f"/workspace/_agent_{next(_counter)}.py"
-        sandbox.files.write(script, code)
         try:
+            sandbox.files.write(script, code)
             result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
         except Exception as exc:
-            # Transport errors and per-command timeouts raise here; surface them as
-            # tool output so the reviewer can see the failure and decide to retry,
-            # rather than letting the exception abort the whole graph run.
+            # A dead sandbox, a failed write, transport errors and per-command
+            # timeouts all raise here; surface them as tool output so the reviewer
+            # can see the failure and decide to retry, rather than letting the
+            # exception abort the whole graph run.
             return f"[command error] {exc}"
         out = result.stdout
         if result.stderr:
@@ -231,12 +232,16 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
+    # Parse the first token so a markdown-wrapped or prose-led verdict
+    # ("**DONE**", "The result is DONE") still resolves correctly.
+    token = (verdict.split() or [""])[0].strip(":*#`")
+    done = token.startswith("DONE")
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {
         "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
         "attempts": state.get("attempts", 0) + 1,
-        "done": verdict.startswith("DONE"),
+        "done": done,
     }
 
 

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -209,7 +209,9 @@ def strip_code_fence(text: str) -> str | None:
         return None
     inner = []
     for line in lines[start + 1:]:
-        if line.strip().startswith(fence):
+        # Only a bare fence (backticks plus optional whitespace) closes the block;
+        # a language-tagged line like ```markdown inside the script stays code.
+        if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
             break
         inner.append(line)
     return "\n".join(inner).strip()
@@ -246,7 +248,7 @@ def reviewer(state: AgentState) -> dict:
     # the first token only — stripping markdown decoration — rather than scanning
     # the whole reply, where a RETRY explanation containing "done" would misfire.
     first = (verdict.split() or [""])[0].strip(":*#`")
-    done = first.startswith("DONE")
+    done = first.rstrip(".,!?;") == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -43,7 +43,7 @@ stages and the run resumable later via checkpointing.
 
 | Component | Version | Notes |
 |---|---|---|
-| langgraph | `>=0.2.50,<1` | `StateGraph`, `START`/`END`, `add_messages` |
+| langgraph | `>=0.2.50,<2` | `StateGraph`, `START`/`END`, `add_messages` |
 | langchain-openai | `>=1.0,<2.0` | `ChatOpenAI` (any OpenAI-compatible endpoint) |
 | cubesandbox SDK | `>=0.6.0` | `Sandbox.create` / `files.write` / `commands.run` |
 | CubeSandbox platform | `>=0.3.0` | core; higher for optional features (see LangChain guide) |
@@ -375,7 +375,7 @@ if __name__ == "__main__":
 Save the code above as `langgraph_agent_demo.py`, then run it:
 
 ```bash
-pip install "langgraph>=0.2.50,<1" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
+pip install "langgraph>=0.2.50,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
 python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
 ```
 

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -307,7 +307,7 @@ def reviewer(state: AgentState) -> dict:
     # token — a "DONE"/"RETRY" later in the explanation is prose, not a second
     # verdict. This avoids both a stray "DONE" in a RETRY explanation stopping
     # the loop and an "I would not RETRY" re-running a correct answer.
-    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;")
+    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;") if verdict else ""
     done = first == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -224,7 +224,10 @@ def coder(state: AgentState, run_python) -> dict:
     # stderr/traceback) land at the end, so they must survive the truncation.
     if len(output) > 4000:
         output = "[earlier output truncated]\n" + output[-4000:]
-    return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
+    # Include the code alongside the output so that on a RETRY the coder can see
+    # what it wrote last time instead of repeating the same mistake.
+    return {"messages": [{"role": "assistant",
+                          "content": f"[code]\n{code}\n[code output]\n{output}"}]}
 
 
 def reviewer(state: AgentState) -> dict:
@@ -232,10 +235,9 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
-    # Parse the first token so a markdown-wrapped or prose-led verdict
-    # ("**DONE**", "The result is DONE") still resolves correctly.
-    token = (verdict.split() or [""])[0].strip(":*#`")
-    done = token.startswith("DONE")
+    # Scan every whitespace-delimited token so a markdown-wrapped or prose-led
+    # verdict ("**DONE**", "The result is DONE") still resolves to DONE.
+    done = any(t.strip(":*#`").startswith("DONE") for t in verdict.split())
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {
@@ -285,8 +287,11 @@ if __name__ == "__main__":
         # The last message is the reviewer's verdict; print the code output
         # instead so the user actually sees the computed numbers.
         for msg in reversed(result["messages"]):
-            if msg.content and str(msg.content).startswith("[code output]"):
-                print(msg.content)
+            content = str(msg.content)
+            marker = "[code output]"
+            idx = content.find(marker)
+            if idx != -1:
+                print(content[idx:])
                 break
         else:
             print("(no code output)")

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -53,7 +53,9 @@ The prerequisites are identical to the LangChain guide — the same sandbox temp
 - A template image with the Python stack (pandas / numpy / matplotlib / scikit-learn) built and
   registered. Follow the LangChain guide's
   [template image](../integrations/langchain.md) steps, or reuse the same template id.
-- `cubesandbox` SDK env vars: `CUBE_API_URL`, `CUBE_TEMPLATE_ID`, `CUBE_PROXY_NODE_IP`.
+- `cubesandbox` SDK env vars: `CUBE_API_URL`, `CUBE_TEMPLATE_ID`, `CUBE_PROXY_NODE_IP`, plus
+  `CUBE_API_KEY` when the CubeAPI backend has auth enabled (the SDK sends no auth header when unset).
+- Python 3.10+ (the sample uses `str | None`, `Annotated`, and `langchain-openai` 1.x).
 - An OpenAI-compatible LLM endpoint via `OPENAI_BASE_URL` / `OPENAI_API_KEY`.
 
 ## Integration steps

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -62,7 +62,13 @@ The prerequisites are identical to the LangChain guide — the same sandbox temp
 
 Reuse the LangChain guide's `Dockerfile` (a Python data-science stack layered on `cubesandbox-base`,
 with envd listening on `:49983`). No LangGraph-specific packages need to be baked into the image —
-the graph runs on the host and only *code execution* happens inside the sandbox.
+the graph runs on the host and only *code execution* happens inside the sandbox. Build and push it
+under the tag you will register in step 2:
+
+```bash
+docker build -t <your-registry>/langgraph-cube:latest <path-to-dockerfile>
+docker push <your-registry>/langgraph-cube:latest
+```
 
 ### 2. Register the template and configure env vars
 
@@ -160,7 +166,8 @@ CODER_PROMPT = (
     "the latest user request using the dataset at /workspace/sales.csv "
     "(columns month,product,units,price). The environment has pandas, numpy, "
     "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
-    "network access. If a previous reviewer message said RETRY, fix the issues it "
+    "network access. Wrap the script in a single markdown ```python ... ``` fenced "
+    "block. If a previous reviewer message said RETRY, fix the issues it "
     "listed before re-running."
 )
 

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -1,0 +1,294 @@
+---
+title: LangGraph Integration Guide
+author: Mikey1129
+date: 2026-08-29
+tags:
+  - integration
+  - langgraph
+  - agent
+lang: en-US
+---
+
+# LangGraph Integration Guide
+
+Run a [LangGraph](https://github.com/langchain-ai/langgraph) agent — an explicit graph of nodes
+and conditional edges — that executes Python inside a
+[CubeSandbox](https://github.com/TencentCloud/CubeSandbox) MicroVM. Because Cube exposes an
+**E2B-compatible API**, the code-execution tool is a drop-in swap from E2B to Cube, while every line
+of agent-generated code gets KVM-level isolation.
+
+This is the LangGraph counterpart to the [LangChain integration](./langchain.md). Where the
+LangChain guide uses the high-level `create_agent` helper, this guide builds the graph **explicitly**
+with `StateGraph`, so you control the control flow, share one sandbox across nodes, and can wire
+LangGraph checkpointing to Cube's `pause()` / `connect()`.
+
+## LangGraph vs `create_agent`
+
+| | `create_agent` (LangChain guide) | Explicit `StateGraph` (this guide) |
+|---|---|---|
+| Graph shape | Fixed tool-calling loop, hidden from you | You define every node and edge |
+| Retry / loops | Implicit in the agent loop | Explicit `add_conditional_edges` |
+| State | Opaque message history | Typed `State` you design (sandbox id, attempts, verdict…) |
+| Resume | Not directly exposed | `checkpointer` ↔ Cube `pause()` / `connect()` |
+
+Use `create_agent` when you just need a tool-calling agent. Reach for an explicit `StateGraph` when
+you want a multi-step workflow — generate → execute → review → retry — with the sandbox shared across
+stages and the run resumable mid-graph.
+
+## Components and versions
+
+| Component | Version | Notes |
+|---|---|---|
+| langgraph | `>=0.2` | `StateGraph`, `START`/`END`, `add_messages` |
+| langchain-openai | `>=1.0,<2.0` | `ChatOpenAI` (any OpenAI-compatible endpoint) |
+| cubesandbox SDK | `>=0.6.0` | `Sandbox.create` / `files.write` / `commands.run` |
+| CubeSandbox platform | `>=0.3.0` | core; higher for optional features (see LangChain guide) |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` | layer your Python stack on top |
+
+## Prerequisites
+
+The prerequisites are identical to the LangChain guide — the same sandbox template works for both:
+
+- CubeSandbox deployed, CubeAPI reachable at `http://<node>:3000`.
+- A template image with the Python stack (pandas / numpy / matplotlib / scikit-learn) built and
+  registered. Follow the LangChain guide's
+  [template image](../integrations/langchain.md) steps, or reuse the same template id.
+- `cubesandbox` SDK env vars: `CUBE_API_URL`, `CUBE_TEMPLATE_ID`, `CUBE_PROXY_NODE_IP`.
+- An OpenAI-compatible LLM endpoint via `OPENAI_BASE_URL` / `OPENAI_API_KEY`.
+
+## Integration steps
+
+### 1. Build the template image
+
+Reuse the LangChain guide's `Dockerfile` (a Python data-science stack layered on `cubesandbox-base`,
+with envd listening on `:49983`). No LangGraph-specific packages need to be baked into the image —
+the graph runs on the host and only *code execution* happens inside the sandbox.
+
+### 2. Register the template and configure env vars
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/langgraph-cube:latest \
+  --writable-layer-size 2G \
+  --expose-port 49983 --probe 49983 --probe-path /health
+```
+
+Then set `CUBE_API_URL`, `CUBE_TEMPLATE_ID`, `CUBE_PROXY_NODE_IP`, and your LLM key. The variable
+table in the LangChain guide applies unchanged.
+
+### 3. Define the graph
+
+The graph has three moving parts:
+
+- **`coder`** — asks the LLM for a Python script and executes it in the sandbox.
+- **`reviewer`** — asks the LLM whether the output answers the request.
+- **a conditional edge** — routes `reviewer` back to `coder` (retry) or to `END`.
+
+One sandbox is created for the whole run and reused across every `coder` invocation; its id is kept
+in `State` so it survives across nodes and can be resumed later.
+
+```python
+from __future__ import annotations
+
+import itertools
+import os
+import sys
+from typing import Annotated, TypedDict
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from cubesandbox import Sandbox
+
+load_dotenv()
+
+for v in ("CUBE_TEMPLATE_ID",):
+    if not os.environ.get(v):
+        raise SystemExit(f"Missing env: {v}")
+
+_llm_key = os.getenv("OPENAI_API_KEY") or os.getenv("TOKENHUB_API_KEY")
+if not _llm_key:
+    raise SystemExit("Missing LLM API key")
+
+llm = ChatOpenAI(
+    model=os.getenv("CHAT_MODEL") or "deepseek-v3",
+    api_key=_llm_key,
+    base_url=os.getenv("OPENAI_BASE_URL") or "https://tokenhub.tencentmaas.com/v1",
+    timeout=60, max_retries=2, temperature=0,
+)
+
+
+class AgentState(TypedDict):
+    """State shared across nodes. `messages` accumulates the conversation;
+    `sandbox_id` pins one MicroVM for the whole graph run so `pause()` /
+    `connect()` can resume it later."""
+    messages: Annotated[list, add_messages]
+    sandbox_id: str
+    attempts: int
+    done: bool
+
+
+def make_run_python(sandbox: Sandbox):
+    """Return a `run_python` tool bound to one Cube sandbox — the same
+    `cubesandbox` SDK pattern used by the LangChain guide."""
+    _counter = itertools.count()
+
+    def run_python(code: str) -> str:
+        script = f"/workspace/_agent_{next(_counter)}.py"
+        sandbox.files.write(script, code)
+        result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
+        out = result.stdout
+        if result.stderr:
+            out += "\n--- stderr ---\n" + result.stderr
+        if result.exit_code != 0:
+            out += f"\n[non-zero exit code: {result.exit_code}]"
+        return out
+
+    return run_python
+
+
+CODER_PROMPT = (
+    "You are a data analyst. Write a single self-contained Python script that answers "
+    "the latest user request using the dataset at /workspace/sales.csv "
+    "(columns month,product,units,price). The environment has pandas, numpy, "
+    "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
+    "network access."
+)
+
+REVIEWER_PROMPT = (
+    "You are a reviewer. Given the user request and the latest code output, decide "
+    "whether the request is fully answered. Reply with exactly one word: DONE if the "
+    "output answers the request, otherwise RETRY followed by one line on what is missing."
+)
+
+
+def coder(state: AgentState, run_python) -> dict:
+    """Ask the LLM for code, execute it in the Cube sandbox, append the output."""
+    code = llm.invoke(
+        [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
+    ).content
+    output = run_python(code)
+    return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
+
+
+def reviewer(state: AgentState) -> dict:
+    """Judge whether the latest output answers the request."""
+    verdict = llm.invoke(
+        [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
+    ).content.strip().upper()
+    return {
+        "messages": [{"role": "assistant", "content": f"[reviewer] {verdict}"}],
+        "attempts": state.get("attempts", 0) + 1,
+        "done": verdict.startswith("DONE"),
+    }
+
+
+def route_after_review(state: AgentState) -> str:
+    """Conditional edge: retry `coder`, or finish after N attempts."""
+    if state["done"] or state["attempts"] >= 3:
+        return "end"
+    return "retry"
+
+
+def build_graph(run_python, checkpointer=None):
+    builder = StateGraph(AgentState)
+    builder.add_node("coder", lambda s: coder(s, run_python))
+    builder.add_node("reviewer", reviewer)
+    builder.add_edge(START, "coder")
+    builder.add_edge("coder", "reviewer")
+    builder.add_conditional_edges(
+        "reviewer",
+        route_after_review,
+        {"retry": "coder", "end": END},
+    )
+    return builder.compile(checkpointer=checkpointer)
+
+
+if __name__ == "__main__":
+    question = sys.argv[1] if len(sys.argv) > 1 else (
+        "Load sales.csv from /workspace, compute total revenue per month, "
+        "and report the month -> revenue numbers."
+    )
+
+    # One MicroVM for the whole run, reused across every coder -> reviewer loop.
+    # The context manager tears it down on exit, so nothing is left behind.
+    with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=600) as sandbox:
+        run_python = make_run_python(sandbox)
+        graph = build_graph(run_python)
+        result = graph.invoke({
+            "messages": [{"role": "user", "content": question}],
+            "sandbox_id": sandbox.sandbox_id,
+            "attempts": 0,
+            "done": False,
+        })
+        for msg in reversed(result["messages"]):
+            if msg.content:
+                print(msg.content)
+                break
+        else:
+            print("(no final answer)")
+```
+
+Run it:
+
+```bash
+pip install langgraph langchain-openai cubesandbox python-dotenv
+python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
+```
+
+### Expected behavior
+
+`coder` writes the LLM-generated script to a fresh `/workspace/_agent_<n>.py` and runs it inside the
+MicroVM; `reviewer` reads the output and either returns `DONE` or sends the graph back to `coder`
+(up to 3 attempts). The `attempts` counter in `State` caps the loop so a stubborn request cannot spin
+forever.
+
+## Advanced: checkpointing + `pause()` / `connect()`
+
+LangGraph checkpoints the graph state; Cube snapshots the sandbox. The two pair naturally for
+long-running, resumable agents:
+
+| LangGraph | Cube Sandbox |
+|---|---|
+| `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
+| `config = {"configurable": {"thread_id": "t1"}}` | `sandbox_id` in `State` |
+| resume with `invoke(..., config)` | `sandbox.pause()` then `Sandbox.connect(sandbox_id)` |
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+
+graph = build_graph(run_python, checkpointer=MemorySaver())
+config = {"configurable": {"thread_id": "t1"}}
+
+with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800) as sandbox:
+    graph.invoke(initial_input, config=config)      # checkpoint saved under thread_id t1
+    sandbox.pause()
+    sandbox = Sandbox.connect(sandbox.sandbox_id)   # /workspace intact after resume
+    graph.invoke(follow_up_input, config=config)    # resumes the same thread_id
+```
+
+Keep the LangGraph `thread_id` aligned with the Cube `sandbox_id` (e.g. store both in your
+orchestration layer) so a resumed graph reattaches to the same sandbox.
+
+## Caveats
+
+- **State is not serialized with the sandbox.** `State` lives in your process (or the LangGraph
+  checkpointer); only `/workspace` persists across `pause()` / `connect()`. Persist anything the
+  graph needs across a hard resume.
+- **One sandbox, one graph run.** The `coder`/`reviewer` loop reuses a single MicroVM; do not create
+  a new sandbox per node — you would pay the lifecycle cost every step.
+- **State does not persist across tool calls.** Each `commands.run` is a fresh `python3` process;
+  inline everything a snippet needs or write intermediate results back to `/workspace`.
+- **Preinstall the stack into the image.** Under a default-deny egress policy a runtime `pip install`
+  fails; bake pandas / numpy / matplotlib into the template.
+- **Cap the retry loop.** Use the `attempts` counter (as above) or LangGraph's recursion limit, so a
+  reviewer that keeps asking for retries cannot exhaust the sandbox `timeout`.
+
+## References
+
+- LangChain integration (the `create_agent` counterpart): [`langchain.md`](./langchain.md)
+- Custom template images: [`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Snapshot / clone / rollback: [`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- LangGraph: <https://github.com/langchain-ai/langgraph>
+- E2B SDK: <https://github.com/e2b-dev/e2b>

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -66,13 +66,13 @@ The prerequisites are identical to the LangChain guide — the same sandbox temp
 
 ### 1. Build the template image
 
-Reuse the LangChain guide's `Dockerfile` (a Python data-science stack layered on `cubesandbox-base`,
+Use the shipped `examples/langgraph-integration/Dockerfile` (a Python data-science stack layered on `cubesandbox-base`,
 with envd listening on `:49983`). No LangGraph-specific packages need to be baked into the image —
 the graph runs on the host and only *code execution* happens inside the sandbox. Build and push it
 under the tag you will register in step 2:
 
 ```bash
-docker build --platform linux/amd64 -t <your-registry>/langgraph-cube:latest <path-to-dockerfile>
+docker build --platform linux/amd64 -t <your-registry>/langgraph-cube:latest examples/langgraph-integration
 docker push <your-registry>/langgraph-cube:latest
 ```
 

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -153,7 +153,8 @@ CODER_PROMPT = (
     "the latest user request using the dataset at /workspace/sales.csv "
     "(columns month,product,units,price). The environment has pandas, numpy, "
     "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
-    "network access."
+    "network access. If a previous reviewer message said RETRY, fix the issues it "
+    "listed before re-running."
 )
 
 REVIEWER_PROMPT = (
@@ -207,8 +208,10 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
+    # Emit the verdict as a user-role message so the coder treats RETRY as a
+    # directive to fix, not as its own prior assistant output.
     return {
-        "messages": [{"role": "assistant", "content": f"[reviewer] {verdict}"}],
+        "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
         "attempts": state.get("attempts", 0) + 1,
         "done": verdict.startswith("DONE"),
     }
@@ -284,14 +287,13 @@ long-running, resumable agents:
 | LangGraph | Cube Sandbox |
 |---|---|
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
-| `config = {"configurable": {"thread_id": "t1"}}` | `sandbox_id` in `State` |
+| `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `sandbox_id` in `State` |
 | resume with `invoke(..., config)` | `sandbox.pause()` then `Sandbox.connect(sandbox_id)` |
 
 ```python
 from langgraph.checkpoint.memory import MemorySaver
 
 checkpointer = MemorySaver()
-config = {"configurable": {"thread_id": "t1"}}
 
 
 def stage_input(messages, sandbox_id):
@@ -303,6 +305,9 @@ def stage_input(messages, sandbox_id):
 
 
 sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
+# Key the checkpoint thread by the sandbox id so the same thread_id reattaches
+# to the same MicroVM across pause() / connect().
+config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
     graph.invoke(stage_input([{"role": "user", "content": "first task"}],
@@ -311,7 +316,7 @@ try:
     sandbox.pause()                                   # snapshot VM + rootfs
     # Sandbox.connect() returns a NEW instance; the run_python closure captured
     # the pre-pause one, so rebind the tool and rebuild the graph on the new
-    # instance, keeping the same checkpointer so thread t1 resumes.
+    # instance, keeping the same checkpointer so the same checkpoint thread resumes.
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
     graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}],

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -232,25 +232,34 @@ def strip_code_fence(text: str) -> str | None:
         return None                      # opener with no body — treat as no code
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # A closer is a line whose leading backtick run matches the opener's
-        # length and is followed by nothing but prose — models sometimes slip as
-        # `` ``` Done! ``. A shorter bare ``` line inside a docstring, or a
-        # 4-backtick fence when the opener was 3, stays code.
-        s = line.strip()
-        run = 0
-        while run < len(s) and s[run] == "`":
-            run += 1
-        if run == fence_len and (len(s) == run or s[run].isspace()):
-            break
+        # A closer is a column-0 line whose leading backtick run matches the
+        # opener's length and is followed by nothing but prose — models sometimes
+        # slip as `` ``` Done! ``. An indented fence inside a docstring or string
+        # literal, a shorter bare ``` line, or a 4-backtick fence when the opener
+        # was 3, all stay code.
+        if line.startswith("`"):
+            s = line.strip()
+            run = 0
+            while run < len(s) and s[run] == "`":
+                run += 1
+            if run == fence_len and (len(s) == run or s[run].isspace()):
+                break
         inner.append(line)
     return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code
 
 
 def coder(state: AgentState, run_python) -> dict:
     """Ask the LLM for code, execute it in the Cube sandbox, append the output."""
-    code = strip_code_fence(extract_text(llm.invoke(
-        [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
-    ).content))
+    try:
+        reply = llm.invoke(
+            [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
+        ).content
+    except Exception as exc:
+        # A transient LLM error (rate limit, 5xx, timeout) must not abort the
+        # whole graph run; surface it as empty code so the reviewer retries.
+        return {"messages": [{"role": "assistant",
+                              "content": f"[code output]\n(llm error: {exc})"}]}
+    code = strip_code_fence(extract_text(reply))
     if code is None:
         # The model returned no fenced code block; surface that instead of writing
         # prose to a .py file and wasting an attempt on a SyntaxError.
@@ -281,15 +290,25 @@ def coder(state: AgentState, run_python) -> dict:
 
 def reviewer(state: AgentState) -> dict:
     """Judge whether the latest output answers the request."""
-    verdict = extract_text(llm.invoke(
-        [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
-    ).content).strip().upper()
-    # Treat the full token list as authoritative: an explicit RETRY anywhere in
-    # the reply wins over DONE — the prompt asks for a single leading verdict
-    # word, so a stray "DONE" inside a RETRY explanation must not stop the loop.
-    # DONE only wins when no RETRY token is present.
-    tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
-    done = "DONE" in tokens and "RETRY" not in tokens
+    try:
+        reply = llm.invoke(
+            [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
+        ).content
+    except Exception as exc:
+        # A transient LLM error in the reviewer degrades to a retry rather than
+        # aborting the run.
+        return {
+            "messages": [{"role": "user", "content": f"[reviewer] RETRY (llm error: {exc})"}],
+            "attempts": state.get("attempts", 0) + 1,
+            "done": False,
+        }
+    verdict = extract_text(reply).strip().upper()
+    # The prompt asks for a single leading verdict word, so parse only the first
+    # token — a "DONE"/"RETRY" later in the explanation is prose, not a second
+    # verdict. This avoids both a stray "DONE" in a RETRY explanation stopping
+    # the loop and an "I would not RETRY" re-running a correct answer.
+    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;")
+    done = first == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -185,10 +185,15 @@ REVIEWER_PROMPT = (
 
 
 def extract_text(content) -> str:
-    """Return plain text from a message content, which may be a str or a list
-    of content blocks (some OpenAI-compatible endpoints return the latter)."""
+    """Return plain text from a message content, which may be a str, a single
+    content block dict, or a list of blocks (some OpenAI-compatible endpoints
+    return the latter two)."""
+    if not content:
+        return ""                     # None / empty content — treat as no text
     if isinstance(content, str):
         return content
+    if isinstance(content, dict):
+        content = [content]           # a lone content block, not a list
     if isinstance(content, list):
         parts = []
         for block in content:

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -116,7 +116,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+for v in ("CUBE_TEMPLATE_ID",):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -263,10 +263,20 @@ def reviewer(state: AgentState) -> dict:
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
     # The prompt asks for exactly one leading word (DONE/RETRY), so classify on
-    # the first token only — stripping markdown decoration — rather than scanning
-    # the whole reply, where a RETRY explanation containing "done" would misfire.
-    first = (verdict.split() or [""])[0].strip(":*#`")
-    done = first.rstrip(".,!?;") == "DONE"
+    # the first token first — stripping markdown decoration. If that token is
+    # neither, fall back to scanning the reply for a bare DONE/RETRY keyword, so
+    # a reviewer that drifts from the format (leading prose, bold markers) still
+    # classifies instead of silently burning retries.
+    tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
+    first = tokens[0] if tokens else ""
+    if first == "DONE":
+        done = True
+    elif first == "RETRY":
+        done = False
+    else:
+        # Prefer an explicit RETRY over a DONE mention, so "RETRY: the numbers
+        # are done but the chart is missing" still retries.
+        done = "DONE" in tokens and "RETRY" not in tokens
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -218,21 +218,28 @@ def strip_code_fence(text: str) -> str | None:
     start = text.find(fence)
     if start == -1:
         return None
+    # Read the full backtick-run length (```, ````, ...) so a 4-backtick fence is
+    # not mistaken for a 3-backtick opener, and require the closer to match it.
+    fence_len = len(fence)
+    while start + fence_len < len(text) and text[start + fence_len] == "`":
+        fence_len += 1
     # Code begins on the line after the opener; a language tag like ```python and
     # any trailing prose on that line are dropped.
-    after = text[start + len(fence):]
+    after = text[start + fence_len:]
     first_nl = after.find("\n")
     if first_nl == -1:
         return None                      # opener with no body — treat as no code
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # A closer starts with a fence run of three-or-more backticks and is
-        # otherwise empty (a bare ``` line) or followed only by prose on the same
-        # line — models sometimes slip as `` ``` Done! ``. A language-tagged line
-        # like ```markdown inside the script stays code. (Known limit: a bare ```
-        # line inside a docstring would still close early.)
+        # A closer is a line whose leading backtick run matches the opener's
+        # length and is followed by nothing but prose — models sometimes slip as
+        # `` ``` Done! ``. A shorter bare ``` line inside a docstring, or a
+        # 4-backtick fence when the opener was 3, stays code.
         s = line.strip()
-        if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
+        run = 0
+        while run < len(s) and s[run] == "`":
+            run += 1
+        if run == fence_len and (len(s) == run or s[run].isspace()):
             break
         inner.append(line)
     return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -33,7 +33,7 @@ LangGraph checkpointing to Cube's `pause()` / `connect()`.
 
 Use `create_agent` when you just need a tool-calling agent. Reach for an explicit `StateGraph` when
 you want a multi-step workflow — generate → execute → review → retry — with the sandbox shared across
-stages and the run resumable mid-graph.
+stages and the run resumable later via checkpointing.
 
 ## Components and versions
 
@@ -137,7 +137,13 @@ def make_run_python(sandbox: Sandbox):
     def run_python(code: str) -> str:
         script = f"/workspace/_agent_{next(_counter)}.py"
         sandbox.files.write(script, code)
-        result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
+        try:
+            result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
+        except Exception as exc:
+            # Transport errors and per-command timeouts raise here; surface them as
+            # tool output so the reviewer can see the failure and decide to retry,
+            # rather than letting the exception abort the whole graph run.
+            return f"[command error] {exc}"
         out = result.stdout
         if result.stderr:
             out += "\n--- stderr ---\n" + result.stderr

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -28,7 +28,7 @@ LangGraph checkpointing to Cube's `pause()` / `connect()`.
 |---|---|---|
 | Graph shape | Fixed tool-calling loop, hidden from you | You define every node and edge |
 | Retry / loops | Implicit in the agent loop | Explicit `add_conditional_edges` |
-| State | Opaque message history | Typed `State` you design (sandbox id, attempts, verdict…) |
+| State | Opaque message history | Typed `State` you design (attempts, verdict…) |
 | Resume | Not directly exposed | `checkpointer` ↔ Cube `pause()` / `connect()` |
 
 Use `create_agent` when you just need a tool-calling agent. Reach for an explicit `StateGraph` when
@@ -84,8 +84,9 @@ The graph has three moving parts:
 - **`reviewer`** — asks the LLM whether the output answers the request.
 - **a conditional edge** — routes `reviewer` back to `coder` (retry) or to `END`.
 
-One sandbox is created for the whole run and reused across every `coder` invocation; its id is kept
-in `State` so it survives across nodes and can be resumed later.
+One sandbox is created for the whole run and reused across every `coder` invocation. The graph holds
+it through the `run_python` closure (not through `State`); its id is the key you use to resume the
+run later via checkpointing.
 
 ```python
 from __future__ import annotations
@@ -121,10 +122,9 @@ llm = ChatOpenAI(
 
 class AgentState(TypedDict):
     """State shared across nodes. `messages` accumulates the conversation;
-    `sandbox_id` pins one MicroVM for the whole graph run so `pause()` /
-    `connect()` can resume it later."""
+    `attempts` / `done` drive the retry loop. The sandbox itself is shared
+    through the `run_python` closure, not through `State`."""
     messages: Annotated[list, add_messages]
-    sandbox_id: str
     attempts: int
     done: bool
 
@@ -159,8 +159,8 @@ CODER_PROMPT = (
 
 REVIEWER_PROMPT = (
     "You are a reviewer. Given the user request and the latest code output, decide "
-    "whether the request is fully answered. Reply with exactly one word: DONE if the "
-    "output answers the request, otherwise RETRY followed by one line on what is missing."
+    "whether the request is fully answered. Reply starting with exactly one word, "
+    "`DONE` or `RETRY`, optionally followed by one line explaining what is missing."
 )
 
 
@@ -251,7 +251,6 @@ if __name__ == "__main__":
         graph = build_graph(run_python)
         result = graph.invoke({
             "messages": [{"role": "user", "content": question}],
-            "sandbox_id": sandbox.sandbox_id,
             "attempts": 0,
             "done": False,
         })
@@ -265,7 +264,7 @@ if __name__ == "__main__":
             print("(no code output)")
 ```
 
-Run it:
+Save the code above as `langgraph_agent_demo.py`, then run it:
 
 ```bash
 pip install langgraph langchain-openai cubesandbox python-dotenv
@@ -287,7 +286,7 @@ long-running, resumable agents:
 | LangGraph | Cube Sandbox |
 |---|---|
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
-| `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `sandbox_id` in `State` |
+| `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `sandbox.sandbox_id` |
 | resume with `invoke(..., config)` | `sandbox.pause()` then `Sandbox.connect(sandbox_id)` |
 
 ```python
@@ -296,12 +295,12 @@ from langgraph.checkpoint.memory import MemorySaver
 checkpointer = MemorySaver()
 
 
-def stage_input(messages, sandbox_id):
+def stage_input(messages):
     """Build the graph input for one stage. `attempts`/`done` have no reducer,
     so explicit values here overwrite whatever the checkpoint stored. `messages`
     uses `add_messages`, so new messages are APPENDED to the prior history —
     use a fresh thread_id if you want a clean slate."""
-    return {"messages": messages, "sandbox_id": sandbox_id, "attempts": 0, "done": False}
+    return {"messages": messages, "attempts": 0, "done": False}
 
 
 sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
@@ -310,8 +309,7 @@ sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
 config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "first task"}],
-                             sandbox.sandbox_id), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "first task"}]), config=config)
 
     sandbox.pause()                                   # snapshot VM + rootfs
     # Sandbox.connect() returns a NEW instance; the run_python closure captured
@@ -319,8 +317,7 @@ try:
     # instance, keeping the same checkpointer so the same checkpoint thread resumes.
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}],
-                             sandbox.sandbox_id), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}]), config=config)
 finally:
     sandbox.kill()
 ```

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -173,11 +173,10 @@ def make_run_python(sandbox: Sandbox):
 
 CODER_PROMPT = (
     "You are a data analyst. Write a single self-contained Python script that answers "
-    "the user's task using the dataset at /workspace/sales.csv "
-    "(columns month,product,units,price). The environment has pandas, numpy, "
-    "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
-    "network access. Wrap the script in a single markdown ```python ... ``` fenced "
-    "block. Messages prefixed with [reviewer] are feedback on your last attempt, "
+    "the user's task using the dataset file(s) named in the task. The environment has "
+    "pandas, numpy, matplotlib, scikit-learn preinstalled. Print the final numbers. "
+    "Do not rely on network access. Wrap the script in a single markdown ```python ... ``` "
+    "fenced block. Messages prefixed with [reviewer] are feedback on your last attempt, "
     "not a new task: if one said RETRY, fix the issues it listed before re-running."
 )
 
@@ -424,15 +423,16 @@ def stage_input(messages):
     return {"messages": messages, "attempts": 0, "done": False}
 
 
-sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
-# Key the checkpoint thread by the sandbox id so the same thread_id reattaches
-# to the same MicroVM across pause() / connect().
-config = {"configurable": {"thread_id": sandbox.sandbox_id}}
+sandbox = None
 try:
+    sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
+    # Key the checkpoint thread by the sandbox id so the same thread_id reattaches
+    # to the same MicroVM across pause() / connect().
+    config = {"configurable": {"thread_id": sandbox.sandbox_id}}
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
     # Stage 1 writes an intermediate artifact so stage 2 reads state that only
     # survives because /workspace persists across pause() / connect().
-    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and write the month -> revenue table to /workspace/monthly_revenue.csv."}]), config=config)
+    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace (columns month,product,units,price), compute total revenue per month, write the month -> revenue table to /workspace/monthly_revenue.csv, and write the exact string 'stage1-complete' to /workspace/stage1_marker.txt."}]), config=config)
     if not stage1["done"]:
         print("(stage 1 not verified: reviewer never returned DONE)")
 
@@ -442,9 +442,13 @@ try:
     # instance, keeping the same checkpointer so the same checkpoint thread resumes.
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv (written by stage 1) and report which month had the highest revenue."}]), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv and /workspace/stage1_marker.txt (both written by stage 1) and report the marker's exact text and which month had the highest revenue. Use only those two files — do not recompute from sales.csv."}]), config=config)
 finally:
-    sandbox.kill()
+    if sandbox is not None:
+        try:
+            sandbox.kill()
+        except Exception:
+            pass
 ```
 
 Keep the LangGraph `thread_id` aligned with the Cube `sandbox_id` (e.g. store both in your

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -235,9 +235,11 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
-    # Scan every whitespace-delimited token so a markdown-wrapped or prose-led
-    # verdict ("**DONE**", "The result is DONE") still resolves to DONE.
-    done = any(t.strip(":*#`").startswith("DONE") for t in verdict.split())
+    # The prompt asks for exactly one leading word (DONE/RETRY), so classify on
+    # the first token only — stripping markdown decoration — rather than scanning
+    # the whole reply, where a RETRY explanation containing "done" would misfire.
+    first = (verdict.split() or [""])[0].strip(":*#`")
+    done = first.startswith("DONE")
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {
@@ -300,7 +302,7 @@ if __name__ == "__main__":
 Save the code above as `langgraph_agent_demo.py`, then run it:
 
 ```bash
-pip install langgraph langchain-openai cubesandbox python-dotenv
+pip install "langgraph>=0.2,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
 python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
 ```
 

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -303,10 +303,9 @@ def reviewer(state: AgentState) -> dict:
             "done": False,
         }
     verdict = extract_text(reply).strip().upper()
-    # The prompt asks for a single leading verdict word, so parse only the first
-    # token — a "DONE"/"RETRY" later in the explanation is prose, not a second
-    # verdict. This avoids both a stray "DONE" in a RETRY explanation stopping
-    # the loop and an "I would not RETRY" re-running a correct answer.
+    # The prompt asks for a single leading verdict word, so only the leading
+    # token counts as the verdict — a "DONE"/"RETRY" later in the explanation
+    # is prose and doesn't flip the result.
     first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;") if verdict else ""
     done = first == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
@@ -361,9 +360,15 @@ if __name__ == "__main__":
             content = str(msg.content)
             marker = "[code output]"
             idx = content.find(marker)
-            if idx != -1:
-                print(content[idx:])
-                break
+            if idx == -1:
+                continue
+            tail = content[idx + len(marker):].lstrip("\n")
+            # Skip placeholder outputs (a failed LLM call or an empty/invalid
+            # extraction) so a "llm error: ..." doesn't read like a real result.
+            if tail.startswith(("(llm error", "(no code block", "(extracted block")):
+                continue
+            print(content[idx:])
+            break
         else:
             print("(no code output)")
         if not result["done"]:

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -163,11 +163,25 @@ REVIEWER_PROMPT = (
 )
 
 
+def strip_code_fence(text: str) -> str:
+    """Strip optional markdown code fences the model may wrap code in."""
+    fence = "`" * 3                      # three backticks, without a literal fence
+    text = text.strip()
+    if text.startswith(fence):
+        lines = text.splitlines()
+        if lines and lines[0].startswith(fence):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == fence:
+            lines = lines[:-1]
+        return "\n".join(lines).strip()
+    return text
+
+
 def coder(state: AgentState, run_python) -> dict:
     """Ask the LLM for code, execute it in the Cube sandbox, append the output."""
-    code = llm.invoke(
+    code = strip_code_fence(llm.invoke(
         [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
-    ).content
+    ).content)
     output = run_python(code)
     return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
 
@@ -222,12 +236,14 @@ if __name__ == "__main__":
             "attempts": 0,
             "done": False,
         })
+        # The last message is the reviewer's verdict; print the code output
+        # instead so the user actually sees the computed numbers.
         for msg in reversed(result["messages"]):
-            if msg.content:
+            if msg.content and str(msg.content).startswith("[code output]"):
                 print(msg.content)
                 break
         else:
-            print("(no final answer)")
+            print("(no code output)")
 ```
 
 Run it:
@@ -258,14 +274,32 @@ long-running, resumable agents:
 ```python
 from langgraph.checkpoint.memory import MemorySaver
 
-graph = build_graph(run_python, checkpointer=MemorySaver())
+checkpointer = MemorySaver()
 config = {"configurable": {"thread_id": "t1"}}
 
-with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800) as sandbox:
-    graph.invoke(initial_input, config=config)      # checkpoint saved under thread_id t1
-    sandbox.pause()
-    sandbox = Sandbox.connect(sandbox.sandbox_id)   # /workspace intact after resume
-    graph.invoke(follow_up_input, config=config)    # resumes the same thread_id
+
+def stage_input(messages, sandbox_id):
+    """Build the graph input for one stage. `attempts`/`done` have no reducer,
+    so explicit values here overwrite whatever the checkpoint stored."""
+    return {"messages": messages, "sandbox_id": sandbox_id, "attempts": 0, "done": False}
+
+
+sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
+try:
+    graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
+    graph.invoke(stage_input([{"role": "user", "content": "first task"}],
+                             sandbox.sandbox_id), config=config)
+
+    sandbox.pause()                                   # snapshot VM + rootfs
+    # Sandbox.connect() returns a NEW instance; the run_python closure captured
+    # the pre-pause one, so rebind the tool and rebuild the graph on the new
+    # instance, keeping the same checkpointer so thread t1 resumes.
+    sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
+    graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
+    graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}],
+                             sandbox.sandbox_id), config=config)
+finally:
+    sandbox.kill()
 ```
 
 Keep the LangGraph `thread_id` aligned with the Cube `sandbox_id` (e.g. store both in your

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -215,10 +215,13 @@ def strip_code_fence(text: str) -> str | None:
         return None
     inner = []
     for line in lines[start + 1:]:
-        # Only a bare fence (backticks plus optional whitespace) closes the block;
-        # a language-tagged line like ```markdown inside the script stays code.
-        # (Known limit: a bare ``` line inside a docstring would still close early.)
-        if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
+        # A closer starts with a fence run of three-or-more backticks and is
+        # otherwise empty (a bare ``` line) or followed only by prose on the same
+        # line — models sometimes slip as `` ``` Done! ``. A language-tagged line
+        # like ```markdown inside the script stays code. (Known limit: a bare ```
+        # line inside a docstring would still close early.)
+        s = line.strip()
+        if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
             break
         inner.append(line)
     return "\n".join(inner).strip()

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -163,6 +163,22 @@ REVIEWER_PROMPT = (
 )
 
 
+def extract_text(content) -> str:
+    """Return plain text from a message content, which may be a str or a list
+    of content blocks (some OpenAI-compatible endpoints return the latter)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "\n".join(parts)
+    return str(content)
+
+
 def strip_code_fence(text: str) -> str:
     """Strip optional markdown code fences the model may wrap code in."""
     fence = "`" * 3                      # three backticks, without a literal fence
@@ -179,18 +195,18 @@ def strip_code_fence(text: str) -> str:
 
 def coder(state: AgentState, run_python) -> dict:
     """Ask the LLM for code, execute it in the Cube sandbox, append the output."""
-    code = strip_code_fence(llm.invoke(
+    code = strip_code_fence(extract_text(llm.invoke(
         [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
-    ).content)
+    ).content))
     output = run_python(code)
     return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
 
 
 def reviewer(state: AgentState) -> dict:
     """Judge whether the latest output answers the request."""
-    verdict = llm.invoke(
+    verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
-    ).content.strip().upper()
+    ).content).strip().upper()
     return {
         "messages": [{"role": "assistant", "content": f"[reviewer] {verdict}"}],
         "attempts": state.get("attempts", 0) + 1,
@@ -280,7 +296,9 @@ config = {"configurable": {"thread_id": "t1"}}
 
 def stage_input(messages, sandbox_id):
     """Build the graph input for one stage. `attempts`/`done` have no reducer,
-    so explicit values here overwrite whatever the checkpoint stored."""
+    so explicit values here overwrite whatever the checkpoint stored. `messages`
+    uses `add_messages`, so new messages are APPENDED to the prior history —
+    use a fresh thread_id if you want a clean slate."""
     return {"messages": messages, "sandbox_id": sandbox_id, "attempts": 0, "done": False}
 
 

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -22,6 +22,10 @@ LangChain guide uses the high-level `create_agent` helper, this guide builds the
 with `StateGraph`, so you control the control flow, share one sandbox across nodes, and can wire
 LangGraph checkpointing to Cube's `pause()` / `connect()`.
 
+A runnable version of this guide ships in
+[`examples/langgraph-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/langgraph-integration),
+which is the source of truth for the code listings below.
+
 ## LangGraph vs `create_agent`
 
 | | `create_agent` (LangChain guide) | Explicit `StateGraph` (this guide) |
@@ -56,7 +60,7 @@ The prerequisites are identical to the LangChain guide — the same sandbox temp
 - `cubesandbox` SDK env vars: `CUBE_API_URL`, `CUBE_TEMPLATE_ID`, `CUBE_PROXY_NODE_IP`, plus
   `CUBE_API_KEY` when the CubeAPI backend has auth enabled (the SDK sends no auth header when unset).
 - Python 3.10+ (the sample uses `str | None`, `Annotated`, and `langchain-openai` 1.x).
-- An OpenAI-compatible LLM endpoint via `OPENAI_BASE_URL` / `OPENAI_API_KEY`.
+- An OpenAI-compatible LLM endpoint via `OPENAI_BASE_URL` / `OPENAI_API_KEY` (or `TOKENHUB_API_KEY`).
 
 ## Integration steps
 
@@ -68,7 +72,7 @@ the graph runs on the host and only *code execution* happens inside the sandbox.
 under the tag you will register in step 2:
 
 ```bash
-docker build -t <your-registry>/langgraph-cube:latest <path-to-dockerfile>
+docker build --platform linux/amd64 -t <your-registry>/langgraph-cube:latest <path-to-dockerfile>
 docker push <your-registry>/langgraph-cube:latest
 ```
 
@@ -213,6 +217,7 @@ def strip_code_fence(text: str) -> str | None:
     for line in lines[start + 1:]:
         # Only a bare fence (backticks plus optional whitespace) closes the block;
         # a language-tagged line like ```markdown inside the script stays code.
+        # (Known limit: a bare ``` line inside a docstring would still close early.)
         if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
             break
         inner.append(line)

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -423,7 +423,9 @@ sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
 config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
+    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
+    if not stage1["done"]:
+        print("(stage 1 not verified: reviewer never returned DONE)")
 
     sandbox.pause()                                   # snapshot VM + rootfs
     # Sandbox.connect() returns a NEW instance; the run_python closure captured

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -43,7 +43,7 @@ stages and the run resumable later via checkpointing.
 
 | Component | Version | Notes |
 |---|---|---|
-| langgraph | `>=0.2` | `StateGraph`, `START`/`END`, `add_messages` |
+| langgraph | `>=0.2.50,<1` | `StateGraph`, `START`/`END`, `add_messages` |
 | langchain-openai | `>=1.0,<2.0` | `ChatOpenAI` (any OpenAI-compatible endpoint) |
 | cubesandbox SDK | `>=0.6.0` | `Sandbox.create` / `files.write` / `commands.run` |
 | CubeSandbox platform | `>=0.3.0` | core; higher for optional features (see LangChain guide) |
@@ -57,8 +57,10 @@ The prerequisites are identical to the LangChain guide — the same sandbox temp
 - A template image with the Python stack (pandas / numpy / matplotlib / scikit-learn) built and
   registered. Follow the LangChain guide's
   [template image](../integrations/langchain.md) steps, or reuse the same template id.
-- `cubesandbox` SDK env vars: `CUBE_API_URL`, `CUBE_TEMPLATE_ID`, `CUBE_PROXY_NODE_IP`, plus
-  `CUBE_API_KEY` when the CubeAPI backend has auth enabled (the SDK sends no auth header when unset).
+- `cubesandbox` SDK env vars: `CUBE_TEMPLATE_ID` (required), plus `CUBE_API_URL` and
+  `CUBE_PROXY_NODE_IP` (required only for remote / direct-IP deployments — the SDK falls back to
+  `http://127.0.0.1:3000` / the wildcard-DNS host when unset), and `CUBE_API_KEY` when the CubeAPI
+  backend has auth enabled (the SDK sends no auth header when unset).
 - Python 3.10+ (the sample uses `str | None`, `Annotated`, and `langchain-openai` 1.x).
 - An OpenAI-compatible LLM endpoint via `OPENAI_BASE_URL` / `OPENAI_API_KEY` (or `TOKENHUB_API_KEY`).
 
@@ -85,8 +87,8 @@ cubemastercli tpl create-from-image \
   --expose-port 49983 --probe 49983 --probe-path /health
 ```
 
-Then set `CUBE_API_URL`, `CUBE_TEMPLATE_ID`, `CUBE_PROXY_NODE_IP`, and your LLM key. The variable
-table in the LangChain guide applies unchanged.
+Then set `CUBE_TEMPLATE_ID` and your LLM key; set `CUBE_API_URL` and `CUBE_PROXY_NODE_IP` only when
+they differ from the SDK defaults. The variable table in the LangChain guide applies unchanged.
 
 ### 3. Define the graph
 
@@ -262,21 +264,12 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
-    # The prompt asks for exactly one leading word (DONE/RETRY), so classify on
-    # the first token first — stripping markdown decoration. If that token is
-    # neither, fall back to scanning the reply for a bare DONE/RETRY keyword, so
-    # a reviewer that drifts from the format (leading prose, bold markers) still
-    # classifies instead of silently burning retries.
+    # Treat the full token list as authoritative: an explicit RETRY anywhere in
+    # the reply wins over DONE — the prompt asks for a single leading verdict
+    # word, so a stray "DONE" inside a RETRY explanation must not stop the loop.
+    # DONE only wins when no RETRY token is present.
     tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
-    first = tokens[0] if tokens else ""
-    if first == "DONE":
-        done = True
-    elif first == "RETRY":
-        done = False
-    else:
-        # Prefer an explicit RETRY over a DONE mention, so "RETRY: the numbers
-        # are done but the chart is missing" still retries.
-        done = "DONE" in tokens and "RETRY" not in tokens
+    done = "DONE" in tokens and "RETRY" not in tokens
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {
@@ -341,7 +334,7 @@ if __name__ == "__main__":
 Save the code above as `langgraph_agent_demo.py`, then run it:
 
 ```bash
-pip install "langgraph>=0.2,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
+pip install "langgraph>=0.2.50,<1" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
 python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
 ```
 
@@ -366,6 +359,10 @@ long-running, resumable agents:
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
 | `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `sandbox.sandbox_id` |
 | continue a new run on the same thread via `invoke(..., config)` | `sandbox.pause()` then `Sandbox.connect(sandbox_id)` |
+
+The snippet below continues the graph defined above — `Sandbox`, `build_graph`, and
+`make_run_python` come from the earlier sections. The standalone runnable script is
+`examples/langgraph-integration/langgraph_checkpoint_demo.py`.
 
 ```python
 from langgraph.checkpoint.memory import MemorySaver

--- a/docs/guide/integrations/langgraph.md
+++ b/docs/guide/integrations/langgraph.md
@@ -43,7 +43,7 @@ stages and the run resumable later via checkpointing.
 
 | Component | Version | Notes |
 |---|---|---|
-| langgraph | `>=0.2.50,<2` | `StateGraph`, `START`/`END`, `add_messages` |
+| langgraph | `>=1,<2` | `StateGraph`, `START`/`END`, `add_messages`; 0.2.x is incompatible with langchain-openai 1.x |
 | langchain-openai | `>=1.0,<2.0` | `ChatOpenAI` (any OpenAI-compatible endpoint) |
 | cubesandbox SDK | `>=0.6.0` | `Sandbox.create` / `files.write` / `commands.run` |
 | CubeSandbox platform | `>=0.3.0` | core; higher for optional features (see LangChain guide) |
@@ -379,7 +379,7 @@ if __name__ == "__main__":
 Save the code above as `langgraph_agent_demo.py`, then run it:
 
 ```bash
-pip install "langgraph>=0.2.50,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
+pip install "langgraph>=1,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
 python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
 ```
 
@@ -435,6 +435,7 @@ try:
     stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace (columns month,product,units,price), compute total revenue per month, write the month -> revenue table to /workspace/monthly_revenue.csv, and write the exact string 'stage1-complete' to /workspace/stage1_marker.txt."}]), config=config)
     if not stage1["done"]:
         print("(stage 1 not verified: reviewer never returned DONE)")
+        sys.exit(1)
 
     sandbox.pause()                                   # snapshot VM + rootfs
     # Sandbox.connect() returns a NEW instance; the run_python closure captured

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -8,7 +8,7 @@
 
 ## 适合收录的内容
 
-- LangChain、Dify、OpenClaw、Claude Code 等 Agent 框架集成
+- LangChain、LangGraph、Dify、OpenClaw、Claude Code 等 Agent 框架集成
 - SDK 接线方式与平台相关配置说明
 - 带示例仓库的端到端集成方案
 - 兼容性说明、限制条件与推荐配置
@@ -51,3 +51,4 @@ lang: zh-CN
 | [Claude Code 集成指南](./claude-code.md) | shsaihdsaiudh | 2026-07-06 | integration, claude-code, coding-agent |
 | [LangChain 集成指南](./langchain.md) | peerless-hero | 2026-07-07 | integration, langchain, agent |
 | [OpenAI Agents SDK 集成指南](./openai-agents-sdk.md) | ZedingZhang | 2026-08-19 | integration, openai-agents-sdk, agent |
+| [LangGraph 集成指南](./langgraph.md) | Mikey1129 | 2026-08-29 | integration, langgraph, agent |

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -109,7 +109,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+for v in ("CUBE_TEMPLATE_ID",):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -247,10 +247,18 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
-    # prompt 要求回复以一个判定词（DONE/RETRY）开头，所以只按第一个 token 判定，
-    # 并剥离 markdown 装饰；不要扫描整句，否则 RETRY 的解释文字里出现 "done" 会误判。
-    first = (verdict.split() or [""])[0].strip(":*#`")
-    done = first.rstrip(".,!?;") == "DONE"
+    # prompt 要求回复以一个判定词（DONE/RETRY）开头，所以先按第一个 token 判定，并剥离
+    # markdown 装饰；若该 token 不是判定词，则回退为扫描整句里的裸 DONE/RETRY 关键词，
+    # 这样偏离格式（前导散文、加粗标记）的回复仍能分类，而不是静默烧掉重试次数。
+    tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
+    first = tokens[0] if tokens else ""
+    if first == "DONE":
+        done = True
+    elif first == "RETRY":
+        done = False
+    else:
+        # 优先显式的 RETRY，而不是 DONE 的提及，避免 "RETRY: 数字已算完但缺图表" 被误判为完成。
+        done = "DONE" in tokens and "RETRY" not in tokens
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
     # 而不是当作它自己先前的 assistant 输出。
     return {

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -97,6 +97,7 @@ cubemastercli tpl create-from-image \
 ```python
 from __future__ import annotations
 
+import ast
 import itertools
 import os
 import sys
@@ -160,12 +161,12 @@ def make_run_python(sandbox: Sandbox):
 
 CODER_PROMPT = (
     "You are a data analyst. Write a single self-contained Python script that answers "
-    "the latest user request using the dataset at /workspace/sales.csv "
+    "the user's task using the dataset at /workspace/sales.csv "
     "(columns month,product,units,price). The environment has pandas, numpy, "
     "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
     "network access. Wrap the script in a single markdown ```python ... ``` fenced "
-    "block. If a previous reviewer message said RETRY, fix the issues it "
-    "listed before re-running."
+    "block. Messages prefixed with [reviewer] are feedback on your last attempt, "
+    "not a new task: if one said RETRY, fix the issues it listed before re-running."
 )
 
 REVIEWER_PROMPT = (
@@ -240,6 +241,13 @@ def coder(state: AgentState, run_python) -> dict:
         # 模型没有返回围栏代码块；直接提示，而不是把散文写进 .py 文件、浪费一次重试机会。
         return {"messages": [{"role": "assistant",
                               "content": "[code output]\n(no code block in model reply)"}]}
+    try:
+        ast.parse(code)
+    except SyntaxError as exc:
+        # 围栏块不是合法 Python（例如模型在真正脚本前加了一个 diff/示例围栏）；
+        # 直接提示让 reviewer 重试，而不是写一个注定失败的 .py。
+        return {"messages": [{"role": "assistant",
+                              "content": f"[code output]\n(extracted block is not valid Python: {exc})"}]}
     output = run_python(code)
     # 同时截断代码与输出，以免超大结果（如打印整个 DataFrame）或过长的生成脚本
     # 在多次重试中撑爆模型上下文窗口；各自保留尾部——打印的数字（以及
@@ -371,14 +379,14 @@ sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
 config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "first task"}]), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
 
     sandbox.pause()                                   # 快照 VM + 根文件系统
     # Sandbox.connect() 返回的是新实例；run_python 闭包捕获的是暂停前的旧实例，
     # 因此需要重新绑定工具并在新实例上重建图，同时保留同一个 checkpointer 以恢复同一 checkpoint 线程。
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # 恢复后 /workspace 保持不变
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}]), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "now compute average units per product"}]), config=config)
 finally:
     sandbox.kill()
 ```

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -40,7 +40,7 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 
 | 组件 | 版本 | 说明 |
 |---|---|---|
-| langgraph | `>=0.2.50,<1` | `StateGraph`、`START`/`END`、`add_messages` |
+| langgraph | `>=0.2.50,<2` | `StateGraph`、`START`/`END`、`add_messages` |
 | langchain-openai | `>=1.0,<2.0` | `ChatOpenAI`（任意 OpenAI 兼容端点） |
 | cubesandbox SDK | `>=0.6.0` | `Sandbox.create` / `files.write` / `commands.run` |
 | CubeSandbox 平台 | `>=0.3.0` | 核心；可选特性见 LangChain 指南 |
@@ -354,7 +354,7 @@ if __name__ == "__main__":
 将上面的代码保存为 `langgraph_agent_demo.py`，然后运行：
 
 ```bash
-pip install "langgraph>=0.2.50,<1" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
+pip install "langgraph>=0.2.50,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
 python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
 ```
 

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -222,9 +222,10 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
-    # 扫描每个空白分隔的 token，这样被 markdown 包裹或前面带散文的判定
-    # （"**DONE**"、"The result is DONE"）也能正确识别为 DONE。
-    done = any(t.strip(":*#`").startswith("DONE") for t in verdict.split())
+    # prompt 要求回复以一个判定词（DONE/RETRY）开头，所以只按第一个 token 判定，
+    # 并剥离 markdown 装饰；不要扫描整句，否则 RETRY 的解释文字里出现 "done" 会误判。
+    first = (verdict.split() or [""])[0].strip(":*#`")
+    done = first.startswith("DONE")
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
     # 而不是当作它自己先前的 assistant 输出。
     return {
@@ -286,7 +287,7 @@ if __name__ == "__main__":
 将上面的代码保存为 `langgraph_agent_demo.py`，然后运行：
 
 ```bash
-pip install langgraph langchain-openai cubesandbox python-dotenv
+pip install "langgraph>=0.2,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
 python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
 ```
 

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -20,6 +20,10 @@ Cube 暴露了**与 E2B 兼容的 API**，代码执行工具可以从 E2B 无缝
 `create_agent`，本文则用 `StateGraph` **显式**搭建图：由你掌控控制流、在节点间共享同一个沙箱，并把
 LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 
+本指南的可运行版本见
+[`examples/langgraph-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/langgraph-integration)，
+它是下方代码清单的权威来源。
+
 ## LangGraph 与 `create_agent` 的对比
 
 | | `create_agent`（LangChain 指南） | 显式 `StateGraph`（本文） |
@@ -52,7 +56,7 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 - `cubesandbox` SDK 所需环境变量：`CUBE_API_URL`、`CUBE_TEMPLATE_ID`、`CUBE_PROXY_NODE_IP`；
   CubeAPI 后端启用鉴权时还需 `CUBE_API_KEY`（未设置时 SDK 不发送鉴权头）。
 - Python 3.10+（示例使用 `str | None`、`Annotated` 及 `langchain-openai` 1.x）。
-- 经 `OPENAI_BASE_URL` / `OPENAI_API_KEY` 接入的 OpenAI 兼容 LLM 端点。
+- 经 `OPENAI_BASE_URL` / `OPENAI_API_KEY`（或 `TOKENHUB_API_KEY`）接入的 OpenAI 兼容 LLM 端点。
 
 ## 接入步骤
 
@@ -63,7 +67,7 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 用第 2 步要注册的 tag 构建并推送：
 
 ```bash
-docker build -t <your-registry>/langgraph-cube:latest <path-to-dockerfile>
+docker build --platform linux/amd64 -t <your-registry>/langgraph-cube:latest <path-to-dockerfile>
 docker push <your-registry>/langgraph-cube:latest
 ```
 
@@ -202,6 +206,7 @@ def strip_code_fence(text: str) -> str | None:
     for line in lines[start + 1:]:
         # 只有裸围栏（反引号加可选空白）才视为关闭；脚本内部像 ```markdown 这样的
         # 语言标签行要当作代码保留。
+        # （已知限制：docstring 里的裸 ``` 行仍会被提前当作关闭。）
         if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
             break
         inner.append(line)

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -397,7 +397,9 @@ sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
 config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
+    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
+    if not stage1["done"]:
+        print("(stage 1 not verified: reviewer never returned DONE)")
 
     sandbox.pause()                                   # 快照 VM + 根文件系统
     # Sandbox.connect() 返回的是新实例；run_python 闭包捕获的是暂停前的旧实例，

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -128,12 +128,12 @@ def make_run_python(sandbox: Sandbox):
 
     def run_python(code: str) -> str:
         script = f"/workspace/_agent_{next(_counter)}.py"
-        sandbox.files.write(script, code)
         try:
+            sandbox.files.write(script, code)
             result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
         except Exception as exc:
-            # 传输错误和单命令超时会在这里抛异常；把它作为工具输出返回，
-            # 让 reviewer 能看到失败并决定重试，而不是让异常直接终止整张图的运行。
+            # 沙箱已死、写入失败、传输错误和单命令超时都会在这里抛异常；把它作为
+            # 工具输出返回，让 reviewer 能看到失败并决定重试，而不是让异常直接终止整张图的运行。
             return f"[command error] {exc}"
         out = result.stdout
         if result.stderr:
@@ -219,12 +219,16 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
+    # 解析第一个 token，这样被 markdown 包裹或前面带散文的判定
+    # （"**DONE**"、"The result is DONE"）也能正确识别。
+    token = (verdict.split() or [""])[0].strip(":*#`")
+    done = token.startswith("DONE")
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
     # 而不是当作它自己先前的 assistant 输出。
     return {
         "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
         "attempts": state.get("attempts", 0) + 1,
-        "done": verdict.startswith("DONE"),
+        "done": done,
     }
 
 

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -40,7 +40,7 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 
 | 组件 | 版本 | 说明 |
 |---|---|---|
-| langgraph | `>=0.2.50,<2` | `StateGraph`、`START`/`END`、`add_messages` |
+| langgraph | `>=1,<2` | `StateGraph`、`START`/`END`、`add_messages`；0.2.x 与 langchain-openai 1.x 不兼容 |
 | langchain-openai | `>=1.0,<2.0` | `ChatOpenAI`（任意 OpenAI 兼容端点） |
 | cubesandbox SDK | `>=0.6.0` | `Sandbox.create` / `files.write` / `commands.run` |
 | CubeSandbox 平台 | `>=0.3.0` | 核心；可选特性见 LangChain 指南 |
@@ -356,7 +356,7 @@ if __name__ == "__main__":
 将上面的代码保存为 `langgraph_agent_demo.py`，然后运行：
 
 ```bash
-pip install "langgraph>=0.2.50,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
+pip install "langgraph>=1,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
 python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
 ```
 
@@ -407,6 +407,7 @@ try:
     stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace (columns month,product,units,price), compute total revenue per month, write the month -> revenue table to /workspace/monthly_revenue.csv, and write the exact string 'stage1-complete' to /workspace/stage1_marker.txt."}]), config=config)
     if not stage1["done"]:
         print("(stage 1 not verified: reviewer never returned DONE)")
+        sys.exit(1)
 
     sandbox.pause()                                   # 快照 VM + 根文件系统
     # Sandbox.connect() 返回的是新实例；run_python 闭包捕获的是暂停前的旧实例，

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -218,18 +218,22 @@ def strip_code_fence(text: str) -> str | None:
     first_nl = after.find("\n")
     if first_nl == -1:
         return None                      # 只有开启符没有正文——视为无代码
+    # 开启符的缩进是其所在行的前导空白。关闭符与开启符同缩进——这样嵌套在 Markdown
+    # 列表里的围栏也能正确关闭，而缩进更深（例如 docstring 或字符串字面量里的 Markdown
+    # 示例）的 ``` 行仍当作代码保留。
+    opener_line = text[text.rfind("\n", 0, start) + 1:start]
+    opener_indent = len(opener_line) - len(opener_line.lstrip())
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # 关闭符必须是顶格（column 0）、开头反引号连串长度与开启符一致且其后只有文字——
-        # 模型偶尔会滑成 `` ``` Done! ``。docstring 或字符串字面量里缩进的围栏、较短的
-        # 裸 ``` 行，或开启符为 3 反引号时出现的 4 反引号围栏，都当作代码保留。
-        if line.startswith("`"):
-            s = line.strip()
-            run = 0
-            while run < len(s) and s[run] == "`":
-                run += 1
-            if run == fence_len and (len(s) == run or s[run].isspace()):
-                break
+        # 关闭符是「去掉前导空白后反引号连串长度等于开启符、与开启符同缩进、且其后只有文字」
+        # 的行——模型偶尔会滑成 `` ``` Done! ``。较短的裸 ``` 行，或开启符为 3 反引号时
+        # 出现的 4 反引号围栏，都当作代码保留。
+        s = line.lstrip()
+        run = 0
+        while run < len(s) and s[run] == "`":
+            run += 1
+        if run == fence_len and (len(s) == run or s[run].isspace()) and len(line) - len(s) == opener_indent:
+            break
         inner.append(line)
     return "\n".join(inner).strip() or None  # 空围栏（```\n```）视为无代码
 
@@ -331,17 +335,15 @@ if __name__ == "__main__":
             "attempts": 0,
             "done": False,
         })
-        # 最后一条消息是 reviewer 的判定；改为打印代码输出，让用户真正看到计算结果。
+        # 最后一条消息是 reviewer 的判定；改为打印代码输出，让用户真正看到计算结果。用 rfind
+        # 锚定真正的标记（而非生成脚本里字面的 "[code output]"），并原样打印最后一个 coder 消息
+        # ——即使是失败尝试的占位输出——这样显示的数字对应本次运行的最终状态，而非 reviewer 已
+        # 拒绝的更早尝试。
         for msg in reversed(result["messages"]):
             content = str(msg.content)
             marker = "[code output]"
-            idx = content.find(marker)
+            idx = content.rfind(marker)
             if idx == -1:
-                continue
-            tail = content[idx + len(marker):].lstrip("\n")
-            # Skip placeholder outputs (a failed LLM call or an empty/invalid
-            # extraction) so a "llm error: ..." doesn't read like a real result.
-            if tail.startswith(("(llm error", "(no code block", "(extracted block")):
                 continue
             print(content[idx:])
             break
@@ -399,7 +401,9 @@ sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
 config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
+    # 阶段 1 写入中间产物，让阶段 2 读取仅因 /workspace 在 pause() / connect() 之间
+    # 持久化而得以保留的状态。
+    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and write the month -> revenue table to /workspace/monthly_revenue.csv."}]), config=config)
     if not stage1["done"]:
         print("(stage 1 not verified: reviewer never returned DONE)")
 
@@ -408,7 +412,7 @@ try:
     # 因此需要重新绑定工具并在新实例上重建图，同时保留同一个 checkpointer 以恢复同一 checkpoint 线程。
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # 恢复后 /workspace 保持不变
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "now compute average units per product"}]), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv (written by stage 1) and report which month had the highest revenue."}]), config=config)
 finally:
     sandbox.kill()
 ```

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -58,6 +58,12 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 
 复用 LangChain 指南的 `Dockerfile`（在 `cubesandbox-base` 之上叠加 Python 数据科学栈，envd 监听
 `:49983`）。镜像里无需烘焙任何 LangGraph 专属依赖——图在宿主机上运行，只有**代码执行**发生在沙箱内。
+用第 2 步要注册的 tag 构建并推送：
+
+```bash
+docker build -t <your-registry>/langgraph-cube:latest <path-to-dockerfile>
+docker push <your-registry>/langgraph-cube:latest
+```
 
 ### 2. 注册模板并配置环境变量
 
@@ -150,7 +156,8 @@ CODER_PROMPT = (
     "the latest user request using the dataset at /workspace/sales.csv "
     "(columns month,product,units,price). The environment has pandas, numpy, "
     "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
-    "network access. If a previous reviewer message said RETRY, fix the issues it "
+    "network access. Wrap the script in a single markdown ```python ... ``` fenced "
+    "block. If a previous reviewer message said RETRY, fix the issues it "
     "listed before re-running."
 )
 

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -109,7 +109,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_API_URL", "CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+for v in ("CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -225,8 +225,11 @@ def coder(state: AgentState, run_python) -> dict:
         return {"messages": [{"role": "assistant",
                               "content": "[code output]\n(no code block in model reply)"}]}
     output = run_python(code)
-    # 截断输出以免超大结果（如打印整个 DataFrame）撑爆模型上下文窗口；保留尾部——
-    # 打印的数字（以及 stderr/traceback）在末尾，必须让它们在截断后仍存活。
+    # 同时截断代码与输出，以免超大结果（如打印整个 DataFrame）或过长的生成脚本
+    # 在多次重试中撑爆模型上下文窗口；各自保留尾部——打印的数字（以及
+    # stderr/traceback）在末尾，脚本尾部仍能展示实际运行的逻辑。
+    if len(code) > 4000:
+        code = "[earlier code truncated]\n" + code[-4000:]
     if len(output) > 4000:
         output = "[earlier output truncated]\n" + output[-4000:]
     # 把代码连同输出一起写入消息，这样 RETRY 时 coder 能看到上次写了什么，

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -26,7 +26,7 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 |---|---|---|
 | 图结构 | 固定的工具调用循环，对你是黑盒 | 每个节点、每条边都由你定义 |
 | 重试 / 循环 | 隐含在 Agent 循环内部 | 显式的 `add_conditional_edges` |
-| 状态 | 不透明的消息历史 | 你设计的类型化 `State`（沙箱 id、重试次数、判定结果…） |
+| 状态 | 不透明的消息历史 | 你设计的类型化 `State`（重试次数、判定结果…） |
 | 恢复 | 不直接暴露 | `checkpointer` 对接 Cube 的 `pause()` / `connect()` |
 
 当你只需要一个能调用工具的 Agent 时，用 `create_agent` 即可。当你想构建「生成 → 执行 → 审查 → 重试」
@@ -79,7 +79,7 @@ cubemastercli tpl create-from-image \
 - **`reviewer`** —— 让 LLM 判断输出是否回答了请求。
 - **一条条件边** —— 将 `reviewer` 路由回 `coder`（重试）或路由到 `END`。
 
-整个运行只创建一个沙箱，并在每次 `coder` 调用间复用；其 id 保存在 `State` 中，从而跨节点存续、之后可恢复。
+整个运行只创建一个沙箱，并在每次 `coder` 调用间复用；图通过 `run_python` 闭包持有它（而非通过 `State`），它的 id 正是之后通过 checkpoint 恢复运行所需的键。
 
 ```python
 from __future__ import annotations
@@ -114,10 +114,9 @@ llm = ChatOpenAI(
 
 
 class AgentState(TypedDict):
-    """跨节点共享的状态。`messages` 累积对话；`sandbox_id` 将同一个 MicroVM
-    固定到整个图运行期间，以便之后用 `pause()` / `connect()` 恢复。"""
+    """跨节点共享的状态。`messages` 累积对话；`attempts` / `done` 驱动重试循环。
+    沙箱本身通过 `run_python` 闭包共享，而非通过 `State`。"""
     messages: Annotated[list, add_messages]
-    sandbox_id: str
     attempts: int
     done: bool
 
@@ -152,8 +151,8 @@ CODER_PROMPT = (
 
 REVIEWER_PROMPT = (
     "You are a reviewer. Given the user request and the latest code output, decide "
-    "whether the request is fully answered. Reply with exactly one word: DONE if the "
-    "output answers the request, otherwise RETRY followed by one line on what is missing."
+    "whether the request is fully answered. Reply starting with exactly one word, "
+    "`DONE` or `RETRY`, optionally followed by one line explaining what is missing."
 )
 
 
@@ -243,7 +242,6 @@ if __name__ == "__main__":
         graph = build_graph(run_python)
         result = graph.invoke({
             "messages": [{"role": "user", "content": question}],
-            "sandbox_id": sandbox.sandbox_id,
             "attempts": 0,
             "done": False,
         })
@@ -256,7 +254,7 @@ if __name__ == "__main__":
             print("(no code output)")
 ```
 
-运行：
+将上面的代码保存为 `langgraph_agent_demo.py`，然后运行：
 
 ```bash
 pip install langgraph langchain-openai cubesandbox python-dotenv
@@ -276,7 +274,7 @@ LangGraph 对图状态做 checkpoint，Cube 对沙箱做快照，二者天然互
 | LangGraph | Cube Sandbox |
 |---|---|
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
-| `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `State` 中的 `sandbox_id` |
+| `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `sandbox.sandbox_id` |
 | 用 `invoke(..., config)` 恢复 | `sandbox.pause()` 后 `Sandbox.connect(sandbox_id)` |
 
 ```python
@@ -285,10 +283,10 @@ from langgraph.checkpoint.memory import MemorySaver
 checkpointer = MemorySaver()
 
 
-def stage_input(messages, sandbox_id):
+def stage_input(messages):
     """构建单阶段的图输入。`attempts`/`done` 没有 reducer，显式传值会覆盖 checkpoint 里的旧值；
     `messages` 使用 `add_messages`，新消息会追加到之前的历史——若想从干净状态开始，请换新的 thread_id。"""
-    return {"messages": messages, "sandbox_id": sandbox_id, "attempts": 0, "done": False}
+    return {"messages": messages, "attempts": 0, "done": False}
 
 
 sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
@@ -297,16 +295,14 @@ sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
 config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "first task"}],
-                             sandbox.sandbox_id), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "first task"}]), config=config)
 
     sandbox.pause()                                   # 快照 VM + 根文件系统
     # Sandbox.connect() 返回的是新实例；run_python 闭包捕获的是暂停前的旧实例，
     # 因此需要重新绑定工具并在新实例上重建图，同时保留同一个 checkpointer 以恢复同一 checkpoint 线程。
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # 恢复后 /workspace 保持不变
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}],
-                             sandbox.sandbox_id), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}]), config=config)
 finally:
     sandbox.kill()
 ```

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -289,6 +289,8 @@ if __name__ == "__main__":
                 break
         else:
             print("(no code output)")
+        if not result["done"]:
+            print("\n(not verified: reviewer never returned DONE)")
 ```
 
 将上面的代码保存为 `langgraph_agent_demo.py`，然后运行：
@@ -316,7 +318,7 @@ LangGraph 对图状态做 checkpoint，Cube 对沙箱做快照，二者天然互
 |---|---|
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
 | `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `sandbox.sandbox_id` |
-| 用 `invoke(..., config)` 恢复 | `sandbox.pause()` 后 `Sandbox.connect(sandbox_id)` |
+| 在同一 thread 上用 `invoke(..., config)` 开始新一轮 | `sandbox.pause()` 后 `Sandbox.connect(sandbox_id)` |
 
 ```python
 from langgraph.checkpoint.memory import MemorySaver

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -204,10 +204,12 @@ def strip_code_fence(text: str) -> str | None:
         return None
     inner = []
     for line in lines[start + 1:]:
-        # 只有裸围栏（反引号加可选空白）才视为关闭；脚本内部像 ```markdown 这样的
-        # 语言标签行要当作代码保留。
-        # （已知限制：docstring 里的裸 ``` 行仍会被提前当作关闭。）
-        if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
+        # 关闭条件：以三个及以上反引号开头，且该行其余部分为空（裸 ``` 行），
+        # 或同行的只是文字（模型偶尔会滑成 `` ``` Done! ``）。脚本内部像
+        # ```markdown 这样的语言标签行要当作代码保留。（已知限制：docstring 里的
+        # 裸 ``` 行仍会被提前当作关闭。）
+        s = line.strip()
+        if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
             break
         inner.append(line)
     return "\n".join(inner).strip()

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -211,7 +211,10 @@ def coder(state: AgentState, run_python) -> dict:
     # 打印的数字（以及 stderr/traceback）在末尾，必须让它们在截断后仍存活。
     if len(output) > 4000:
         output = "[earlier output truncated]\n" + output[-4000:]
-    return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
+    # 把代码连同输出一起写入消息，这样 RETRY 时 coder 能看到上次写了什么，
+    # 而不是重复犯同样的错误。
+    return {"messages": [{"role": "assistant",
+                          "content": f"[code]\n{code}\n[code output]\n{output}"}]}
 
 
 def reviewer(state: AgentState) -> dict:
@@ -219,10 +222,9 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
-    # 解析第一个 token，这样被 markdown 包裹或前面带散文的判定
-    # （"**DONE**"、"The result is DONE"）也能正确识别。
-    token = (verdict.split() or [""])[0].strip(":*#`")
-    done = token.startswith("DONE")
+    # 扫描每个空白分隔的 token，这样被 markdown 包裹或前面带散文的判定
+    # （"**DONE**"、"The result is DONE"）也能正确识别为 DONE。
+    done = any(t.strip(":*#`").startswith("DONE") for t in verdict.split())
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
     # 而不是当作它自己先前的 assistant 输出。
     return {
@@ -271,8 +273,11 @@ if __name__ == "__main__":
         })
         # 最后一条消息是 reviewer 的判定；改为打印代码输出，让用户真正看到计算结果。
         for msg in reversed(result["messages"]):
-            if msg.content and str(msg.content).startswith("[code output]"):
-                print(msg.content)
+            content = str(msg.content)
+            marker = "[code output]"
+            idx = content.find(marker)
+            if idx != -1:
+                print(content[idx:])
                 break
         else:
             print("(no code output)")

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -156,6 +156,21 @@ REVIEWER_PROMPT = (
 )
 
 
+def extract_text(content) -> str:
+    """从消息内容中提取纯文本；content 可能是 str，也可能是 content blocks 列表。"""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "\n".join(parts)
+    return str(content)
+
+
 def strip_code_fence(text: str) -> str:
     """剥离模型可能包裹代码的 Markdown 围栏。"""
     fence = "`" * 3                      # 三个反引号，避免字面量围栏
@@ -172,18 +187,18 @@ def strip_code_fence(text: str) -> str:
 
 def coder(state: AgentState, run_python) -> dict:
     """让 LLM 生成代码，在 Cube 沙箱内执行，并追加输出。"""
-    code = strip_code_fence(llm.invoke(
+    code = strip_code_fence(extract_text(llm.invoke(
         [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
-    ).content)
+    ).content))
     output = run_python(code)
     return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
 
 
 def reviewer(state: AgentState) -> dict:
     """判断最新输出是否回答了请求。"""
-    verdict = llm.invoke(
+    verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
-    ).content.strip().upper()
+    ).content).strip().upper()
     return {
         "messages": [{"role": "assistant", "content": f"[reviewer] {verdict}"}],
         "attempts": state.get("attempts", 0) + 1,
@@ -269,7 +284,8 @@ config = {"configurable": {"thread_id": "t1"}}
 
 
 def stage_input(messages, sandbox_id):
-    """构建单阶段的图输入。`attempts`/`done` 没有 reducer，显式传值会覆盖 checkpoint 里的旧值。"""
+    """构建单阶段的图输入。`attempts`/`done` 没有 reducer，显式传值会覆盖 checkpoint 里的旧值；
+    `messages` 使用 `add_messages`，新消息会追加到之前的历史——若想从干净状态开始，请换新的 thread_id。"""
     return {"messages": messages, "sandbox_id": sandbox_id, "attempts": 0, "done": False}
 
 

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -107,7 +107,7 @@ from dotenv import load_dotenv
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, START, END
-from langgraph.graph.message import add_messages
+from langgraph.graph import add_messages
 from cubesandbox import Sandbox
 
 load_dotenv()
@@ -336,9 +336,10 @@ if __name__ == "__main__":
             "done": False,
         })
         # 最后一条消息是 reviewer 的判定；改为打印代码输出，让用户真正看到计算结果。用 rfind
-        # 锚定真正的标记（而非生成脚本里字面的 "[code output]"），并原样打印最后一个 coder 消息
-        # ——即使是失败尝试的占位输出——这样显示的数字对应本次运行的最终状态，而非 reviewer 已
-        # 拒绝的更早尝试。
+        # 取最后一个 "[code output]" 出现位置，这样生成脚本里（真实标记之前）的字面不会偏移
+        # 截取；唯一残余是 stdout 自身恰好打印该 token，仅会导致显示截断。原样打印最后一个
+        # coder 消息——即使是失败尝试的占位输出——让显示的数字对应本次运行的最终状态，而非
+        # reviewer 已拒绝的更早尝试。
         for msg in reversed(result["messages"]):
             content = str(msg.content)
             marker = "[code output]"

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -287,7 +287,7 @@ def reviewer(state: AgentState) -> dict:
     # prompt 要求回复以一个判定词开头，因此只解析第一个 token——解释文字里出现的
     # "DONE"/"RETRY" 是补充说明，不是第二个判定。这样既能避免 RETRY 解释里的 "DONE"
     # 提前停掉循环，也能避免 "I would not RETRY" 让正确答案被重跑。
-    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;")
+    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;") if verdict else ""
     done = first == "DONE"
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
     # 而不是当作它自己先前的 assistant 输出。

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -40,7 +40,7 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 
 | 组件 | 版本 | 说明 |
 |---|---|---|
-| langgraph | `>=0.2` | `StateGraph`、`START`/`END`、`add_messages` |
+| langgraph | `>=0.2.50,<1` | `StateGraph`、`START`/`END`、`add_messages` |
 | langchain-openai | `>=1.0,<2.0` | `ChatOpenAI`（任意 OpenAI 兼容端点） |
 | cubesandbox SDK | `>=0.6.0` | `Sandbox.create` / `files.write` / `commands.run` |
 | CubeSandbox 平台 | `>=0.3.0` | 核心；可选特性见 LangChain 指南 |
@@ -53,7 +53,8 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 - 已部署 CubeSandbox，CubeAPI 可从 `http://<node>:3000` 访问。
 - 已构建并注册一个含 Python 栈（pandas / numpy / matplotlib / scikit-learn）的模板镜像。可参考
   LangChain 指南的[模板镜像](../integrations/langchain.md)步骤，或直接复用同一个 template id。
-- `cubesandbox` SDK 所需环境变量：`CUBE_API_URL`、`CUBE_TEMPLATE_ID`、`CUBE_PROXY_NODE_IP`；
+- `cubesandbox` SDK 环境变量：`CUBE_TEMPLATE_ID`（必填），以及 `CUBE_API_URL`、`CUBE_PROXY_NODE_IP`
+  （仅远程 / 直连 IP 部署时需要——未设置时 SDK 回退到 `http://127.0.0.1:3000` / wildcard-DNS 主机）；
   CubeAPI 后端启用鉴权时还需 `CUBE_API_KEY`（未设置时 SDK 不发送鉴权头）。
 - Python 3.10+（示例使用 `str | None`、`Annotated` 及 `langchain-openai` 1.x）。
 - 经 `OPENAI_BASE_URL` / `OPENAI_API_KEY`（或 `TOKENHUB_API_KEY`）接入的 OpenAI 兼容 LLM 端点。
@@ -80,8 +81,8 @@ cubemastercli tpl create-from-image \
   --expose-port 49983 --probe 49983 --probe-path /health
 ```
 
-随后设置 `CUBE_API_URL`、`CUBE_TEMPLATE_ID`、`CUBE_PROXY_NODE_IP` 以及 LLM key。LangChain 指南中的
-环境变量表此处完全适用。
+随后设置 `CUBE_TEMPLATE_ID` 以及 LLM key；`CUBE_API_URL`、`CUBE_PROXY_NODE_IP` 仅在不同于 SDK
+默认值时才需设置。LangChain 指南中的环境变量表此处完全适用。
 
 ### 3. 定义图
 
@@ -247,18 +248,10 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
-    # prompt 要求回复以一个判定词（DONE/RETRY）开头，所以先按第一个 token 判定，并剥离
-    # markdown 装饰；若该 token 不是判定词，则回退为扫描整句里的裸 DONE/RETRY 关键词，
-    # 这样偏离格式（前导散文、加粗标记）的回复仍能分类，而不是静默烧掉重试次数。
+    # 以完整 token 列表为权威：回复中任何位置的显式 RETRY 都优先于 DONE——prompt 要求回复以一个
+    # 判定词开头，因此 RETRY 解释文字里的 "DONE" 不应停止循环；只有不存在 RETRY 时才判定为 DONE。
     tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
-    first = tokens[0] if tokens else ""
-    if first == "DONE":
-        done = True
-    elif first == "RETRY":
-        done = False
-    else:
-        # 优先显式的 RETRY，而不是 DONE 的提及，避免 "RETRY: 数字已算完但缺图表" 被误判为完成。
-        done = "DONE" in tokens and "RETRY" not in tokens
+    done = "DONE" in tokens and "RETRY" not in tokens
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
     # 而不是当作它自己先前的 assistant 输出。
     return {
@@ -322,7 +315,7 @@ if __name__ == "__main__":
 将上面的代码保存为 `langgraph_agent_demo.py`，然后运行：
 
 ```bash
-pip install "langgraph>=0.2,<2" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
+pip install "langgraph>=0.2.50,<1" "langchain-openai>=1.0,<2.0" "cubesandbox>=0.6.0" python-dotenv
 python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
 ```
 
@@ -345,6 +338,9 @@ LangGraph 对图状态做 checkpoint，Cube 对沙箱做快照，二者天然互
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
 | `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `sandbox.sandbox_id` |
 | 在同一 thread 上用 `invoke(..., config)` 开始新一轮 | `sandbox.pause()` 后 `Sandbox.connect(sandbox_id)` |
+
+下面的片段是前文的延续——`Sandbox`、`build_graph`、`make_run_python` 均来自前几节。
+独立的可运行脚本见 `examples/langgraph-integration/langgraph_checkpoint_demo.py`。
 
 ```python
 from langgraph.checkpoint.memory import MemorySaver

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -284,9 +284,8 @@ def reviewer(state: AgentState) -> dict:
             "done": False,
         }
     verdict = extract_text(reply).strip().upper()
-    # prompt 要求回复以一个判定词开头，因此只解析第一个 token——解释文字里出现的
-    # "DONE"/"RETRY" 是补充说明，不是第二个判定。这样既能避免 RETRY 解释里的 "DONE"
-    # 提前停掉循环，也能避免 "I would not RETRY" 让正确答案被重跑。
+    # prompt 要求回复以一个判定词开头，因此只有前导 token 才作数——解释文字里出现的
+    # "DONE"/"RETRY" 是补充说明，不会翻转判定结果。
     first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;") if verdict else ""
     done = first == "DONE"
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
@@ -340,9 +339,15 @@ if __name__ == "__main__":
             content = str(msg.content)
             marker = "[code output]"
             idx = content.find(marker)
-            if idx != -1:
-                print(content[idx:])
-                break
+            if idx == -1:
+                continue
+            tail = content[idx + len(marker):].lstrip("\n")
+            # Skip placeholder outputs (a failed LLM call or an empty/invalid
+            # extraction) so a "llm error: ..." doesn't read like a real result.
+            if tail.startswith(("(llm error", "(no code block", "(extracted block")):
+                continue
+            print(content[idx:])
+            break
         else:
             print("(no code output)")
         if not result["done"]:

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -104,6 +104,7 @@ import sys
 from typing import Annotated, TypedDict
 
 from dotenv import load_dotenv
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, START, END
 from langgraph.graph.message import add_messages
@@ -242,20 +243,17 @@ def coder(state: AgentState, run_python) -> dict:
     except Exception as exc:
         # 瞬时 LLM 错误（限流、5xx、超时）不应中止整个图运行；当作空代码提示，
         # 让 reviewer 重试。
-        return {"messages": [{"role": "assistant",
-                              "content": f"[code output]\n(llm error: {exc})"}]}
+        return {"messages": [AIMessage(content=f"[code output]\n(llm error: {exc})")]}
     code = strip_code_fence(extract_text(reply))
     if code is None:
         # 模型没有返回围栏代码块；直接提示，而不是把散文写进 .py 文件、浪费一次重试机会。
-        return {"messages": [{"role": "assistant",
-                              "content": "[code output]\n(no code block in model reply)"}]}
+        return {"messages": [AIMessage(content="[code output]\n(no code block in model reply)")]}
     try:
         ast.parse(code)
     except SyntaxError as exc:
         # 围栏块不是合法 Python（例如模型在真正脚本前加了一个 diff/示例围栏）；
         # 直接提示让 reviewer 重试，而不是写一个注定失败的 .py。
-        return {"messages": [{"role": "assistant",
-                              "content": f"[code output]\n(extracted block is not valid Python: {exc})"}]}
+        return {"messages": [AIMessage(content=f"[code output]\n(extracted block is not valid Python: {exc})")]}
     output = run_python(code)
     # 同时截断代码与输出，以免超大结果（如打印整个 DataFrame）或过长的生成脚本
     # 在多次重试中撑爆模型上下文窗口；各自保留尾部——打印的数字（以及
@@ -266,8 +264,7 @@ def coder(state: AgentState, run_python) -> dict:
         output = "[earlier output truncated]\n" + output[-4000:]
     # 把代码连同输出一起写入消息，这样 RETRY 时 coder 能看到上次写了什么，
     # 而不是重复犯同样的错误。
-    return {"messages": [{"role": "assistant",
-                          "content": f"[code]\n{code}\n[code output]\n{output}"}]}
+    return {"messages": [AIMessage(content=f"[code]\n{code}\n[code output]\n{output}")]}
 
 
 def reviewer(state: AgentState) -> dict:
@@ -279,7 +276,7 @@ def reviewer(state: AgentState) -> dict:
     except Exception as exc:
         # reviewer 里的瞬时 LLM 错误降级为一次重试，而不是中止整个运行。
         return {
-            "messages": [{"role": "user", "content": f"[reviewer] RETRY (llm error: {exc})"}],
+            "messages": [HumanMessage(content=f"[reviewer] RETRY (llm error: {exc})")],
             "attempts": state.get("attempts", 0) + 1,
             "done": False,
         }
@@ -291,7 +288,7 @@ def reviewer(state: AgentState) -> dict:
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
     # 而不是当作它自己先前的 assistant 输出。
     return {
-        "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
+        "messages": [HumanMessage(content=f"[reviewer] {verdict}")],
         "attempts": state.get("attempts", 0) + 1,
         "done": done,
     }

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -1,0 +1,284 @@
+---
+title: LangGraph 集成指南
+author: Mikey1129
+date: 2026-08-29
+tags:
+  - integration
+  - langgraph
+  - agent
+lang: zh-CN
+---
+
+# LangGraph 集成指南
+
+将一个 [LangGraph](https://github.com/langchain-ai/langgraph) Agent——由节点与条件边构成的显式图——运行在
+[CubeSandbox](https://github.com/TencentCloud/CubeSandbox) 的 MicroVM 中，让它在沙箱内执行 Python。由于
+Cube 暴露了**与 E2B 兼容的 API**，代码执行工具可以从 E2B 无缝切换到 Cube，同时为 Agent 生成的每一行
+代码获得 KVM 级隔离。
+
+本文是 [LangChain 集成](./langchain.md)的 LangGraph 对应版本。LangChain 指南使用高层封装
+`create_agent`，本文则用 `StateGraph` **显式**搭建图：由你掌控控制流、在节点间共享同一个沙箱，并把
+LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
+
+## LangGraph 与 `create_agent` 的对比
+
+| | `create_agent`（LangChain 指南） | 显式 `StateGraph`（本文） |
+|---|---|---|
+| 图结构 | 固定的工具调用循环，对你是黑盒 | 每个节点、每条边都由你定义 |
+| 重试 / 循环 | 隐含在 Agent 循环内部 | 显式的 `add_conditional_edges` |
+| 状态 | 不透明的消息历史 | 你设计的类型化 `State`（沙箱 id、重试次数、判定结果…） |
+| 恢复 | 不直接暴露 | `checkpointer` 对接 Cube 的 `pause()` / `connect()` |
+
+当你只需要一个能调用工具的 Agent 时，用 `create_agent` 即可。当你想构建「生成 → 执行 → 审查 → 重试」
+这样的多步工作流、让沙箱跨阶段复用、并在图中途可恢复时，请使用显式的 `StateGraph`。
+
+## 集成对象与版本
+
+| 组件 | 版本 | 说明 |
+|---|---|---|
+| langgraph | `>=0.2` | `StateGraph`、`START`/`END`、`add_messages` |
+| langchain-openai | `>=1.0,<2.0` | `ChatOpenAI`（任意 OpenAI 兼容端点） |
+| cubesandbox SDK | `>=0.6.0` | `Sandbox.create` / `files.write` / `commands.run` |
+| CubeSandbox 平台 | `>=0.3.0` | 核心；可选特性见 LangChain 指南 |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` | 在其上叠加 Python 栈 |
+
+## 前置条件
+
+前置条件与 LangChain 指南完全一致——同一个沙箱模板对两者都适用：
+
+- 已部署 CubeSandbox，CubeAPI 可从 `http://<node>:3000` 访问。
+- 已构建并注册一个含 Python 栈（pandas / numpy / matplotlib / scikit-learn）的模板镜像。可参考
+  LangChain 指南的[模板镜像](../integrations/langchain.md)步骤，或直接复用同一个 template id。
+- `cubesandbox` SDK 所需环境变量：`CUBE_API_URL`、`CUBE_TEMPLATE_ID`、`CUBE_PROXY_NODE_IP`。
+- 经 `OPENAI_BASE_URL` / `OPENAI_API_KEY` 接入的 OpenAI 兼容 LLM 端点。
+
+## 接入步骤
+
+### 1. 构建模板镜像
+
+复用 LangChain 指南的 `Dockerfile`（在 `cubesandbox-base` 之上叠加 Python 数据科学栈，envd 监听
+`:49983`）。镜像里无需烘焙任何 LangGraph 专属依赖——图在宿主机上运行，只有**代码执行**发生在沙箱内。
+
+### 2. 注册模板并配置环境变量
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/langgraph-cube:latest \
+  --writable-layer-size 2G \
+  --expose-port 49983 --probe 49983 --probe-path /health
+```
+
+随后设置 `CUBE_API_URL`、`CUBE_TEMPLATE_ID`、`CUBE_PROXY_NODE_IP` 以及 LLM key。LangChain 指南中的
+环境变量表此处完全适用。
+
+### 3. 定义图
+
+图由三个活动部分组成：
+
+- **`coder`** —— 让 LLM 生成 Python 脚本，并在沙箱内执行。
+- **`reviewer`** —— 让 LLM 判断输出是否回答了请求。
+- **一条条件边** —— 将 `reviewer` 路由回 `coder`（重试）或路由到 `END`。
+
+整个运行只创建一个沙箱，并在每次 `coder` 调用间复用；其 id 保存在 `State` 中，从而跨节点存续、之后可恢复。
+
+```python
+from __future__ import annotations
+
+import itertools
+import os
+import sys
+from typing import Annotated, TypedDict
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from cubesandbox import Sandbox
+
+load_dotenv()
+
+for v in ("CUBE_TEMPLATE_ID",):
+    if not os.environ.get(v):
+        raise SystemExit(f"Missing env: {v}")
+
+_llm_key = os.getenv("OPENAI_API_KEY") or os.getenv("TOKENHUB_API_KEY")
+if not _llm_key:
+    raise SystemExit("Missing LLM API key")
+
+llm = ChatOpenAI(
+    model=os.getenv("CHAT_MODEL") or "deepseek-v3",
+    api_key=_llm_key,
+    base_url=os.getenv("OPENAI_BASE_URL") or "https://tokenhub.tencentmaas.com/v1",
+    timeout=60, max_retries=2, temperature=0,
+)
+
+
+class AgentState(TypedDict):
+    """跨节点共享的状态。`messages` 累积对话；`sandbox_id` 将同一个 MicroVM
+    固定到整个图运行期间，以便之后用 `pause()` / `connect()` 恢复。"""
+    messages: Annotated[list, add_messages]
+    sandbox_id: str
+    attempts: int
+    done: bool
+
+
+def make_run_python(sandbox: Sandbox):
+    """返回一个绑定到单个 Cube 沙箱的 `run_python` 工具——与 LangChain 指南使用
+    相同的 `cubesandbox` SDK 模式。"""
+    _counter = itertools.count()
+
+    def run_python(code: str) -> str:
+        script = f"/workspace/_agent_{next(_counter)}.py"
+        sandbox.files.write(script, code)
+        result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
+        out = result.stdout
+        if result.stderr:
+            out += "\n--- stderr ---\n" + result.stderr
+        if result.exit_code != 0:
+            out += f"\n[non-zero exit code: {result.exit_code}]"
+        return out
+
+    return run_python
+
+
+CODER_PROMPT = (
+    "You are a data analyst. Write a single self-contained Python script that answers "
+    "the latest user request using the dataset at /workspace/sales.csv "
+    "(columns month,product,units,price). The environment has pandas, numpy, "
+    "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
+    "network access."
+)
+
+REVIEWER_PROMPT = (
+    "You are a reviewer. Given the user request and the latest code output, decide "
+    "whether the request is fully answered. Reply with exactly one word: DONE if the "
+    "output answers the request, otherwise RETRY followed by one line on what is missing."
+)
+
+
+def coder(state: AgentState, run_python) -> dict:
+    """让 LLM 生成代码，在 Cube 沙箱内执行，并追加输出。"""
+    code = llm.invoke(
+        [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
+    ).content
+    output = run_python(code)
+    return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
+
+
+def reviewer(state: AgentState) -> dict:
+    """判断最新输出是否回答了请求。"""
+    verdict = llm.invoke(
+        [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
+    ).content.strip().upper()
+    return {
+        "messages": [{"role": "assistant", "content": f"[reviewer] {verdict}"}],
+        "attempts": state.get("attempts", 0) + 1,
+        "done": verdict.startswith("DONE"),
+    }
+
+
+def route_after_review(state: AgentState) -> str:
+    """条件边：重试 `coder`，或达到次数上限后结束。"""
+    if state["done"] or state["attempts"] >= 3:
+        return "end"
+    return "retry"
+
+
+def build_graph(run_python, checkpointer=None):
+    builder = StateGraph(AgentState)
+    builder.add_node("coder", lambda s: coder(s, run_python))
+    builder.add_node("reviewer", reviewer)
+    builder.add_edge(START, "coder")
+    builder.add_edge("coder", "reviewer")
+    builder.add_conditional_edges(
+        "reviewer",
+        route_after_review,
+        {"retry": "coder", "end": END},
+    )
+    return builder.compile(checkpointer=checkpointer)
+
+
+if __name__ == "__main__":
+    question = sys.argv[1] if len(sys.argv) > 1 else (
+        "Load sales.csv from /workspace, compute total revenue per month, "
+        "and report the month -> revenue numbers."
+    )
+
+    # 整个运行只用一个 MicroVM，在 coder -> reviewer 循环中反复复用。
+    # 上下文管理器在退出时销毁沙箱，不会留下残留。
+    with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=600) as sandbox:
+        run_python = make_run_python(sandbox)
+        graph = build_graph(run_python)
+        result = graph.invoke({
+            "messages": [{"role": "user", "content": question}],
+            "sandbox_id": sandbox.sandbox_id,
+            "attempts": 0,
+            "done": False,
+        })
+        for msg in reversed(result["messages"]):
+            if msg.content:
+                print(msg.content)
+                break
+        else:
+            print("(no final answer)")
+```
+
+运行：
+
+```bash
+pip install langgraph langchain-openai cubesandbox python-dotenv
+python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month."
+```
+
+### 预期行为
+
+`coder` 将 LLM 生成的脚本写入全新的 `/workspace/_agent_<n>.py` 并在 MicroVM 内运行；`reviewer` 读取
+输出，要么返回 `DONE`，要么把图送回 `coder`（最多 3 次）。`State` 中的 `attempts` 计数器给循环设了上限，
+避免一个执拗的请求无限循环下去。
+
+## 进阶：checkpoint 与 `pause()` / `connect()`
+
+LangGraph 对图状态做 checkpoint，Cube 对沙箱做快照，二者天然互补，适合长时间、可恢复的 Agent：
+
+| LangGraph | Cube Sandbox |
+|---|---|
+| `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
+| `config = {"configurable": {"thread_id": "t1"}}` | `State` 中的 `sandbox_id` |
+| 用 `invoke(..., config)` 恢复 | `sandbox.pause()` 后 `Sandbox.connect(sandbox_id)` |
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+
+graph = build_graph(run_python, checkpointer=MemorySaver())
+config = {"configurable": {"thread_id": "t1"}}
+
+with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800) as sandbox:
+    graph.invoke(initial_input, config=config)      # 在 thread_id 下保存 checkpoint
+    sandbox.pause()
+    sandbox = Sandbox.connect(sandbox.sandbox_id)   # 恢复后 /workspace 保持不变
+    graph.invoke(follow_up_input, config=config)    # 在同一 thread_id 上恢复
+```
+
+让 LangGraph 的 `thread_id` 与 Cube 的 `sandbox_id` 保持一致（例如都存放在你的编排层），这样恢复的图才能
+重新挂载到同一个沙箱上。
+
+## 注意事项
+
+- **State 不会随沙箱序列化。** `State` 存在于你的进程（或 LangGraph 的 checkpointer）中；只有 `/workspace`
+  会在 `pause()` / `connect()` 之间保留。任何需要在硬恢复后仍存在的图状态，都要自行持久化。
+- **一个沙箱、一次图运行。** `coder`/`reviewer` 循环复用同一个 MicroVM；不要每个节点新建沙箱——那样每一步
+  都要付一次生命周期开销。
+- **工具调用之间状态不保留。** 每次 `commands.run` 都是全新的 `python3` 进程；代码片段所需内容都要内联，
+  或把中间结果写回 `/workspace`。
+- **把栈预先装进镜像。** 在默认拒绝出口流量的策略下，运行时的 `pip install` 会失败；请把 pandas / numpy /
+  matplotlib 烘焙进模板。
+- **给重试循环设上限。** 用 `attempts` 计数器（如上）或 LangGraph 的递归限制，避免一直要求重试的 reviewer
+  耗尽沙箱的 `timeout`。
+
+## References
+
+- LangChain 集成（`create_agent` 对应版本）：[`langchain.md`](./langchain.md)
+- 自定义模板镜像：[`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- LangGraph：<https://github.com/langchain-ai/langgraph>
+- E2B SDK：<https://github.com/e2b-dev/e2b>

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -62,12 +62,12 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 
 ### 1. 构建模板镜像
 
-复用 LangChain 指南的 `Dockerfile`（在 `cubesandbox-base` 之上叠加 Python 数据科学栈，envd 监听
+使用随附的 `examples/langgraph-integration/Dockerfile`（在 `cubesandbox-base` 之上叠加 Python 数据科学栈，envd 监听
 `:49983`）。镜像里无需烘焙任何 LangGraph 专属依赖——图在宿主机上运行，只有**代码执行**发生在沙箱内。
 用第 2 步要注册的 tag 构建并推送：
 
 ```bash
-docker build --platform linux/amd64 -t <your-registry>/langgraph-cube:latest <path-to-dockerfile>
+docker build --platform linux/amd64 -t <your-registry>/langgraph-cube:latest examples/langgraph-integration
 docker push <your-registry>/langgraph-cube:latest
 ```
 

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -97,7 +97,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_TEMPLATE_ID",):
+for v in ("CUBE_API_URL", "CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -171,8 +171,8 @@ def extract_text(content) -> str:
     return str(content)
 
 
-def strip_code_fence(text: str) -> str:
-    """返回第一个 Markdown 围栏内的代码；若没有围栏则返回原文。
+def strip_code_fence(text: str) -> str | None:
+    """返回第一个 Markdown 围栏内的代码；若没有围栏则返回 None。
     模型常在围栏块前加上说明文字，因此不能假设回复以围栏开头。"""
     fence = "`" * 3                      # 三个反引号，避免字面量围栏
     text = text.strip()
@@ -183,7 +183,7 @@ def strip_code_fence(text: str) -> str:
             start = i
             break
     if start is None:
-        return text
+        return None
     inner = []
     for line in lines[start + 1:]:
         if line.strip().startswith(fence):
@@ -197,9 +197,15 @@ def coder(state: AgentState, run_python) -> dict:
     code = strip_code_fence(extract_text(llm.invoke(
         [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
     ).content))
+    if code is None:
+        # 模型没有返回围栏代码块；直接提示，而不是把散文写进 .py 文件、浪费一次重试机会。
+        return {"messages": [{"role": "assistant",
+                              "content": "[code output]\n(no code block in model reply)"}]}
     output = run_python(code)
-    # 截断输出，避免超大结果（如打印整个 DataFrame）在下一次 llm.invoke 时撑爆模型上下文窗口。
-    output = output[:4000]
+    # 截断输出以免超大结果（如打印整个 DataFrame）撑爆模型上下文窗口；保留尾部——
+    # 打印的数字（以及 stderr/traceback）在末尾，必须让它们在截断后仍存活。
+    if len(output) > 4000:
+        output = "[earlier output truncated]\n" + output[-4000:]
     return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
 
 

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -30,7 +30,7 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 | 恢复 | 不直接暴露 | `checkpointer` 对接 Cube 的 `pause()` / `connect()` |
 
 当你只需要一个能调用工具的 Agent 时，用 `create_agent` 即可。当你想构建「生成 → 执行 → 审查 → 重试」
-这样的多步工作流、让沙箱跨阶段复用、并在图中途可恢复时，请使用显式的 `StateGraph`。
+这样的多步工作流、让沙箱跨阶段复用、并在之后可通过 checkpoint 恢复运行时，请使用显式的 `StateGraph`。
 
 ## 集成对象与版本
 
@@ -129,7 +129,12 @@ def make_run_python(sandbox: Sandbox):
     def run_python(code: str) -> str:
         script = f"/workspace/_agent_{next(_counter)}.py"
         sandbox.files.write(script, code)
-        result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
+        try:
+            result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
+        except Exception as exc:
+            # 传输错误和单命令超时会在这里抛异常；把它作为工具输出返回，
+            # 让 reviewer 能看到失败并决定重试，而不是让异常直接终止整张图的运行。
+            return f"[command error] {exc}"
         out = result.stdout
         if result.stderr:
             out += "\n--- stderr ---\n" + result.stderr

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -146,7 +146,8 @@ CODER_PROMPT = (
     "the latest user request using the dataset at /workspace/sales.csv "
     "(columns month,product,units,price). The environment has pandas, numpy, "
     "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
-    "network access."
+    "network access. If a previous reviewer message said RETRY, fix the issues it "
+    "listed before re-running."
 )
 
 REVIEWER_PROMPT = (
@@ -199,8 +200,10 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
+    # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
+    # 而不是当作它自己先前的 assistant 输出。
     return {
-        "messages": [{"role": "assistant", "content": f"[reviewer] {verdict}"}],
+        "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
         "attempts": state.get("attempts", 0) + 1,
         "done": verdict.startswith("DONE"),
     }
@@ -273,14 +276,13 @@ LangGraph 对图状态做 checkpoint，Cube 对沙箱做快照，二者天然互
 | LangGraph | Cube Sandbox |
 |---|---|
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
-| `config = {"configurable": {"thread_id": "t1"}}` | `State` 中的 `sandbox_id` |
+| `config = {"configurable": {"thread_id": sandbox.sandbox_id}}` | `State` 中的 `sandbox_id` |
 | 用 `invoke(..., config)` 恢复 | `sandbox.pause()` 后 `Sandbox.connect(sandbox_id)` |
 
 ```python
 from langgraph.checkpoint.memory import MemorySaver
 
 checkpointer = MemorySaver()
-config = {"configurable": {"thread_id": "t1"}}
 
 
 def stage_input(messages, sandbox_id):
@@ -290,6 +292,9 @@ def stage_input(messages, sandbox_id):
 
 
 sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
+# 以 sandbox_id 作为 checkpoint 线程的键，使同一个 thread_id 在 pause() / connect()
+# 之后重新挂载到同一个 MicroVM。
+config = {"configurable": {"thread_id": sandbox.sandbox_id}}
 try:
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
     graph.invoke(stage_input([{"role": "user", "content": "first task"}],
@@ -297,7 +302,7 @@ try:
 
     sandbox.pause()                                   # 快照 VM + 根文件系统
     # Sandbox.connect() 返回的是新实例；run_python 闭包捕获的是暂停前的旧实例，
-    # 因此需要重新绑定工具并在新实例上重建图，同时保留同一个 checkpointer 以恢复 thread t1。
+    # 因此需要重新绑定工具并在新实例上重建图，同时保留同一个 checkpointer 以恢复同一 checkpoint 线程。
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # 恢复后 /workspace 保持不变
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
     graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}],

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -219,24 +219,32 @@ def strip_code_fence(text: str) -> str | None:
         return None                      # 只有开启符没有正文——视为无代码
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # 关闭符：该行开头的反引号连串长度与开启符一致，且其后只有文字——
-        # 模型偶尔会滑成 `` ``` Done! ``。docstring 内较短的裸 ``` 行，或开启
-        # 符为 3 反引号时出现的 4 反引号围栏，都当作代码保留。
-        s = line.strip()
-        run = 0
-        while run < len(s) and s[run] == "`":
-            run += 1
-        if run == fence_len and (len(s) == run or s[run].isspace()):
-            break
+        # 关闭符必须是顶格（column 0）、开头反引号连串长度与开启符一致且其后只有文字——
+        # 模型偶尔会滑成 `` ``` Done! ``。docstring 或字符串字面量里缩进的围栏、较短的
+        # 裸 ``` 行，或开启符为 3 反引号时出现的 4 反引号围栏，都当作代码保留。
+        if line.startswith("`"):
+            s = line.strip()
+            run = 0
+            while run < len(s) and s[run] == "`":
+                run += 1
+            if run == fence_len and (len(s) == run or s[run].isspace()):
+                break
         inner.append(line)
     return "\n".join(inner).strip() or None  # 空围栏（```\n```）视为无代码
 
 
 def coder(state: AgentState, run_python) -> dict:
     """让 LLM 生成代码，在 Cube 沙箱内执行，并追加输出。"""
-    code = strip_code_fence(extract_text(llm.invoke(
-        [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
-    ).content))
+    try:
+        reply = llm.invoke(
+            [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
+        ).content
+    except Exception as exc:
+        # 瞬时 LLM 错误（限流、5xx、超时）不应中止整个图运行；当作空代码提示，
+        # 让 reviewer 重试。
+        return {"messages": [{"role": "assistant",
+                              "content": f"[code output]\n(llm error: {exc})"}]}
+    code = strip_code_fence(extract_text(reply))
     if code is None:
         # 模型没有返回围栏代码块；直接提示，而不是把散文写进 .py 文件、浪费一次重试机会。
         return {"messages": [{"role": "assistant",
@@ -264,13 +272,23 @@ def coder(state: AgentState, run_python) -> dict:
 
 def reviewer(state: AgentState) -> dict:
     """判断最新输出是否回答了请求。"""
-    verdict = extract_text(llm.invoke(
-        [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
-    ).content).strip().upper()
-    # 以完整 token 列表为权威：回复中任何位置的显式 RETRY 都优先于 DONE——prompt 要求回复以一个
-    # 判定词开头，因此 RETRY 解释文字里的 "DONE" 不应停止循环；只有不存在 RETRY 时才判定为 DONE。
-    tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
-    done = "DONE" in tokens and "RETRY" not in tokens
+    try:
+        reply = llm.invoke(
+            [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
+        ).content
+    except Exception as exc:
+        # reviewer 里的瞬时 LLM 错误降级为一次重试，而不是中止整个运行。
+        return {
+            "messages": [{"role": "user", "content": f"[reviewer] RETRY (llm error: {exc})"}],
+            "attempts": state.get("attempts", 0) + 1,
+            "done": False,
+        }
+    verdict = extract_text(reply).strip().upper()
+    # prompt 要求回复以一个判定词开头，因此只解析第一个 token——解释文字里出现的
+    # "DONE"/"RETRY" 是补充说明，不是第二个判定。这样既能避免 RETRY 解释里的 "DONE"
+    # 提前停掉循环，也能避免 "I would not RETRY" 让正确答案被重跑。
+    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;")
+    done = first == "DONE"
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
     # 而不是当作它自己先前的 assistant 输出。
     return {

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -156,11 +156,25 @@ REVIEWER_PROMPT = (
 )
 
 
+def strip_code_fence(text: str) -> str:
+    """剥离模型可能包裹代码的 Markdown 围栏。"""
+    fence = "`" * 3                      # 三个反引号，避免字面量围栏
+    text = text.strip()
+    if text.startswith(fence):
+        lines = text.splitlines()
+        if lines and lines[0].startswith(fence):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == fence:
+            lines = lines[:-1]
+        return "\n".join(lines).strip()
+    return text
+
+
 def coder(state: AgentState, run_python) -> dict:
     """让 LLM 生成代码，在 Cube 沙箱内执行，并追加输出。"""
-    code = llm.invoke(
+    code = strip_code_fence(llm.invoke(
         [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
-    ).content
+    ).content)
     output = run_python(code)
     return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
 
@@ -215,12 +229,13 @@ if __name__ == "__main__":
             "attempts": 0,
             "done": False,
         })
+        # 最后一条消息是 reviewer 的判定；改为打印代码输出，让用户真正看到计算结果。
         for msg in reversed(result["messages"]):
-            if msg.content:
+            if msg.content and str(msg.content).startswith("[code output]"):
                 print(msg.content)
                 break
         else:
-            print("(no final answer)")
+            print("(no code output)")
 ```
 
 运行：
@@ -249,14 +264,30 @@ LangGraph 对图状态做 checkpoint，Cube 对沙箱做快照，二者天然互
 ```python
 from langgraph.checkpoint.memory import MemorySaver
 
-graph = build_graph(run_python, checkpointer=MemorySaver())
+checkpointer = MemorySaver()
 config = {"configurable": {"thread_id": "t1"}}
 
-with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800) as sandbox:
-    graph.invoke(initial_input, config=config)      # 在 thread_id 下保存 checkpoint
-    sandbox.pause()
-    sandbox = Sandbox.connect(sandbox.sandbox_id)   # 恢复后 /workspace 保持不变
-    graph.invoke(follow_up_input, config=config)    # 在同一 thread_id 上恢复
+
+def stage_input(messages, sandbox_id):
+    """构建单阶段的图输入。`attempts`/`done` 没有 reducer，显式传值会覆盖 checkpoint 里的旧值。"""
+    return {"messages": messages, "sandbox_id": sandbox_id, "attempts": 0, "done": False}
+
+
+sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
+try:
+    graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
+    graph.invoke(stage_input([{"role": "user", "content": "first task"}],
+                             sandbox.sandbox_id), config=config)
+
+    sandbox.pause()                                   # 快照 VM + 根文件系统
+    # Sandbox.connect() 返回的是新实例；run_python 闭包捕获的是暂停前的旧实例，
+    # 因此需要重新绑定工具并在新实例上重建图，同时保留同一个 checkpointer 以恢复 thread t1。
+    sandbox = Sandbox.connect(sandbox.sandbox_id)     # 恢复后 /workspace 保持不变
+    graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
+    graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}],
+                             sandbox.sandbox_id), config=config)
+finally:
+    sandbox.kill()
 ```
 
 让 LangGraph 的 `thread_id` 与 Cube 的 `sandbox_id` 保持一致（例如都存放在你的编排层），这样恢复的图才能
@@ -275,7 +306,7 @@ with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800) as sa
 - **给重试循环设上限。** 用 `attempts` 计数器（如上）或 LangGraph 的递归限制，避免一直要求重试的 reviewer
   耗尽沙箱的 `timeout`。
 
-## References
+## 参考资料
 
 - LangChain 集成（`create_agent` 对应版本）：[`langchain.md`](./langchain.md)
 - 自定义模板镜像：[`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -162,11 +162,10 @@ def make_run_python(sandbox: Sandbox):
 
 CODER_PROMPT = (
     "You are a data analyst. Write a single self-contained Python script that answers "
-    "the user's task using the dataset at /workspace/sales.csv "
-    "(columns month,product,units,price). The environment has pandas, numpy, "
-    "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
-    "network access. Wrap the script in a single markdown ```python ... ``` fenced "
-    "block. Messages prefixed with [reviewer] are feedback on your last attempt, "
+    "the user's task using the dataset file(s) named in the task. The environment has "
+    "pandas, numpy, matplotlib, scikit-learn preinstalled. Print the final numbers. "
+    "Do not rely on network access. Wrap the script in a single markdown ```python ... ``` "
+    "fenced block. Messages prefixed with [reviewer] are feedback on your last attempt, "
     "not a new task: if one said RETRY, fix the issues it listed before re-running."
 )
 
@@ -396,15 +395,16 @@ def stage_input(messages):
     return {"messages": messages, "attempts": 0, "done": False}
 
 
-sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
-# 以 sandbox_id 作为 checkpoint 线程的键，使同一个 thread_id 在 pause() / connect()
-# 之后重新挂载到同一个 MicroVM。
-config = {"configurable": {"thread_id": sandbox.sandbox_id}}
+sandbox = None
 try:
+    sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
+    # 以 sandbox_id 作为 checkpoint 线程的键，使同一个 thread_id 在 pause() / connect()
+    # 之后重新挂载到同一个 MicroVM。
+    config = {"configurable": {"thread_id": sandbox.sandbox_id}}
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
     # 阶段 1 写入中间产物，让阶段 2 读取仅因 /workspace 在 pause() / connect() 之间
     # 持久化而得以保留的状态。
-    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and write the month -> revenue table to /workspace/monthly_revenue.csv."}]), config=config)
+    stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace (columns month,product,units,price), compute total revenue per month, write the month -> revenue table to /workspace/monthly_revenue.csv, and write the exact string 'stage1-complete' to /workspace/stage1_marker.txt."}]), config=config)
     if not stage1["done"]:
         print("(stage 1 not verified: reviewer never returned DONE)")
 
@@ -413,9 +413,13 @@ try:
     # 因此需要重新绑定工具并在新实例上重建图，同时保留同一个 checkpointer 以恢复同一 checkpoint 线程。
     sandbox = Sandbox.connect(sandbox.sandbox_id)     # 恢复后 /workspace 保持不变
     graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-    graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv (written by stage 1) and report which month had the highest revenue."}]), config=config)
+    graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv and /workspace/stage1_marker.txt (both written by stage 1) and report the marker's exact text and which month had the highest revenue. Use only those two files — do not recompute from sales.csv."}]), config=config)
 finally:
-    sandbox.kill()
+    if sandbox is not None:
+        try:
+            sandbox.kill()
+        except Exception:
+            pass
 ```
 
 让 LangGraph 的 `thread_id` 与 Cube 的 `sandbox_id` 保持一致（例如都存放在你的编排层），这样恢复的图才能

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -198,7 +198,9 @@ def strip_code_fence(text: str) -> str | None:
         return None
     inner = []
     for line in lines[start + 1:]:
-        if line.strip().startswith(fence):
+        # 只有裸围栏（反引号加可选空白）才视为关闭；脚本内部像 ```markdown 这样的
+        # 语言标签行要当作代码保留。
+        if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
             break
         inner.append(line)
     return "\n".join(inner).strip()
@@ -232,7 +234,7 @@ def reviewer(state: AgentState) -> dict:
     # prompt 要求回复以一个判定词（DONE/RETRY）开头，所以只按第一个 token 判定，
     # 并剥离 markdown 装饰；不要扫描整句，否则 RETRY 的解释文字里出现 "done" 会误判。
     first = (verdict.split() or [""])[0].strip(":*#`")
-    done = first.startswith("DONE")
+    done = first.rstrip(".,!?;") == "DONE"
     # 把判定作为 user 角色消息发出，让 coder 把 RETRY 当作需要修复的指令，
     # 而不是当作它自己先前的 assistant 输出。
     return {

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -175,9 +175,13 @@ REVIEWER_PROMPT = (
 
 
 def extract_text(content) -> str:
-    """从消息内容中提取纯文本；content 可能是 str，也可能是 content blocks 列表。"""
+    """从消息内容中提取纯文本；content 可能是 str、单个 content block dict，或 block 列表。"""
+    if not content:
+        return ""                     # None / 空内容——视为无文本，避免返回字面量 "None"
     if isinstance(content, str):
         return content
+    if isinstance(content, dict):
+        content = [content]           # 单个 content block，而非列表
     if isinstance(content, list):
         parts = []
         for block in content:

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -205,20 +205,27 @@ def strip_code_fence(text: str) -> str | None:
     start = text.find(fence)
     if start == -1:
         return None
+    # 读取完整的反引号连串长度（```、````、……），避免把 4 反引号围栏误当成
+    # 3 反引号开启符，并要求关闭符与之等长。
+    fence_len = len(fence)
+    while start + fence_len < len(text) and text[start + fence_len] == "`":
+        fence_len += 1
     # 代码从开启符所在行的下一行开始；```python 这样的语言标签以及该行其余
     # 文字都会被丢弃。
-    after = text[start + len(fence):]
+    after = text[start + fence_len:]
     first_nl = after.find("\n")
     if first_nl == -1:
         return None                      # 只有开启符没有正文——视为无代码
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # 关闭条件：以三个及以上反引号开头，且该行其余部分为空（裸 ``` 行），
-        # 或同行的只是文字（模型偶尔会滑成 `` ``` Done! ``）。脚本内部像
-        # ```markdown 这样的语言标签行要当作代码保留。（已知限制：docstring 里的
-        # 裸 ``` 行仍会被提前当作关闭。）
+        # 关闭符：该行开头的反引号连串长度与开启符一致，且其后只有文字——
+        # 模型偶尔会滑成 `` ``` Done! ``。docstring 内较短的裸 ``` 行，或开启
+        # 符为 3 反引号时出现的 4 反引号围栏，都当作代码保留。
         s = line.strip()
-        if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
+        run = 0
+        while run < len(s) and s[run] == "`":
+            run += 1
+        if run == fence_len and (len(s) == run or s[run].isspace()):
             break
         inner.append(line)
     return "\n".join(inner).strip() or None  # 空围栏（```\n```）视为无代码

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -172,17 +172,24 @@ def extract_text(content) -> str:
 
 
 def strip_code_fence(text: str) -> str:
-    """剥离模型可能包裹代码的 Markdown 围栏。"""
+    """返回第一个 Markdown 围栏内的代码；若没有围栏则返回原文。
+    模型常在围栏块前加上说明文字，因此不能假设回复以围栏开头。"""
     fence = "`" * 3                      # 三个反引号，避免字面量围栏
     text = text.strip()
-    if text.startswith(fence):
-        lines = text.splitlines()
-        if lines and lines[0].startswith(fence):
-            lines = lines[1:]
-        if lines and lines[-1].strip() == fence:
-            lines = lines[:-1]
-        return "\n".join(lines).strip()
-    return text
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith(fence):
+            start = i
+            break
+    if start is None:
+        return text
+    inner = []
+    for line in lines[start + 1:]:
+        if line.strip().startswith(fence):
+            break
+        inner.append(line)
+    return "\n".join(inner).strip()
 
 
 def coder(state: AgentState, run_python) -> dict:
@@ -191,6 +198,8 @@ def coder(state: AgentState, run_python) -> dict:
         [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
     ).content))
     output = run_python(code)
+    # 截断输出，避免超大结果（如打印整个 DataFrame）在下一次 llm.invoke 时撑爆模型上下文窗口。
+    output = output[:4000]
     return {"messages": [{"role": "assistant", "content": f"[code output]\n{output}"}]}
 
 
@@ -271,6 +280,10 @@ python langgraph_agent_demo.py "Load sales.csv, compute total revenue per month.
 
 LangGraph 对图状态做 checkpoint，Cube 对沙箱做快照，二者天然互补，适合长时间、可恢复的 Agent：
 
+> 下面的 `MemorySaver` 把 checkpoint 存在**进程内存**里——适合 demo，但进程重启后即丢失。
+> 如需跨进程恢复，请改用持久化 checkpointer，例如 `langgraph-checkpoint-sqlite` /
+> `-postgres` 提供的 `SqliteSaver` / `PostgresSaver`。
+
 | LangGraph | Cube Sandbox |
 |---|---|
 | `builder.compile(checkpointer=MemorySaver())` | `Sandbox.create(template=...)` |
@@ -280,7 +293,7 @@ LangGraph 对图状态做 checkpoint，Cube 对沙箱做快照，二者天然互
 ```python
 from langgraph.checkpoint.memory import MemorySaver
 
-checkpointer = MemorySaver()
+checkpointer = MemorySaver()  # 进程内 demo；真正的恢复需改用持久化 checkpointer
 
 
 def stage_input(messages):
@@ -308,7 +321,8 @@ finally:
 ```
 
 让 LangGraph 的 `thread_id` 与 Cube 的 `sandbox_id` 保持一致（例如都存放在你的编排层），这样恢复的图才能
-重新挂载到同一个沙箱上。
+重新挂载到同一个沙箱上。由于 `MemorySaver` 只在当前进程内有效，跨重启恢复还需把编排层与持久化
+checkpointer（`SqliteSaver` / `PostgresSaver`）配合使用。
 
 ## 注意事项
 
@@ -322,6 +336,9 @@ finally:
   matplotlib 烘焙进模板。
 - **给重试循环设上限。** 用 `attempts` 计数器（如上）或 LangGraph 的递归限制，避免一直要求重试的 reviewer
   耗尽沙箱的 `timeout`。
+- **`MemorySaver` 仅限进程内。** checkpoint 存在内存里，进程重启即丢失；即使 Cube 沙箱本身能在
+  `pause()` / `connect()` 后存续，跨进程恢复也需改用 `SqliteSaver` / `PostgresSaver`（来自
+  `langgraph-checkpoint-sqlite` / `-postgres`）。
 
 ## 参考资料
 

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -189,7 +189,7 @@ def extract_text(content) -> str:
             if isinstance(block, str):
                 parts.append(block)
             elif isinstance(block, dict) and block.get("type") == "text":
-                parts.append(block.get("text", ""))
+                parts.append(block.get("text") or "")
         return "\n".join(parts)
     return str(content)
 
@@ -198,17 +198,21 @@ def strip_code_fence(text: str) -> str | None:
     """返回第一个 Markdown 围栏内的代码；若没有围栏则返回 None。
     模型常在围栏块前加上说明文字，因此不能假设回复以围栏开头。"""
     fence = "`" * 3                      # 三个反引号，避免字面量围栏
-    text = text.strip()
-    lines = text.splitlines()
-    start = None
-    for i, line in enumerate(lines):
-        if line.strip().startswith(fence):
-            start = i
-            break
-    if start is None:
+    if not text:
         return None
+    # 围栏开启符可能与说明文字同行（如 `` 代码如下：```python ``），因此要在
+    # 全文任意位置查找第一个围栏 token，而不是只在行首匹配。
+    start = text.find(fence)
+    if start == -1:
+        return None
+    # 代码从开启符所在行的下一行开始；```python 这样的语言标签以及该行其余
+    # 文字都会被丢弃。
+    after = text[start + len(fence):]
+    first_nl = after.find("\n")
+    if first_nl == -1:
+        return None                      # 只有开启符没有正文——视为无代码
     inner = []
-    for line in lines[start + 1:]:
+    for line in after[first_nl + 1:].splitlines():
         # 关闭条件：以三个及以上反引号开头，且该行其余部分为空（裸 ``` 行），
         # 或同行的只是文字（模型偶尔会滑成 `` ``` Done! ``）。脚本内部像
         # ```markdown 这样的语言标签行要当作代码保留。（已知限制：docstring 里的
@@ -217,7 +221,7 @@ def strip_code_fence(text: str) -> str | None:
         if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
             break
         inner.append(line)
-    return "\n".join(inner).strip()
+    return "\n".join(inner).strip() or None  # 空围栏（```\n```）视为无代码
 
 
 def coder(state: AgentState, run_python) -> dict:

--- a/docs/zh/guide/integrations/langgraph.md
+++ b/docs/zh/guide/integrations/langgraph.md
@@ -49,7 +49,9 @@ LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 对接。
 - 已部署 CubeSandbox，CubeAPI 可从 `http://<node>:3000` 访问。
 - 已构建并注册一个含 Python 栈（pandas / numpy / matplotlib / scikit-learn）的模板镜像。可参考
   LangChain 指南的[模板镜像](../integrations/langchain.md)步骤，或直接复用同一个 template id。
-- `cubesandbox` SDK 所需环境变量：`CUBE_API_URL`、`CUBE_TEMPLATE_ID`、`CUBE_PROXY_NODE_IP`。
+- `cubesandbox` SDK 所需环境变量：`CUBE_API_URL`、`CUBE_TEMPLATE_ID`、`CUBE_PROXY_NODE_IP`；
+  CubeAPI 后端启用鉴权时还需 `CUBE_API_KEY`（未设置时 SDK 不发送鉴权头）。
+- Python 3.10+（示例使用 `str | None`、`Annotated` 及 `langchain-openai` 1.x）。
 - 经 `OPENAI_BASE_URL` / `OPENAI_API_KEY` 接入的 OpenAI 兼容 LLM 端点。
 
 ## 接入步骤

--- a/examples/langgraph-integration/.env.example
+++ b/examples/langgraph-integration/.env.example
@@ -1,0 +1,25 @@
+# CubeSandbox native SDK (from cubesandbox import Sandbox)
+# (optional) defaults to http://127.0.0.1:3000
+CUBE_API_URL="http://<your-node-ip>:3000"
+# (optional) only for an auth-enabled CubeAPI backend; SDK sends no auth header when unset
+CUBE_API_KEY="<your-cube-api-key>"
+# (required) sandbox template used by the demo
+CUBE_TEMPLATE_ID="<your-template-id>"
+# (optional) direct IP to reach CubeProxy; unset = use normal DNS
+CUBE_PROXY_NODE_IP="<your-node-ip>"
+# (optional) CubeProxy HTTP port; defaults to 80. Uncomment only if the proxy
+# listens on a non-default port.
+# CUBE_PROXY_PORT_HTTP=8081
+
+# LLM (OpenAI-compatible)
+# (optional) defaults to https://tokenhub.tencentmaas.com/v1
+OPENAI_BASE_URL="<your-openai-compatible-endpoint>"
+# (required) LLM API key
+OPENAI_API_KEY="<your-api-key>"
+# (optional) defaults to deepseek-v3
+CHAT_MODEL="<your-chat-model>"
+
+# (optional) self-signed CA cert PEM path for the CubeAPI HTTPS endpoint.
+# The demo exports it as SSL_CERT_FILE (process-global), so the bundle must
+# also include public root CAs or the LLM endpoint will be affected too.
+# CUBE_SSL_CERT_FILE="/path/to/ca-cert.pem"

--- a/examples/langgraph-integration/.env.example
+++ b/examples/langgraph-integration/.env.example
@@ -5,8 +5,9 @@ CUBE_API_URL="http://<your-node-ip>:3000"
 CUBE_API_KEY="<your-cube-api-key>"
 # (required) sandbox template used by the demo
 CUBE_TEMPLATE_ID="<your-template-id>"
-# (required) direct IP to reach CubeProxy
-CUBE_PROXY_NODE_IP="<your-node-ip>"
+# (optional) direct IP to reach CubeProxy; the SDK falls back to the wildcard-DNS
+# host <port>-<sandboxID>.cube.app when unset. Uncomment for a direct-IP deployment.
+# CUBE_PROXY_NODE_IP="<your-node-ip>"
 # (optional) CubeProxy HTTP port; defaults to 80. Uncomment only if the proxy
 # listens on a non-default port.
 # CUBE_PROXY_PORT_HTTP=8081

--- a/examples/langgraph-integration/.env.example
+++ b/examples/langgraph-integration/.env.example
@@ -1,11 +1,11 @@
 # CubeSandbox native SDK (from cubesandbox import Sandbox)
-# (optional) defaults to http://127.0.0.1:3000
+# (required) defaults to http://127.0.0.1:3000
 CUBE_API_URL="http://<your-node-ip>:3000"
 # (optional) only for an auth-enabled CubeAPI backend; SDK sends no auth header when unset
 CUBE_API_KEY="<your-cube-api-key>"
 # (required) sandbox template used by the demo
 CUBE_TEMPLATE_ID="<your-template-id>"
-# (optional) direct IP to reach CubeProxy; unset = use normal DNS
+# (required) direct IP to reach CubeProxy
 CUBE_PROXY_NODE_IP="<your-node-ip>"
 # (optional) CubeProxy HTTP port; defaults to 80. Uncomment only if the proxy
 # listens on a non-default port.
@@ -18,8 +18,3 @@ OPENAI_BASE_URL="<your-openai-compatible-endpoint>"
 OPENAI_API_KEY="<your-api-key>"
 # (optional) defaults to deepseek-v3
 CHAT_MODEL="<your-chat-model>"
-
-# (optional) self-signed CA cert PEM path for the CubeAPI HTTPS endpoint.
-# The demo exports it as SSL_CERT_FILE (process-global), so the bundle must
-# also include public root CAs or the LLM endpoint will be affected too.
-# CUBE_SSL_CERT_FILE="/path/to/ca-cert.pem"

--- a/examples/langgraph-integration/.env.example
+++ b/examples/langgraph-integration/.env.example
@@ -14,7 +14,8 @@ CUBE_PROXY_NODE_IP="<your-node-ip>"
 # LLM (OpenAI-compatible)
 # (optional) defaults to https://tokenhub.tencentmaas.com/v1
 OPENAI_BASE_URL="<your-openai-compatible-endpoint>"
-# (required) LLM API key
+# (required) LLM API key — set either OPENAI_API_KEY or TOKENHUB_API_KEY
 OPENAI_API_KEY="<your-api-key>"
+TOKENHUB_API_KEY="<your-api-key>"
 # (optional) defaults to deepseek-v3
 CHAT_MODEL="<your-chat-model>"

--- a/examples/langgraph-integration/.env.example
+++ b/examples/langgraph-integration/.env.example
@@ -1,8 +1,10 @@
 # CubeSandbox native SDK (from cubesandbox import Sandbox)
-# (optional) defaults to http://127.0.0.1:3000; set it when CubeAPI runs on a remote node
-CUBE_API_URL="http://<your-node-ip>:3000"
-# (optional) only for an auth-enabled CubeAPI backend; SDK sends no auth header when unset
-CUBE_API_KEY="<your-cube-api-key>"
+# (optional) defaults to http://127.0.0.1:3000; uncomment to override when CubeAPI
+# runs on a remote node.
+# CUBE_API_URL="http://<your-node-ip>:3000"
+# (optional) only for an auth-enabled CubeAPI backend; SDK sends no auth header when
+# unset. Uncomment only when it differs from the SDK default.
+# CUBE_API_KEY="<your-cube-api-key>"
 # (required) sandbox template used by the demo
 CUBE_TEMPLATE_ID="<your-template-id>"
 # (optional) direct IP to reach CubeProxy; the SDK falls back to the wildcard-DNS

--- a/examples/langgraph-integration/.env.example
+++ b/examples/langgraph-integration/.env.example
@@ -12,12 +12,12 @@ CUBE_PROXY_NODE_IP="<your-node-ip>"
 # CUBE_PROXY_PORT_HTTP=8081
 
 # LLM (OpenAI-compatible)
-# (optional) defaults to https://tokenhub.tencentmaas.com/v1
-OPENAI_BASE_URL="<your-openai-compatible-endpoint>"
+# (optional) defaults to https://tokenhub.tencentmaas.com/v1; uncomment to override
+# OPENAI_BASE_URL="<your-openai-compatible-endpoint>"
 # (required) LLM API key — uncomment exactly one of the two lines below. The demos
 # read OPENAI_API_KEY first and fall back to TOKENHUB_API_KEY; leaving the other line
 # with its placeholder would silently send the literal "<your-api-key>" as the key.
 # OPENAI_API_KEY="<your-api-key>"
 # TOKENHUB_API_KEY="<your-api-key>"
-# (optional) defaults to deepseek-v3
-CHAT_MODEL="<your-chat-model>"
+# (optional) defaults to deepseek-v3; uncomment to override
+# CHAT_MODEL="<your-chat-model>"

--- a/examples/langgraph-integration/.env.example
+++ b/examples/langgraph-integration/.env.example
@@ -1,5 +1,5 @@
 # CubeSandbox native SDK (from cubesandbox import Sandbox)
-# (required) defaults to http://127.0.0.1:3000
+# (optional) defaults to http://127.0.0.1:3000; set it when CubeAPI runs on a remote node
 CUBE_API_URL="http://<your-node-ip>:3000"
 # (optional) only for an auth-enabled CubeAPI backend; SDK sends no auth header when unset
 CUBE_API_KEY="<your-cube-api-key>"
@@ -14,8 +14,10 @@ CUBE_PROXY_NODE_IP="<your-node-ip>"
 # LLM (OpenAI-compatible)
 # (optional) defaults to https://tokenhub.tencentmaas.com/v1
 OPENAI_BASE_URL="<your-openai-compatible-endpoint>"
-# (required) LLM API key — set either OPENAI_API_KEY or TOKENHUB_API_KEY
-OPENAI_API_KEY="<your-api-key>"
-TOKENHUB_API_KEY="<your-api-key>"
+# (required) LLM API key — uncomment exactly one of the two lines below. The demos
+# read OPENAI_API_KEY first and fall back to TOKENHUB_API_KEY; leaving the other line
+# with its placeholder would silently send the literal "<your-api-key>" as the key.
+# OPENAI_API_KEY="<your-api-key>"
+# TOKENHUB_API_KEY="<your-api-key>"
 # (optional) defaults to deepseek-v3
 CHAT_MODEL="<your-chat-model>"

--- a/examples/langgraph-integration/.gitignore
+++ b/examples/langgraph-integration/.gitignore
@@ -1,0 +1,7 @@
+.env
+.env.*
+!.env.example
+__pycache__/
+*.pyc
+*.log
+output/

--- a/examples/langgraph-integration/Dockerfile
+++ b/examples/langgraph-integration/Dockerfile
@@ -4,7 +4,7 @@
 ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
 FROM ${CUBE_BASE_IMAGE}
 
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Pin data-science versions for reproducible builds. Bump as needed.
 # The base image ships pip 22.0.2, which predates the --break-system-packages

--- a/examples/langgraph-integration/Dockerfile
+++ b/examples/langgraph-integration/Dockerfile
@@ -1,0 +1,25 @@
+# examples/langgraph-integration/Dockerfile
+# Stacks a Python data-science stack on top of cubesandbox-base so LangGraph
+# agents can execute pandas / numpy / matplotlib code inside the MicroVM.
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Pin data-science versions for reproducible builds. Bump as needed.
+# The base image ships pip 22.0.2, which predates the --break-system-packages
+# flag (added in pip 23.0), so upgrade pip first, then install with the flag.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 python3-pip ca-certificates git \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir --break-system-packages \
+        pandas==2.2.3 numpy==1.26.4 matplotlib==3.9.3 scikit-learn==1.6.1
+
+WORKDIR /workspace
+
+# Pre-seed a demo dataset so the example agent can run without external inputs.
+COPY sales.csv /workspace/sales.csv
+
+EXPOSE 49983

--- a/examples/langgraph-integration/Dockerfile
+++ b/examples/langgraph-integration/Dockerfile
@@ -7,8 +7,9 @@ FROM ${CUBE_BASE_IMAGE}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Pin data-science versions for reproducible builds. Bump as needed.
-# The base image ships pip 22.0.2, which predates the --break-system-packages
-# flag (added in pip 23.0), so upgrade pip first, then install with the flag.
+# Ubuntu 22.04's apt python3-pip is 22.0.2, which predates the
+# --break-system-packages flag (added in pip 23.0), so upgrade pip first, then
+# install with the flag.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         python3 python3-pip ca-certificates git \

--- a/examples/langgraph-integration/README.md
+++ b/examples/langgraph-integration/README.md
@@ -42,7 +42,7 @@ python langgraph_checkpoint_demo.py
 |---|---|---|
 | `CUBE_API_URL` | — | CubeAPI base URL (defaults to `http://127.0.0.1:3000`) |
 | `CUBE_TEMPLATE_ID` | ✓ | Sandbox template id used by the demo |
-| `CUBE_PROXY_NODE_IP` | ✓ | Direct IP to reach CubeProxy |
+| `CUBE_PROXY_NODE_IP` | — | Direct IP to reach CubeProxy (SDK falls back to wildcard-DNS when unset) |
 | `CUBE_API_KEY` | — | Only for an auth-enabled CubeAPI backend |
 | `OPENAI_API_KEY` | ✓ | LLM API key (or `TOKENHUB_API_KEY`) |
 | `OPENAI_BASE_URL` | — | OpenAI-compatible endpoint |

--- a/examples/langgraph-integration/README.md
+++ b/examples/langgraph-integration/README.md
@@ -1,0 +1,49 @@
+# LangGraph + CubeSandbox Integration Examples
+
+[中文文档](README_zh.md)
+
+Run a [LangGraph](https://github.com/langchain-ai/langgraph) agent — an explicit `StateGraph` of
+nodes and conditional edges — whose code-execution tool runs inside a
+[CubeSandbox](https://github.com/TencentCloud/CubeSandbox) MicroVM via the official
+**`cubesandbox` Python SDK**. These are the runnable counterparts of the
+[LangGraph integration guide](../../docs/guide/integrations/langgraph.md).
+
+| Script | Purpose |
+|---|---|
+| `langgraph_agent_demo.py` | A generate → execute → review → retry loop on one MicroVM |
+| `langgraph_checkpoint_demo.py` | Resume across `pause()` / `connect()` with a LangGraph checkpointer |
+
+## Prerequisites
+
+- Python 3.10+
+- CubeSandbox deployed, with a template image containing pandas / numpy / matplotlib /
+  scikit-learn built and registered (see the `Dockerfile`).
+
+## Quick start
+
+```bash
+# Build & register the shared template image
+docker build --platform linux/amd64 -t <your-registry>/langgraph-cube:latest .
+docker push <your-registry>/langgraph-cube:latest
+cubemastercli tpl create-from-image \
+  --image <your-registry>/langgraph-cube:latest \
+  --writable-layer-size 2G --expose-port 49983 --probe 49983 --probe-path /health
+
+# Configure env vars and run
+cp .env.example .env        # fill in the values
+pip install -r requirements.txt
+python langgraph_agent_demo.py
+python langgraph_checkpoint_demo.py
+```
+
+## Environment variables
+
+| Variable | Required | Notes |
+|---|---|---|
+| `CUBE_API_URL` | ✓ | CubeAPI base URL (defaults to `http://127.0.0.1:3000`) |
+| `CUBE_TEMPLATE_ID` | ✓ | Sandbox template id used by the demo |
+| `CUBE_PROXY_NODE_IP` | ✓ | Direct IP to reach CubeProxy |
+| `CUBE_API_KEY` | — | Only for an auth-enabled CubeAPI backend |
+| `OPENAI_API_KEY` | ✓ | LLM API key (or `TOKENHUB_API_KEY`) |
+| `OPENAI_BASE_URL` | — | OpenAI-compatible endpoint |
+| `CHAT_MODEL` | — | Model name (defaults to `deepseek-v3`) |

--- a/examples/langgraph-integration/README.md
+++ b/examples/langgraph-integration/README.md
@@ -40,7 +40,7 @@ python langgraph_checkpoint_demo.py
 
 | Variable | Required | Notes |
 |---|---|---|
-| `CUBE_API_URL` | ✓ | CubeAPI base URL (defaults to `http://127.0.0.1:3000`) |
+| `CUBE_API_URL` | — | CubeAPI base URL (defaults to `http://127.0.0.1:3000`) |
 | `CUBE_TEMPLATE_ID` | ✓ | Sandbox template id used by the demo |
 | `CUBE_PROXY_NODE_IP` | ✓ | Direct IP to reach CubeProxy |
 | `CUBE_API_KEY` | — | Only for an auth-enabled CubeAPI backend |

--- a/examples/langgraph-integration/README_zh.md
+++ b/examples/langgraph-integration/README_zh.md
@@ -1,0 +1,48 @@
+# LangGraph + CubeSandbox 集成示例
+
+[English](README.md)
+
+在 [CubeSandbox](https://github.com/TencentCloud/CubeSandbox) MicroVM 中，通过官方 **`cubesandbox`**
+Python SDK 运行一个 [LangGraph](https://github.com/langchain-ai/langgraph) Agent —— 由节点和条件边
+构成的显式 `StateGraph`，其代码执行工具在沙箱内运行。这些是可运行的
+[LangGraph 集成指南](../../docs/guide/integrations/langgraph.md) 对应脚本。
+
+| 脚本 | 用途 |
+|---|---|
+| `langgraph_agent_demo.py` | 在单个 MicroVM 上运行「生成 → 执行 → 审查 → 重试」循环 |
+| `langgraph_checkpoint_demo.py` | 结合 LangGraph checkpointer，在 `pause()` / `connect()` 之间恢复 |
+
+## 前置条件
+
+- Python 3.10+
+- 已部署 CubeSandbox，并构建注册了一个含 pandas / numpy / matplotlib / scikit-learn 的
+  模板镜像（见 `Dockerfile`）。
+
+## 快速开始
+
+```bash
+# 构建并注册共享模板镜像
+docker build --platform linux/amd64 -t <your-registry>/langgraph-cube:latest .
+docker push <your-registry>/langgraph-cube:latest
+cubemastercli tpl create-from-image \
+  --image <your-registry>/langgraph-cube:latest \
+  --writable-layer-size 2G --expose-port 49983 --probe 49983 --probe-path /health
+
+# 配置环境变量并运行
+cp .env.example .env        # 填入实际值
+pip install -r requirements.txt
+python langgraph_agent_demo.py
+python langgraph_checkpoint_demo.py
+```
+
+## 环境变量
+
+| 变量 | 必填 | 说明 |
+|---|---|---|
+| `CUBE_API_URL` | ✓ | CubeAPI 基础地址（默认 `http://127.0.0.1:3000`） |
+| `CUBE_TEMPLATE_ID` | ✓ | 演示使用的沙箱模板 id |
+| `CUBE_PROXY_NODE_IP` | ✓ | 直连 CubeProxy 的 IP |
+| `CUBE_API_KEY` | — | 仅当 CubeAPI 后端启用鉴权时需要 |
+| `OPENAI_API_KEY` | ✓ | LLM API key（或 `TOKENHUB_API_KEY`） |
+| `OPENAI_BASE_URL` | — | OpenAI 兼容端点 |
+| `CHAT_MODEL` | — | 模型名（默认 `deepseek-v3`） |

--- a/examples/langgraph-integration/README_zh.md
+++ b/examples/langgraph-integration/README_zh.md
@@ -5,7 +5,7 @@
 在 [CubeSandbox](https://github.com/TencentCloud/CubeSandbox) MicroVM 中，通过官方 **`cubesandbox`**
 Python SDK 运行一个 [LangGraph](https://github.com/langchain-ai/langgraph) Agent —— 由节点和条件边
 构成的显式 `StateGraph`，其代码执行工具在沙箱内运行。这些是可运行的
-[LangGraph 集成指南](../../docs/guide/integrations/langgraph.md) 对应脚本。
+[LangGraph 集成指南](../../docs/zh/guide/integrations/langgraph.md) 对应脚本。
 
 | 脚本 | 用途 |
 |---|---|

--- a/examples/langgraph-integration/README_zh.md
+++ b/examples/langgraph-integration/README_zh.md
@@ -39,7 +39,7 @@ python langgraph_checkpoint_demo.py
 
 | 变量 | 必填 | 说明 |
 |---|---|---|
-| `CUBE_API_URL` | ✓ | CubeAPI 基础地址（默认 `http://127.0.0.1:3000`） |
+| `CUBE_API_URL` | — | CubeAPI 基础地址（默认 `http://127.0.0.1:3000`） |
 | `CUBE_TEMPLATE_ID` | ✓ | 演示使用的沙箱模板 id |
 | `CUBE_PROXY_NODE_IP` | ✓ | 直连 CubeProxy 的 IP |
 | `CUBE_API_KEY` | — | 仅当 CubeAPI 后端启用鉴权时需要 |

--- a/examples/langgraph-integration/README_zh.md
+++ b/examples/langgraph-integration/README_zh.md
@@ -41,7 +41,7 @@ python langgraph_checkpoint_demo.py
 |---|---|---|
 | `CUBE_API_URL` | — | CubeAPI 基础地址（默认 `http://127.0.0.1:3000`） |
 | `CUBE_TEMPLATE_ID` | ✓ | 演示使用的沙箱模板 id |
-| `CUBE_PROXY_NODE_IP` | ✓ | 直连 CubeProxy 的 IP |
+| `CUBE_PROXY_NODE_IP` | — | 直连 CubeProxy 的 IP（未设置时 SDK 回退到 wildcard-DNS 主机） |
 | `CUBE_API_KEY` | — | 仅当 CubeAPI 后端启用鉴权时需要 |
 | `OPENAI_API_KEY` | ✓ | LLM API key（或 `TOKENHUB_API_KEY`） |
 | `OPENAI_BASE_URL` | — | OpenAI 兼容端点 |

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -13,7 +13,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_API_URL", "CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+for v in ("CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -135,9 +135,12 @@ def coder(state: AgentState, run_python) -> dict:
         return {"messages": [{"role": "assistant",
                               "content": "[code output]\n(no code block in model reply)"}]}
     output = run_python(code)
-    # Cap the output so a huge result (e.g. a printed DataFrame) cannot blow the
-    # model's context window. Keep the tail: the printed numbers (and any
-    # stderr/traceback) land at the end, so they must survive the truncation.
+    # Cap both the code and the output so a huge result (e.g. a printed DataFrame)
+    # or a large generated script cannot blow the model's context window across
+    # retries. Keep the tail of each: the printed numbers (and any stderr/traceback)
+    # land at the end, and the script's tail still shows the logic that ran.
+    if len(code) > 4000:
+        code = "[earlier code truncated]\n" + code[-4000:]
     if len(output) > 4000:
         output = "[earlier output truncated]\n" + output[-4000:]
     # Include the code alongside the output so that on a RETRY the coder can see

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -97,7 +97,7 @@ def extract_text(content) -> str:
             if isinstance(block, str):
                 parts.append(block)
             elif isinstance(block, dict) and block.get("type") == "text":
-                parts.append(block.get("text", ""))
+                parts.append(block.get("text") or "")
         return "\n".join(parts)
     return str(content)
 
@@ -106,17 +106,21 @@ def strip_code_fence(text: str) -> str | None:
     """Return the code inside the first markdown fence, or None when the reply
     has no fenced block — models often prefix the fenced block with prose."""
     fence = "`" * 3                      # three backticks, without a literal fence
-    text = text.strip()
-    lines = text.splitlines()
-    start = None
-    for i, line in enumerate(lines):
-        if line.strip().startswith(fence):
-            start = i
-            break
-    if start is None:
+    if not text:
         return None
+    # The opener may share a line with prose (`` The code is: ```python ``), so
+    # search for the first fence token anywhere rather than only at a line start.
+    start = text.find(fence)
+    if start == -1:
+        return None
+    # Code begins on the line after the opener; a language tag like ```python and
+    # any trailing prose on that line are dropped.
+    after = text[start + len(fence):]
+    first_nl = after.find("\n")
+    if first_nl == -1:
+        return None                      # opener with no body — treat as no code
     inner = []
-    for line in lines[start + 1:]:
+    for line in after[first_nl + 1:].splitlines():
         # A closer starts with a fence run of three-or-more backticks and is
         # otherwise empty (a bare ``` line) or followed only by prose on the same
         # line — models sometimes slip as `` ``` Done! ``. A language-tagged line
@@ -126,7 +130,7 @@ def strip_code_fence(text: str) -> str | None:
         if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
             break
         inner.append(line)
-    return "\n".join(inner).strip()
+    return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code
 
 
 def coder(state: AgentState, run_python) -> dict:

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -159,21 +159,12 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
-    # The prompt asks for exactly one leading word (DONE/RETRY), so classify on
-    # the first token first — stripping markdown decoration. If that token is
-    # neither, fall back to scanning the reply for a bare DONE/RETRY keyword, so
-    # a reviewer that drifts from the format (leading prose, bold markers) still
-    # classifies instead of silently burning retries.
+    # Treat the full token list as authoritative: an explicit RETRY anywhere in
+    # the reply wins over DONE — the prompt asks for a single leading verdict
+    # word, so a stray "DONE" inside a RETRY explanation must not stop the loop.
+    # DONE only wins when no RETRY token is present.
     tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
-    first = tokens[0] if tokens else ""
-    if first == "DONE":
-        done = True
-    elif first == "RETRY":
-        done = False
-    else:
-        # Prefer an explicit RETRY over a DONE mention, so "RETRY: the numbers
-        # are done but the chart is missing" still retries.
-        done = "DONE" in tokens and "RETRY" not in tokens
+    done = "DONE" in tokens and "RETRY" not in tokens
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, START, END
-from langgraph.graph.message import add_messages
+from langgraph.graph import add_messages
 from cubesandbox import Sandbox
 
 load_dotenv()
@@ -251,11 +251,13 @@ if __name__ == "__main__":
             "done": False,
         })
         # The last message is the reviewer's verdict; print the code output
-        # instead so the user actually sees the computed numbers. rfind anchors on
-        # the real marker (not a literal "[code output]" inside the generated
-        # script), and we print the last coder message verbatim — even a failed
-        # attempt's placeholder — so the numbers shown match the run's final state
-        # rather than an earlier attempt the reviewer already rejected.
+        # instead so the user actually sees the computed numbers. rfind takes the
+        # last "[code output]" occurrence, so a literal inside the generated script
+        # (before the real marker) can't shift the excerpt — only stdout that itself
+        # prints that token would, which merely truncates the display. Print the
+        # last coder message verbatim, even a failed attempt's placeholder, so the
+        # numbers shown match the run's final state rather than an earlier attempt
+        # the reviewer already rejected.
         for msg in reversed(result["messages"]):
             content = str(msg.content)
             marker = "[code output]"

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import itertools
 import os
 import sys
@@ -66,12 +67,12 @@ def make_run_python(sandbox: Sandbox):
 
 CODER_PROMPT = (
     "You are a data analyst. Write a single self-contained Python script that answers "
-    "the latest user request using the dataset at /workspace/sales.csv "
+    "the user's task using the dataset at /workspace/sales.csv "
     "(columns month,product,units,price). The environment has pandas, numpy, "
     "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
     "network access. Wrap the script in a single markdown ```python ... ``` fenced "
-    "block. If a previous reviewer message said RETRY, fix the issues it "
-    "listed before re-running."
+    "block. Messages prefixed with [reviewer] are feedback on your last attempt, "
+    "not a new task: if one said RETRY, fix the issues it listed before re-running."
 )
 
 REVIEWER_PROMPT = (
@@ -150,6 +151,14 @@ def coder(state: AgentState, run_python) -> dict:
         # prose to a .py file and wasting an attempt on a SyntaxError.
         return {"messages": [{"role": "assistant",
                               "content": "[code output]\n(no code block in model reply)"}]}
+    try:
+        ast.parse(code)
+    except SyntaxError as exc:
+        # The fenced block isn't valid Python (e.g. the model prefaced the real
+        # script with a diff/example fence); surface it so the reviewer retries
+        # instead of writing a .py that always fails.
+        return {"messages": [{"role": "assistant",
+                              "content": f"[code output]\n(extracted block is not valid Python: {exc})"}]}
     output = run_python(code)
     # Cap both the code and the output so a huge result (e.g. a printed DataFrame)
     # or a large generated script cannot blow the model's context window across

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -126,20 +126,24 @@ def strip_code_fence(text: str) -> str | None:
     first_nl = after.find("\n")
     if first_nl == -1:
         return None                      # opener with no body — treat as no code
+    # The opener's indentation is the leading whitespace on its own line. A closer
+    # sits at that same indent, so a fence nested in a markdown list still closes
+    # correctly, while a ``` line indented deeper (a markdown example inside a
+    # docstring or string literal) stays code.
+    opener_line = text[text.rfind("\n", 0, start) + 1:start]
+    opener_indent = len(opener_line) - len(opener_line.lstrip())
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # A closer is a column-0 line whose leading backtick run matches the
-        # opener's length and is followed by nothing but prose — models sometimes
-        # slip as `` ``` Done! ``. An indented fence inside a docstring or string
-        # literal, a shorter bare ``` line, or a 4-backtick fence when the opener
-        # was 3, all stay code.
-        if line.startswith("`"):
-            s = line.strip()
-            run = 0
-            while run < len(s) and s[run] == "`":
-                run += 1
-            if run == fence_len and (len(s) == run or s[run].isspace()):
-                break
+        # A closer is a line whose stripped leading backtick run matches the
+        # opener's length at the opener's indent and is followed by nothing but
+        # prose — models sometimes slip as `` ``` Done! ``. A shorter bare ``` line
+        # or a 4-backtick fence when the opener was 3 all stay code.
+        s = line.lstrip()
+        run = 0
+        while run < len(s) and s[run] == "`":
+            run += 1
+        if run == fence_len and (len(s) == run or s[run].isspace()) and len(line) - len(s) == opener_indent:
+            break
         inner.append(line)
     return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code
 
@@ -247,17 +251,16 @@ if __name__ == "__main__":
             "done": False,
         })
         # The last message is the reviewer's verdict; print the code output
-        # instead so the user actually sees the computed numbers.
+        # instead so the user actually sees the computed numbers. rfind anchors on
+        # the real marker (not a literal "[code output]" inside the generated
+        # script), and we print the last coder message verbatim — even a failed
+        # attempt's placeholder — so the numbers shown match the run's final state
+        # rather than an earlier attempt the reviewer already rejected.
         for msg in reversed(result["messages"]):
             content = str(msg.content)
             marker = "[code output]"
-            idx = content.find(marker)
+            idx = content.rfind(marker)
             if idx == -1:
-                continue
-            tail = content[idx + len(marker):].lstrip("\n")
-            # Skip placeholder outputs (a failed LLM call or an empty/invalid
-            # extraction) so a "llm error: ..." doesn't read like a real result.
-            if tail.startswith(("(llm error", "(no code block", "(extracted block")):
                 continue
             print(content[idx:])
             break

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import itertools
+import os
+import sys
+from typing import Annotated, TypedDict
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from cubesandbox import Sandbox
+
+load_dotenv()
+
+for v in ("CUBE_API_URL", "CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+    if not os.environ.get(v):
+        raise SystemExit(f"Missing env: {v}")
+
+_llm_key = os.getenv("OPENAI_API_KEY") or os.getenv("TOKENHUB_API_KEY")
+if not _llm_key:
+    raise SystemExit("Missing LLM API key")
+
+llm = ChatOpenAI(
+    model=os.getenv("CHAT_MODEL") or "deepseek-v3",
+    api_key=_llm_key,
+    base_url=os.getenv("OPENAI_BASE_URL") or "https://tokenhub.tencentmaas.com/v1",
+    timeout=60, max_retries=2, temperature=0,
+)
+
+
+class AgentState(TypedDict):
+    """State shared across nodes. `messages` accumulates the conversation;
+    `attempts` / `done` drive the retry loop. The sandbox itself is shared
+    through the `run_python` closure, not through `State`."""
+    messages: Annotated[list, add_messages]
+    attempts: int
+    done: bool
+
+
+def make_run_python(sandbox: Sandbox):
+    """Return a `run_python` tool bound to one Cube sandbox — the same
+    `cubesandbox` SDK pattern used by the LangChain guide."""
+    _counter = itertools.count()
+
+    def run_python(code: str) -> str:
+        script = f"/workspace/_agent_{next(_counter)}.py"
+        try:
+            sandbox.files.write(script, code)
+            result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
+        except Exception as exc:
+            # A dead sandbox, a failed write, transport errors and per-command
+            # timeouts all raise here; surface them as tool output so the reviewer
+            # can see the failure and decide to retry, rather than letting the
+            # exception abort the whole graph run.
+            return f"[command error] {exc}"
+        out = result.stdout
+        if result.stderr:
+            out += "\n--- stderr ---\n" + result.stderr
+        if result.exit_code != 0:
+            out += f"\n[non-zero exit code: {result.exit_code}]"
+        return out
+
+    return run_python
+
+
+CODER_PROMPT = (
+    "You are a data analyst. Write a single self-contained Python script that answers "
+    "the latest user request using the dataset at /workspace/sales.csv "
+    "(columns month,product,units,price). The environment has pandas, numpy, "
+    "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
+    "network access. Wrap the script in a single markdown ```python ... ``` fenced "
+    "block. If a previous reviewer message said RETRY, fix the issues it "
+    "listed before re-running."
+)
+
+REVIEWER_PROMPT = (
+    "You are a reviewer. Given the user request and the latest code output, decide "
+    "whether the request is fully answered. Reply starting with exactly one word, "
+    "`DONE` or `RETRY`, optionally followed by one line explaining what is missing."
+)
+
+
+def extract_text(content) -> str:
+    """Return plain text from a message content, which may be a str or a list
+    of content blocks (some OpenAI-compatible endpoints return the latter)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "\n".join(parts)
+    return str(content)
+
+
+def strip_code_fence(text: str) -> str | None:
+    """Return the code inside the first markdown fence, or None when the reply
+    has no fenced block — models often prefix the fenced block with prose."""
+    fence = "`" * 3                      # three backticks, without a literal fence
+    text = text.strip()
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith(fence):
+            start = i
+            break
+    if start is None:
+        return None
+    inner = []
+    for line in lines[start + 1:]:
+        # Only a bare fence (backticks plus optional whitespace) closes the block;
+        # a language-tagged line like ```markdown inside the script stays code.
+        if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
+            break
+        inner.append(line)
+    return "\n".join(inner).strip()
+
+
+def coder(state: AgentState, run_python) -> dict:
+    """Ask the LLM for code, execute it in the Cube sandbox, append the output."""
+    code = strip_code_fence(extract_text(llm.invoke(
+        [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
+    ).content))
+    if code is None:
+        # The model returned no fenced code block; surface that instead of writing
+        # prose to a .py file and wasting an attempt on a SyntaxError.
+        return {"messages": [{"role": "assistant",
+                              "content": "[code output]\n(no code block in model reply)"}]}
+    output = run_python(code)
+    # Cap the output so a huge result (e.g. a printed DataFrame) cannot blow the
+    # model's context window. Keep the tail: the printed numbers (and any
+    # stderr/traceback) land at the end, so they must survive the truncation.
+    if len(output) > 4000:
+        output = "[earlier output truncated]\n" + output[-4000:]
+    # Include the code alongside the output so that on a RETRY the coder can see
+    # what it wrote last time instead of repeating the same mistake.
+    return {"messages": [{"role": "assistant",
+                          "content": f"[code]\n{code}\n[code output]\n{output}"}]}
+
+
+def reviewer(state: AgentState) -> dict:
+    """Judge whether the latest output answers the request."""
+    verdict = extract_text(llm.invoke(
+        [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
+    ).content).strip().upper()
+    # The prompt asks for exactly one leading word (DONE/RETRY), so classify on
+    # the first token only — stripping markdown decoration — rather than scanning
+    # the whole reply, where a RETRY explanation containing "done" would misfire.
+    first = (verdict.split() or [""])[0].strip(":*#`")
+    done = first.rstrip(".,!?;") == "DONE"
+    # Emit the verdict as a user-role message so the coder treats RETRY as a
+    # directive to fix, not as its own prior assistant output.
+    return {
+        "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
+        "attempts": state.get("attempts", 0) + 1,
+        "done": done,
+    }
+
+
+def route_after_review(state: AgentState) -> str:
+    """Conditional edge: retry `coder`, or finish after N attempts."""
+    if state["done"] or state["attempts"] >= 3:
+        return "end"
+    return "retry"
+
+
+def build_graph(run_python, checkpointer=None):
+    builder = StateGraph(AgentState)
+    builder.add_node("coder", lambda s: coder(s, run_python))
+    builder.add_node("reviewer", reviewer)
+    builder.add_edge(START, "coder")
+    builder.add_edge("coder", "reviewer")
+    builder.add_conditional_edges(
+        "reviewer",
+        route_after_review,
+        {"retry": "coder", "end": END},
+    )
+    return builder.compile(checkpointer=checkpointer)
+
+
+if __name__ == "__main__":
+    question = sys.argv[1] if len(sys.argv) > 1 else (
+        "Load sales.csv from /workspace, compute total revenue per month, "
+        "and report the month -> revenue numbers."
+    )
+
+    # One MicroVM for the whole run, reused across every coder -> reviewer loop.
+    # The context manager tears it down on exit, so nothing is left behind.
+    with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=600) as sandbox:
+        run_python = make_run_python(sandbox)
+        graph = build_graph(run_python)
+        result = graph.invoke({
+            "messages": [{"role": "user", "content": question}],
+            "attempts": 0,
+            "done": False,
+        })
+        # The last message is the reviewer's verdict; print the code output
+        # instead so the user actually sees the computed numbers.
+        for msg in reversed(result["messages"]):
+            content = str(msg.content)
+            marker = "[code output]"
+            idx = content.find(marker)
+            if idx != -1:
+                print(content[idx:])
+                break
+        else:
+            print("(no code output)")
+        if not result["done"]:
+            print("\n(not verified: reviewer never returned DONE)")

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -113,21 +113,28 @@ def strip_code_fence(text: str) -> str | None:
     start = text.find(fence)
     if start == -1:
         return None
+    # Read the full backtick-run length (```, ````, ...) so a 4-backtick fence is
+    # not mistaken for a 3-backtick opener, and require the closer to match it.
+    fence_len = len(fence)
+    while start + fence_len < len(text) and text[start + fence_len] == "`":
+        fence_len += 1
     # Code begins on the line after the opener; a language tag like ```python and
     # any trailing prose on that line are dropped.
-    after = text[start + len(fence):]
+    after = text[start + fence_len:]
     first_nl = after.find("\n")
     if first_nl == -1:
         return None                      # opener with no body — treat as no code
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # A closer starts with a fence run of three-or-more backticks and is
-        # otherwise empty (a bare ``` line) or followed only by prose on the same
-        # line — models sometimes slip as `` ``` Done! ``. A language-tagged line
-        # like ```markdown inside the script stays code. (Known limit: a bare ```
-        # line inside a docstring would still close early.)
+        # A closer is a line whose leading backtick run matches the opener's
+        # length and is followed by nothing but prose — models sometimes slip as
+        # `` ``` Done! ``. A shorter bare ``` line inside a docstring, or a
+        # 4-backtick fence when the opener was 3, stays code.
         s = line.strip()
-        if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
+        run = 0
+        while run < len(s) and s[run] == "`":
+            run += 1
+        if run == fence_len and (len(s) == run or s[run].isspace()):
             break
         inner.append(line)
     return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -82,10 +82,15 @@ REVIEWER_PROMPT = (
 
 
 def extract_text(content) -> str:
-    """Return plain text from a message content, which may be a str or a list
-    of content blocks (some OpenAI-compatible endpoints return the latter)."""
+    """Return plain text from a message content, which may be a str, a single
+    content block dict, or a list of blocks (some OpenAI-compatible endpoints
+    return the latter two)."""
+    if not content:
+        return ""                     # None / empty content — treat as no text
     if isinstance(content, str):
         return content
+    if isinstance(content, dict):
+        content = [content]           # a lone content block, not a list
     if isinstance(content, list):
         parts = []
         for block in content:

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -7,6 +7,7 @@ import sys
 from typing import Annotated, TypedDict
 
 from dotenv import load_dotenv
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, START, END
 from langgraph.graph.message import add_messages
@@ -152,22 +153,19 @@ def coder(state: AgentState, run_python) -> dict:
     except Exception as exc:
         # A transient LLM error (rate limit, 5xx, timeout) must not abort the
         # whole graph run; surface it as empty code so the reviewer retries.
-        return {"messages": [{"role": "assistant",
-                              "content": f"[code output]\n(llm error: {exc})"}]}
+        return {"messages": [AIMessage(content=f"[code output]\n(llm error: {exc})")]}
     code = strip_code_fence(extract_text(reply))
     if code is None:
         # The model returned no fenced code block; surface that instead of writing
         # prose to a .py file and wasting an attempt on a SyntaxError.
-        return {"messages": [{"role": "assistant",
-                              "content": "[code output]\n(no code block in model reply)"}]}
+        return {"messages": [AIMessage(content="[code output]\n(no code block in model reply)")]}
     try:
         ast.parse(code)
     except SyntaxError as exc:
         # The fenced block isn't valid Python (e.g. the model prefaced the real
         # script with a diff/example fence); surface it so the reviewer retries
         # instead of writing a .py that always fails.
-        return {"messages": [{"role": "assistant",
-                              "content": f"[code output]\n(extracted block is not valid Python: {exc})"}]}
+        return {"messages": [AIMessage(content=f"[code output]\n(extracted block is not valid Python: {exc})")]}
     output = run_python(code)
     # Cap both the code and the output so a huge result (e.g. a printed DataFrame)
     # or a large generated script cannot blow the model's context window across
@@ -179,8 +177,7 @@ def coder(state: AgentState, run_python) -> dict:
         output = "[earlier output truncated]\n" + output[-4000:]
     # Include the code alongside the output so that on a RETRY the coder can see
     # what it wrote last time instead of repeating the same mistake.
-    return {"messages": [{"role": "assistant",
-                          "content": f"[code]\n{code}\n[code output]\n{output}"}]}
+    return {"messages": [AIMessage(content=f"[code]\n{code}\n[code output]\n{output}")]}
 
 
 def reviewer(state: AgentState) -> dict:
@@ -193,7 +190,7 @@ def reviewer(state: AgentState) -> dict:
         # A transient LLM error in the reviewer degrades to a retry rather than
         # aborting the run.
         return {
-            "messages": [{"role": "user", "content": f"[reviewer] RETRY (llm error: {exc})"}],
+            "messages": [HumanMessage(content=f"[reviewer] RETRY (llm error: {exc})")],
             "attempts": state.get("attempts", 0) + 1,
             "done": False,
         }
@@ -206,7 +203,7 @@ def reviewer(state: AgentState) -> dict:
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {
-        "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
+        "messages": [HumanMessage(content=f"[reviewer] {verdict}")],
         "attempts": state.get("attempts", 0) + 1,
         "done": done,
     }

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -13,7 +13,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+for v in ("CUBE_TEMPLATE_ID",):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -160,10 +160,20 @@ def reviewer(state: AgentState) -> dict:
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
     # The prompt asks for exactly one leading word (DONE/RETRY), so classify on
-    # the first token only — stripping markdown decoration — rather than scanning
-    # the whole reply, where a RETRY explanation containing "done" would misfire.
-    first = (verdict.split() or [""])[0].strip(":*#`")
-    done = first.rstrip(".,!?;") == "DONE"
+    # the first token first — stripping markdown decoration. If that token is
+    # neither, fall back to scanning the reply for a bare DONE/RETRY keyword, so
+    # a reviewer that drifts from the format (leading prose, bold markers) still
+    # classifies instead of silently burning retries.
+    tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
+    first = tokens[0] if tokens else ""
+    if first == "DONE":
+        done = True
+    elif first == "RETRY":
+        done = False
+    else:
+        # Prefer an explicit RETRY over a DONE mention, so "RETRY: the numbers
+        # are done but the chart is missing" still retries.
+        done = "DONE" in tokens and "RETRY" not in tokens
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -68,11 +68,10 @@ def make_run_python(sandbox: Sandbox):
 
 CODER_PROMPT = (
     "You are a data analyst. Write a single self-contained Python script that answers "
-    "the user's task using the dataset at /workspace/sales.csv "
-    "(columns month,product,units,price). The environment has pandas, numpy, "
-    "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
-    "network access. Wrap the script in a single markdown ```python ... ``` fenced "
-    "block. Messages prefixed with [reviewer] are feedback on your last attempt, "
+    "the user's task using the dataset file(s) named in the task. The environment has "
+    "pandas, numpy, matplotlib, scikit-learn preinstalled. Print the final numbers. "
+    "Do not rely on network access. Wrap the script in a single markdown ```python ... ``` "
+    "fenced block. Messages prefixed with [reviewer] are feedback on your last attempt, "
     "not a new task: if one said RETRY, fix the issues it listed before re-running."
 )
 

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -127,25 +127,34 @@ def strip_code_fence(text: str) -> str | None:
         return None                      # opener with no body — treat as no code
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # A closer is a line whose leading backtick run matches the opener's
-        # length and is followed by nothing but prose — models sometimes slip as
-        # `` ``` Done! ``. A shorter bare ``` line inside a docstring, or a
-        # 4-backtick fence when the opener was 3, stays code.
-        s = line.strip()
-        run = 0
-        while run < len(s) and s[run] == "`":
-            run += 1
-        if run == fence_len and (len(s) == run or s[run].isspace()):
-            break
+        # A closer is a column-0 line whose leading backtick run matches the
+        # opener's length and is followed by nothing but prose — models sometimes
+        # slip as `` ``` Done! ``. An indented fence inside a docstring or string
+        # literal, a shorter bare ``` line, or a 4-backtick fence when the opener
+        # was 3, all stay code.
+        if line.startswith("`"):
+            s = line.strip()
+            run = 0
+            while run < len(s) and s[run] == "`":
+                run += 1
+            if run == fence_len and (len(s) == run or s[run].isspace()):
+                break
         inner.append(line)
     return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code
 
 
 def coder(state: AgentState, run_python) -> dict:
     """Ask the LLM for code, execute it in the Cube sandbox, append the output."""
-    code = strip_code_fence(extract_text(llm.invoke(
-        [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
-    ).content))
+    try:
+        reply = llm.invoke(
+            [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
+        ).content
+    except Exception as exc:
+        # A transient LLM error (rate limit, 5xx, timeout) must not abort the
+        # whole graph run; surface it as empty code so the reviewer retries.
+        return {"messages": [{"role": "assistant",
+                              "content": f"[code output]\n(llm error: {exc})"}]}
+    code = strip_code_fence(extract_text(reply))
     if code is None:
         # The model returned no fenced code block; surface that instead of writing
         # prose to a .py file and wasting an attempt on a SyntaxError.
@@ -176,15 +185,25 @@ def coder(state: AgentState, run_python) -> dict:
 
 def reviewer(state: AgentState) -> dict:
     """Judge whether the latest output answers the request."""
-    verdict = extract_text(llm.invoke(
-        [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
-    ).content).strip().upper()
-    # Treat the full token list as authoritative: an explicit RETRY anywhere in
-    # the reply wins over DONE — the prompt asks for a single leading verdict
-    # word, so a stray "DONE" inside a RETRY explanation must not stop the loop.
-    # DONE only wins when no RETRY token is present.
-    tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
-    done = "DONE" in tokens and "RETRY" not in tokens
+    try:
+        reply = llm.invoke(
+            [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
+        ).content
+    except Exception as exc:
+        # A transient LLM error in the reviewer degrades to a retry rather than
+        # aborting the run.
+        return {
+            "messages": [{"role": "user", "content": f"[reviewer] RETRY (llm error: {exc})"}],
+            "attempts": state.get("attempts", 0) + 1,
+            "done": False,
+        }
+    verdict = extract_text(reply).strip().upper()
+    # The prompt asks for a single leading verdict word, so parse only the first
+    # token — a "DONE"/"RETRY" later in the explanation is prose, not a second
+    # verdict. This avoids both a stray "DONE" in a RETRY explanation stopping
+    # the loop and an "I would not RETRY" re-running a correct answer.
+    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;")
+    done = first == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -198,10 +198,9 @@ def reviewer(state: AgentState) -> dict:
             "done": False,
         }
     verdict = extract_text(reply).strip().upper()
-    # The prompt asks for a single leading verdict word, so parse only the first
-    # token — a "DONE"/"RETRY" later in the explanation is prose, not a second
-    # verdict. This avoids both a stray "DONE" in a RETRY explanation stopping
-    # the loop and an "I would not RETRY" re-running a correct answer.
+    # The prompt asks for a single leading verdict word, so only the leading
+    # token counts as the verdict — a "DONE"/"RETRY" later in the explanation
+    # is prose and doesn't flip the result.
     first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;") if verdict else ""
     done = first == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
@@ -256,9 +255,15 @@ if __name__ == "__main__":
             content = str(msg.content)
             marker = "[code output]"
             idx = content.find(marker)
-            if idx != -1:
-                print(content[idx:])
-                break
+            if idx == -1:
+                continue
+            tail = content[idx + len(marker):].lstrip("\n")
+            # Skip placeholder outputs (a failed LLM call or an empty/invalid
+            # extraction) so a "llm error: ..." doesn't read like a real result.
+            if tail.startswith(("(llm error", "(no code block", "(extracted block")):
+                continue
+            print(content[idx:])
+            break
         else:
             print("(no code output)")
         if not result["done"]:

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -114,6 +114,7 @@ def strip_code_fence(text: str) -> str | None:
     for line in lines[start + 1:]:
         # Only a bare fence (backticks plus optional whitespace) closes the block;
         # a language-tagged line like ```markdown inside the script stays code.
+        # (Known limit: a bare ``` line inside a docstring would still close early.)
         if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
             break
         inner.append(line)

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -202,7 +202,7 @@ def reviewer(state: AgentState) -> dict:
     # token — a "DONE"/"RETRY" later in the explanation is prose, not a second
     # verdict. This avoids both a stray "DONE" in a RETRY explanation stopping
     # the loop and an "I would not RETRY" re-running a correct answer.
-    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;")
+    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;") if verdict else ""
     done = first == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.

--- a/examples/langgraph-integration/langgraph_agent_demo.py
+++ b/examples/langgraph-integration/langgraph_agent_demo.py
@@ -112,10 +112,13 @@ def strip_code_fence(text: str) -> str | None:
         return None
     inner = []
     for line in lines[start + 1:]:
-        # Only a bare fence (backticks plus optional whitespace) closes the block;
-        # a language-tagged line like ```markdown inside the script stays code.
-        # (Known limit: a bare ``` line inside a docstring would still close early.)
-        if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
+        # A closer starts with a fence run of three-or-more backticks and is
+        # otherwise empty (a bare ``` line) or followed only by prose on the same
+        # line — models sometimes slip as `` ``` Done! ``. A language-tagged line
+        # like ```markdown inside the script stays code. (Known limit: a bare ```
+        # line inside a docstring would still close early.)
+        s = line.strip()
+        if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
             break
         inner.append(line)
     return "\n".join(inner).strip()

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -13,7 +13,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_API_URL", "CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+for v in ("CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -135,9 +135,12 @@ def coder(state: AgentState, run_python) -> dict:
         return {"messages": [{"role": "assistant",
                               "content": "[code output]\n(no code block in model reply)"}]}
     output = run_python(code)
-    # Cap the output so a huge result (e.g. a printed DataFrame) cannot blow the
-    # model's context window. Keep the tail: the printed numbers (and any
-    # stderr/traceback) land at the end, so they must survive the truncation.
+    # Cap both the code and the output so a huge result (e.g. a printed DataFrame)
+    # or a large generated script cannot blow the model's context window across
+    # retries. Keep the tail of each: the printed numbers (and any stderr/traceback)
+    # land at the end, and the script's tail still shows the logic that ran.
+    if len(code) > 4000:
+        code = "[earlier code truncated]\n" + code[-4000:]
     if len(output) > 4000:
         output = "[earlier output truncated]\n" + output[-4000:]
     # Include the code alongside the output so that on a RETRY the coder can see

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import itertools
 import os
 from typing import Annotated, TypedDict
@@ -66,12 +67,12 @@ def make_run_python(sandbox: Sandbox):
 
 CODER_PROMPT = (
     "You are a data analyst. Write a single self-contained Python script that answers "
-    "the latest user request using the dataset at /workspace/sales.csv "
+    "the user's task using the dataset at /workspace/sales.csv "
     "(columns month,product,units,price). The environment has pandas, numpy, "
     "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
     "network access. Wrap the script in a single markdown ```python ... ``` fenced "
-    "block. If a previous reviewer message said RETRY, fix the issues it "
-    "listed before re-running."
+    "block. Messages prefixed with [reviewer] are feedback on your last attempt, "
+    "not a new task: if one said RETRY, fix the issues it listed before re-running."
 )
 
 REVIEWER_PROMPT = (
@@ -150,6 +151,14 @@ def coder(state: AgentState, run_python) -> dict:
         # prose to a .py file and wasting an attempt on a SyntaxError.
         return {"messages": [{"role": "assistant",
                               "content": "[code output]\n(no code block in model reply)"}]}
+    try:
+        ast.parse(code)
+    except SyntaxError as exc:
+        # The fenced block isn't valid Python (e.g. the model prefaced the real
+        # script with a diff/example fence); surface it so the reviewer retries
+        # instead of writing a .py that always fails.
+        return {"messages": [{"role": "assistant",
+                              "content": f"[code output]\n(extracted block is not valid Python: {exc})"}]}
     output = run_python(code)
     # Cap both the code and the output so a huge result (e.g. a printed DataFrame)
     # or a large generated script cannot blow the model's context window across
@@ -223,7 +232,7 @@ if __name__ == "__main__":
     config = {"configurable": {"thread_id": sandbox.sandbox_id}}
     try:
         graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-        graph.invoke(stage_input([{"role": "user", "content": "first task"}]), config=config)
+        graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
 
         sandbox.pause()                                   # snapshot VM + rootfs
         # Sandbox.connect() returns a NEW instance; the run_python closure captured
@@ -231,7 +240,7 @@ if __name__ == "__main__":
         # instance, keeping the same checkpointer so the same checkpoint thread resumes.
         sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
         graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-        result = graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}]), config=config)
+        result = graph.invoke(stage_input([{"role": "user", "content": "now compute average units per product"}]), config=config)
         # Print the second stage's code output so the resume is observable.
         for msg in reversed(result["messages"]):
             content = str(msg.content)

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -97,7 +97,7 @@ def extract_text(content) -> str:
             if isinstance(block, str):
                 parts.append(block)
             elif isinstance(block, dict) and block.get("type") == "text":
-                parts.append(block.get("text", ""))
+                parts.append(block.get("text") or "")
         return "\n".join(parts)
     return str(content)
 
@@ -106,17 +106,21 @@ def strip_code_fence(text: str) -> str | None:
     """Return the code inside the first markdown fence, or None when the reply
     has no fenced block — models often prefix the fenced block with prose."""
     fence = "`" * 3                      # three backticks, without a literal fence
-    text = text.strip()
-    lines = text.splitlines()
-    start = None
-    for i, line in enumerate(lines):
-        if line.strip().startswith(fence):
-            start = i
-            break
-    if start is None:
+    if not text:
         return None
+    # The opener may share a line with prose (`` The code is: ```python ``), so
+    # search for the first fence token anywhere rather than only at a line start.
+    start = text.find(fence)
+    if start == -1:
+        return None
+    # Code begins on the line after the opener; a language tag like ```python and
+    # any trailing prose on that line are dropped.
+    after = text[start + len(fence):]
+    first_nl = after.find("\n")
+    if first_nl == -1:
+        return None                      # opener with no body — treat as no code
     inner = []
-    for line in lines[start + 1:]:
+    for line in after[first_nl + 1:].splitlines():
         # A closer starts with a fence run of three-or-more backticks and is
         # otherwise empty (a bare ``` line) or followed only by prose on the same
         # line — models sometimes slip as `` ``` Done! ``. A language-tagged line
@@ -126,7 +130,7 @@ def strip_code_fence(text: str) -> str | None:
         if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
             break
         inner.append(line)
-    return "\n".join(inner).strip()
+    return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code
 
 
 def coder(state: AgentState, run_python) -> dict:

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -114,6 +114,7 @@ def strip_code_fence(text: str) -> str | None:
     for line in lines[start + 1:]:
         # Only a bare fence (backticks plus optional whitespace) closes the block;
         # a language-tagged line like ```markdown inside the script stays code.
+        # (Known limit: a bare ``` line inside a docstring would still close early.)
         if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
             break
         inner.append(line)
@@ -207,6 +208,18 @@ if __name__ == "__main__":
         # instance, keeping the same checkpointer so the same checkpoint thread resumes.
         sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
         graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-        graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}]), config=config)
+        result = graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}]), config=config)
+        # Print the second stage's code output so the resume is observable.
+        for msg in reversed(result["messages"]):
+            content = str(msg.content)
+            marker = "[code output]"
+            idx = content.find(marker)
+            if idx != -1:
+                print(content[idx:])
+                break
+        else:
+            print("(no code output)")
+        if not result["done"]:
+            print("\n(not verified: reviewer never returned DONE)")
     finally:
         sandbox.kill()

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -198,10 +198,9 @@ def reviewer(state: AgentState) -> dict:
             "done": False,
         }
     verdict = extract_text(reply).strip().upper()
-    # The prompt asks for a single leading verdict word, so parse only the first
-    # token — a "DONE"/"RETRY" later in the explanation is prose, not a second
-    # verdict. This avoids both a stray "DONE" in a RETRY explanation stopping
-    # the loop and an "I would not RETRY" re-running a correct answer.
+    # The prompt asks for a single leading verdict word, so only the leading
+    # token counts as the verdict — a "DONE"/"RETRY" later in the explanation
+    # is prose and doesn't flip the result.
     first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;") if verdict else ""
     done = first == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
@@ -267,9 +266,15 @@ if __name__ == "__main__":
             content = str(msg.content)
             marker = "[code output]"
             idx = content.find(marker)
-            if idx != -1:
-                print(content[idx:])
-                break
+            if idx == -1:
+                continue
+            tail = content[idx + len(marker):].lstrip("\n")
+            # Skip placeholder outputs (a failed LLM call or an empty/invalid
+            # extraction) so a "llm error: ..." doesn't read like a real result.
+            if tail.startswith(("(llm error", "(no code block", "(extracted block")):
+                continue
+            print(content[idx:])
+            break
         else:
             print("(no code output)")
         if not result["done"]:

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -159,21 +159,12 @@ def reviewer(state: AgentState) -> dict:
     verdict = extract_text(llm.invoke(
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
-    # The prompt asks for exactly one leading word (DONE/RETRY), so classify on
-    # the first token first — stripping markdown decoration. If that token is
-    # neither, fall back to scanning the reply for a bare DONE/RETRY keyword, so
-    # a reviewer that drifts from the format (leading prose, bold markers) still
-    # classifies instead of silently burning retries.
+    # Treat the full token list as authoritative: an explicit RETRY anywhere in
+    # the reply wins over DONE — the prompt asks for a single leading verdict
+    # word, so a stray "DONE" inside a RETRY explanation must not stop the loop.
+    # DONE only wins when no RETRY token is present.
     tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
-    first = tokens[0] if tokens else ""
-    if first == "DONE":
-        done = True
-    elif first == "RETRY":
-        done = False
-    else:
-        # Prefer an explicit RETRY over a DONE mention, so "RETRY: the numbers
-        # are done but the chart is missing" still retries.
-        done = "DONE" in tokens and "RETRY" not in tokens
+    done = "DONE" in tokens and "RETRY" not in tokens
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -10,7 +10,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import StateGraph, START, END
-from langgraph.graph.message import add_messages
+from langgraph.graph import add_messages
 from cubesandbox import Sandbox
 
 load_dotenv()
@@ -265,10 +265,12 @@ if __name__ == "__main__":
         graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
         result = graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv (written by stage 1) and report which month had the highest revenue."}]), config=config)
         # Print the second stage's code output so the resume is observable. rfind
-        # anchors on the real marker (not a literal "[code output]" inside the
-        # generated script), and we print the last coder message verbatim — even a
-        # failed attempt's placeholder — so the numbers shown match the run's final
-        # state rather than an earlier attempt the reviewer already rejected.
+        # takes the last "[code output]" occurrence, so a literal inside the
+        # generated script (before the real marker) can't shift the excerpt — only
+        # stdout that itself prints that token would, which merely truncates the
+        # display. Print the last coder message verbatim, even a failed attempt's
+        # placeholder, so the numbers shown match the run's final state rather than
+        # an earlier attempt the reviewer already rejected.
         for msg in reversed(result["messages"]):
             content = str(msg.content)
             marker = "[code output]"

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -251,7 +251,9 @@ if __name__ == "__main__":
     config = {"configurable": {"thread_id": sandbox.sandbox_id}}
     try:
         graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-        graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
+        stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
+        if not stage1["done"]:
+            print("(stage 1 not verified: reviewer never returned DONE)")
 
         sandbox.pause()                                   # snapshot VM + rootfs
         # Sandbox.connect() returns a NEW instance; the run_python closure captured

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -68,11 +68,10 @@ def make_run_python(sandbox: Sandbox):
 
 CODER_PROMPT = (
     "You are a data analyst. Write a single self-contained Python script that answers "
-    "the user's task using the dataset at /workspace/sales.csv "
-    "(columns month,product,units,price). The environment has pandas, numpy, "
-    "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
-    "network access. Wrap the script in a single markdown ```python ... ``` fenced "
-    "block. Messages prefixed with [reviewer] are feedback on your last attempt, "
+    "the user's task using the dataset file(s) named in the task. The environment has "
+    "pandas, numpy, matplotlib, scikit-learn preinstalled. Print the final numbers. "
+    "Do not rely on network access. Wrap the script in a single markdown ```python ... ``` "
+    "fenced block. Messages prefixed with [reviewer] are feedback on your last attempt, "
     "not a new task: if one said RETRY, fix the issues it listed before re-running."
 )
 
@@ -245,15 +244,16 @@ def stage_input(messages):
 if __name__ == "__main__":
     checkpointer = MemorySaver()  # in-process demo; use a durable checkpointer for real resume
 
-    sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
-    # Key the checkpoint thread by the sandbox id so the same thread_id reattaches
-    # to the same MicroVM across pause() / connect().
-    config = {"configurable": {"thread_id": sandbox.sandbox_id}}
+    sandbox = None
     try:
+        sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
+        # Key the checkpoint thread by the sandbox id so the same thread_id reattaches
+        # to the same MicroVM across pause() / connect().
+        config = {"configurable": {"thread_id": sandbox.sandbox_id}}
         graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
         # Stage 1 writes an intermediate artifact so stage 2 reads state that only
         # survives because /workspace persists across pause() / connect().
-        stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and write the month -> revenue table to /workspace/monthly_revenue.csv."}]), config=config)
+        stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace (columns month,product,units,price), compute total revenue per month, write the month -> revenue table to /workspace/monthly_revenue.csv, and write the exact string 'stage1-complete' to /workspace/stage1_marker.txt."}]), config=config)
         if not stage1["done"]:
             print("(stage 1 not verified: reviewer never returned DONE)")
 
@@ -263,7 +263,7 @@ if __name__ == "__main__":
         # instance, keeping the same checkpointer so the same checkpoint thread resumes.
         sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
         graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-        result = graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv (written by stage 1) and report which month had the highest revenue."}]), config=config)
+        result = graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv and /workspace/stage1_marker.txt (both written by stage 1) and report the marker's exact text and which month had the highest revenue. Use only those two files — do not recompute from sales.csv."}]), config=config)
         # Print the second stage's code output so the resume is observable. rfind
         # takes the last "[code output]" occurrence, so a literal inside the
         # generated script (before the real marker) can't shift the excerpt — only
@@ -284,4 +284,8 @@ if __name__ == "__main__":
         if not result["done"]:
             print("\n(not verified: reviewer never returned DONE)")
     finally:
-        sandbox.kill()
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+            except Exception:
+                pass

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -126,20 +126,24 @@ def strip_code_fence(text: str) -> str | None:
     first_nl = after.find("\n")
     if first_nl == -1:
         return None                      # opener with no body — treat as no code
+    # The opener's indentation is the leading whitespace on its own line. A closer
+    # sits at that same indent, so a fence nested in a markdown list still closes
+    # correctly, while a ``` line indented deeper (a markdown example inside a
+    # docstring or string literal) stays code.
+    opener_line = text[text.rfind("\n", 0, start) + 1:start]
+    opener_indent = len(opener_line) - len(opener_line.lstrip())
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # A closer is a column-0 line whose leading backtick run matches the
-        # opener's length and is followed by nothing but prose — models sometimes
-        # slip as `` ``` Done! ``. An indented fence inside a docstring or string
-        # literal, a shorter bare ``` line, or a 4-backtick fence when the opener
-        # was 3, all stay code.
-        if line.startswith("`"):
-            s = line.strip()
-            run = 0
-            while run < len(s) and s[run] == "`":
-                run += 1
-            if run == fence_len and (len(s) == run or s[run].isspace()):
-                break
+        # A closer is a line whose stripped leading backtick run matches the
+        # opener's length at the opener's indent and is followed by nothing but
+        # prose — models sometimes slip as `` ``` Done! ``. A shorter bare ``` line
+        # or a 4-backtick fence when the opener was 3 all stay code.
+        s = line.lstrip()
+        run = 0
+        while run < len(s) and s[run] == "`":
+            run += 1
+        if run == fence_len and (len(s) == run or s[run].isspace()) and len(line) - len(s) == opener_indent:
+            break
         inner.append(line)
     return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code
 
@@ -247,7 +251,9 @@ if __name__ == "__main__":
     config = {"configurable": {"thread_id": sandbox.sandbox_id}}
     try:
         graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-        stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and report the month -> revenue numbers."}]), config=config)
+        # Stage 1 writes an intermediate artifact so stage 2 reads state that only
+        # survives because /workspace persists across pause() / connect().
+        stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace, compute total revenue per month, and write the month -> revenue table to /workspace/monthly_revenue.csv."}]), config=config)
         if not stage1["done"]:
             print("(stage 1 not verified: reviewer never returned DONE)")
 
@@ -257,18 +263,17 @@ if __name__ == "__main__":
         # instance, keeping the same checkpointer so the same checkpoint thread resumes.
         sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
         graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
-        result = graph.invoke(stage_input([{"role": "user", "content": "now compute average units per product"}]), config=config)
-        # Print the second stage's code output so the resume is observable.
+        result = graph.invoke(stage_input([{"role": "user", "content": "Read /workspace/monthly_revenue.csv (written by stage 1) and report which month had the highest revenue."}]), config=config)
+        # Print the second stage's code output so the resume is observable. rfind
+        # anchors on the real marker (not a literal "[code output]" inside the
+        # generated script), and we print the last coder message verbatim — even a
+        # failed attempt's placeholder — so the numbers shown match the run's final
+        # state rather than an earlier attempt the reviewer already rejected.
         for msg in reversed(result["messages"]):
             content = str(msg.content)
             marker = "[code output]"
-            idx = content.find(marker)
+            idx = content.rfind(marker)
             if idx == -1:
-                continue
-            tail = content[idx + len(marker):].lstrip("\n")
-            # Skip placeholder outputs (a failed LLM call or an empty/invalid
-            # extraction) so a "llm error: ..." doesn't read like a real result.
-            if tail.startswith(("(llm error", "(no code block", "(extracted block")):
                 continue
             print(content[idx:])
             break

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -113,21 +113,28 @@ def strip_code_fence(text: str) -> str | None:
     start = text.find(fence)
     if start == -1:
         return None
+    # Read the full backtick-run length (```, ````, ...) so a 4-backtick fence is
+    # not mistaken for a 3-backtick opener, and require the closer to match it.
+    fence_len = len(fence)
+    while start + fence_len < len(text) and text[start + fence_len] == "`":
+        fence_len += 1
     # Code begins on the line after the opener; a language tag like ```python and
     # any trailing prose on that line are dropped.
-    after = text[start + len(fence):]
+    after = text[start + fence_len:]
     first_nl = after.find("\n")
     if first_nl == -1:
         return None                      # opener with no body — treat as no code
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # A closer starts with a fence run of three-or-more backticks and is
-        # otherwise empty (a bare ``` line) or followed only by prose on the same
-        # line — models sometimes slip as `` ``` Done! ``. A language-tagged line
-        # like ```markdown inside the script stays code. (Known limit: a bare ```
-        # line inside a docstring would still close early.)
+        # A closer is a line whose leading backtick run matches the opener's
+        # length and is followed by nothing but prose — models sometimes slip as
+        # `` ``` Done! ``. A shorter bare ``` line inside a docstring, or a
+        # 4-backtick fence when the opener was 3, stays code.
         s = line.strip()
-        if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
+        run = 0
+        while run < len(s) and s[run] == "`":
+            run += 1
+        if run == fence_len and (len(s) == run or s[run].isspace()):
             break
         inner.append(line)
     return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import itertools
 import os
+import sys
 from typing import Annotated, TypedDict
 
 from dotenv import load_dotenv
@@ -256,6 +257,7 @@ if __name__ == "__main__":
         stage1 = graph.invoke(stage_input([{"role": "user", "content": "Load sales.csv from /workspace (columns month,product,units,price), compute total revenue per month, write the month -> revenue table to /workspace/monthly_revenue.csv, and write the exact string 'stage1-complete' to /workspace/stage1_marker.txt."}]), config=config)
         if not stage1["done"]:
             print("(stage 1 not verified: reviewer never returned DONE)")
+            sys.exit(1)
 
         sandbox.pause()                                   # snapshot VM + rootfs
         # Sandbox.connect() returns a NEW instance; the run_python closure captured

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -82,10 +82,15 @@ REVIEWER_PROMPT = (
 
 
 def extract_text(content) -> str:
-    """Return plain text from a message content, which may be a str or a list
-    of content blocks (some OpenAI-compatible endpoints return the latter)."""
+    """Return plain text from a message content, which may be a str, a single
+    content block dict, or a list of blocks (some OpenAI-compatible endpoints
+    return the latter two)."""
+    if not content:
+        return ""                     # None / empty content — treat as no text
     if isinstance(content, str):
         return content
+    if isinstance(content, dict):
+        content = [content]           # a lone content block, not a list
     if isinstance(content, list):
         parts = []
         for block in content:

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -13,7 +13,7 @@ from cubesandbox import Sandbox
 
 load_dotenv()
 
-for v in ("CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+for v in ("CUBE_TEMPLATE_ID",):
     if not os.environ.get(v):
         raise SystemExit(f"Missing env: {v}")
 
@@ -160,10 +160,20 @@ def reviewer(state: AgentState) -> dict:
         [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
     ).content).strip().upper()
     # The prompt asks for exactly one leading word (DONE/RETRY), so classify on
-    # the first token only — stripping markdown decoration — rather than scanning
-    # the whole reply, where a RETRY explanation containing "done" would misfire.
-    first = (verdict.split() or [""])[0].strip(":*#`")
-    done = first.rstrip(".,!?;") == "DONE"
+    # the first token first — stripping markdown decoration. If that token is
+    # neither, fall back to scanning the reply for a bare DONE/RETRY keyword, so
+    # a reviewer that drifts from the format (leading prose, bold markers) still
+    # classifies instead of silently burning retries.
+    tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
+    first = tokens[0] if tokens else ""
+    if first == "DONE":
+        done = True
+    elif first == "RETRY":
+        done = False
+    else:
+        # Prefer an explicit RETRY over a DONE mention, so "RETRY: the numbers
+        # are done but the chart is missing" still retries.
+        done = "DONE" in tokens and "RETRY" not in tokens
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -6,6 +6,7 @@ import os
 from typing import Annotated, TypedDict
 
 from dotenv import load_dotenv
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import StateGraph, START, END
@@ -152,22 +153,19 @@ def coder(state: AgentState, run_python) -> dict:
     except Exception as exc:
         # A transient LLM error (rate limit, 5xx, timeout) must not abort the
         # whole graph run; surface it as empty code so the reviewer retries.
-        return {"messages": [{"role": "assistant",
-                              "content": f"[code output]\n(llm error: {exc})"}]}
+        return {"messages": [AIMessage(content=f"[code output]\n(llm error: {exc})")]}
     code = strip_code_fence(extract_text(reply))
     if code is None:
         # The model returned no fenced code block; surface that instead of writing
         # prose to a .py file and wasting an attempt on a SyntaxError.
-        return {"messages": [{"role": "assistant",
-                              "content": "[code output]\n(no code block in model reply)"}]}
+        return {"messages": [AIMessage(content="[code output]\n(no code block in model reply)")]}
     try:
         ast.parse(code)
     except SyntaxError as exc:
         # The fenced block isn't valid Python (e.g. the model prefaced the real
         # script with a diff/example fence); surface it so the reviewer retries
         # instead of writing a .py that always fails.
-        return {"messages": [{"role": "assistant",
-                              "content": f"[code output]\n(extracted block is not valid Python: {exc})"}]}
+        return {"messages": [AIMessage(content=f"[code output]\n(extracted block is not valid Python: {exc})")]}
     output = run_python(code)
     # Cap both the code and the output so a huge result (e.g. a printed DataFrame)
     # or a large generated script cannot blow the model's context window across
@@ -179,8 +177,7 @@ def coder(state: AgentState, run_python) -> dict:
         output = "[earlier output truncated]\n" + output[-4000:]
     # Include the code alongside the output so that on a RETRY the coder can see
     # what it wrote last time instead of repeating the same mistake.
-    return {"messages": [{"role": "assistant",
-                          "content": f"[code]\n{code}\n[code output]\n{output}"}]}
+    return {"messages": [AIMessage(content=f"[code]\n{code}\n[code output]\n{output}")]}
 
 
 def reviewer(state: AgentState) -> dict:
@@ -193,7 +190,7 @@ def reviewer(state: AgentState) -> dict:
         # A transient LLM error in the reviewer degrades to a retry rather than
         # aborting the run.
         return {
-            "messages": [{"role": "user", "content": f"[reviewer] RETRY (llm error: {exc})"}],
+            "messages": [HumanMessage(content=f"[reviewer] RETRY (llm error: {exc})")],
             "attempts": state.get("attempts", 0) + 1,
             "done": False,
         }
@@ -206,7 +203,7 @@ def reviewer(state: AgentState) -> dict:
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {
-        "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
+        "messages": [HumanMessage(content=f"[reviewer] {verdict}")],
         "attempts": state.get("attempts", 0) + 1,
         "done": done,
     }

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -127,25 +127,34 @@ def strip_code_fence(text: str) -> str | None:
         return None                      # opener with no body — treat as no code
     inner = []
     for line in after[first_nl + 1:].splitlines():
-        # A closer is a line whose leading backtick run matches the opener's
-        # length and is followed by nothing but prose — models sometimes slip as
-        # `` ``` Done! ``. A shorter bare ``` line inside a docstring, or a
-        # 4-backtick fence when the opener was 3, stays code.
-        s = line.strip()
-        run = 0
-        while run < len(s) and s[run] == "`":
-            run += 1
-        if run == fence_len and (len(s) == run or s[run].isspace()):
-            break
+        # A closer is a column-0 line whose leading backtick run matches the
+        # opener's length and is followed by nothing but prose — models sometimes
+        # slip as `` ``` Done! ``. An indented fence inside a docstring or string
+        # literal, a shorter bare ``` line, or a 4-backtick fence when the opener
+        # was 3, all stay code.
+        if line.startswith("`"):
+            s = line.strip()
+            run = 0
+            while run < len(s) and s[run] == "`":
+                run += 1
+            if run == fence_len and (len(s) == run or s[run].isspace()):
+                break
         inner.append(line)
     return "\n".join(inner).strip() or None  # empty fence (```\n```) counts as no code
 
 
 def coder(state: AgentState, run_python) -> dict:
     """Ask the LLM for code, execute it in the Cube sandbox, append the output."""
-    code = strip_code_fence(extract_text(llm.invoke(
-        [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
-    ).content))
+    try:
+        reply = llm.invoke(
+            [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
+        ).content
+    except Exception as exc:
+        # A transient LLM error (rate limit, 5xx, timeout) must not abort the
+        # whole graph run; surface it as empty code so the reviewer retries.
+        return {"messages": [{"role": "assistant",
+                              "content": f"[code output]\n(llm error: {exc})"}]}
+    code = strip_code_fence(extract_text(reply))
     if code is None:
         # The model returned no fenced code block; surface that instead of writing
         # prose to a .py file and wasting an attempt on a SyntaxError.
@@ -176,15 +185,25 @@ def coder(state: AgentState, run_python) -> dict:
 
 def reviewer(state: AgentState) -> dict:
     """Judge whether the latest output answers the request."""
-    verdict = extract_text(llm.invoke(
-        [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
-    ).content).strip().upper()
-    # Treat the full token list as authoritative: an explicit RETRY anywhere in
-    # the reply wins over DONE — the prompt asks for a single leading verdict
-    # word, so a stray "DONE" inside a RETRY explanation must not stop the loop.
-    # DONE only wins when no RETRY token is present.
-    tokens = [t.strip(":*#`").rstrip(".,!?;") for t in verdict.split()]
-    done = "DONE" in tokens and "RETRY" not in tokens
+    try:
+        reply = llm.invoke(
+            [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
+        ).content
+    except Exception as exc:
+        # A transient LLM error in the reviewer degrades to a retry rather than
+        # aborting the run.
+        return {
+            "messages": [{"role": "user", "content": f"[reviewer] RETRY (llm error: {exc})"}],
+            "attempts": state.get("attempts", 0) + 1,
+            "done": False,
+        }
+    verdict = extract_text(reply).strip().upper()
+    # The prompt asks for a single leading verdict word, so parse only the first
+    # token — a "DONE"/"RETRY" later in the explanation is prose, not a second
+    # verdict. This avoids both a stray "DONE" in a RETRY explanation stopping
+    # the loop and an "I would not RETRY" re-running a correct answer.
+    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;")
+    done = first == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.
     return {

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -202,7 +202,7 @@ def reviewer(state: AgentState) -> dict:
     # token — a "DONE"/"RETRY" later in the explanation is prose, not a second
     # verdict. This avoids both a stray "DONE" in a RETRY explanation stopping
     # the loop and an "I would not RETRY" re-running a correct answer.
-    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;")
+    first = verdict.split(maxsplit=1)[0].strip(":*#`").rstrip(".,!?;") if verdict else ""
     done = first == "DONE"
     # Emit the verdict as a user-role message so the coder treats RETRY as a
     # directive to fix, not as its own prior assistant output.

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -112,10 +112,13 @@ def strip_code_fence(text: str) -> str | None:
         return None
     inner = []
     for line in lines[start + 1:]:
-        # Only a bare fence (backticks plus optional whitespace) closes the block;
-        # a language-tagged line like ```markdown inside the script stays code.
-        # (Known limit: a bare ``` line inside a docstring would still close early.)
-        if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
+        # A closer starts with a fence run of three-or-more backticks and is
+        # otherwise empty (a bare ``` line) or followed only by prose on the same
+        # line — models sometimes slip as `` ``` Done! ``. A language-tagged line
+        # like ```markdown inside the script stays code. (Known limit: a bare ```
+        # line inside a docstring would still close early.)
+        s = line.strip()
+        if s.startswith(fence) and set(s.split(None, 1)[0]) == {"`"}:
             break
         inner.append(line)
     return "\n".join(inner).strip()

--- a/examples/langgraph-integration/langgraph_checkpoint_demo.py
+++ b/examples/langgraph-integration/langgraph_checkpoint_demo.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import itertools
+import os
+from typing import Annotated, TypedDict
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from cubesandbox import Sandbox
+
+load_dotenv()
+
+for v in ("CUBE_API_URL", "CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP"):
+    if not os.environ.get(v):
+        raise SystemExit(f"Missing env: {v}")
+
+_llm_key = os.getenv("OPENAI_API_KEY") or os.getenv("TOKENHUB_API_KEY")
+if not _llm_key:
+    raise SystemExit("Missing LLM API key")
+
+llm = ChatOpenAI(
+    model=os.getenv("CHAT_MODEL") or "deepseek-v3",
+    api_key=_llm_key,
+    base_url=os.getenv("OPENAI_BASE_URL") or "https://tokenhub.tencentmaas.com/v1",
+    timeout=60, max_retries=2, temperature=0,
+)
+
+
+class AgentState(TypedDict):
+    """State shared across nodes. `messages` accumulates the conversation;
+    `attempts` / `done` drive the retry loop. The sandbox itself is shared
+    through the `run_python` closure, not through `State`."""
+    messages: Annotated[list, add_messages]
+    attempts: int
+    done: bool
+
+
+def make_run_python(sandbox: Sandbox):
+    """Return a `run_python` tool bound to one Cube sandbox — the same
+    `cubesandbox` SDK pattern used by the LangChain guide."""
+    _counter = itertools.count()
+
+    def run_python(code: str) -> str:
+        script = f"/workspace/_agent_{next(_counter)}.py"
+        try:
+            sandbox.files.write(script, code)
+            result = sandbox.commands.run(f"python3 {script}", timeout=120, cwd="/workspace")
+        except Exception as exc:
+            # A dead sandbox, a failed write, transport errors and per-command
+            # timeouts all raise here; surface them as tool output so the reviewer
+            # can see the failure and decide to retry, rather than letting the
+            # exception abort the whole graph run.
+            return f"[command error] {exc}"
+        out = result.stdout
+        if result.stderr:
+            out += "\n--- stderr ---\n" + result.stderr
+        if result.exit_code != 0:
+            out += f"\n[non-zero exit code: {result.exit_code}]"
+        return out
+
+    return run_python
+
+
+CODER_PROMPT = (
+    "You are a data analyst. Write a single self-contained Python script that answers "
+    "the latest user request using the dataset at /workspace/sales.csv "
+    "(columns month,product,units,price). The environment has pandas, numpy, "
+    "matplotlib, scikit-learn preinstalled. Print the final numbers. Do not rely on "
+    "network access. Wrap the script in a single markdown ```python ... ``` fenced "
+    "block. If a previous reviewer message said RETRY, fix the issues it "
+    "listed before re-running."
+)
+
+REVIEWER_PROMPT = (
+    "You are a reviewer. Given the user request and the latest code output, decide "
+    "whether the request is fully answered. Reply starting with exactly one word, "
+    "`DONE` or `RETRY`, optionally followed by one line explaining what is missing."
+)
+
+
+def extract_text(content) -> str:
+    """Return plain text from a message content, which may be a str or a list
+    of content blocks (some OpenAI-compatible endpoints return the latter)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "\n".join(parts)
+    return str(content)
+
+
+def strip_code_fence(text: str) -> str | None:
+    """Return the code inside the first markdown fence, or None when the reply
+    has no fenced block — models often prefix the fenced block with prose."""
+    fence = "`" * 3                      # three backticks, without a literal fence
+    text = text.strip()
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith(fence):
+            start = i
+            break
+    if start is None:
+        return None
+    inner = []
+    for line in lines[start + 1:]:
+        # Only a bare fence (backticks plus optional whitespace) closes the block;
+        # a language-tagged line like ```markdown inside the script stays code.
+        if line.strip().rstrip("`").strip() == "" and line.count("`") >= 3:
+            break
+        inner.append(line)
+    return "\n".join(inner).strip()
+
+
+def coder(state: AgentState, run_python) -> dict:
+    """Ask the LLM for code, execute it in the Cube sandbox, append the output."""
+    code = strip_code_fence(extract_text(llm.invoke(
+        [{"role": "system", "content": CODER_PROMPT}, *state["messages"]]
+    ).content))
+    if code is None:
+        # The model returned no fenced code block; surface that instead of writing
+        # prose to a .py file and wasting an attempt on a SyntaxError.
+        return {"messages": [{"role": "assistant",
+                              "content": "[code output]\n(no code block in model reply)"}]}
+    output = run_python(code)
+    # Cap the output so a huge result (e.g. a printed DataFrame) cannot blow the
+    # model's context window. Keep the tail: the printed numbers (and any
+    # stderr/traceback) land at the end, so they must survive the truncation.
+    if len(output) > 4000:
+        output = "[earlier output truncated]\n" + output[-4000:]
+    # Include the code alongside the output so that on a RETRY the coder can see
+    # what it wrote last time instead of repeating the same mistake.
+    return {"messages": [{"role": "assistant",
+                          "content": f"[code]\n{code}\n[code output]\n{output}"}]}
+
+
+def reviewer(state: AgentState) -> dict:
+    """Judge whether the latest output answers the request."""
+    verdict = extract_text(llm.invoke(
+        [{"role": "system", "content": REVIEWER_PROMPT}, *state["messages"]]
+    ).content).strip().upper()
+    # The prompt asks for exactly one leading word (DONE/RETRY), so classify on
+    # the first token only — stripping markdown decoration — rather than scanning
+    # the whole reply, where a RETRY explanation containing "done" would misfire.
+    first = (verdict.split() or [""])[0].strip(":*#`")
+    done = first.rstrip(".,!?;") == "DONE"
+    # Emit the verdict as a user-role message so the coder treats RETRY as a
+    # directive to fix, not as its own prior assistant output.
+    return {
+        "messages": [{"role": "user", "content": f"[reviewer] {verdict}"}],
+        "attempts": state.get("attempts", 0) + 1,
+        "done": done,
+    }
+
+
+def route_after_review(state: AgentState) -> str:
+    """Conditional edge: retry `coder`, or finish after N attempts."""
+    if state["done"] or state["attempts"] >= 3:
+        return "end"
+    return "retry"
+
+
+def build_graph(run_python, checkpointer=None):
+    builder = StateGraph(AgentState)
+    builder.add_node("coder", lambda s: coder(s, run_python))
+    builder.add_node("reviewer", reviewer)
+    builder.add_edge(START, "coder")
+    builder.add_edge("coder", "reviewer")
+    builder.add_conditional_edges(
+        "reviewer",
+        route_after_review,
+        {"retry": "coder", "end": END},
+    )
+    return builder.compile(checkpointer=checkpointer)
+
+
+def stage_input(messages):
+    """Build the graph input for one stage. `attempts`/`done` have no reducer,
+    so explicit values here overwrite whatever the checkpoint stored. `messages`
+    uses `add_messages`, so new messages are APPENDED to the prior history —
+    use a fresh thread_id if you want a clean slate."""
+    return {"messages": messages, "attempts": 0, "done": False}
+
+
+if __name__ == "__main__":
+    checkpointer = MemorySaver()  # in-process demo; use a durable checkpointer for real resume
+
+    sandbox = Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"], timeout=1800)
+    # Key the checkpoint thread by the sandbox id so the same thread_id reattaches
+    # to the same MicroVM across pause() / connect().
+    config = {"configurable": {"thread_id": sandbox.sandbox_id}}
+    try:
+        graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
+        graph.invoke(stage_input([{"role": "user", "content": "first task"}]), config=config)
+
+        sandbox.pause()                                   # snapshot VM + rootfs
+        # Sandbox.connect() returns a NEW instance; the run_python closure captured
+        # the pre-pause one, so rebind the tool and rebuild the graph on the new
+        # instance, keeping the same checkpointer so the same checkpoint thread resumes.
+        sandbox = Sandbox.connect(sandbox.sandbox_id)     # /workspace intact after resume
+        graph = build_graph(make_run_python(sandbox), checkpointer=checkpointer)
+        graph.invoke(stage_input([{"role": "user", "content": "follow-up task"}]), config=config)
+    finally:
+        sandbox.kill()

--- a/examples/langgraph-integration/requirements.txt
+++ b/examples/langgraph-integration/requirements.txt
@@ -1,5 +1,8 @@
 # LangGraph StateGraph demos — require Python 3.10+
-langgraph>=0.2.50,<1
+# langgraph is capped at <2 (not <1): langchain-openai>=1.0 pulls in
+# langchain-core>=1.0, which langgraph 0.x (langchain-core<0.4) cannot satisfy,
+# so langgraph must be free to resolve to 1.x.
+langgraph>=0.2.50,<2
 langchain-openai>=1.0,<2.0
 # Official CubeSandbox Python SDK (from cubesandbox import Sandbox).
 # >=0.6.0 for the envd-process commands/files API these demos rely on.

--- a/examples/langgraph-integration/requirements.txt
+++ b/examples/langgraph-integration/requirements.txt
@@ -1,5 +1,5 @@
 # LangGraph StateGraph demos — require Python 3.10+
-langgraph>=0.2,<2
+langgraph>=0.2.50,<1
 langchain-openai>=1.0,<2.0
 # Official CubeSandbox Python SDK (from cubesandbox import Sandbox).
 # >=0.6.0 for the envd-process commands/files API these demos rely on.

--- a/examples/langgraph-integration/requirements.txt
+++ b/examples/langgraph-integration/requirements.txt
@@ -1,8 +1,7 @@
 # LangGraph StateGraph demos — require Python 3.10+
-# langgraph is capped at <2 (not <1): langchain-openai>=1.0 pulls in
-# langchain-core>=1.0, which langgraph 0.x (langchain-core<0.4) cannot satisfy,
-# so langgraph must be free to resolve to 1.x.
-langgraph>=0.2.50,<2
+# langgraph 1.x: langchain-openai>=1.0 requires langchain-core>=1.0, which
+# langgraph 0.x (langchain-core<0.4) cannot satisfy.
+langgraph>=1,<2
 langchain-openai>=1.0,<2.0
 # Official CubeSandbox Python SDK (from cubesandbox import Sandbox).
 # >=0.6.0 for the envd-process commands/files API these demos rely on.

--- a/examples/langgraph-integration/requirements.txt
+++ b/examples/langgraph-integration/requirements.txt
@@ -1,0 +1,7 @@
+# LangGraph StateGraph demos — require Python 3.10+
+langgraph>=0.2,<2
+langchain-openai>=1.0,<2.0
+# Official CubeSandbox Python SDK (from cubesandbox import Sandbox).
+# >=0.6.0 for the envd-process commands/files API these demos rely on.
+cubesandbox>=0.6.0
+python-dotenv

--- a/examples/langgraph-integration/sales.csv
+++ b/examples/langgraph-integration/sales.csv
@@ -1,0 +1,7 @@
+month,product,units,price
+2024-01,Widget,140,10.0
+2024-01,Gadget,138,10.0
+2024-02,Widget,200,10.0
+2024-02,Gadget,131,10.5
+2024-03,Widget,236,9.5
+2024-03,Gadget,163,10.0


### PR DESCRIPTION
## Summary

Adds a LangGraph integration guide (English and Chinese) and two runnable examples under `examples/langgraph-integration/` that demonstrate running an explicit LangGraph `StateGraph` agent — a `coder → reviewer` graph with a conditional retry edge — whose code-execution node invokes Python inside a Cube Sandbox MicroVM through the official `cubesandbox` SDK. A single MicroVM is shared across every node via a `run_python` closure, and LangGraph checkpointing is wired to Cube's `pause()` / `connect()` lifecycle so a run can be snapshotted and resumed on the same MicroVM.

本 PR 新增 LangGraph 集成指南（中英双语）与 `examples/langgraph-integration/` 下两个可运行示例，演示运行一个显式的 LangGraph `StateGraph` agent——`coder → reviewer` 图带条件重试边，其代码执行节点通过官方 `cubesandbox` SDK 在 Cube Sandbox MicroVM 内执行 Python。单个 MicroVM 通过 `run_python` 闭包在全部图节点间共享，LangGraph 的 checkpoint 机制与 Cube 的 `pause()` / `connect()` 生命周期对接，使一次运行可被快照并在同一 MicroVM 上恢复。

## Why

The existing LangChain guide only covers the high-level `create_agent` helper, which hides the graph topology and retry policy behind a black box. Real agents need explicit control over the node structure, the review loop, and where code actually executes — the three things `create_agent` abstracts away.

现有 LangChain 指南只覆盖高层 `create_agent` 封装，把图拓扑与重试策略隐藏在黑盒之后。而真实的 agent 需要对节点结构、审查循环以及代码实际执行的位置拥有显式控制——这正是 `create_agent` 抽象掉的三件事。

This PR fills that gap with an explicit-graph counterpart:

- **Explicit node and edge control** — a `coder → reviewer` graph with a conditional retry edge (`route_after_review`), so the attempt cap and retry predicate can be tuned directly.
- **Code execution isolated in a MicroVM** — each code-execution node runs Python in a Cube Sandbox MicroVM via the `cubesandbox` SDK, giving the agent a disposable, reproducible runtime instead of the host process.
- **Checkpointing mapped to the sandbox lifecycle** — the LangGraph checkpointer is keyed by `sandbox_id` and mapped to Cube's `pause()` / `connect()`, so a graph run survives a MicroVM snapshot and resumes with its `/workspace` filesystem intact — a scenario the existing guide does not cover.

本 PR 以显式图版本填补这一空白：

- **显式节点与边控制**——`coder → reviewer` 图带条件重试边（`route_after_review`），尝试次数上限与重试判定可直接调优。
- **代码执行隔离在 MicroVM 内**——每个代码执行节点通过 `cubesandbox` SDK 在 Cube Sandbox MicroVM 内运行 Python，为 agent 提供一次性、可复现的运行环境，而非宿主机进程。
- **Checkpoint 与沙箱生命周期对接**——LangGraph 的 checkpointer 以 `sandbox_id` 为键并映射到 Cube 的 `pause()` / `connect()`，使一次图运行能在 MicroVM 快照后存活，并以完整的 `/workspace` 文件系统恢复——这是现有指南未覆盖的场景。

## What changed

**Docs**
- `docs/guide/integrations/langgraph.md` — 英文指南（new）
- `docs/zh/guide/integrations/langgraph.md` — 中文指南（new）
- `docs/guide/integrations/index.md` / `docs/zh/guide/integrations/index.md` — 注册文章
- `docs/.vitepress/config.mjs` — 注册导航

**Runnable examples**（`examples/langgraph-integration/`，new）
- `langgraph_agent_demo.py` — 单 MicroVM 的 generate → execute → review → retry 循环
- `langgraph_checkpoint_demo.py` — 通过 checkpointer 跨 `pause()` / `connect()` 恢复
- `Dockerfile` — 含 pandas/numpy/matplotlib/scikit-learn 的模板镜像
- `requirements.txt` — `langgraph>=1,<2`、`langchain-openai>=1.0`、`cubesandbox>=0.6.0`
- `.env.example` / `.gitignore` / `README.md` / `README_zh.md` / `sales.csv`

## Two demos at a glance

| Demo | Purpose / 作用 |
|---|---|
| `langgraph_agent_demo.py` | One-MicroVM generate → execute → review → retry loop / 单 MicroVM 的生成→执行→审查→重试循环 |
| `langgraph_checkpoint_demo.py` | Stage 1 writes an artifact to `/workspace`, `pause()` → `connect()`, stage 2 reads it back — proving `/workspace` persists across the snapshot / 阶段 1 写中间产物到 `/workspace`，`pause()` 后 `connect()` 恢复，阶段 2 读回，证明 `/workspace` 跨快照持久化 |

## How to run

```bash
docker build --platform linux/amd64 -t <registry>/langgraph-cube:latest .
cubemastercli tpl create-from-image --image <registry>/langgraph-cube:latest ...
cp .env.example .env       # 填入 CUBE_TEMPLATE_ID 与 OPENAI_API_KEY
pip install -r requirements.txt
python langgraph_agent_demo.py
python langgraph_checkpoint_demo.py
```

## How it was checked

- 两个 demo 通过 `python -m py_compile`；核心纯函数（`strip_code_fence`、`extract_text`、verdict 解析）覆盖了边界场景（列表缩进围栏、docstring 围栏、空/纯空白 verdict、prose opener）。
- 依赖约束已核实：`langgraph<2` 解析到 1.x，与 `langchain-openai>=1.0` 兼容；import 采用 LangGraph 1.x 的 canonical `from langgraph.graph import add_messages`。
- 可运行 demo 与指南（英/中）四文件严格同步，代码可直接复制运行。

Refs #244
