### PR TITLE
fix(cubelog): accept case-insensitive log levels

### DIFF
--- a/pkgs/CubeLog/contract_test.go
+++ b/pkgs/CubeLog/contract_test.go
@@ -65,12 +65,20 @@ func TestSetLevelGetLevelAndStringToLevel(t *testing.T) {
 		{"WARN", WARN},
 		{"ERROR", ERROR},
 		{"FATAL", FATAL},
+		{"debug", DEBUG},
+		{"info", INFO},
+		{"warn", WARN},
+		{"error", ERROR},
+		{"fatal", FATAL},
+		{"Info", INFO},
+		{" INFO ", INFO},
 		{"unknown", DEBUG},
+		{"", DEBUG},
 	}
 	for _, tc := range cases {
 		got := StringToLevel(tc.in)
 		if got != tc.want {
-			t.Fatalf("StringToLevel(%q) = %v, want %v", tc.in, got, tc.want)
+			t.Errorf("StringToLevel(%q) = %v, want %v", tc.in, got, tc.want)
 		}
 	}
 

--- a/pkgs/CubeLog/logger.go
+++ b/pkgs/CubeLog/logger.go
@@ -144,7 +144,7 @@ func EnableLongFilePath() {
 }
 
 func StringToLevel(level string) LogLevel {
-	switch level {
+	switch strings.ToUpper(strings.TrimSpace(level)) {
 	case "DEBUG":
 		return DEBUG
 	case "INFO":


### PR DESCRIPTION
## Summary

Fixes #1593
Accept case-insensitive log levels and ignore leading/trailing whitespace.

## Root cause

CubeMaster configurations use values such as `level: "info"`.
CubeMaster passes this value to `StringToLevel`, which previously matched only exact uppercase strings, causing valid lowercase values to fall back to `DEBUG`.

## Changes

- Normalize input with `strings.TrimSpace` and `strings.ToUpper`.
- Add contract coverage for uppercase, lowercase, mixed-case, whitespace-padded, unknown, and empty values.
- Keep the existing `DEBUG` fallback behavior.
- No configuration templates were modified.

## Tests

- CubeLog tests passed.
- CubeMaster tests passed in the builder environment.



Issue #1289 is already fixed and is outside this PR.
Issue #1470 is outside this PR scope.