### PR TITLE
fix(cubeopscli): report build-injected version instead of hardcoded 0.1.0

### DIFF
--- a/CubeMaster/docker/Dockerfile.cubemastercli
+++ b/CubeMaster/docker/Dockerfile.cubemastercli
@@ -49,6 +49,9 @@ RUN set -eux; \
 # ── Build stage: cubeopscli ────────────────────────────────────────────────────
 FROM golang:1.25-bookworm AS builder-ops
 ARG TARGETARCH
+ARG CUBE_VERSION=0.0.0-dev
+ARG CUBE_COMMIT=unknown
+ARG CUBE_BUILD_TIME=unknown
 
 WORKDIR /src
 
@@ -69,7 +72,10 @@ RUN set -eux; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     GOOS=linux GOARCH="${goarch}" go build -o /out/cubeopscli \
-      -ldflags "-s -w" \
+      -ldflags "-s -w \
+        -X 'github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.Version=${CUBE_VERSION}' \
+        -X 'github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.Commit=${CUBE_COMMIT}' \
+        -X 'github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.BuildTime=${CUBE_BUILD_TIME}'" \
       ./cmd/cubeopscli
 
 # ── Runtime stage ──────────────────────────────────────────────────────────────

--- a/CubeOps/Makefile
+++ b/CubeOps/Makefile
@@ -1,8 +1,9 @@
 # Copyright (c) 2026 Tencent Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-.PHONY: build run test vet fmt clean docker
+.PHONY: build run test vet fmt clean docker deps
 
+APPS=cubeops cubeopscli
 BINARY=cubeops
 BIND=127.0.0.1:3010
 
@@ -18,8 +19,13 @@ BUILD_FLAGS=-ldflags "-s -w \
   -X '$(VERSION_PKG).Commit=$(CUBE_COMMIT)' \
   -X '$(VERSION_PKG).BuildTime=$(CUBE_BUILD_TIME)'"
 
-build:
-	go build $(BUILD_FLAGS) -o bin/$(BINARY) ./cmd/cubeops
+build: $(APPS)
+
+deps:
+	go mod download
+
+$(APPS): deps
+	go build $(BUILD_FLAGS) -o bin/$@ ./cmd/$@
 
 run: build
 	JWT_SECRET=test-secret-dummy \

--- a/CubeOps/cmd/cubeopscli/app/app_test.go
+++ b/CubeOps/cmd/cubeopscli/app/app_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/version"
+)
+
+// captureStdout runs fn and returns everything written to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = old })
+
+	fn()
+	_ = w.Close()
+	data, _ := io.ReadAll(r)
+	_ = r.Close()
+	return string(data)
+}
+
+// TestVersionFlag exercises the init()-installed cli.VersionPrinter end to end.
+func TestVersionFlag(t *testing.T) {
+	out := captureStdout(t, func() {
+		assert.NoError(t, New().Run([]string{"cubeopscli", "--version"}))
+	})
+	assert.Contains(t, out, "cubeopscli")
+	assert.Contains(t, out, version.ShowVersion())
+	assert.Contains(t, out, version.BuildTime)
+}

--- a/CubeOps/cmd/cubeopscli/app/main.go
+++ b/CubeOps/cmd/cubeopscli/app/main.go
@@ -4,18 +4,27 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"time"
 
 	"github.com/tencentcloud/CubeSandbox/CubeOps/cmd/cubeopscli/commands/node"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/cmd/cubeopscli/commands/version"
+	pkgv "github.com/tencentcloud/CubeSandbox/CubeOps/internal/version"
 	"github.com/urfave/cli"
 )
 
-func Run() error {
+func init() {
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Println(pkgv.VersionString("cubeopscli"))
+	}
+}
+
+func New() *cli.App {
 	app := cli.NewApp()
 	app.Name = "cubeopscli"
 	app.Usage = "CubeOps command line tool"
-	app.Version = "0.1.0"
+	app.Version = pkgv.ShowVersion()
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "a, address",
@@ -34,7 +43,12 @@ func Run() error {
 		},
 	}
 	app.Commands = []cli.Command{
+		version.Command,
 		node.NodeCommand,
 	}
-	return app.Run(os.Args)
+	return app
+}
+
+func Run() error {
+	return New().Run(os.Args)
 }

--- a/CubeOps/cmd/cubeopscli/commands/version/version.go
+++ b/CubeOps/cmd/cubeopscli/commands/version/version.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package version provides the version subcommand for cubeopscli.
+package version
+
+import (
+	"fmt"
+
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/version"
+	"github.com/urfave/cli"
+)
+
+var Command = cli.Command{
+	Name:  "version",
+	Usage: "print the cubeopscli version",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "versiononly, v",
+			Usage: "print the semantic version only",
+		},
+	},
+	Action: func(context *cli.Context) error {
+		if context.Bool("versiononly") {
+			fmt.Println(version.Version)
+			return nil
+		}
+		fmt.Println(version.VersionString("cubeopscli"))
+		return nil
+	},
+}

