### PR TITLE
CLM: Drop leftover sidecar comments and simplify subscriber retry

### DIFF
--- a/cube-lifecycle-manager/Dockerfile
+++ b/cube-lifecycle-manager/Dockerfile
@@ -3,8 +3,7 @@
 #
 # Multi-stage build for cube-lifecycle-manager — the standalone service that
 # owns sandbox auto-pause / auto-resume coordination between CubeMaster,
-# CubeProxy and Redis. It supersedes the older in-container cube-proxy-sidecar
-# with an unchanged wire protocol (admin push + /_sidecar_resume callback).
+# CubeProxy and Redis.
 #
 # Usage:
 #   docker build -t cube-lifecycle-manager:one-click .

--- a/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
+++ b/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
@@ -3,9 +3,7 @@
 //
 
 // cube-lifecycle-manager drives the auto-pause / auto-resume loop that sits
-// between CubeMaster, CubeProxy, and Redis. It supersedes the older
-// in-container "cube-proxy-sidecar"; the wire protocol with CubeProxy
-// (admin push endpoints + /_sidecar_resume callback) is unchanged.
+// between CubeMaster, CubeProxy, and Redis.
 package main
 
 import (
@@ -338,7 +336,7 @@ func handleEvent(ctx context.Context, ev redisstream.Event, push *proxypush.Clie
 		}
 		reg.Upsert(*ev.Meta)
 		// Log every create at info level: this is the heartbeat that
-		// proves CubeMaster -> Redis -> sidecar is wired correctly. The
+		// proves CubeMaster -> Redis -> CLM is wired correctly. The
 		// volume is bounded by sandbox creation rate (≪ QPS) so this is
 		// not a noise concern.
 		log.Info("create event applied",

--- a/cube-lifecycle-manager/internal/config/config.go
+++ b/cube-lifecycle-manager/internal/config/config.go
@@ -32,12 +32,12 @@ type Config struct {
 	RedisSentinelPassword string
 
 	// CubeProxy admin endpoints to push to and pull from. Multiple endpoints
-	// are supported even though the recommended deployment is one sidecar
+	// are supported even though the recommended deployment is one CLM
 	// per CubeProxy: future operators may consolidate.
 	CubeProxyAdminURLs []string
 	CubeAdminToken     string // optional shared secret; sent as X-Cube-Admin-Token
 
-	// CubeMaster internal HTTP for pause/resume. Sidecar calls
+	// CubeMaster internal HTTP for pause/resume. CLM calls
 	// POST <CubeMasterURL>/cube/sandbox/update with action=pause|resume.
 	CubeMasterURL string
 
@@ -54,18 +54,18 @@ type Config struct {
 	StreamReadBlock   time.Duration // XREADGROUP BLOCK arg
 	LastActivePoll    time.Duration // GET /admin/last_active cadence
 	IdleSweepInterval time.Duration // sweeper cadence
-	// BootstrapWarmup: after sidecar restart, wait this long before pausing
+	// BootstrapWarmup: after CLM restart, wait this long before pausing
 	// any sandbox that was loaded via HGETALL bootstrap. Lets the
 	// last_active poller backfill activity timestamps first. New sandboxes
 	// that arrive AFTER startup are not affected by this delay.
 	BootstrapWarmup time.Duration
 
 	// Pause/resume locks (SETNX TTL). Long enough to outlive a slow
-	// CubeMaster RPC, short enough that a crashed sidecar releases the lock.
+	// CubeMaster RPC, short enough that a crashed CLM replica releases the lock.
 	StateLockTTL time.Duration
 
 	// Consumer group identity. Group name is fixed; consumer name defaults
-	// to the host's name so multiple sidecars in a cluster get independent
+	// to the host's name so multiple CLM replicas in a cluster get independent
 	// pending-entries lists.
 	ConsumerGroup string
 	ConsumerName  string // empty → derived from os.Hostname()
@@ -253,7 +253,7 @@ func Load() (*Config, error) {
 }
 
 // Validate returns an error if the config has any field combination that the
-// sidecar can't proceed with.
+// CLM can't proceed with.
 func (c *Config) Validate() error {
 	if c.RedisMasterName != "" {
 		if len(c.RedisSentinelAddrs) == 0 {

--- a/cube-lifecycle-manager/internal/cubemasterclient/client.go
+++ b/cube-lifecycle-manager/internal/cubemasterclient/client.go
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// Package cubemasterclient is the sidecar's tiny HTTP client for CubeMaster.
+// Package cubemasterclient is CLM's tiny HTTP client for CubeMaster.
 // It calls the same /cube/sandbox/update endpoint that CubeAPI uses; we go
-// directly here to avoid the sidecar → CubeAPI → CubeMaster round-trip.
+// directly here to avoid the CLM → CubeAPI → CubeMaster round-trip.
 package cubemasterclient
 
 import (
@@ -20,9 +20,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// CubeMaster ret_code constants the sidecar reasons about. The full set
+// CubeMaster ret_code constants CLM reasons about. The full set
 // lives in pkgs/proto/services/errorcode/v1/errorcode.proto; we mirror
-// only the codes we need to react to here, keeping the sidecar free of a
+// only the codes we need to react to here, keeping CLM free of a
 // build-time dependency on the master proto.
 const (
 	// RetCodeSuccess is CubeMaster's "operation succeeded" code.
@@ -44,7 +44,7 @@ const (
 	// human or SDK client. Used by CubeAPI's kill_sandbox path.
 	KillReasonRequest = "request"
 
-	// KillReasonTimeout is the sidecar sweeper reaping an idle sandbox that
+	// KillReasonTimeout is the CLM sweeper reaping an idle sandbox that
 	// did not opt into auto_pause (lifecycle.on_timeout=kill, the default).
 	KillReasonTimeout = "timeout"
 
@@ -67,14 +67,14 @@ func (e *APIError) Error() string {
 }
 
 // IsNotFound reports whether the master replied with the "sandbox does not
-// exist" ret_code. Sidecar uses this to evict stale registry entries instead
+// exist" ret_code. CLM uses this to evict stale registry entries instead
 // of retrying a doomed pause/resume forever.
 func (e *APIError) IsNotFound() bool {
 	return e != nil && e.RetCode == RetCodeInvalidParamFormat
 }
 
 // IsAlreadyInState reports whether the master refused the transition because
-// the sandbox is already in the desired state. From the sidecar's POV this
+// the sandbox is already in the desired state. From CLM's POV this
 // is success: the sandbox is already where we wanted it, no retry needed.
 func (e *APIError) IsAlreadyInState() bool {
 	return e != nil && e.RetCode == RetCodeTaskStateInvalid

--- a/cube-lifecycle-manager/internal/eventbus/subscriber.go
+++ b/cube-lifecycle-manager/internal/eventbus/subscriber.go
@@ -43,14 +43,7 @@ func (s *Subscriber) Run(ctx context.Context) error {
 		s.log.Warn("eventbus subscriber unavailable; retrying",
 			zap.Duration("retry_delay", retryDelay),
 			zap.Error(err))
-
-		timer := time.NewTimer(retryDelay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		case <-timer.C:
-		}
+		time.Sleep(retryDelay)
 	}
 }
 

--- a/cube-lifecycle-manager/internal/httpapi/server.go
+++ b/cube-lifecycle-manager/internal/httpapi/server.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// Package httpapi exposes the sidecar's internal HTTP surface used by the
+// Package httpapi exposes CLM's internal HTTP surface used by the
 // CubeProxy /_sidecar_resume internal location. Routes:
 //
 //	POST /internal/resume?sandbox_id=...&request_id=...

--- a/cube-lifecycle-manager/internal/lifecycle/parity_test.go
+++ b/cube-lifecycle-manager/internal/lifecycle/parity_test.go
@@ -11,7 +11,7 @@ import "testing"
 // fails and the diff makes the divergence obvious.
 //
 // Source of truth lives in CubeMaster; we hardcode the same values here so
-// the sidecar can be built without taking a build-time dependency on the
+// CLM can be built without taking a build-time dependency on the
 // CubeMaster module. Whenever you touch the constants, update both files in
 // the same commit.
 func TestSchemaConstants(t *testing.T) {

--- a/cube-lifecycle-manager/internal/lifecycle/schema.go
+++ b/cube-lifecycle-manager/internal/lifecycle/schema.go
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// Package lifecycle is the sidecar-local mirror of
+// Package lifecycle is the CLM-local mirror of
 // CubeMaster/pkg/lifecycle. The two MUST stay byte-compatible: CubeMaster is
-// the single writer, the sidecar is a pure consumer.
+// the single writer, CLM is a pure consumer.
 //
 // We do not import the CubeMaster module directly because it would drag in
 // MySQL, gRPC, scheduler, and a host of other heavy dependencies that have no
-// place in the sidecar. The schema is small enough that copying it (with a
-// pointer to the canonical definition) is cheaper than the cross-module wire.
+// place in Cube Lifecycle Manager. The schema is small enough that copying it
+// (with a pointer to the canonical definition) is cheaper than the
+// cross-module wire.
 //
 // Source of truth:
 //
@@ -25,7 +26,7 @@ const (
 	// EventStreamKey is the append-only stream of create/delete events.
 	EventStreamKey = "cube:v1:shared:sandbox:lifecycle:events"
 
-	// EventStreamMaxLen caps the stream so an offline sidecar cannot drive
+	// EventStreamMaxLen caps the stream so an offline CLM replica cannot drive
 	// unbounded Redis growth.
 	EventStreamMaxLen = 100000
 

--- a/cube-lifecycle-manager/internal/proxypush/client.go
+++ b/cube-lifecycle-manager/internal/proxypush/client.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// Package proxypush is the HTTP client the sidecar uses to push lifecycle
+// Package proxypush is the HTTP client CLM uses to push lifecycle
 // metadata + state to one or more CubeProxy admin endpoints, and to pull the
 // per-request last_active timestamps back. The protocol is documented in
 // CubeProxy/lua/admin_phase.lua — this file is the canonical Go peer.

--- a/cube-lifecycle-manager/internal/redisstream/stream.go
+++ b/cube-lifecycle-manager/internal/redisstream/stream.go
@@ -4,7 +4,7 @@
 
 // Package redisstream owns every interaction with the lifecycle Redis schema:
 // the meta HSet bootstrap, the events stream consumer, and the per-sandbox
-// state locks used to serialize pause/resume across sidecar instances.
+// state locks used to serialize pause/resume across CLM replicas.
 package redisstream
 
 import (
@@ -164,7 +164,7 @@ func (c *Client) Ack(ctx context.Context, group, id string) error {
 
 // AcquireState performs a SET NX EX on the per-sandbox lifecycle state key with
 // the supplied desired state. Returns true on success. Used to coordinate
-// concurrent pause/resume across sidecars: whoever wins the SETNX owns the
+// concurrent pause/resume across CLM replicas: whoever wins the SETNX owns the
 // transition.
 func (c *Client) AcquireState(ctx context.Context, sandboxID, state string, ttl time.Duration) (bool, error) {
 	key := lifecycle.StateKey(sandboxID)

--- a/cube-lifecycle-manager/internal/registry/registry.go
+++ b/cube-lifecycle-manager/internal/registry/registry.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// Package registry holds the in-memory map of every sandbox the sidecar is
+// Package registry holds the in-memory map of every sandbox CLM is
 // tracking. It is the single source of truth that the sweeper reads to make
 // pause decisions and that the resume HTTP handler consults to know whether
 // auto-resume is enabled for a given sandbox.
@@ -22,14 +22,14 @@ type Entry struct {
 	Meta lifecycle.SandboxLifecycleMeta
 
 	// LastActiveMs is the most recent activity timestamp seen across all
-	// CubeProxy instances (sidecar takes max() over instances). Zero means
+	// CubeProxy instances (CLM takes max() over instances). Zero means
 	// "never observed" — the sweeper falls back to Meta.CreatedAt for the
 	// idle calculation.
 	LastActiveMs int64
 
-	// FirstSeenAt is when the sidecar registered the sandbox locally. The
+	// FirstSeenAt is when CLM registered the sandbox locally. The
 	// sweeper compares this against config.GracePeriod so a freshly-restarted
-	// sidecar doesn't pause everything in its first sweep before it has a
+	// CLM doesn't pause everything in its first sweep before it has a
 	// chance to receive any activity reports.
 	FirstSeenAt time.Time
 }
@@ -142,7 +142,7 @@ func (r *Registry) Len() int {
 }
 
 // Reset removes every entry. Bootstrap uses it before re-applying a fresh
-// HGETALL to avoid leaking stale entries across sidecar restarts within the
+// HGETALL to avoid leaking stale entries across CLM restarts within the
 // same in-memory state (e.g. tests).
 func (r *Registry) Reset() {
 	r.mu.Lock()

--- a/cube-lifecycle-manager/internal/resumer/resumer.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer.go
@@ -23,8 +23,8 @@ import (
 )
 
 // Options bundles dependencies for the Resumer. Concrete production wiring
-// lives in cmd/sidecar/main.go; the interface types defined in iface.go let
-// tests substitute fakes for Redis / CubeMaster / CubeProxy.
+// lives in cmd/cube-lifecycle-manager/main.go; the interface types defined
+// in iface.go let tests substitute fakes for Redis / CubeMaster / CubeProxy.
 type Options struct {
 	Registry     *registry.Registry
 	Redis        stateStore
@@ -157,8 +157,8 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 
 	// Success bookkeeping. Three writes, all best-effort:
 	//
-	//  1. Redis state → "running" so the next request from any sidecar
-	//     instance sees the right state.
+	//  1. Redis state → "running" so the next request from any CLM replica
+	//     sees the right state.
 	//  2. CubeProxy local state dict → "running" so the rewrite_phase gate
 	//     stops triggering resumes for this sandbox.
 	//  3. In-memory registry LastActiveMs → now. Without (3) the sweeper
@@ -271,7 +271,7 @@ func (r *Resumer) callCubeMasterResume(ctx context.Context, sandboxID, instanceT
 //     for race-recovery).
 //   - "pausing" or "resuming":    a peer is in flight → waitForRunning
 //
-// This is intentionally racy: between GET and SET another sidecar could
+// This is intentionally racy: between GET and SET another CLM replica could
 // claim the key. That's fine because the worst case is two resumers both
 // calling CubeMaster.Resume — which CubeMaster handles idempotently
 // (returns "already running" the second time, which we already map to

--- a/cube-lifecycle-manager/internal/resumer/resumer_test.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer_test.go
@@ -365,7 +365,7 @@ func TestResumer_RollsBackOnRPCFailure(t *testing.T) {
 }
 
 func TestResumer_WaitsWhenPeerHoldsLock(t *testing.T) {
-	// Pre-seed the state key with "resuming" — simulates a peer sidecar
+	// Pre-seed the state key with "resuming" — simulates a peer CLM replica
 	// that's already mid-flight on this sandbox. acquireResumeOwnership
 	// should observe it via GetState and route to waitForRunning instead
 	// of issuing a duplicate CubeMaster RPC.

--- a/cube-lifecycle-manager/internal/sweeper/sweeper.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper.go
@@ -29,10 +29,10 @@ type Options struct {
 	ProxyPush          stateNotifier
 	DefaultIdleTimeout time.Duration
 
-	// BootstrapWarmup delays the first sweep after the sidecar starts so the
+	// BootstrapWarmup delays the first sweep after CLM starts so the
 	// last_active poller has a chance to populate activity timestamps for
-	// sandboxes that were already running before this sidecar instance came
-	// up. Without this delay, a fresh sidecar would observe LastActiveMs=0
+	// sandboxes that were already running before this CLM instance came
+	// up. Without this delay, a fresh CLM would observe LastActiveMs=0
 	// for every bootstrap entry and immediately try to pause anything past
 	// its idle deadline — even if the sandbox has been actively serving
 	// traffic on the proxy.
@@ -43,7 +43,7 @@ type Options struct {
 	StateLockTTL time.Duration
 	Interval     time.Duration
 
-	// StartedAt is the sidecar's process start time. Used as the boundary
+	// StartedAt is CLM's process start time. Used as the boundary
 	// between "bootstrap" and "stream" entries for the warmup gate. When
 	// zero, defaults to Now() at construction time.
 	StartedAt time.Time
@@ -95,7 +95,7 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 	now := s.o.Now()
 	nowMs := now.UnixMilli()
 
-	// Bootstrap-warmup gate: when the sidecar just started, hold off on
+	// Bootstrap-warmup gate: when CLM just started, hold off on
 	// pausing entries that came in via HGETALL bootstrap (FirstSeenAt ≈
 	// startedAt). Two reasons:
 	//   * LastActiveMs hasn't been backfilled yet — first last_active
@@ -117,7 +117,7 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 		}
 
 		// Baseline = the most recent of (LastActiveMs, CreatedAt). For a
-		// sandbox the sidecar has just observed via stream, LastActiveMs
+		// sandbox CLM has just observed via stream, LastActiveMs
 		// is 0 until the next request arrives — fall through to CreatedAt
 		// which always carries a real timestamp from CubeMaster.
 		baseline := e.LastActiveMs
@@ -209,7 +209,7 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 //     from the registry so the next sweep doesn't keep retrying forever
 //     and don't leave the proxy seeing a stale "pausing" state.
 //   - TaskStateInvalid / "sandbox is already paused" → the sandbox is
-//     already where we wanted it (peer sidecar / earlier failed-but-applied
+//     already where we wanted it (peer CLM replica / earlier failed-but-applied
 //     attempt). Treat exactly like a fresh successful pause.
 func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 	sid := e.Meta.SandboxID
@@ -218,7 +218,7 @@ func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 		return err
 	}
 	if !got {
-		// Another sidecar (or our own resume handler) holds the state. Skip.
+		// Another CLM replica (or our own resume handler) holds the state. Skip.
 		return nil
 	}
 
@@ -248,7 +248,7 @@ func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 		case errors.As(pauseErr, &apiErr) && apiErr.IsAlreadyInState():
 			// CubeMaster says the sandbox is already paused. Fall through
 			// to the success path so we still write `paused` state to
-			// Redis + push it to CubeProxy (in case a peer sidecar paused
+			// Redis + push it to CubeProxy (in case a peer CLM replica paused
 			// it but didn't push, or our previous attempt failed only on
 			// the post-RPC bookkeeping).
 			s.o.Log.Info("sandbox already paused on cubemaster; reconciling state",
@@ -306,7 +306,7 @@ func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 		return err
 	}
 	if !got {
-		// A peer sidecar (or our own resume / pause path) holds the state.
+		// A peer CLM replica (or our own resume / pause path) holds the state.
 		// Skip — the holder will drive the transition.
 		return nil
 	}

--- a/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
@@ -360,7 +360,7 @@ func TestSweeper_KillSkipsAlreadyKillingSandbox(t *testing.T) {
 }
 
 func TestSweeper_BootstrapWarmupSkipsBootstrapEntries(t *testing.T) {
-	// Verifies the bootstrap-warmup gate: while the sidecar is still in
+	// Verifies the bootstrap-warmup gate: while CLM is still in
 	// its warmup window, sandboxes whose FirstSeenAt is at-or-before the
 	// sweeper's StartedAt (i.e. loaded from HGETALL) are skipped, even if
 	// their CreatedAt is hours old. After the warmup elapses, the sweeper
@@ -680,7 +680,7 @@ func TestSweeper_NilTimeoutFallsBackToDefaultIdle(t *testing.T) {
 
 func TestSweeper_AlreadyPausedReconcilesAsSuccess(t *testing.T) {
 	// CubeMaster returns "sandbox is already paused" (RetCodeTaskStateInvalid)
-	// when a peer sidecar already paused this sandbox. The sweeper should NOT
+	// when a peer CLM replica already paused this sandbox. The sweeper should NOT
 	// roll back: it should write `paused` state to Redis + push to CubeProxy
 	// just like a fresh successful pause, so all callers converge on the
 	// same view.


### PR DESCRIPTION
CubeProxy-sidecar is gone; comments in cube-lifecycle-manager still named the old sidecar. Call the current process Cube Lifecycle Manager (CLM). Keep the cube-proxy-sidecar consumer group and CubeProxy /_sidecar_resume location so the wire protocol does not need a lock-step rename.

Retry Pub/Sub setup with time.Sleep instead of NewTimer so a cancelled context cannot leave an undrained timer.