### PR TITLE
fix(images): gate cubelog probe behind consumer images

### DIFF
--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -394,8 +394,16 @@ ensure_source_tree() {
     || fail "SOURCE_REF=${SOURCE_REF} is not a valid git ref in ${WORKTREE_ROOT}"
   SOURCE_REF_SHA="$(git -C "${WORKTREE_ROOT}" rev-parse "${SOURCE_REF}^{commit}")"
   SOURCE_TREE_STAMP="${SOURCE_TREE_DIR}/.exported-sha"
-  CUBELOG_SRC="$(cubelog_module_at_ref "${SOURCE_REF_SHA}")" \
-    || fail "SOURCE_REF=${SOURCE_REF} has neither pkgs/CubeLog nor cubelog"
+  # Probe cubelog only when a consumer image is selected. cube-api / cube-proxy /
+  # cube-webui / cube-egress / cube-lifecycle-manager never export it, so a
+  # SOURCE_REF that predates both pkgs/CubeLog and cubelog must still be able to
+  # build those images (same reason CubeOps is gated below).
+  CUBELOG_SRC=""
+  if should_build cube-master || should_build cubemastercli \
+     || should_build cubelet || should_build cube-ops; then
+    CUBELOG_SRC="$(cubelog_module_at_ref "${SOURCE_REF_SHA}")" \
+      || fail "SOURCE_REF=${SOURCE_REF} has neither pkgs/CubeLog nor cubelog"
+  fi
   # CubeOps is post-v0.5.1; only export when building cube-ops so older release
   # tags still work for cube-api / cube-proxy / webui / etc. cube-master /
   # cubemastercli need ${CUBELOG_SRC} / CubeDB / Cubelet; cubemastercli also needs


### PR DESCRIPTION
## What this PR does

`ensure_source_tree()` in `deploy/kubernetes/images/build-cube-images.sh` always probed the cubelog module via `cubelog_module_at_ref` when `SOURCE_REF` is set. That probe fails when `SOURCE_REF` predates both `pkgs/CubeLog` and the legacy `cubelog` module (for example when building from an older release tag).

Only `cube-master`, `cubemastercli`, `cubelet` and `cube-ops` actually consume cubelog. This change gates the probe behind those images, mirroring how the CubeOps export is already gated, so older release tags can still build `cube-api`, `cube-proxy`, `cube-webui`, `cube-egress` and `cube-lifecycle-manager`.

## Why it matters

Follows up on the cubelog relocation (#1574) and unblocks building older release tags for images that never exported cubelog.

## Testing notes

- Building only `cube-api` from a `SOURCE_REF` that predates `pkgs/CubeLog` no longer runs the cubelog probe and should succeed.
- Building `cube-master` from the same `SOURCE_REF` still fails with the existing clear error message, since cubelog is a hard requirement there.