--- a/CubeOps/cmd/cubeopscli/commands/version/version_test.go
+++ b/CubeOps/cmd/cubeopscli/commands/version/version_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/version"
+	"github.com/urfave/cli"
+)
+
+// captureStdout runs fn and returns everything written to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = old })
+
+	fn()
+	_ = w.Close()
+	data, _ := io.ReadAll(r)
+	_ = r.Close()
+	return string(data)
+}
+
+func runVersion(args ...string) error {
+	app := cli.NewApp()
+	app.Name = "cubeopscli"
+	app.Commands = []cli.Command{Command}
+	return app.Run(append([]string{"cubeopscli"}, args...))
+}
+
+func TestVersionCommand_Default(t *testing.T) {
+	out := captureStdout(t, func() {
+		assert.NoError(t, runVersion("version"))
+	})
+	assert.Contains(t, out, "cubeopscli")
+	assert.Contains(t, out, version.Version)
+	assert.Contains(t, out, version.BuildTime)
+}
+
+func TestVersionCommand_VersionOnly(t *testing.T) {
+	out := captureStdout(t, func() {
+		assert.NoError(t, runVersion("version", "--versiononly"))
+	})
+	assert.Equal(t, version.Version+"\n", out)
+	assert.False(t, strings.Contains(out, "built at"))
+}

--- a/CubeOps/internal/version/version.go
+++ b/CubeOps/internal/version/version.go
@@ -4,7 +4,10 @@
 // Package version provides CubeOps build version information.
 package version
 
