### PR TITLE
docs(guide): clarify CubeS3lvol deployment scope in v0.7.0

### DIFF
--- a/docs/guide/cross-node-snapshot.md
+++ b/docs/guide/cross-node-snapshot.md
@@ -1,5 +1,9 @@
 # Cross-Node Snapshots (Pause / Resume / Snapshot)
 
+::: tip Deployment scope (v0.7.0)
+In this release, CubeS3lvol can only be enabled on compute nodes installed via **one-click (bare-metal) deployment**; Kubernetes (Helm) deployments do not include the s3lvol target, so the cross-node S3 snapshot path is unavailable there.
+:::
+
 CubeSandbox persists a sandbox as a **package** of three objects (rootfs / memory / metadata) so you can **Pause**, **Resume**, and take a **Snapshot**:
 
 - **Pause / Resume**: freeze a running sandbox (memory + filesystem) into a pause package, then restore it on the same node or another compatible node.

--- a/docs/zh/guide/cross-node-snapshot.md
+++ b/docs/zh/guide/cross-node-snapshot.md
@@ -1,5 +1,9 @@
 # 跨机快照（Pause / Resume / Snapshot）
 
+::: tip 部署范围（v0.7.0）
+本版本暂时只支持在 **one-click 部署**的计算节点上启用 CubeS3lvol；Kubernetes（Helm）部署暂未包含 s3lvol 组件，无法启用跨机 S3 快照。
+:::
+
 CubeSandbox 通过一份可持久化的「包对象」（rootfs / memory / metadata）实现沙箱的
 **暂停（Pause）**、**恢复（Resume）** 与 **快照（Snapshot）**：
 


### PR DESCRIPTION
## Summary

Clarifies that in v0.7.0, the cross-node S3 snapshotting path is only available on compute nodes installed via one-click (bare-metal) deployment. Kubernetes (Helm) deployments do not ship the s3lvol target, so that path is unavailable there.

## Changes

- `docs/guide/cross-node-snapshot.md`: add a v0.7.0 deployment-scope note (English)
- `docs/zh/guide/cross-node-snapshot.md`: add the corresponding note (Chinese)

## Test Plan

Documentation-only change; no runtime code affected.

## Related

- v0.7.0 release notes
