### PR TITLE
refactor(cubemaster): consolidate CPU/mem overcommit into Cubelet

### DIFF
--- a/CubeMaster/conf.yaml
+++ b/CubeMaster/conf.yaml
@@ -82,20 +82,6 @@ scheduler:
   # during scheduling. Defaults to false: account for the Redis allocation
   # records when computing schedulable capacity.
   ignore_redis_allocation: false
-  # Global CPU/Mem overcommit ratio applied to the node-reported quota capacity.
-  # Defaults to CPU=3, Mem=2.
-  overcommit_ratio:
-    cpu_ratio: 3.0
-    mem_ratio: 2.0
-  # Per-instance-type overcommit ratio (takes precedence over the global
-  # overcommit_ratio).
-  # overcommit_ratio_conf:
-  #   cubebox:
-  #     cpu_ratio: 6.0
-  #     mem_ratio: 4.0
-  #   cubebox_gpu:
-  #     cpu_ratio: 1.0
-  #     mem_ratio: 1.0
   filter:
     enable_filters:
       - "cpu"

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -251,12 +251,6 @@ type SchedulerConf struct {
 	// 0). A pointer is used so an unset value can default to false while still
 	// allowing operators to explicitly enable it. Defaults to false.
 	IgnoreRedisAllocation *bool `yaml:"ignore_redis_allocation"`
-	// OvercommitRatio is the global CPU/Mem overcommit ratio applied to the
-	// node-reported quota during scheduling. Defaults to CPU=3, Mem=2.
-	OvercommitRatio *OvercommitRatioConf `yaml:"overcommit_ratio"`
-	// OvercommitRatioByType overrides OvercommitRatio for specific instance
-	// types and takes precedence over the global ratio.
-	OvercommitRatioByType map[string]OvercommitRatioConf `yaml:"overcommit_ratio_conf"`
 }
 
 var defaultNodeAffinitySelectorAllowedKeys = []string{
@@ -295,57 +289,6 @@ func IsReservedLabelKey(k string) bool {
 	return false
 }
 
-// OvercommitRatioConf describes the CPU/Mem overcommit multipliers applied to
-// a node's reported quota when computing schedulable capacity.
-type OvercommitRatioConf struct {
-	CPURatio float64 `yaml:"cpu_ratio"`
-	MemRatio float64 `yaml:"mem_ratio"`
-}
-
-const (
-	defaultCPUOvercommitRatio = 3.0
-	defaultMemOvercommitRatio = 2.0
-)
-
-// GetEffectiveOvercommitRatio returns the overcommit ratio for the given
-// instance type, falling back to the global ratio and then to the built-in
-// defaults (CPU=3, Mem=2).
-func (s *SchedulerConf) GetEffectiveOvercommitRatio(instanceType string) OvercommitRatioConf {
-	if s.OvercommitRatioByType != nil {
-		if v, ok := s.OvercommitRatioByType[instanceType]; ok {
-			return v.sanitized()
-		}
-	}
-	if s.OvercommitRatio != nil {
-		return s.OvercommitRatio.sanitized()
-	}
-	return OvercommitRatioConf{CPURatio: defaultCPUOvercommitRatio, MemRatio: defaultMemOvercommitRatio}
-}
-
-// sanitized guarantees non-positive, NaN, or infinite ratios fall back to the
-// defaults so a malformed config never shrinks a node's schedulable capacity to
-// zero or produces a garbage (NaN/Inf) capacity when multiplied with the quota.
-func (c OvercommitRatioConf) sanitized() OvercommitRatioConf {
-	out := c
-	if !isValidRatio(out.CPURatio) {
-		out.CPURatio = defaultCPUOvercommitRatio
-	}
-	if !isValidRatio(out.MemRatio) {
-		out.MemRatio = defaultMemOvercommitRatio
-	}
-	return out
-}
-
-// isValidRatio reports whether r is a usable overcommit multiplier: it must be
-// a finite, positive number. NaN and ±Inf (e.g. ".nan"/".inf" in YAML) are
-// rejected so they never propagate into capacity arithmetic.
-func isValidRatio(r float64) bool {
-	if math.IsNaN(r) || math.IsInf(r, 0) {
-		return false
-	}
-	return r > 0
-}
-
 // ShouldIgnoreRedisAllocation reports whether the scheduler must ignore the
 // allocated CPU/Mem usage recorded in Redis. Defaults to false when unset.
 func (s *SchedulerConf) ShouldIgnoreRedisAllocation() bool {
@@ -353,40 +296,6 @@ func (s *SchedulerConf) ShouldIgnoreRedisAllocation() bool {
 		return false
 	}
 	return *s.IgnoreRedisAllocation
-}
-
-// EffectiveQuotaCpu returns the schedulable CPU capacity (milli-cores) for a
-// node after applying the configured overcommit ratio to its reported quota.
-func (s *SchedulerConf) EffectiveQuotaCpu(instanceType string, quotaCpu int64) int64 {
-	ratio := s.GetEffectiveOvercommitRatio(instanceType)
-	return floatToInt64Clamped(float64(quotaCpu) * ratio.CPURatio)
-}
-
-// EffectiveQuotaMem returns the schedulable memory capacity (MB) for a node
-// after applying the configured overcommit ratio to its reported quota.
-func (s *SchedulerConf) EffectiveQuotaMem(instanceType string, quotaMem int64) int64 {
-	ratio := s.GetEffectiveOvercommitRatio(instanceType)
-	return floatToInt64Clamped(float64(quotaMem) * ratio.MemRatio)
-}
-
-// floatToInt64Clamped safely converts a float64 to int64. Converting an
-// out-of-range or non-finite float64 to int64 is implementation-defined in Go
-// and yields a garbage value, so NaN maps to 0 and values beyond the int64
-// range (including ±Inf) are clamped to math.MaxInt64 / math.MinInt64. This
-// guards capacity computation against quota * ratio overflowing int64.
-func floatToInt64Clamped(f float64) int64 {
-	if math.IsNaN(f) {
-		return 0
-	}
-	// float64(math.MaxInt64) rounds up to 2^63, so use >= to treat the
-	// boundary and any larger value (incl. +Inf) as overflow.
-	if f >= float64(math.MaxInt64) {
-		return math.MaxInt64
-	}
-	if f <= float64(math.MinInt64) {
-		return math.MinInt64
-	}
-	return int64(f)
 }
 
 // EffectiveAllocated returns the allocated usage the scheduler should account
@@ -1042,23 +951,6 @@ func preHandleScheduler(config *Config) error {
 	if config.Scheduler.IgnoreRedisAllocation == nil {
 		ignore := false
 		config.Scheduler.IgnoreRedisAllocation = &ignore
-	}
-	// Default overcommit ratio: CPU=3, Mem=2. sanitized() guards against
-	// non-positive, NaN, or infinite values supplied by operators.
-	if config.Scheduler.OvercommitRatio == nil {
-		config.Scheduler.OvercommitRatio = &OvercommitRatioConf{
-			CPURatio: defaultCPUOvercommitRatio,
-			MemRatio: defaultMemOvercommitRatio,
-		}
-	} else {
-		sanitized := config.Scheduler.OvercommitRatio.sanitized()
-		config.Scheduler.OvercommitRatio = &sanitized
-	}
-	// Sanitize per-instance-type overrides at init time as well so malformed
-	// (non-positive/NaN/Inf) ratios are normalized once up front rather than
-	// relying solely on the lazy sanitize in GetEffectiveOvercommitRatio.
-	for k, v := range config.Scheduler.OvercommitRatioByType {
-		config.Scheduler.OvercommitRatioByType[k] = v.sanitized()
 	}
 
 	if config.Scheduler.NodeMaxMvmNum == 0 {

--- a/CubeMaster/pkg/base/config/config_test.go
+++ b/CubeMaster/pkg/base/config/config_test.go
@@ -7,7 +7,6 @@ package config
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -93,54 +92,19 @@ func TestGetEffectiveNodeMaxMemReservedInMBKeepsConfiguredValue(t *testing.T) {
 	assert.Equal(t, int64(512), got)
 }
 
-func TestPreHandleSchedulerOvercommitAndIgnoreDefaults(t *testing.T) {
+func TestPreHandleSchedulerIgnoreDefaults(t *testing.T) {
 	cfg := &Config{Scheduler: &WrapperSchedulerConf{}}
 	err := preHandleScheduler(cfg)
 	assert.NoError(t, err)
 
 	assert.NotNil(t, cfg.Scheduler.IgnoreRedisAllocation)
 	assert.False(t, cfg.Scheduler.ShouldIgnoreRedisAllocation())
-
-	ratio := cfg.Scheduler.GetEffectiveOvercommitRatio("cubebox")
-	assert.Equal(t, 3.0, ratio.CPURatio)
-	assert.Equal(t, 2.0, ratio.MemRatio)
 }
 
-func TestGetEffectiveOvercommitRatioPrecedence(t *testing.T) {
-	sconf := &SchedulerConf{
-		OvercommitRatio: &OvercommitRatioConf{CPURatio: 6.0, MemRatio: 4.0},
-		OvercommitRatioByType: map[string]OvercommitRatioConf{
-			"cubebox_gpu": {CPURatio: 1.0, MemRatio: 1.0},
-		},
-	}
-
-	// per-type override wins
-	gpu := sconf.GetEffectiveOvercommitRatio("cubebox_gpu")
-	assert.Equal(t, 1.0, gpu.CPURatio)
-	assert.Equal(t, 1.0, gpu.MemRatio)
-
-	// fall back to global ratio
-	other := sconf.GetEffectiveOvercommitRatio("cubebox")
-	assert.Equal(t, 6.0, other.CPURatio)
-	assert.Equal(t, 4.0, other.MemRatio)
-
-	// fall back to built-in default when nothing configured
-	empty := &SchedulerConf{}
-	def := empty.GetEffectiveOvercommitRatio("cubebox")
-	assert.Equal(t, 3.0, def.CPURatio)
-	assert.Equal(t, 2.0, def.MemRatio)
-}
-
-func TestEffectiveQuotaAndAllocated(t *testing.T) {
-	ignore := false
-	sconf := &SchedulerConf{
-		IgnoreRedisAllocation: &ignore,
-		OvercommitRatio:       &OvercommitRatioConf{CPURatio: 6.0, MemRatio: 4.0},
-	}
-
-	assert.Equal(t, int64(48000), sconf.EffectiveQuotaCpu("cubebox", 8000))
-	assert.Equal(t, int64(64000), sconf.EffectiveQuotaMem("cubebox", 16000))
+func TestEffectiveAllocated(t *testing.T) {
 	// allocation kept when not ignoring
+	ignore := false
+	sconf := &SchedulerConf{IgnoreRedisAllocation: &ignore}
 	assert.Equal(t, int64(1234), sconf.EffectiveAllocated(1234))
 
 	// allocation kept by default (not ignoring)
@@ -151,83 +115,6 @@ func TestEffectiveQuotaAndAllocated(t *testing.T) {
 	ignoreTrue := true
 	ignoring := &SchedulerConf{IgnoreRedisAllocation: &ignoreTrue}
 	assert.Equal(t, int64(0), ignoring.EffectiveAllocated(1234))
-}
-
-func TestOvercommitRatioSanitizesNonPositive(t *testing.T) {
-	sconf := &SchedulerConf{
-		OvercommitRatio: &OvercommitRatioConf{CPURatio: 0, MemRatio: -1},
-	}
-	ratio := sconf.GetEffectiveOvercommitRatio("cubebox")
-	assert.Equal(t, 3.0, ratio.CPURatio)
-	assert.Equal(t, 2.0, ratio.MemRatio)
-}
-
-func TestOvercommitRatioSanitizesNaNAndInf(t *testing.T) {
-	cases := []OvercommitRatioConf{
-		{CPURatio: math.NaN(), MemRatio: math.NaN()},
-		{CPURatio: math.Inf(1), MemRatio: math.Inf(1)},
-		{CPURatio: math.Inf(-1), MemRatio: math.Inf(-1)},
-	}
-	for _, c := range cases {
-		sconf := &SchedulerConf{OvercommitRatio: &c}
-		ratio := sconf.GetEffectiveOvercommitRatio("cubebox")
-		assert.Equal(t, 3.0, ratio.CPURatio)
-		assert.Equal(t, 2.0, ratio.MemRatio)
-
-		// capacity arithmetic must stay finite after sanitizing
-		assert.Equal(t, int64(24000), sconf.EffectiveQuotaCpu("cubebox", 8000))
-		assert.Equal(t, int64(32000), sconf.EffectiveQuotaMem("cubebox", 16000))
-	}
-}
-
-func TestPreHandleSchedulerSanitizesPerTypeRatios(t *testing.T) {
-	cfg := &Config{Scheduler: &WrapperSchedulerConf{
-		SchedulerConf: SchedulerConf{
-			OvercommitRatioByType: map[string]OvercommitRatioConf{
-				"bad_zero": {CPURatio: 0, MemRatio: -1},
-				"bad_nan":  {CPURatio: math.NaN(), MemRatio: math.Inf(1)},
-				"good":     {CPURatio: 8, MemRatio: 5},
-			},
-		},
-	}}
-	err := preHandleScheduler(cfg)
-	assert.NoError(t, err)
-
-	// malformed per-type ratios are normalized to defaults at init time
-	bz := cfg.Scheduler.OvercommitRatioByType["bad_zero"]
-	assert.Equal(t, 3.0, bz.CPURatio)
-	assert.Equal(t, 2.0, bz.MemRatio)
-
-	bn := cfg.Scheduler.OvercommitRatioByType["bad_nan"]
-	assert.Equal(t, 3.0, bn.CPURatio)
-	assert.Equal(t, 2.0, bn.MemRatio)
-
-	// valid per-type ratios are preserved
-	g := cfg.Scheduler.OvercommitRatioByType["good"]
-	assert.Equal(t, 8.0, g.CPURatio)
-	assert.Equal(t, 5.0, g.MemRatio)
-}
-
-func TestFloatToInt64Clamped(t *testing.T) {
-	assert.Equal(t, int64(0), floatToInt64Clamped(math.NaN()))
-	assert.Equal(t, int64(math.MaxInt64), floatToInt64Clamped(math.Inf(1)))
-	assert.Equal(t, int64(math.MinInt64), floatToInt64Clamped(math.Inf(-1)))
-	// overflow beyond int64 range clamps instead of wrapping to garbage
-	assert.Equal(t, int64(math.MaxInt64), floatToInt64Clamped(1e30))
-	assert.Equal(t, int64(math.MinInt64), floatToInt64Clamped(-1e30))
-	// normal values convert (truncate toward zero) as usual
-	assert.Equal(t, int64(42), floatToInt64Clamped(42.9))
-	assert.Equal(t, int64(0), floatToInt64Clamped(0))
-}
-
-func TestEffectiveQuotaClampsOverflow(t *testing.T) {
-	// A huge quota combined with a large overcommit ratio must not wrap to a
-	// garbage int64; it clamps to MaxInt64 instead.
-	sconf := &SchedulerConf{
-		OvercommitRatio: &OvercommitRatioConf{CPURatio: 1e6, MemRatio: 1e6},
-	}
-	assert.Equal(t, int64(math.MaxInt64), sconf.EffectiveQuotaCpu("cubebox", math.MaxInt64))
-	assert.Equal(t, int64(math.MaxInt64), sconf.EffectiveQuotaMem("cubebox", math.MaxInt64))
 }
 
 func TestNodeAffinitySelectorAllowedKeySet(t *testing.T) {

--- a/CubeMaster/pkg/selector/filter/cpufilter.go
+++ b/CubeMaster/pkg/selector/filter/cpufilter.go
@@ -39,8 +39,7 @@ func (l *cpuFilter) Select(selCtx *selctx.SelectorCtx) (node.NodeList, error) {
 	inList := selCtx.Nodes()
 	nodes := make(node.NodeList, 0, inList.Len())
 	for i := range inList {
-
-		quotaCpuFree := sconf.EffectiveQuotaCpu(inList[i].InstanceType, inList[i].QuotaCpu) -
+		quotaCpuFree := inList[i].QuotaCpu -
 			sconf.EffectiveAllocated(inList[i].QuotaCpuUsage)
 		if quotaCpuFree <= cpuq.MilliValue() {
 			log.G(selCtx.Ctx).Warnf("%v select:%v, quotaCpuFree:%v, cpuq:%v",

--- a/CubeMaster/pkg/selector/filter/memfilter.go
+++ b/CubeMaster/pkg/selector/filter/memfilter.go
@@ -38,7 +38,7 @@ func (l *memFilter) Select(selCtx *selctx.SelectorCtx) (node.NodeList, error) {
 	inList := selCtx.Nodes()
 	nodes := make(node.NodeList, 0, inList.Len())
 	for i := range inList {
-		quotaMemFree := sconf.EffectiveQuotaMem(inList[i].InstanceType, inList[i].QuotaMem) -
+		quotaMemFree := inList[i].QuotaMem -
 			sconf.EffectiveAllocated(inList[i].QuotaMemUsage)
 
 		if quotaMemFree <= memq.Value()/1024/1024 {

--- a/CubeMaster/pkg/selector/score/realtimescore.go
+++ b/CubeMaster/pkg/selector/score/realtimescore.go
@@ -119,7 +119,7 @@ func getRealtimeWeightedAverageScore(n *node.Node, cpuq, memq *resource.Quantity
 	if cpuq != nil {
 
 		cpuReqValue := cpuq.MilliValue()
-		effCpu := schedConf.EffectiveQuotaCpu(n.InstanceType, n.QuotaCpu)
+		effCpu := n.QuotaCpu
 		cpuLeft := getReciprocal(effCpu-schedConf.EffectiveAllocated(n.QuotaCpuUsage)-cpuReqValue, effCpu)
 		scores += cpuLeft * getFactorWeight(constants.WeightFactorReqCpu)
 	}
@@ -127,7 +127,7 @@ func getRealtimeWeightedAverageScore(n *node.Node, cpuq, memq *resource.Quantity
 	if memq != nil {
 
 		memReqValue := memq.Value() / 1024 / 1024
-		effMem := schedConf.EffectiveQuotaMem(n.InstanceType, n.QuotaMem)
+		effMem := n.QuotaMem
 		memLeft := getReciprocal(effMem-schedConf.EffectiveAllocated(n.QuotaMemUsage)-memReqValue, effMem)
 		scores += memLeft * getFactorWeight(constants.WeightFactorReqMem)
 	}

--- a/CubeMaster/pkg/selector/score/utils.go
+++ b/CubeMaster/pkg/selector/score/utils.go
@@ -107,7 +107,7 @@ func getQuotaCpuUsageScore(n *node.Node) float64 {
 	if sconf == nil {
 		return 0.0
 	}
-	effCpu := sconf.EffectiveQuotaCpu(n.InstanceType, n.QuotaCpu)
+	effCpu := n.QuotaCpu
 	if effCpu <= 0 {
 
 		return 0.0
@@ -121,7 +121,7 @@ func getQuotaMemMbUsageScore(n *node.Node) float64 {
 	if sconf == nil {
 		return 0.0
 	}
-	effMem := sconf.EffectiveQuotaMem(n.InstanceType, n.QuotaMem)
+	effMem := n.QuotaMem
 	if effMem <= 0 {
 		return 0.0
 	}

--- a/docs/guide/cubemaster-scheduler-config.md
+++ b/docs/guide/cubemaster-scheduler-config.md
@@ -49,11 +49,11 @@ Without scoring, CubeMaster still filters nodes but may choose from the filtered
 
 ## Key scheduler fields
 
-Merge the following scoring fields into the existing `scheduler` section of `cubemaster.yaml`. Keep your existing `filter`, timeout, overcommit, and instance-type-specific settings unless you intentionally want to replace them.
+Merge the following scoring fields into the existing `scheduler` section of `cubemaster.yaml`. Keep your existing `filter`, timeout, and instance-type-specific settings unless you intentionally want to replace them.
 
 ```yaml
 scheduler:
-  # Keep your existing filter, timeout, overcommit, and other scheduler settings.
+  # Keep your existing filter, timeout, and other scheduler settings.
   priority_select_num: 3
   score:
     enable_scorers:
@@ -81,7 +81,6 @@ scheduler:
 | `filter.enable_filters` | Enables scheduling filters. Common filters include CPU, memory, template locality, and real-time create concurrency. |
 | `score.enable_scorers` | Enables scoring plugins. Multi-node deployments usually enable `real_time_weighted_average`; when it is enabled, the matching `score.plugin_conf.real_time_weighted_average` block is required or CubeMaster can panic during scheduler startup. |
 | `score.resource_weights` | Controls the influence of MVM count, create concurrency, CPU quota usage, and memory quota usage. Higher weight means stronger influence; factors must also be listed under `score.plugin_conf.real_time_weighted_average.enable_weight_factors`. |
-| `overcommit_ratio` / `overcommit_ratio_conf` | Applies CPU/memory overcommit ratios to Cubelet-reported quota. Defaults are CPU `3` and memory `2`; overrides can be set per instance type. |
 | `node_max_mvm_num` / `node_max_mvm_num_conf` | Global or per-instance-type single-node MVM limits. Cubelet-reported `max_mvm_num` also participates in the effective limit. |
 | `disk_usage_max_percent` | Threshold used by the `disk` filter and backoff path to avoid placing more sandboxes on nearly full machines. |
 | `affinityconf` / `node_affinity_selector_allowed_keys` | Controls affinity and constraints by cluster label, zone, CPU type, instance type, and other allowed selector keys. |
@@ -92,10 +91,10 @@ Cubelet registers nodes and continuously reports status through CubeOps's `/inte
 
 | Cubelet-reported field | Source | Scheduling effect |
 |------------------------|--------|-------------------|
-| `instance_type` | Cubelet node identity / instance type | Matches request `instance_type`, selects template replicas, and applies type-specific MVM / overcommit settings. |
+| `instance_type` | Cubelet node identity / instance type | Matches request `instance_type`, selects template replicas, and applies type-specific MVM settings. |
 | `cluster_label` | `host.scheduler_label` | Used for cluster-label affinity and node-pool isolation. |
-| `quota_cpu` | `host.quota.mcpu_limit` or derived from host resources | Base schedulable CPU capacity, with overcommit applied before CPU filtering and scoring. |
-| `quota_mem_mb` | `host.quota.mem_limit` or derived from host resources | Base schedulable memory capacity, with overcommit applied before memory filtering and scoring. |
+| `quota_cpu` | `host.quota.mcpu_limit` or derived from host resources | Schedulable CPU capacity (milli-cores). Cubelet bakes its overcommit factor in when deriving the quota; CubeMaster uses the reported value directly. |
+| `quota_mem_mb` | `host.quota.mem_limit` or derived from host resources | Schedulable memory capacity (MB). Cubelet bakes its overcommit factor in when deriving the quota; CubeMaster uses the reported value directly. |
 | `max_mvm_num` | `host.quota.mvm_limit` or memory-derived default | Single-node MVM limit. Nodes at the limit are filtered out. |
 | `create_concurrent_num` | `host.quota.creation_concurrent_num` | Reported per-node create concurrency. `0` means Cubelet does not set an additional engine flow limit, but CubeMaster scheduling still falls back to `cubelet_conf.create_concurrent_limit`. |
 | allocated / disk usage / cgroup metrics | Periodic Cubelet reports | Used for current resource usage, disk watermarks, and scoring factors. |
@@ -175,7 +174,7 @@ Recommendations:
 For higher concurrency or long-running environments:
 
 - Set clear `host.scheduler_label` values per node pool, such as general, memory-heavy, or load-test pools.
-- Configure `node_max_mvm_num_conf` and `overcommit_ratio_conf` per `instance_type`; avoid using one limit for both large and small nodes.
+- Configure `node_max_mvm_num_conf` per `instance_type`; avoid using one limit for both large and small nodes.
 - Increase `priority_select_num` to a small fraction of healthy compute nodes, but avoid making final selection fully random.
 - Keep the `template_locality` filter enabled so creation only lands on nodes with usable template replicas.
 - Set explicit `host.quota.creation_concurrent_num` values to avoid a burst of image, disk, or VMM work overloading a single node.
@@ -214,8 +213,7 @@ Recommended scale-out flow:
 Check:
 
 - Whether `quota_cpu` / `quota_mem_mb` are lower than the requested resources.
-- Whether `host.quota.mcpu_limit`, `host.quota.mem_limit`, and `host.quota.mvm_limit` still use low derived defaults.
-- Whether `overcommit_ratio` is too low or per-type overrides are not what you expected.
+- Whether `host.quota.mcpu_limit`, `host.quota.mem_limit`, and `host.quota.mvm_limit` still use low derived defaults. Overcommit is applied by Cubelet when deriving the quota, not by CubeMaster.
 - Whether `mvm_num` reached `max_mvm_num` or `node_max_mvm_num_conf`.
 - Whether the effective create concurrency limit is blocking the node. Remember that `create_concurrent_num: 0` still falls back to CubeMaster's `cubelet_conf.create_concurrent_limit` at the scheduler layer.
 

--- a/docs/guide/multi-node-deploy.md
+++ b/docs/guide/multi-node-deploy.md
@@ -147,11 +147,11 @@ The response should include the compute node's IP and a healthy status.
 
 For multi-node deployments, configure CubeMaster's `scheduler.score` on the control node. If scoring is omitted, CubeMaster filters eligible nodes and then selects from the filtered node order, which can concentrate new sandboxes on the first eligible node until resource filters push traffic elsewhere.
 
-Merge the following scheduler fields into the existing `scheduler` section of `cubemaster.yaml`. Keep your existing `filter`, timeout, overcommit, and other scheduler settings.
+Merge the following scheduler fields into the existing `scheduler` section of `cubemaster.yaml`. Keep your existing `filter`, timeout, and other scheduler settings.
 
 ```yaml
 scheduler:
-  # Keep your existing filter, timeout, overcommit, and other scheduler settings.
+  # Keep your existing filter, timeout, and other scheduler settings.
   priority_select_num: 3
   score:
     enable_scorers:

--- a/docs/zh/guide/cubemaster-scheduler-config.md
+++ b/docs/zh/guide/cubemaster-scheduler-config.md
@@ -49,11 +49,11 @@ host:
 
 ## 关键 scheduler 字段
 
-推荐把下面的评分相关配置合并到现有 `cubemaster.yaml` 的 `scheduler` 段中。除非确实要替换，否则请保留已有的 `filter`、超时、overcommit 和实例类型专用配置。
+推荐把下面的评分相关配置合并到现有 `cubemaster.yaml` 的 `scheduler` 段中。除非确实要替换，否则请保留已有的 `filter`、超时和实例类型专用配置。
 
 ```yaml
 scheduler:
-  # 保留当前部署已有的 filter、超时、overcommit 和其他 scheduler 配置。
+  # 保留当前部署已有的 filter、超时和其他 scheduler 配置。
   priority_select_num: 3
   score:
     enable_scorers:
@@ -81,7 +81,6 @@ scheduler:
 | `filter.enable_filters` | 启用调度过滤器。常见过滤器包括 CPU、内存、模板本地性和实时创建并发。 |
 | `score.enable_scorers` | 启用评分器。多机部署通常启用 `real_time_weighted_average`；启用时必须同时配置 `score.plugin_conf.real_time_weighted_average`，否则 CubeMaster 可能在 scheduler 启动阶段 panic。 |
 | `score.resource_weights` | 控制 MVM 数、创建并发、CPU/内存 quota 使用率等因子的权重。权重越高，该因子对分数影响越大；对应因子也必须列在 `score.plugin_conf.real_time_weighted_average.enable_weight_factors` 中。 |
-| `overcommit_ratio` / `overcommit_ratio_conf` | 对 Cubelet 上报 quota 应用 CPU/内存超卖比例。默认 CPU 为 `3`、内存为 `2`，可按实例类型覆盖。 |
 | `node_max_mvm_num` / `node_max_mvm_num_conf` | 全局或按实例类型限制单节点 MVM 数。Cubelet 上报的 `max_mvm_num` 也会参与实际上限计算。 |
 | `disk_usage_max_percent` | `disk` filter 和 backoff 路径使用的磁盘水位阈值，用于避免继续调度到快满的机器。 |
 | `affinityconf` / `node_affinity_selector_allowed_keys` | 控制按 cluster label、zone、CPU 类型、机型等做亲和或约束选择。 |
@@ -92,10 +91,10 @@ Cubelet 会通过 CubeOps 的 `/internal/v1/node-agent` 接口注册节点并持
 
 | Cubelet 上报字段 | 来源 | 调度影响 |
 |------------------|------|----------|
-| `instance_type` | Cubelet 节点身份 / 实例类型 | 用于匹配请求的 `instance_type`、按类型选择模板副本、套用按类型的 MVM/overcommit 配置。 |
+| `instance_type` | Cubelet 节点身份 / 实例类型 | 用于匹配请求的 `instance_type`、按类型选择模板副本、套用按类型的 MVM 配置。 |
 | `cluster_label` | `host.scheduler_label` | 用于 cluster label 亲和、隔离不同节点池或指定模板分发范围。 |
-| `quota_cpu` | `host.quota.mcpu_limit` 或宿主机推导值 | CPU 可调度容量的基础值，叠加 overcommit 后参与 CPU 过滤和评分。 |
-| `quota_mem_mb` | `host.quota.mem_limit` 或宿主机推导值 | 内存可调度容量的基础值，叠加 overcommit 后参与内存过滤和评分。 |
+| `quota_cpu` | `host.quota.mcpu_limit` 或宿主机推导值 | CPU 可调度容量（毫核）。Cubelet 在推导 quota 时已内置超卖因子，CubeMaster 直接使用上报值。 |
+| `quota_mem_mb` | `host.quota.mem_limit` 或宿主机推导值 | 内存可调度容量（MB）。Cubelet 在推导 quota 时已内置超卖因子，CubeMaster 直接使用上报值。 |
 | `max_mvm_num` | `host.quota.mvm_limit` 或按内存推导 | 单节点可承载的 MVM 数上限，超过后节点会被过滤。 |
 | `create_concurrent_num` | `host.quota.creation_concurrent_num` | 节点上报的创建并发配置。`0` 表示 Cubelet 不设置额外 engine flow limit，但 CubeMaster 调度层仍会回落到 `cubelet_conf.create_concurrent_limit`。 |
 | allocated / disk usage / cgroup metrics | Cubelet 周期上报 | 用于判断当前资源使用率、磁盘水位和评分因子。 |
@@ -175,7 +174,7 @@ scheduler:
 适合更高并发或长期运行：
 
 - 按节点池设置清晰的 `host.scheduler_label`，例如通用池、内存型池、压测池，避免不同用途互相挤占。
-- 为不同 `instance_type` 配置 `node_max_mvm_num_conf` 和 `overcommit_ratio_conf`，不要把大规格节点和小规格节点套同一组上限。
+- 为不同 `instance_type` 配置 `node_max_mvm_num_conf`，不要把大规格节点和小规格节点套同一组上限。
 - 适当增大 `priority_select_num`，通常可设置为健康计算节点数的一个小比例，但不建议大到完全随机。
 - 保留 `template_locality` 过滤器，确保创建只落到已有模板副本的节点。
 - 为 `host.quota.creation_concurrent_num` 设置明确上限，避免镜像、磁盘或 VMM 创建在单节点上被突发流量打满。
@@ -214,8 +213,7 @@ cubemastercli tpl redo \
 检查方向：
 
 - `quota_cpu` / `quota_mem_mb` 是否低于实际创建需求。
-- `host.quota.mcpu_limit`、`host.quota.mem_limit`、`host.quota.mvm_limit` 是否仍为默认推导值。
-- `overcommit_ratio` 是否过低或按类型覆盖不符合预期。
+- `host.quota.mcpu_limit`、`host.quota.mem_limit`、`host.quota.mvm_limit` 是否仍为默认推导值。超卖由 Cubelet 在推导 quota 时应用，而非 CubeMaster。
 - `mvm_num` 是否达到 `max_mvm_num` 或 `node_max_mvm_num_conf` 上限。
 - 有效创建并发上限是否阻塞了当前节点。注意 `create_concurrent_num: 0` 在调度层仍会回落到 CubeMaster 的 `cubelet_conf.create_concurrent_limit`。
 

--- a/docs/zh/guide/multi-node-deploy.md
+++ b/docs/zh/guide/multi-node-deploy.md
@@ -146,11 +146,11 @@ curl http://127.0.0.1:3010/internal/v1/nodes
 
 多机部署时，应在控制节点的 CubeMaster 配置中设置 `scheduler.score`。如果未配置评分，CubeMaster 会先过滤可用节点，再按照过滤后的节点顺序进行选择，新的沙箱可能集中到第一个可用节点，直到资源过滤器把流量推到其他节点。
 
-可以将下面这些调度字段合并到 `cubemaster.yaml` 中已有的 `scheduler` 段。请保留当前部署已有的 `filter`、超时、overcommit 和其他 scheduler 配置。
+可以将下面这些调度字段合并到 `cubemaster.yaml` 中已有的 `scheduler` 段。请保留当前部署已有的 `filter`、超时和其他 scheduler 配置。
 
 ```yaml
 scheduler:
-  # 保留当前部署已有的 filter、超时、overcommit 和其他 scheduler 配置。
+  # 保留当前部署已有的 filter、超时和其他 scheduler 配置。
   priority_select_num: 3
   score:
     enable_scorers:


### PR DESCRIPTION
## Summary

Fixes #1565

## Motivation

When sandboxes are created concurrently in batches, CubeMaster admits far more sandboxes onto a node than the configured overcommit ratios should permit (issue #1565). One of the root causes is that CPU/mem overcommit is applied **twice**, so the effective overcommit is much larger than what an operator configures:

- **Cubelet** bakes a hardcoded overcommit factor into the node-reported quota when deriving it from host hardware   (CPU ×2, Mem ×1.25).
- **CubeMaster** then multiplies that already-inflated value by its own
  `overcommit_ratio` (default CPU ×3, Mem ×2).

The compounded default becomes **6× CPU / 2.5× memory** instead of the 3× / 2× the operator expects, so the scheduler admits roughly twice the intended number of sandboxes onto a node.

Overcommit is fundamentally a per-node decision — it depends on the node's hardware, workload, and local policy — so it belongs at the node agent (Cubelet), not in the centralized scheduler. Consolidating it in one place also removes the double-application footgun and leaves room for future Cubelet-side resource reservation.

  ## What this PR does

Remove CPU/mem overcommit from CubeMaster entirely. The scheduler now treats the Cubelet-reported `quota_cpu` / `quota_mem_mb` as the final schedulable capacity, since that value already carries Cubelet's overcommit factor.

- `CubeMaster/pkg/base/config/config.go`: remove the `OvercommitRatio` / `OvercommitRatioByType` fields, the `OvercommitRatioConf` type, the `GetEffectiveOvercommitRatio` / `sanitized` / `isValidRatio` / `EffectiveQuotaCpu` / `EffectiveQuotaMem` / `floatToInt64Clamped` helpers, the default ratio constants, and the default-value injection in `preHandleScheduler`. `EffectiveAllocated` (the `ignore_redis_allocation` path) is kept untouched.
- `CubeMaster/pkg/selector/filter/cpufilter.go`, `memfilter.go`: compute `quotaCpuFree` / `quotaMemFree` directly from the node-reported `QuotaCpu` / `QuotaMem` instead of the overcommit-adjusted effective quota.
- `CubeMaster/pkg/selector/score/utils.go`, `realtimescore.go`: score against `n.QuotaCpu` / `n.QuotaMem` directly.
- `CubeMaster/pkg/base/config/config_test.go`: drop the overcommit and `floatToInt64Clamped` tests; keep and rename the `EffectiveAllocated` and ignore-defaults coverage; drop the now-unused `math` import.
- `CubeMaster/conf.yaml`: remove the `overcommit_ratio` / `overcommit_ratio_conf` block.
- `docs/guide/cubemaster-scheduler-config.md` (+ zh): remove the overcommit field reference, clarify that the reported quota already carries Cubelet's overcommit, and drop stale overcommit guidance in the multi-node deploy guide.

  ## Notes

- Cubelet is intentionally untouched; its existing quota-derivation overcommit strategy is preserved as the single source of overcommit.
- Existing deployments with a stale `overcommit_ratio` key in `cubemaster.yaml` are unaffected: the YAML loader ignores unknown fields, so the stale key is silently dropped rather than failing startup. Operators can safely remove it from their config.