### PR TITLE
fix(chart): rewrite imageRegistry only for official Cube TCR hosts

### DIFF
--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -76,9 +76,8 @@ global:
   timezone: Asia/Shanghai
   # Non-default cluster DNS domain (empty falls back to cluster.local).
   clusterDomain: ""
-  # Optional private-registry prefix that rewrites every Cube-owned image
-  # repository so operators mirroring the chart into a private registry
-  # only need to change one value.
+  # Optional private-registry host: rewrites the official Cube TCR host
+  # on Cube-owned images; other repositories are left as declared.
   imageRegistry: ""
 
 # StorageClass — off by default so PVCs use the cluster's default
@@ -368,9 +367,10 @@ helm upgrade --install cube ./deploy/kubernetes/chart \
   -n cube-system --create-namespace
 ```
 
-Combine with `values-tke.yaml` when installing on TKE in China. The preset sets
-`global.imageRegistry` to the cn host and overrides mysql / redis / minio / kubectl
-repositories that do not go through `cube.cubeImage`.
+`global.imageRegistry` (set by `values-cn.yaml`) only rewrites the official
+Cube TCR hosts, so per-image overrides pointing at other hosts are left as
+declared. On TKE in China, also combine with `values-tke.yaml` (StorageClass /
+PVC / LoadBalancer only — it does not set `global.imageRegistry`).
 
 ## Database migration
 

--- a/deploy/kubernetes/chart/runtime-values.example.yaml
+++ b/deploy/kubernetes/chart/runtime-values.example.yaml
@@ -131,12 +131,12 @@ redis:
 # Production with a pre-mounted XFS volume at /data/cubelet:
 #         enabled: false
 
-# Optional: mirror Cube-owned images into a private registry
+# Optional: mirror the official Cube images into a private registry
+# (only official Cube TCR hosts are rewritten):
 # global:
-#   imageRegistry: my-mirror.example.com/cubesandbox
+#   imageRegistry: my-mirror.example.com
 #
-# Or override per-image repositories (required when the path differs from the
-# chart default cube-sandbox/... — e.g. private TCR with a different namespace):
+# Or override selected images individually:
 # images:
 #   ops:
 #     repository: my-mirror.example.com/cube-sandbox/cube-ops

--- a/deploy/kubernetes/chart/scripts/test-cube-image-registry-guard.sh
+++ b/deploy/kubernetes/chart/scripts/test-cube-image-registry-guard.sh
@@ -1,0 +1,204 @@
+#!/bin/sh
+# Guard: cube.cubeImage rewrites only official Cube TCR hosts
+# (cube-sandbox-int / cube-sandbox-cn). Private repositories stay as
+# declared so values-cn.yaml can mix with a partial image override.
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+CHART_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Component image tag the chart renders by default (values.yaml `tag: vX.Y.Z`).
+# Derive it at runtime so this guard survives release bumps and never
+# hard-codes a release tag that scripts/bump-image.sh --check would flag.
+TAG="$(awk '/^[[:space:]]+tag:[[:space:]]+v[0-9]/{print $2; exit}' "$CHART_DIR/values.yaml")"
+if [ -z "$TAG" ]; then
+  echo "error: no component image tag (tag: vX.Y.Z) in values.yaml" >&2
+  exit 1
+fi
+
+python3 - "$CHART_DIR" "$TAG" <<'PY'
+import pathlib
+import re
+import subprocess
+import sys
+
+chart = sys.argv[1]
+tag = sys.argv[2]
+custom = f"{tag}-custom"
+
+common = [
+    "helm",
+    "template",
+    "cube-image-registry-guard",
+    chart,
+    "--set-string",
+    "mysql.password=test",
+    "--set-string",
+    "mysql.rootPassword=test",
+    "--set-string",
+    "redis.password=test",
+]
+
+
+def render(*extra: str) -> str:
+    proc = subprocess.run(
+        common + list(extra),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+# Primary (non-init) container name per component. The guard asserts only the
+# image of this container, so a future initContainer / sidecar does not break
+# the assertions (the registry-rewrite behavior it checks is per-image).
+PRIMARY_CONTAINER = {"ops": "cube-ops", "master": "cube-master", "mysql": "mysql"}
+
+
+def find_sts_or_deploy_image(text: str, component: str) -> str:
+    container = PRIMARY_CONTAINER[component]
+    docs = [d for d in text.split("\n---\n") if d.strip()]
+    matches = []
+    for doc in docs:
+        body = f"\n{doc}\n"
+        if "\nkind: Deployment\n" not in body and "\nkind: StatefulSet\n" not in body:
+            continue
+        if f"\n    app.kubernetes.io/component: {component}\n" not in body:
+            continue
+        m = re.search(
+            r"- name:\s+" + re.escape(container) + r"\s*\n(\s+)image:\s*([^\n]+)",
+            doc,
+        )
+        if not m:
+            raise SystemExit(
+                f"container '{container}' not found in {component} Deployment/StatefulSet"
+            )
+        matches.append(m.group(2).strip().strip('"'))
+    if len(matches) != 1:
+        raise SystemExit(f"expected one image for {component}, found {matches}")
+    return matches[0]
+
+
+def expect(label: str, got: str, want: str) -> None:
+    if got != want:
+        raise SystemExit(f"{label}: expected {want!r}, got {got!r}")
+    print(f"ok: {label} -> {got}")
+
+
+INT = "cube-sandbox-int.tencentcloudcr.com"
+CN = "cube-sandbox-cn.tencentcloudcr.com"
+MIRROR = "my-mirror.example.com"
+PRIVATE = "private.example.com"
+
+# The official-host allowlist lives in templates/_helpers.tpl
+# (cube.officialImageRegistries). Assert it still names both hosts so this
+# guard cannot pass if the template allowlist drifts (e.g. cn dropped).
+helpers_text = (pathlib.Path(chart) / "templates" / "_helpers.tpl").read_text()
+for host in (INT, CN):
+    if host not in helpers_text:
+        raise SystemExit(f"cube.officialImageRegistries no longer mentions {host}")
+print("ok: cube.officialImageRegistries still lists both official hosts")
+
+# 1. Chart defaults stay on TCR int.
+default = render()
+expect(
+    "default cube-ops",
+    find_sts_or_deploy_image(default, "ops"),
+    f"{INT}/cube-sandbox/cube-ops:{tag}",
+)
+expect(
+    "default cube-master",
+    find_sts_or_deploy_image(default, "master"),
+    f"{INT}/cube-sandbox/cube-master:{tag}",
+)
+expect(
+    "default mysql (cube.image, no rewrite)",
+    find_sts_or_deploy_image(default, "mysql"),
+    "mysql:8.0",
+)
+
+# 2. values-cn.yaml rewrites official Cube hosts and third-party images.
+cn_file = str(pathlib.Path(chart) / "values-cn.yaml")
+cn = render("-f", cn_file)
+expect(
+    "values-cn cube-ops",
+    find_sts_or_deploy_image(cn, "ops"),
+    f"{CN}/cube-sandbox/cube-ops:{tag}",
+)
+if f"{CN}/cube-sandbox/cube-kernel:{tag}" not in cn:
+    raise SystemExit("values-cn must rewrite official cube-kernel to CN")
+print(f"ok: values-cn cube-kernel -> {CN}/cube-sandbox/cube-kernel:{tag}")
+expect(
+    "values-cn mysql",
+    find_sts_or_deploy_image(cn, "mysql"),
+    f"{CN}/cube-sandbox/mysql:8.0",
+)
+
+# 3. values-cn + one private repo: private host stays, uncovered official images go CN.
+partial = render(
+    "-f",
+    cn_file,
+    "--set-string",
+    f"images.ops.repository={PRIVATE}/cube-sandbox/cube-ops",
+    "--set-string",
+    f"images.ops.tag={custom}",
+)
+expect(
+    "cn + private cube-ops",
+    find_sts_or_deploy_image(partial, "ops"),
+    f"{PRIVATE}/cube-sandbox/cube-ops:{custom}",
+)
+expect(
+    "cn + private cube-ops leaves cube-master on CN",
+    find_sts_or_deploy_image(partial, "master"),
+    f"{CN}/cube-sandbox/cube-master:{tag}",
+)
+if f"{PRIVATE}/cube-sandbox/cube-kernel:" in partial:
+    raise SystemExit("cn + private ops must not rewrite cube-kernel to the private host")
+if f"{CN}/cube-sandbox/cube-kernel:{tag}" not in partial:
+    raise SystemExit("cn + private ops must keep official cube-kernel on CN")
+print("ok: cn + private cube-ops leaves cube-kernel on CN")
+
+# 4. Full-mirror imageRegistry still rewrites official defaults.
+mirrored = render("--set-string", f"global.imageRegistry={MIRROR}")
+expect(
+    "full-mirror cube-ops",
+    find_sts_or_deploy_image(mirrored, "ops"),
+    f"{MIRROR}/cube-sandbox/cube-ops:{tag}",
+)
+expect(
+    "full-mirror cube-master",
+    find_sts_or_deploy_image(mirrored, "master"),
+    f"{MIRROR}/cube-sandbox/cube-master:{tag}",
+)
+expect(
+    "full-mirror mysql stays on default (cube.image)",
+    find_sts_or_deploy_image(mirrored, "mysql"),
+    "mysql:8.0",
+)
+
+# 5. Full-mirror + private ops: private host is not rewritten.
+mixed = render(
+    "--set-string",
+    f"global.imageRegistry={MIRROR}",
+    "--set-string",
+    f"images.ops.repository={PRIVATE}/cube-sandbox/cube-ops",
+    "--set-string",
+    "images.ops.tag=custom",
+)
+expect(
+    "full-mirror + private cube-ops",
+    find_sts_or_deploy_image(mixed, "ops"),
+    f"{PRIVATE}/cube-sandbox/cube-ops:custom",
+)
+expect(
+    "full-mirror + private cube-ops still mirrors cube-master",
+    find_sts_or_deploy_image(mixed, "master"),
+    f"{MIRROR}/cube-sandbox/cube-master:{tag}",
+)
+
+print("ok: cube.cubeImage rewrites only official Cube TCR hosts")
+PY
+
+echo "All cube.cubeImage registry guard tests passed"

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -39,22 +39,28 @@ Cube-owned images should use `cube.cubeImage` instead.
 {{- end -}}
 
 {{- /*
-Render "<repository>:<tag>" for a Cube-owned image with optional
-$.Values.global.imageRegistry override applied to the registry portion of
-.repository. Call as:
+Official Cube TCR hosts that global.imageRegistry may rewrite.
+*/}}
+{{- define "cube.officialImageRegistries" -}}
+cube-sandbox-int.tencentcloudcr.com,cube-sandbox-cn.tencentcloudcr.com
+{{- end -}}
+
+{{- /*
+Render "<repository>:<tag>" for a Cube-owned image. Call as:
   include "cube.cubeImage" (dict "image" .Values.images.master "context" $)
-When global.imageRegistry is empty the output is identical to cube.image;
-setting it rewrites the leading registry host (segment before the first "/")
-so the same chart can be republished to any private registry without editing
-each per-image entry. Everything after the first "/" (the repository path)
-is preserved.
+When global.imageRegistry is set, the leading host of .repository is
+rewritten to it — but only if it is an official Cube TCR host
+(cube.officialImageRegistries); other repositories render unchanged.
+Without it the output is identical to cube.image.
 */}}
 {{- define "cube.cubeImage" -}}
 {{- $image := .image -}}
 {{- $ctx := .context -}}
 {{- $repo := $image.repository -}}
 {{- $override := (default (dict) $ctx.Values.global).imageRegistry | default "" -}}
-{{- if $override -}}
+{{- $host := index (splitList "/" $repo) 0 -}}
+{{- $official := splitList "," (include "cube.officialImageRegistries" .context) -}}
+{{- if and $override (has $host $official) -}}
   {{- $parts := splitList "/" $repo -}}
   {{- if gt (len $parts) 1 -}}
     {{- $repo = printf "%s/%s" (trimSuffix "/" $override) (join "/" (rest $parts)) -}}

--- a/deploy/kubernetes/chart/values-cn.yaml
+++ b/deploy/kubernetes/chart/values-cn.yaml
@@ -6,9 +6,8 @@
 #     -f runtime-values.yaml   # passwords / advertiseIP / TLS
 #
 # What this file does compared to values.yaml defaults:
-#   1. Rewrites Cube-owned image hosts from cube-sandbox-int → cube-sandbox-cn
-#      via global.imageRegistry (cube.cubeImage only replaces the registry host
-#      segment before the first "/"; do NOT include /cube-sandbox here).
+#   1. Sets global.imageRegistry to the cn host so cube.cubeImage
+#      repositories move int → cn.
 #   2. Points mysql / redis / minio / kubectl (cube.image, no registry rewrite) at the
 #      mirrored CN repositories under cube-sandbox/.
 #

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -11,15 +11,8 @@ global:
   # kubelet --cluster-domain=<non-default>. Empty falls back to
   # cubeNode.dns.clusterDomain, then "cluster.local".
   clusterDomain: ""
-  # Optional registry prefix that replaces the registry portion of every
-  # Cube-owned image below. Leave empty to keep the per-image repository
-  # exactly as declared. Set to e.g. "my-registry.example.com/cubesandbox"
-  # to mirror all images into a private registry without editing each entry
-  # individually. Applies to the pvmHostBootstrap / nodeInit / node / master
-  # / api / ops / cubemastercli / proxy / lifecycleManager / cubeEgress /
-  # cubeEgressNet / webui / cubelet / cubeShim / cubeKernel /
-  # cubeGuest / cubeAgent / waitNodePrep / kubectl (alpine-k8s mirror) entries but not to
-  # third-party images such as mysql / redis / minio.
+  # Optional private registry host that rewrites the official Cube TCR host
+  # on Cube-owned images. Set to a host only, e.g. my-registry.example.com.
   imageRegistry: ""
 
 images:


### PR DESCRIPTION
## Summary

`global.imageRegistry` previously rewrote the leading registry host of every Cube-owned image, so a single override could accidentally rewrite images explicitly pointed at a private or third-party host. This change restricts the rewrite to the official Cube TCR hosts (`cube-sandbox-int` / `cube-sandbox-cn`), leaving any other declared repository untouched.

## Changes

- `cube.cubeImage` now rewrites the host only when the current repository starts with an official Cube TCR host, via the new `cube.officialImageRegistries` helper.
- Added `deploy/kubernetes/chart/scripts/test-cube-image-registry-guard.sh`, which renders the chart with `helm template` across chart defaults, `values-cn.yaml`, partial private overrides, full-mirror `global.imageRegistry`, and mixed configurations.
- Updated chart docs (`README.md`, `values.yaml`, `values-cn.yaml`, `runtime-values.example.yaml`) to describe the new behavior.

## How to verify

```sh
./deploy/kubernetes/chart/scripts/test-cube-image-registry-guard.sh
```

All assertions pass:

- chart defaults stay on the int TCR host
- `values-cn.yaml` moves official images to the cn TCR host
- private per-image repositories are never rewritten
- full-mirror `imageRegistry` still rewrites official defaults
