### PR TITLE
CubeEgress: Cap inject secrets at 2048 bytes and grow policy_store

### DIFF
--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -1109,6 +1109,7 @@ pub(crate) fn build_cube_network_config(
     if let Some(rs) = network.and_then(|n| n.rules.as_ref()) {
         for (index, rule) in rs.iter().enumerate() {
             validate_egress_rule_match(&rule.r#match, index)?;
+            validate_egress_rule_injects(rule, index)?;
         }
     }
 
@@ -1141,6 +1142,24 @@ pub(crate) fn build_cube_network_config(
         deny_out,
         rules,
     }))
+}
+
+/// Cap inline inject secrets at e2b's maxNetworkRuleHeaderValueLen (2048).
+/// That is well under nginx's default large_client_header_buffers (8k).
+const SECRET_MAX_BYTES: usize = 2048;
+
+fn validate_egress_rule_injects(rule: &EgressRule, index: usize) -> AppResult<()> {
+    let Some(injects) = rule.action.inject.as_ref() else {
+        return Ok(());
+    };
+    for (j, inj) in injects.iter().enumerate() {
+        if inj.secret.len() > SECRET_MAX_BYTES {
+            return Err(AppError::BadRequest(format!(
+                "network.rules[{index}].action.inject[{j}].secret exceeds {SECRET_MAX_BYTES} bytes"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Validate the port/scheme pair on one egress rule match, mirroring the
@@ -1746,6 +1765,48 @@ mod tests {
             })),
         )
         .expect("uppercase scheme is accepted");
+    }
+
+    fn network_with_inject(secret: String) -> SandboxNetworkConfig {
+        SandboxNetworkConfig {
+            allow_public_traffic: None,
+            allow_out: None,
+            deny_out: None,
+            mask_request_host: None,
+            rules: Some(vec![EgressRule {
+                name: "r1".to_string(),
+                r#match: EgressRuleMatch::default(),
+                action: EgressRuleAction {
+                    allow: true,
+                    audit: None,
+                    inject: Some(vec![EgressRuleInject {
+                        header: "Authorization".to_string(),
+                        secret,
+                        format: None,
+                    }]),
+                },
+            }]),
+        }
+    }
+
+    #[test]
+    fn egress_inject_secret_at_cap_accepted() {
+        let context = build_cube_network_config(None, Some(&network_with_inject("x".repeat(2048))))
+            .expect("2048-byte secret is at the cap")
+            .expect("context should exist");
+        assert_eq!(
+            context.rules[0].action.inject.as_ref().unwrap()[0]
+                .secret
+                .len(),
+            2048
+        );
+    }
+
+    #[test]
+    fn egress_inject_secret_over_cap_rejected() {
+        let err = build_cube_network_config(None, Some(&network_with_inject("x".repeat(2049))))
+            .expect_err("2049-byte secret must be rejected");
+        assert!(err.to_string().contains("exceeds 2048 bytes"), "{err}");
     }
 
     #[test]

--- a/CubeEgress/lua/policy.lua
+++ b/CubeEgress/lua/policy.lua
@@ -28,10 +28,6 @@ local INDEX_KEY = "__index__"
 local INDEX_LOCK_KEY = "__index_lock__"
 local INDEX_LOCK_TIMEOUT_MS = 1000
 
--- Inline secret value cap. 64 KiB matches the old standalone secret_store
--- per-entry limit; anything larger is almost certainly a misconfiguration
--- (and would bloat policy_store fast).
-local SECRET_MAX_BYTES = 65536
 local MAX_L7_PORTS_PER_HOST = 8
 
 -- ---------- validation ----------
@@ -214,11 +210,6 @@ local function validate_policy(p)
                 if type(inj.secret) ~= "string" or inj.secret == "" then
                     return false, string.format(
                         "rules[%d].action.inject[%d].secret required (non-empty string)", i, j)
-                end
-                if #inj.secret > SECRET_MAX_BYTES then
-                    return false, string.format(
-                        "rules[%d].action.inject[%d].secret exceeds %d bytes",
-                        i, j, SECRET_MAX_BYTES)
                 end
                 -- format optional; defaults to "${SECRET}" at inject time
             end

--- a/CubeEgress/nginx.conf
+++ b/CubeEgress/nginx.conf
@@ -23,7 +23,8 @@ http {
     more_clear_headers Server;
     lua_shared_dict cert_cache 64m;
     lua_shared_dict cert_locks 8m;
-    lua_shared_dict policy_store 16m;
+    # 1000 sandboxes × 10 inject rules × 2048-byte secrets, plus JSON/slab overhead.
+    lua_shared_dict policy_store 128m;
     lua_shared_dict meta_store 1m;
     # ---- Lua ----
     lua_package_path "/usr/local/openresty/site/lualib/?.lua;/usr/local/openresty/nginx/lua/?.lua;;";

--- a/sdk/go/aligned_test.go
+++ b/sdk/go/aligned_test.go
@@ -148,6 +148,63 @@ func TestCreateRejectsInvalidRulePortScheme(t *testing.T) {
 	}
 }
 
+func TestCreateRejectsOversizedInjectSecret(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-env"))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-env"})
+	_, err := client.Create(context.Background(), CreateOptions{
+		Network: NetworkOptions{
+			Rules: []Rule{{
+				Name:  "r1",
+				Match: Match{Host: "api.example.com"},
+				Action: Action{
+					Allow:  true,
+					Inject: []Inject{{Header: "Authorization", Secret: strings.Repeat("x", secretMaxBytes+1)}},
+				},
+			}},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "exceeds 2048 bytes") {
+		t.Fatalf("err=%v, want inject.secret cap", err)
+	}
+	if called {
+		t.Fatal("server was called despite client-side validation failure")
+	}
+}
+
+func TestCreateAcceptsInjectSecretAtCap(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-env"))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-env", Timeout: 300 * time.Second})
+	_, err := client.Create(context.Background(), CreateOptions{
+		Network: NetworkOptions{
+			Rules: []Rule{{
+				Name:  "r1",
+				Match: Match{Host: "api.example.com"},
+				Action: Action{
+					Allow:  true,
+					Inject: []Inject{{Header: "Authorization", Secret: strings.Repeat("x", secretMaxBytes)}},
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
 func TestMatchValidateAcceptsLegacySchemeOnly(t *testing.T) {
 	// Scheme alone (no port) filters HTTP vs HTTPS on the default {80, 443}
 	// set — the classic behavior, not the port-scoped feature.

--- a/sdk/go/policy.go
+++ b/sdk/go/policy.go
@@ -73,6 +73,13 @@ type Inject struct {
 	Format string `json:"format,omitempty"`
 }
 
+func (i Inject) validate() error {
+	if len(i.Secret) > secretMaxBytes {
+		return fmt.Errorf("inject.secret exceeds %d bytes", secretMaxBytes)
+	}
+	return nil
+}
+
 // Render returns the final injected header value (preview helper).
 func (i Inject) Render() string {
 	format := i.Format
@@ -99,6 +106,9 @@ type Rule struct {
 }
 
 const (
+	// secretMaxBytes matches e2b maxNetworkRuleHeaderValueLen and sits under
+	// nginx's default large_client_header_buffers (8k).
+	secretMaxBytes                = 2048
 	denyAllIPv4CIDR               = "0.0.0.0/0"
 	allowOutDomainRequiresDenyAll = "When specifying allowed domains in allow_out, you must disable public " +
 		"outbound traffic or include '0.0.0.0/0' in deny_out to block all other traffic."
@@ -136,6 +146,11 @@ func buildNetworkPayload(opts NetworkOptions, internetAccessDisabled bool) (map[
 		for i, rule := range opts.Rules {
 			if err := rule.Match.validate(); err != nil {
 				return nil, fmt.Errorf("network.rules[%d] %q: %w", i, rule.Name, err)
+			}
+			for j, inj := range rule.Action.Inject {
+				if err := inj.validate(); err != nil {
+					return nil, fmt.Errorf("network.rules[%d] %q: inject[%d]: %w", i, rule.Name, j, err)
+				}
 			}
 			rule.Match = rule.Match.normalized()
 			rules[i] = rule

--- a/sdk/node/src/policy.ts
+++ b/sdk/node/src/policy.ts
@@ -12,6 +12,9 @@
 
 import { ApiError } from "./exceptions.js";
 
+/** Align with e2b maxNetworkRuleHeaderValueLen; under nginx's 8k header buffers. */
+export const SECRET_MAX_BYTES = 2048;
+
 export type Scheme = "http" | "https";
 
 export type Method =
@@ -160,7 +163,18 @@ function serializeMatch(match: Match): Record<string, unknown> {
   return out;
 }
 
+function secretByteLength(secret: string): number {
+  return new TextEncoder().encode(secret).length;
+}
+
+function validateInjectSecret(secret: string, field: string): void {
+  if (secretByteLength(secret) > SECRET_MAX_BYTES) {
+    throw new Error(`${field} exceeds ${SECRET_MAX_BYTES} bytes`);
+  }
+}
+
 function serializeInject(inject: Inject): Record<string, unknown> {
+  validateInjectSecret(inject.secret, "inject.secret");
   const out: Record<string, unknown> = { header: inject.header, secret: inject.secret };
   if (inject.format !== undefined) out.format = inject.format;
   return out;
@@ -214,6 +228,7 @@ function convertE2BTransformToInject(transform: {
     if (typeof value !== "string") {
       throw new Error(`network.rules transform.headers[${name}] must be a string`);
     }
+    validateInjectSecret(value, `network.rules transform.headers[${name}]`);
     injects.push({ header: name, secret: value });
   }
   return injects;

--- a/sdk/node/test/policy.test.ts
+++ b/sdk/node/test/policy.test.ts
@@ -8,6 +8,7 @@ import {
   convertE2BPerHostRules,
   normalizeRulesArg,
   renderInject,
+  SECRET_MAX_BYTES,
   serializeRule,
   validateAllowOutDomainsRequireDenyAll,
   type Rule,
@@ -65,6 +66,31 @@ describe("serializeRule", () => {
     expect((wire.action as Record<string, unknown>).inject).toEqual([
       { header: "Authorization", secret: "sk_xxx", format: "Bearer ${SECRET}" },
     ]);
+  });
+
+  it("accepts an inject secret at the byte cap", () => {
+    const secret = "x".repeat(SECRET_MAX_BYTES);
+    const wire = serializeRule({
+      name: "r1",
+      match: { host: "api.example.com" },
+      action: { allow: true, inject: [{ header: "Authorization", secret }] },
+    });
+    expect((wire.action as Record<string, unknown>).inject).toEqual([
+      { header: "Authorization", secret },
+    ]);
+  });
+
+  it("rejects an inject secret over the byte cap", () => {
+    expect(() =>
+      serializeRule({
+        name: "r1",
+        match: { host: "api.example.com" },
+        action: {
+          allow: true,
+          inject: [{ header: "Authorization", secret: "x".repeat(SECRET_MAX_BYTES + 1) }],
+        },
+      }),
+    ).toThrow("exceeds 2048 bytes");
   });
 
   it("emits port and normalizes scheme casing on the wire", () => {
@@ -179,12 +205,14 @@ describe("convertE2BPerHostRules", () => {
     ]);
   });
 
-  it("fans out multiple hosts preserving order", () => {
-    const rules = convertE2BPerHostRules({
-      "api.example.com": [{ transform: { headers: { "X-A": "1" } } }],
-      "api.other.com": [{ transform: { headers: { "X-B": "2" } } }],
-    });
-    expect(rules.map((r) => r.match.host)).toEqual(["api.example.com", "api.other.com"]);
+  it("rejects a header value over the byte cap", () => {
+    expect(() =>
+      convertE2BPerHostRules({
+        "api.example.com": [
+          { transform: { headers: { Authorization: "x".repeat(SECRET_MAX_BYTES + 1) } } },
+        ],
+      }),
+    ).toThrow("exceeds 2048 bytes");
   });
 });
 

--- a/sdk/python/cubesandbox/_policy.py
+++ b/sdk/python/cubesandbox/_policy.py
@@ -25,6 +25,17 @@ Method = Literal[
 
 AuditLevel = Literal["full", "metadata", "none"]
 
+# Align with e2b maxNetworkRuleHeaderValueLen. Well under nginx's default
+# large_client_header_buffers (8k), so injected headers fit common proxies.
+SECRET_MAX_BYTES = 2048
+
+
+def _validate_inject_secret(secret: Any, field: str) -> None:
+    if not isinstance(secret, str):
+        return
+    if len(secret.encode("utf-8")) > SECRET_MAX_BYTES:
+        raise ValueError(f"{field} exceeds {SECRET_MAX_BYTES} bytes")
+
 
 def _validate_scheme(value: Any, field: str) -> Optional[str]:
     """Normalize *value* (strip + lowercase) and validate against http/https.
@@ -118,6 +129,9 @@ class Inject:
     secret: str
     format: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        _validate_inject_secret(self.secret, "Inject.secret")
+
     def render(self) -> str:
         """Render the final injected header value (preview helper)."""
         fmt = self.format or "${SECRET}"
@@ -204,7 +218,9 @@ def _normalize_match_dict(m: Dict[str, Any]) -> Dict[str, Any]:
 
 def _normalize_inject_dict(i: Dict[str, Any]) -> Dict[str, Any]:
     # No snake_case keys to translate today; pass through verbatim.
-    return dict(i)
+    out = dict(i)
+    _validate_inject_secret(out.get("secret"), "inject.secret")
+    return out
 
 
 def _normalize_action_dict(a: Dict[str, Any]) -> Dict[str, Any]:

--- a/sdk/python/tests/test_policy.py
+++ b/sdk/python/tests/test_policy.py
@@ -8,7 +8,9 @@ import pytest
 
 from cubesandbox import Action, Inject, Match, Rule
 from cubesandbox._policy import (
+    SECRET_MAX_BYTES,
     _convert_e2b_per_host_rules,
+    _normalize_inject_dict,
     _normalize_match_dict,
     _serialize_rule,
 )
@@ -133,6 +135,28 @@ class TestRuleSerializerHandlesPortScheme:
             "action": {"allow": True},
         })
         assert wire["match"]["port"] == 8443
+
+
+class TestInjectSecretValidation:
+    def test_secret_at_cap_accepted(self):
+        inj = Inject(header="Authorization", secret="x" * SECRET_MAX_BYTES)
+        assert inj.to_wire()["secret"] == "x" * SECRET_MAX_BYTES
+
+    def test_secret_over_cap_rejected(self):
+        with pytest.raises(ValueError, match="exceeds 2048 bytes"):
+            Inject(header="Authorization", secret="x" * (SECRET_MAX_BYTES + 1))
+
+    def test_dict_secret_over_cap_rejected(self):
+        with pytest.raises(ValueError, match="exceeds 2048 bytes"):
+            _normalize_inject_dict({"header": "Authorization", "secret": "x" * (SECRET_MAX_BYTES + 1)})
+
+    def test_e2b_header_over_cap_rejected(self):
+        with pytest.raises(ValueError, match="exceeds 2048 bytes"):
+            _convert_e2b_per_host_rules({
+                "api.example.com": [
+                    {"transform": {"headers": {"Authorization": "x" * (SECRET_MAX_BYTES + 1)}}},
+                ],
+            })
 
 
 class TestE2BPerHostRulesCompat:


### PR DESCRIPTION
64 KiB secrets overflow nginx's default 8k header buffers and fill the 16m store. Align the cap with e2b (maxNetworkRuleHeaderValueLen=2048) in CubeAPI and the SDKs, drop the CubeEgress runtime size check, and size policy_store for 1000 sandboxes × 10 inject rules.

Closes #1428 and #1449.