### PR TITLE
fix(ci): run pkgs/proto's own unit tests in CI

### DIFF
--- a/.github/workflows/unit-test-check.yml
+++ b/.github/workflows/unit-test-check.yml
@@ -65,6 +65,7 @@ on:
           - hypervisor
           - volume-s3
           - volume-cos-rpc
+          - proto
 
 concurrency:
   group: unit-test-${{ github.event.pull_request.number || github.ref }}
@@ -123,6 +124,7 @@ jobs:
             add_component "hypervisor"
             add_component "volume-s3"
             add_component "volume-cos-rpc"
+            add_component "proto"
           }
 
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
@@ -143,6 +145,7 @@ jobs:
               hypervisor) add_component "hypervisor" ;;
               volume-s3) add_component "volume-s3" ;;
               volume-cos-rpc) add_component "volume-cos-rpc" ;;
+              proto) add_component "proto" ;;
               *)
                 echo "::error::unsupported component input: ${selected_component}"
                 exit 1
@@ -214,8 +217,11 @@ jobs:
                 pkgs/proto/*)
                   # Shared proto module; consumers import via replace =>
                   # ../pkgs/proto. Changes re-run the consumer test sets
-                  # (CubeMaster, cubelet) and the cos/rpc example (the only
-                  # example consuming pkgs/proto).
+                  # (CubeMaster, cubelet), the cos/rpc example (the only
+                  # example consuming pkgs/proto), and the module's own
+                  # unit tests -- importer `go test` never runs a
+                  # dependency's _test.go files.
+                  add_component "proto"
                   add_component "CubeMaster"
                   add_component "cubelet"
                   add_component "volume-cos-rpc"
@@ -276,6 +282,7 @@ jobs:
                     elif . == "hypervisor" then "Hypervisor"
                     elif . == "volume-s3" then "S3 Volume Plugin"
                     elif . == "volume-cos-rpc" then "COS RPC Volume Plugin"
+                    elif . == "proto" then "Proto"
                     else error("unsupported component: " + .)
                     end
                   ),
@@ -295,10 +302,11 @@ jobs:
                     elif . == "hypervisor" then "hypervisor-test"
                     elif . == "volume-s3" then "cube-volume-s3-test"
                     elif . == "volume-cos-rpc" then "cube-volume-cos-rpc-test"
+                    elif . == "proto" then "proto-test"
                     else error("unsupported component: " + .)
                     end
                   ),
-                  requires_builder: (. != "CubeProxy" and . != "cubelog" and . != "cubedb")
+                  requires_builder: (. != "CubeProxy" and . != "cubelog" and . != "cubedb" and . != "proto")
                 })
               | map(
                   . as $c

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ help:
 	@printf "  shim-test     Run CubeShim unit tests in Docker\n"
 	@printf "  cubelog-test  Run cubelog unit tests on the host\n"
 	@printf "  cubedb-test   Run CubeDB unit tests on the host\n"
+	@printf "  proto-test    Run pkgs/proto unit tests on the host\n"
 	@printf "  cube-lifecycle-manager-test Run cube-lifecycle-manager unit tests in Docker\n"
 	@printf "  cubelet-pkg-test Run Cubelet ./pkg/... unit tests in Docker (no coverage)\n"
 	@printf "  agent-test    Run cube-agent unit tests in Docker\n"
@@ -491,6 +492,15 @@ cubelog-test:
 .PHONY: cubedb-test
 cubedb-test:
 	cd CubeDB && go mod download && go test ./...
+
+# pkgs/proto runs on the host: pure Go (generated .pb.go + grpc/protobuf
+# deps, no CGO/builder-only deps), like cubelog/cubedb. Consumers only
+# compile its non-test code via replace, so the module's own _test.go files
+# must be run here -- `go test ./...` in an importer never runs a
+# dependency's tests.
+.PHONY: proto-test
+proto-test:
+	cd pkgs/proto && go mod download && go vet ./... && go test ./...
 
 .PHONY: cube-lifecycle-manager-test
 cube-lifecycle-manager-test: builder-image

--- a/pkgs/proto/services/images/v1/images_utils.go
+++ b/pkgs/proto/services/images/v1/images_utils.go
@@ -4,7 +4,11 @@
 
 package images
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"google.golang.org/protobuf/proto"
+)
 
 const (
 	MasterAnnotationsImageUserName = "cube.master.image.username"
@@ -25,10 +29,13 @@ func SafePrintImageSpec(imageReq *ImageSpec) string {
 	}
 	// Annotations carry registry credentials (MasterAnnotationsImagetoken /
 	// MasterAnnotationsImageUserName); mask them before the spec is logged.
-	safe := *imageReq
-	if imageReq.Annotations != nil {
-		ann := make(map[string]string, len(imageReq.Annotations))
-		for k, v := range imageReq.Annotations {
+	// Clone (deep copy) instead of copying the struct by value -- a proto
+	// message embeds protoimpl.MessageState (a sync.Mutex), so a value copy
+	// trips go vet's copylocks and is unsafe to modify.
+	safe := proto.Clone(imageReq).(*ImageSpec)
+	if safe.Annotations != nil {
+		ann := make(map[string]string, len(safe.Annotations))
+		for k, v := range safe.Annotations {
 			if k == MasterAnnotationsImagetoken || k == MasterAnnotationsImageUserName {
 				v = "***"
 			}
@@ -36,6 +43,6 @@ func SafePrintImageSpec(imageReq *ImageSpec) string {
 		}
 		safe.Annotations = ann
 	}
-	tmpdata, _ := json.Marshal(&safe)
+	tmpdata, _ := json.Marshal(safe)
 	return string(tmpdata)
 }


### PR DESCRIPTION
## Summary

`pkgs/proto` is a standalone Go module imported by CubeMaster, Cubelet and the cos/rpc example via a `replace` directive. `go test ./...` in an importing module never compiles or runs a dependency's `_test.go` files, so the credential-masking and address-normalization unit tests shipped with `pkgs/proto` were only exercised locally and silently skipped by CI.

## Changes

- Add a `proto-test` make target (host-run, like `cubedb-test`) that runs `go vet ./... && go test ./...` inside the `pkgs/proto` module.
- Wire a `proto` component into `unit-test-check`: `pkgs/proto/*` changes now re-run the module's own tests alongside the consumer test sets, and `workflow_dispatch` gains a `proto` option.
- Fix a `go vet` copylocks warning in `SafePrintImageSpec`: copy the proto message via `proto.Clone` instead of copying the struct by value (a proto message embeds `protoimpl.MessageState`, a `sync.Mutex`).

## Testing

- `make proto-test` passes: go vet is clean and all pkgs/proto tests pass, including the `TestSafePrintImageSpec*` and grpctarget `TestNormalize` / `TestParseListen` cases.
- Simulated the workflow select logic: a `pkgs/proto/*` change now yields a `Proto (amd64)` / `Proto (arm64)` matrix entry with `make=proto-test`.
