### PR TITLE
fix(web&&cubeops): drop stale CubeAPI config fields from CubeOps /config

### DIFF
--- a/CubeOps/internal/handler/config.go
+++ b/CubeOps/internal/handler/config.go
@@ -14,32 +14,23 @@ import (
 
 // ConfigHandler handles runtime config HTTP requests.
 type ConfigHandler struct {
-	bind            string
-	rateLimitPerSec uint32
-	authEnabled     bool
-	sandboxDomain   string
-	instanceType    string
+	bind          string
+	sandboxDomain string
 }
 
 // NewConfigHandler creates a new config handler.
-func NewConfigHandler(bind string, rateLimitPerSec uint32, authEnabled bool, sandboxDomain, instanceType string) *ConfigHandler {
+func NewConfigHandler(bind, sandboxDomain string) *ConfigHandler {
 	return &ConfigHandler{
-		bind:            bind,
-		rateLimitPerSec: rateLimitPerSec,
-		authEnabled:     authEnabled,
-		sandboxDomain:   sandboxDomain,
-		instanceType:    instanceType,
+		bind:          bind,
+		sandboxDomain: sandboxDomain,
 	}
 }
 
 // RuntimeConfig is the response for GET /config.
 type RuntimeConfig struct {
-	APIEndpoint     string `json:"apiEndpoint"`    // CUBE_API_PUBLIC_HOST + /cubeapi/v1 (E2B SDK compatible, legacy)
-	OpsAPIEndpoint  string `json:"opsApiEndpoint"` // CUBE_OPS_PUBLIC_HOST + /opsapi/v1 (CubeOps ops API)
-	RateLimitPerSec uint32 `json:"rateLimitPerSec"`
-	AuthEnabled     bool   `json:"authEnabled"`
-	SandboxDomain   string `json:"sandboxDomain"`
-	InstanceType    string `json:"instanceType"`
+	APIEndpoint    string `json:"apiEndpoint"`    // CUBE_API_PUBLIC_HOST + /cubeapi/v1 (E2B SDK compatible, legacy)
+	OpsAPIEndpoint string `json:"opsApiEndpoint"` // CUBE_OPS_PUBLIC_HOST + /opsapi/v1 (CubeOps ops API)
+	SandboxDomain  string `json:"sandboxDomain"`
 }
 
 // Register installs the config routes on the given router group.
@@ -50,12 +41,9 @@ func (h *ConfigHandler) Register(r *gin.RouterGroup) {
 // GetConfig handles GET /config.
 func (h *ConfigHandler) GetConfig(c *gin.Context) {
 	httputil.WriteJSON(c, http.StatusOK, RuntimeConfig{
-		APIEndpoint:     publicAPIEndpoint(h.bind),
-		OpsAPIEndpoint:  publicOpsAPIEndpoint(h.bind),
-		RateLimitPerSec: h.rateLimitPerSec,
-		AuthEnabled:     h.authEnabled,
-		SandboxDomain:   h.sandboxDomain,
-		InstanceType:    h.instanceType,
+		APIEndpoint:    publicAPIEndpoint(h.bind),
+		OpsAPIEndpoint: publicOpsAPIEndpoint(h.bind),
+		SandboxDomain:  h.sandboxDomain,
 	})
 }
 

--- a/CubeOps/internal/handler/store_test.go
+++ b/CubeOps/internal/handler/store_test.go
@@ -391,7 +391,7 @@ func TestStore_RefreshRateLimit(t *testing.T) {
 func newConfigRouter(t *testing.T) *gin.Engine {
 	t.Helper()
 	r := gin.New()
-	h := NewConfigHandler("127.0.0.1:3010", 100, true, "cube.app", "cubebox")
+	h := NewConfigHandler("127.0.0.1:3010", "cube.app")
 	g := r.Group("/api/v1")
 	h.Register(g)
 	return r
@@ -408,17 +408,14 @@ func TestConfig_GetConfig(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
 		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
 	}
-	if cfg["rateLimitPerSec"] != float64(100) {
-		t.Errorf("rateLimitPerSec = %v, want 100", cfg["rateLimitPerSec"])
-	}
-	if cfg["authEnabled"] != true {
-		t.Errorf("authEnabled = %v, want true", cfg["authEnabled"])
-	}
 	if cfg["sandboxDomain"] != "cube.app" {
 		t.Errorf("sandboxDomain = %v, want cube.app", cfg["sandboxDomain"])
 	}
-	if cfg["instanceType"] != "cubebox" {
-		t.Errorf("instanceType = %v, want cubebox", cfg["instanceType"])
+	// Removed fields must not be present in the response.
+	for _, key := range []string{"rateLimitPerSec", "authEnabled", "instanceType"} {
+		if _, ok := cfg[key]; ok {
+			t.Errorf("unexpected field %q present in config response", key)
+		}
 	}
 	// APIEndpoint should fall back to bind address when env var is unset.
 	if cfg["apiEndpoint"] != "http://127.0.0.1:3010/cubeapi/v1" {

--- a/CubeOps/internal/server/server.go
+++ b/CubeOps/internal/server/server.go
@@ -117,7 +117,7 @@ func (s *Server) buildRouter() *gin.Engine {
 	authH := auth.NewHandler(authSvc)
 	clusterH := handler.NewClusterHandler(s.cm).WithNodeService(s.nodeSvc)
 	storeH := handler.NewStoreHandler(handler.DefaultRegistryClient())
-	configH := handler.NewConfigHandler(s.cfg.Bind, 100, s.cfg.JWTSecret != "", s.cfg.SandboxDomain, "cubebox")
+	configH := handler.NewConfigHandler(s.cfg.Bind, s.cfg.SandboxDomain)
 	agenthubH := handler.NewAgentHubHandler(s.store, s.cm)
 	// SDK handler gets the AgentHubService so that E2B template/snapshot
 	// deletions can reverse-sync AgentHub registrations

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -306,10 +306,7 @@ export const clusterApi = {
     ops<{
       apiEndpoint: string;
       opsApiEndpoint: string;
-      rateLimitPerSec: number;
-      authEnabled: boolean;
       sandboxDomain: string;
-      instanceType: string;
     }>('/config'),
 };
 

--- a/web/src/locales/en/network.json
+++ b/web/src/locales/en/network.json
@@ -3,13 +3,8 @@
   "description": "API gateway config and node rate limits.",
   "gateway": {
     "title": "API Gateway",
-    "desc": "CubeAPI runtime configuration — rate limiting and auth status.",
-    "rateLimit": "Rate Limit",
-    "auth": "Auth",
-    "authOn": "Enabled",
-    "authOff": "Disabled",
-    "domain": "Sandbox Domain",
-    "instanceType": "Default Instance Type"
+    "desc": "API gateway access configuration.",
+    "domain": "Sandbox Domain"
   },
   "quota": {
     "title": "Node Quota / Rate Limits",

--- a/web/src/locales/en/observability.json
+++ b/web/src/locales/en/observability.json
@@ -28,11 +28,7 @@
   },
   "api": {
     "title": "API Monitor",
-    "desc": "CubeOps gateway connectivity and rate-limit config",
-    "rateLimit": "Rate Limit",
-    "auth": "Auth",
-    "authOn": "Enabled",
-    "authOff": "Disabled",
+    "desc": "CubeOps gateway connectivity check",
     "latency": "Latency",
     "test": "Test Connectivity",
     "testing": "Testing…",

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -22,15 +22,7 @@
     "endpoint": "API Endpoint",
     "endpointDesc": "The public-facing CubeOps ops API address. Configure via CUBE_OPS_PUBLIC_HOST env var at startup.",
     "test": "Test",
-    "connected": "Connected",
-    "runtime": "Runtime Config",
-    "runtimeDesc": "Read-only runtime information from CubeOps.",
-    "sandboxDomain": "Sandbox Domain",
-    "instanceType": "Default Instance Type",
-    "rateLimit": "Rate Limit",
-    "auth": "Auth",
-    "authOn": "Enabled",
-    "authOff": "Disabled"
+    "connected": "Connected"
   },
   "shortcuts": {
     "title": "Keyboard Shortcuts",
@@ -55,7 +47,6 @@
     "desc": "Version and related links.",
     "version": "Version",
     "cubeApi": "CubeOps Endpoint",
-    "instanceType": "Default Instance Type",
     "docs": "Docs"
   }
 }

--- a/web/src/locales/zh/network.json
+++ b/web/src/locales/zh/network.json
@@ -3,13 +3,8 @@
   "description": "API 网关配置与节点限流概览。",
   "gateway": {
     "title": "API 网关",
-    "desc": "CubeAPI 运行时配置，包含限流策略与认证状态。",
-    "rateLimit": "限流策略",
-    "auth": "认证状态",
-    "authOn": "已启用",
-    "authOff": "未启用",
-    "domain": "沙箱域名",
-    "instanceType": "默认实例类型"
+    "desc": "API 网关接入配置。",
+    "domain": "沙箱域名"
   },
   "quota": {
     "title": "节点限流 / Quota",

--- a/web/src/locales/zh/observability.json
+++ b/web/src/locales/zh/observability.json
@@ -28,11 +28,7 @@
   },
   "api": {
     "title": "API 请求监控",
-    "desc": "CubeOps 网关连通性与限流配置",
-    "rateLimit": "限流阈值",
-    "auth": "认证状态",
-    "authOn": "已启用",
-    "authOff": "未启用",
+    "desc": "CubeOps 网关连通性检查",
     "latency": "延迟",
     "test": "测试连通性",
     "testing": "测试中…",

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -22,15 +22,7 @@
     "endpoint": "API 端点",
     "endpointDesc": "CubeOps 的对外访问地址。启动时通过 CUBE_OPS_PUBLIC_HOST 环境变量配置。",
     "test": "测试连接",
-    "connected": "连接正常",
-    "runtime": "运行时配置",
-    "runtimeDesc": "来自 CubeOps 的运行时只读信息。",
-    "sandboxDomain": "沙箱域名",
-    "instanceType": "默认实例类型",
-    "rateLimit": "限流策略",
-    "auth": "认证状态",
-    "authOn": "已启用",
-    "authOff": "未启用"
+    "connected": "连接正常"
   },
   "shortcuts": {
     "title": "快捷键",
@@ -55,7 +47,6 @@
     "desc": "版本信息与相关链接。",
     "version": "版本",
     "cubeApi": "CubeOps 地址",
-    "instanceType": "默认实例类型",
     "docs": "文档"
   }
 }

--- a/web/src/pages/Network.tsx
+++ b/web/src/pages/Network.tsx
@@ -9,7 +9,7 @@ import { useRuntimeConfig } from '@/hooks/useRuntimeConfig';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Shield, Gauge, Server, ExternalLink, Minus } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { BoolBadge, MetricValue } from '@/components/ui/typography';
+import { MetricValue } from '@/components/ui/typography';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -71,32 +71,10 @@ function GatewaySection() {
       <div className="rounded-xl border border-border/60 bg-card/40 px-5 py-1">
         {isLoading ? (
           <div className="space-y-3 py-3">
-            {[1, 2, 3, 4].map((i) => (
-              <Skeleton key={i} className="h-4 w-full" />
-            ))}
+            <Skeleton className="h-4 w-full" />
           </div>
         ) : (
-          <>
-            <InfoRow
-              label={t('gateway.rateLimit')}
-              value={
-                <MetricValue value={data?.rateLimitPerSec ?? '—'} unit="req/s · per API Key" />
-              }
-            />
-            <InfoRow
-              label={t('gateway.auth')}
-              value={undefined}
-              badge={
-                <BoolBadge
-                  value={data?.authEnabled}
-                  trueLabel={t('gateway.authOn')}
-                  falseLabel={t('gateway.authOff')}
-                />
-              }
-            />
-            <InfoRow label={t('gateway.domain')} value={data?.sandboxDomain ?? '—'} />
-            <InfoRow label={t('gateway.instanceType')} value={data?.instanceType ?? '—'} />
-          </>
+          <InfoRow label={t('gateway.domain')} value={data?.sandboxDomain ?? '—'} />
         )}
       </div>
     </div>

--- a/web/src/pages/Observability.tsx
+++ b/web/src/pages/Observability.tsx
@@ -3,7 +3,6 @@
 
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useRuntimeConfig } from '@/hooks/useRuntimeConfig';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -16,12 +15,10 @@ import {
   Wifi,
   WifiOff,
   CheckCircle2,
-  XCircle,
   AlertTriangle,
 } from 'lucide-react';
 import { clusterApi, sandboxApi, templateApi } from '@/api/client';
 import { Skeleton } from '@/components/ui/skeleton';
-import { MetricValue } from '@/components/ui/typography';
 import { cn, formatRelative } from '@/lib/utils';
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
@@ -360,8 +357,6 @@ function ApiSection() {
     null,
   );
 
-  const { data: cfg, isLoading } = useRuntimeConfig();
-
   const handleTest = async () => {
     setTesting(true);
     setResult(null);
@@ -379,37 +374,6 @@ function ApiSection() {
   return (
     <div>
       <SectionHeader icon={Gauge} title={t('api.title')} desc={t('api.desc')} />
-      <div className="rounded-xl border border-border/60 bg-card/40 px-5 py-1 mb-3">
-        {isLoading ? (
-          <div className="space-y-3 py-3">
-            {[1, 2].map((i) => (
-              <Skeleton key={i} className="h-4 w-full" />
-            ))}
-          </div>
-        ) : (
-          <>
-            <div className="flex items-center justify-between py-2.5 border-b border-border/40">
-              <span className="text-sm text-muted-foreground">{t('api.rateLimit')}</span>
-              <MetricValue value={cfg?.rateLimitPerSec ?? '—'} unit="req/s" />
-            </div>
-            <div className="flex items-center justify-between py-2.5">
-              <span className="text-sm text-muted-foreground">{t('api.auth')}</span>
-              {cfg?.authEnabled ? (
-                <span className="inline-flex items-center gap-1 text-cube-ok text-xs font-medium">
-                  <CheckCircle2 size={12} />
-                  {t('api.authOn')}
-                </span>
-              ) : (
-                <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
-                  <XCircle size={12} />
-                  {t('api.authOff')}
-                </span>
-              )}
-            </div>
-          </>
-        )}
-      </div>
-
       {/* Test button + result */}
       <div className="flex items-center gap-3">
         <button

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -145,7 +145,7 @@ function ClusterSection() {
     msg?: string;
   } | null>(null);
 
-  const { data: cfg, isLoading } = useRuntimeConfig();
+  const { data: cfg } = useRuntimeConfig();
 
   const handleTest = async () => {
     setTesting(true);
@@ -203,49 +203,6 @@ function ClusterSection() {
             </div>
           )}
         </div>
-      </SettingRow>
-
-      {/* Runtime info */}
-      <SettingRow label={t('cluster.runtime')} desc={t('cluster.runtimeDesc')}>
-        {isLoading ? (
-          <div className="space-y-2">
-            {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="h-4 w-48 animate-pulse rounded bg-muted/60" />
-            ))}
-          </div>
-        ) : (
-          <dl className="space-y-2 text-sm">
-            {(
-              [
-                {
-                  label: t('cluster.sandboxDomain'),
-                  value: cfg?.sandboxDomain ?? '—',
-                  numeric: false,
-                },
-                {
-                  label: t('cluster.instanceType'),
-                  value: cfg?.instanceType ?? '—',
-                  numeric: false,
-                },
-                {
-                  label: t('cluster.rateLimit'),
-                  value: `${cfg?.rateLimitPerSec ?? '—'} req/s`,
-                  numeric: true,
-                },
-                {
-                  label: t('cluster.auth'),
-                  value: cfg?.authEnabled ? t('cluster.authOn') : t('cluster.authOff'),
-                  numeric: false,
-                },
-              ] as Array<{ label: string; value: string; numeric: boolean }>
-            ).map(({ label, value, numeric }) => (
-              <div key={label} className="flex items-center gap-3">
-                <span className="w-36 text-muted-foreground">{label}</span>
-                <span className={cn('text-foreground/90', numeric && 'text-num')}>{value}</span>
-              </div>
-            ))}
-          </dl>
-        )}
       </SettingRow>
     </div>
   );
@@ -440,7 +397,6 @@ function AboutSection() {
               value: cfg?.apiEndpoint ?? `${window.location.origin}/cubeapi/v1`,
               mono: true,
             },
-            { label: t('about.instanceType'), value: cfg?.instanceType ?? '—', mono: false },
           ] as Array<{ label: string; value: string; mono: boolean }>
         ).map(({ label, value, mono }) => (
           <div key={label} className="flex items-center justify-between px-5 py-3.5">


### PR DESCRIPTION
CubeOps no longer uses rateLimitPerSec, instanceType, or authEnabled. Remove them from the /config response to avoid returning meaningless data to the WebUI (#1502). Drop the fields from the backend RuntimeConfig and the WebUI rows + locale keys.（Fixes #1502）