### PR TITLE
fix(chart): use stable labels for redis PVC volumeClaimTemplates

### DIFF
--- a/deploy/kubernetes/chart/templates/redis.yaml
+++ b/deploy/kubernetes/chart/templates/redis.yaml
@@ -135,7 +135,8 @@ spec:
     - metadata:
         name: redis-data
         labels:
-          {{- include "cube.labels" . | nindent 10 }}
+          app.kubernetes.io/name: {{ include "cube.name" . }}
+          app.kubernetes.io/instance: {{ .Release.Name }}
           app.kubernetes.io/component: redis
       spec:
         accessModes:


### PR DESCRIPTION
## Summary

Fixes the redis StatefulSet upgrade failure. The `cube.labels` helper renders version-dependent labels (`helm.sh/chart`, `app.kubernetes.io/version`). These labels are inherited by the PVCs created by the redis StatefulSet `volumeClaimTemplates`. On `helm upgrade`, a chart or app version bump changes the PVC labels, so the StatefulSet controller can no longer adopt the existing volumes and the upgrade fails.

## Changes

- Replace `cube.labels` in the redis `volumeClaimTemplates` metadata with a stable label set (`app.kubernetes.io/name`, `app.kubernetes.io/instance`, `app.kubernetes.io/component`) so existing PVCs remain matched across upgrades.

## How to verify

- `helm template` renders stable, version-independent labels on the PVC.
- Subsequent `helm upgrade` runs reuse the existing PVCs instead of recreating them.
