### PR TITLE
fix(hotswap): use bytes.Equal and handle yaml.Marshal error in reload

### DIFF
--- a/CubeMaster/pkg/base/hotswap/file.go
+++ b/CubeMaster/pkg/base/hotswap/file.go
@@ -91,7 +91,11 @@ func (o *FileOperator) reload(path string) bool {
 		return false
 	}
 	new, err := yaml.Marshal(config)
-	if len(o.backupOldCfg) == len(new) && bytes.EqualFold(o.backupOldCfg, new) {
+	if err != nil {
+		o.Errorf(context.Background(), "Marshal config fail:%v", err)
+		return false
+	}
+	if bytes.Equal(o.backupOldCfg, new) {
 		return false
 	}
 	o.backupOldCfg = new

--- a/Cubelet/pkg/hotswap/file.go
+++ b/Cubelet/pkg/hotswap/file.go
@@ -91,7 +91,11 @@ func (o *FileOperator) reload(path string) bool {
 		return false
 	}
 	new, err := yaml.Marshal(config)
-	if len(o.backupOldCfg) == len(new) && bytes.EqualFold(o.backupOldCfg, new) {
+	if err != nil {
+		o.Errorf(context.Background(), "Marshal config fail:%v", err)
+		return false
+	}
+	if bytes.Equal(o.backupOldCfg, new) {
 		return false
 	}
 	o.backupOldCfg = new


### PR DESCRIPTION
Fixes #1470

## Summary
FileOperator.reload compared marshalled config with bytes.EqualFold, so any edit that only changes ASCII letter case was treated as "no change" and never applied. The yaml.Marshal error on the same line was also unchecked (staticcheck SA4006).

Repro:
- log level INFO -> info => reload() returns false (silently ignored)
- host Foo.internal -> foo.internal => same
- genuine content change => true (control)
- length differs => true (control)

Root cause: CubeMaster/pkg/base/hotswap/file.go:94 and identical Cubelet/pkg/hotswap/file.go:94

```
new, err := yaml.Marshal(config)
if len(o.backupOldCfg) == len(new) && bytes.EqualFold(o.backupOldCfg, new) { return false }
```

EqualFold is Unicode case-folding, not byte identity. Error from Marshal never checked -- on failure new is nil, so backupOldCfg is wiped to nil and notify still fires.

## Fix
- Check yaml.Marshal error, log via o.Errorf and return false
- Use bytes.Equal for exact comparison (handles length internally)
- Apply to both copies (CubeMaster and Cubelet -- they are vendored copies)

Mirrors Init() at 71-74 which already checks the marshal error.

## How tested
- git diff shows 10 insertions, 2 deletions across 2 files.
- Manual inspection: bytes.Equal is exact, case-sensitive; error path logs and aborts.
- No other files use EqualFold for config comparison (grep -r EqualFold confirms only these two).

Autonomously-by: Muse Spark:muse-spark-1.2-contributor-free