-import "runtime"
+import (
+	"fmt"
+	"runtime"
+)
 
 var (
 	// Version is injected at build time with -ldflags.
@@ -19,4 +22,9 @@ var (
 // ShowVersion returns the semantic version used by cubelog records.
 func ShowVersion() string {
 	return Version
+}
+
+// VersionString returns the unified version string for the given binary name.
+func VersionString(binaryName string) string {
+	return fmt.Sprintf("%s %s (%s) built at %s", binaryName, Version, Commit, BuildTime)
 }

--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,7 @@ cube-api: cubeapi
 .PHONY: cubeops
 cubeops: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
-	$(MAKE) builder-run BUILDER_CMD="mkdir -p /workspace/_output/bin && cd /workspace/CubeOps && go mod download && CGO_ENABLED=0 GOOS=linux GOARCH=$$(go env GOARCH) go build -ldflags '-s -w -X github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.Version=$(CUBE_VERSION) -X github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.Commit=$(CUBE_COMMIT) -X github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.BuildTime=$(CUBE_BUILD_TIME)' -o /workspace/_output/bin/cubeops ./cmd/cubeops && go build -ldflags '-s -w' -o /workspace/_output/bin/cubeopscli ./cmd/cubeopscli"
+	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/CubeOps && CGO_ENABLED=0 make build && cp bin/cubeops bin/cubeopscli /workspace/_output/bin/'
 
 .PHONY: cubeops-test
 cubeops-test: builder-image

--- a/deploy/one-click/build-release-bundle-builder.sh
+++ b/deploy/one-click/build-release-bundle-builder.sh
@@ -347,6 +347,9 @@ track_cubeops() {
   cd /workspace/CubeOps
   go mod download
   go build -ldflags "${CUBEOPS_LDFLAGS}" -o "${PREBUILT_DIR}/cubeops" ./cmd/cubeops
+  # cubeopscli shares the CubeOps module, so build it in the same track and
+  # reuse the module cache warmed by the cubeops build above.
+  go build -ldflags "${CUBEOPS_LDFLAGS}" -o "${PREBUILT_DIR}/cubeopscli" ./cmd/cubeopscli
 }
 
 track_volume_s3() {
@@ -444,9 +447,6 @@ queue_track cubemaster track_cubemaster
 queue_track netstack   track_netstack
 queue_track cubeops    track_cubeops
 queue_track volume-s3 track_volume_s3
-
-echo "[one-click] building cubeopscli in builder" >&2
-(cd /workspace/CubeOps && go build -ldflags "-s -w" -o "${PREBUILT_DIR}/cubeopscli" ./cmd/cubeopscli)
 
 run_tracks
 SCRIPT_EOF

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -371,6 +371,14 @@ components["cubeops"] = {
     "digest_sha256": required_sha256(os.path.join(core_bin_dir, "cubeops")),
 }
 
+# ── cubeopscli from CORE_BIN_DIR ──
+components["cubeopscli"] = {
+    "version": cube_version,
+    "commit": cube_commit,
+    "build_time": cube_build_time,
+    "digest_sha256": required_sha256(os.path.join(core_bin_dir, "cubeopscli")),
+}
+
 # ── Rust binaries from build-vm-assets.sh ──
 components["cube-agent"] = {
     "version": cube_version,
@@ -723,7 +731,7 @@ build_or_copy_go_binary \
 build_or_copy_go_binary \
   "cubeopscli" "${CUBE_OPS_CLI_BIN_OVERRIDE}" \
   "${ROOT_DIR}/CubeOps" "${CUBE_OPS_BUILD_MODE}" \
-  "${CORE_BIN_DIR}/cubeopscli" ./cmd/cubeopscli
+  "${CORE_BIN_DIR}/cubeopscli" ./cmd/cubeopscli "${CUBEOPS_VERSION_PKG}"
 build_or_copy_go_binary \
   "cubevsmapdump" "${CUBEVSMAPDUMP_BIN_OVERRIDE}" \
   "${ROOT_DIR}/CubeNet/cubevs" "${CUBEVSMAPDUMP_BUILD_MODE}" \

--- a/docs/guide/cli-tools.md
+++ b/docs/guide/cli-tools.md
@@ -74,9 +74,14 @@ cubeopscli --address <cubeops-host> --port 3010 node list
 cubeopscli --address <cubeops-host> --port 3010 node isolate <node-id>
 cubeopscli --address <cubeops-host> --port 3010 node unisolate <node-id>
 cubeopscli --address <cubeops-host> --port 3010 node delete <node-id>
+cubeopscli --version
+cubeopscli version
+cubeopscli version --versiononly
 ```
 
 Deleting a node requires it to be **isolated and free of sandboxes**; in a batch, a failure on one node does not stop the rest, and the command exits non-zero if any deletion fails. `delete` is aliased as `rm`; use `--force` to delete when the sandbox inventory cannot be verified (isolation is still required).
+
+`cubeopscli --version` and `cubeopscli version` print the release version (e.g. `cubeopscli v0.7.0 (<commit>) built at <timestamp>`); `cubeopscli version --versiononly` prints just the semantic version.
 
 For adding, isolating, and deleting nodes, see [Node Operations](./node-operations.md).
 

--- a/docs/zh/guide/cli-tools.md
+++ b/docs/zh/guide/cli-tools.md
@@ -74,9 +74,14 @@ cubeopscli --address <cubeops-host> --port 3010 node list
 cubeopscli --address <cubeops-host> --port 3010 node isolate <node-id>
 cubeopscli --address <cubeops-host> --port 3010 node unisolate <node-id>
 cubeopscli --address <cubeops-host> --port 3010 node delete <node-id>
+cubeopscli --version
+cubeopscli version
+cubeopscli version --versiononly
 ```
 
 删除节点要求节点**已隔离且无沙箱**；批量删除时单个节点失败不会中断后续节点，命令最终返回非零退出码。`delete` 的别名是 `rm`；用 `--force` 可在无法校验沙箱清单时强制删除（仍要求先隔离）。
+
+`cubeopscli --version` 与 `cubeopscli version` 输出发布版本（如 `cubeopscli v0.7.0 (<commit>) built at <timestamp>`）；`cubeopscli version --versiononly` 只输出语义化版本号。
 
 增加、隔离与删除节点的详细用法见[节点相关操作](./node-operations.md)。
 


### PR DESCRIPTION
## Summary

`cubeopscli --version` printed a hardcoded `0.1.0`, and `cubeopscli version`
failed with `No help topic for 'version'`, because no build path injected the
canonical `CUBE_VERSION` / `CUBE_COMMIT` / `CUBE_BUILD_TIME` triplet into
`CubeOps/internal/version`.

This change fixes both the code and every build path, mirroring the existing
`cubemastercli` pattern.

## Changes

### Code
- Add `VersionString(binaryName)` to `CubeOps/internal/version` (keeps
  `ShowVersion()`, which logging depends on).
- `cubeopscli` now consumes the injected version: `app.Version` comes from
  `version.ShowVersion()`, a `cli.VersionPrinter` prints the unified string,
  and a new `version` subcommand is registered.
- `cubeopscli version` prints the full version string by default
  (e.g. `cubeopscli v0.7.0 (<commit>) built at <timestamp>`) and bare semver
  with `--versiononly`, which is script-friendly.

### Build
- The top-level `make cubeops` target now delegates to the CubeOps Makefile
  build (`APPS=cubeops cubeopscli`; `BUILD_FLAGS` owns the version injection),
  matching the `cubemaster` / `cubelet` pattern.
- The one-click builder builds `cubeopscli` inside `track_cubeops` with the
  shared ldflags.
- `build-release-bundle.sh` passes the CubeOps version package to the binary
  helper.
- The `cubemastercli` Docker image `builder-ops` stage declares the version
  build args and injects them like `builder-master`.

### Tests and docs
- End-to-end tests for `--version` and the `version` subcommand.
- Documented the `cubeopscli version` commands in the CLI tools guide
  (English and Chinese).

## Verification

- `make cubeops` and the one-click packaging both produce binaries that report
  the injected version; a plain `go build` without ldflags falls back to
  `0.0.0-dev (unknown) built at unknown`.