### PR TITLE
fix(cubeops): support configurable Redis database selection

### DIFF
--- a/CubeOps/README.md
+++ b/CubeOps/README.md
@@ -125,7 +125,8 @@ defaults.
 | `DATABASE_URL` | *(required)* | MySQL connection URL. If unset, built from `CUBE_SANDBOX_MYSQL_{HOST,PORT,USER,PASSWORD,DB}` env vars. |
 | `CUBE_MASTER_ADDR` | `http://127.0.0.1:8089` | CubeMaster base URL |
 | `CUBE_API_SANDBOX_DOMAIN` | `cube.app` | Sandbox domain (used by SDK handler for sandbox URL construction) |
-| `REDIS_URL` | *(optional)* | Redis connection URL. Alternatively use `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD`. |
+| `REDIS_URL` | *(optional)* | Complete Redis connection URL, including the database path when needed (for example, `/7`). When set, it overrides all Sentinel and split Redis settings. |
+| `REDIS_DB` | `0` | Redis database index used only with split host/port/password or Sentinel settings. |
 | `CUBE_OPS_WAREHOUSE_WORK_DIR` | `/var/tmp/cubeops-warehouse` | Local unpack scratch (`warehouse.work_dir`); also used as `TMPDIR` |
 | `CUBE_OPS_WAREHOUSE_UPLOAD_TIMEOUT` | `30m` | HTTP write timeout and S3 Put abort budget (`warehouse.upload_timeout`) |
 | `CUBE_OPS_WAREHOUSE_FETCH_TIMEOUT` | `30m` | GitHub/CNB download timeout for one-click imports (`warehouse.fetch_timeout`) |
@@ -169,6 +170,8 @@ export CUBE_OPS_CONFIG=/path/to/your/config.yaml
 
 See [`config.example.yaml`](./config.example.yaml) for all available fields
 with inline comments. One-click does not install this file.
+
+**Redis connection priority**: `REDIS_URL` > Sentinel settings > split `REDIS_HOST`/`REDIS_PORT`/`REDIS_DB`/`REDIS_PASSWORD` settings.
 
 ## Authentication
 

--- a/CubeOps/config.example.yaml
+++ b/CubeOps/config.example.yaml
@@ -45,9 +45,12 @@ cubemaster_addr: "http://127.0.0.1:8089"   # CUBE_MASTER_ADDR
 cubeapi_url: "http://127.0.0.1:3000"       # CUBE_API_URL
 
 # --- Redis (optional, used for node metric fan-out) ---
+# A non-empty redis_url is the complete connection configuration and overrides
+# Sentinel and split settings. Include the logical database in the URL path.
 redis_url: ""
 redis_host: ""
 redis_port: 0
+redis_db: 0
 redis_password: ""
 
 # --- Sandbox domain exposed to SDK clients via /config ---

--- a/CubeOps/internal/config/config.go
+++ b/CubeOps/internal/config/config.go
@@ -61,11 +61,12 @@ type Config struct {
 	// CubeAPI (for SDK endpoint proxy)
 	CubeAPIURL string `yaml:"cubeapi_url"`
 
-	// Redis (optional): REDIS_URL or the split REDIS_HOST/PORT/PASSWORD triple.
-	// Sentinel: set MasterName (+ SentinelNodes/Password) to use Sentinel mode.
+	// Redis (optional): REDIS_URL is the complete source of truth when set.
+	// Otherwise, MasterName selects Sentinel; split HOST/PORT/DB/PASSWORD is the fallback.
 	RedisURL              string `yaml:"redis_url"`
 	RedisHost             string `yaml:"redis_host"`
 	RedisPort             int    `yaml:"redis_port"`
+	RedisDB               int    `yaml:"redis_db"`
 	RedisPassword         string `yaml:"redis_password"`
 	RedisMasterName       string `yaml:"redis_master_name"`
 	RedisSentinelNodes    string `yaml:"redis_sentinel_nodes"`
@@ -418,6 +419,11 @@ func overrideFromEnv(cfg *Config) {
 	if v := os.Getenv("REDIS_PORT"); v != "" {
 		if p, err := strconv.Atoi(v); err == nil {
 			cfg.RedisPort = p
+		}
+	}
+	if v := os.Getenv("REDIS_DB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.RedisDB = n
 		}
 	}
 	if v := os.Getenv("REDIS_PASSWORD"); v != "" {

--- a/CubeOps/internal/config/config_test.go
+++ b/CubeOps/internal/config/config_test.go
@@ -25,11 +25,13 @@ database_url: "mysql://root:pass@127.0.0.1:3306/testdb"
 jwt_secret: "yaml-secret"
 access_ttl: "30m"
 refresh_ttl: "336h"
+redis_db: 7
 `)
 	if err := os.WriteFile(yamlPath, yamlContent, 0o644); err != nil {
 		t.Fatalf("write yaml: %v", err)
 	}
 	t.Setenv("CUBE_OPS_CONFIG", yamlPath)
+	t.Setenv("REDIS_DB", "")
 
 	cfg, err := Load()
 	if err != nil {
@@ -50,6 +52,9 @@ refresh_ttl: "336h"
 	if cfg.JWTSecret != "yaml-secret" {
 		t.Errorf("JWTSecret = %q, want yaml-secret", cfg.JWTSecret)
 	}
+	if cfg.RedisDB != 7 {
+		t.Errorf("RedisDB = %d, want 7", cfg.RedisDB)
+	}
 }
 
 // TestLoad_EnvOverridesYAML proves that environment variables take
@@ -59,12 +64,14 @@ func TestLoad_EnvOverridesYAML(t *testing.T) {
 	yamlPath := filepath.Join(dir, "config.yaml")
 	yamlContent := []byte(`bind: "0.0.0.0:9999"
 database_url: "mysql://root:pass@127.0.0.1:3306/yamldb"
+redis_db: 3
 `)
 	if err := os.WriteFile(yamlPath, yamlContent, 0o644); err != nil {
 		t.Fatalf("write yaml: %v", err)
 	}
 	t.Setenv("CUBE_OPS_CONFIG", yamlPath)
 	t.Setenv("CUBE_OPS_BIND", "127.0.0.1:7777")
+	t.Setenv("REDIS_DB", "9")
 
 	cfg, err := Load()
 	if err != nil {
@@ -72,6 +79,9 @@ database_url: "mysql://root:pass@127.0.0.1:3306/yamldb"
 	}
 	if cfg.Bind != "127.0.0.1:7777" {
 		t.Errorf("Bind = %q, want 127.0.0.1:7777 (env should override YAML)", cfg.Bind)
+	}
+	if cfg.RedisDB != 9 {
+		t.Errorf("RedisDB = %d, want 9 (env should override YAML)", cfg.RedisDB)
 	}
 }
 

--- a/CubeOps/internal/nodemanagement/nodemetric/redis_metric.go
+++ b/CubeOps/internal/nodemanagement/nodemetric/redis_metric.go
@@ -42,18 +42,14 @@ func SetWriteNodeMetricHook(hook func(*NodeMetric) error) func() {
 }
 
 // Init initializes the Redis pool and verifies connectivity. Redis is required.
-// Supports standalone (REDIS_URL/HOST) and Sentinel (MASTER_NAME) modes.
+// REDIS_URL takes precedence over Sentinel and split host settings.
 func Init(cfg *config.Config) error {
 	if cfg == nil {
 		return errors.New("nodemetric: config is nil; redis is required")
 	}
-	sentinel := cfg.RedisMasterName != ""
-	url := cfg.RedisURL
-	if !sentinel && url == "" && cfg.RedisHost != "" {
-		url = buildRedisURL(cfg.RedisHost, cfg.RedisPort, cfg.RedisPassword)
-	}
-	if !sentinel && url == "" {
-		return errors.New("nodemetric: redis is not configured (set REDIS_URL or REDIS_HOST/REDIS_MASTER_NAME)")
+	url, sentinel, err := resolveRedisConnection(cfg)
+	if err != nil {
+		return err
 	}
 	poolOnce.Do(func() {
 		pool = &redis.Pool{
@@ -82,6 +78,21 @@ func Init(cfg *config.Config) error {
 	return nil
 }
 
+// resolveRedisConnection applies the connection source priority:
+// REDIS_URL, then Sentinel, then split host settings.
+func resolveRedisConnection(cfg *config.Config) (string, bool, error) {
+	if cfg.RedisURL != "" {
+		return cfg.RedisURL, false, nil
+	}
+	if cfg.RedisMasterName != "" {
+		return "", true, nil
+	}
+	if cfg.RedisHost != "" {
+		return buildRedisURL(cfg.RedisHost, cfg.RedisPort, cfg.RedisDB, cfg.RedisPassword), false, nil
+	}
+	return "", false, errors.New("nodemetric: redis is not configured (set REDIS_URL or REDIS_HOST/REDIS_MASTER_NAME)")
+}
+
 // dialSentinel resolves the current master via SENTINEL get-master-addr-by-name,
 // then dials it directly.
 func dialSentinel(cfg *config.Config) (redis.Conn, error) {
@@ -93,6 +104,7 @@ func dialSentinel(cfg *config.Config) (redis.Conn, error) {
 		redis.DialConnectTimeout(redisDialTimeout),
 		redis.DialReadTimeout(redisDialTimeout),
 		redis.DialWriteTimeout(redisDialTimeout),
+		redis.DialDatabase(cfg.RedisDB),
 		redis.DialPassword(cfg.RedisPassword),
 	)
 }
@@ -154,15 +166,15 @@ func parseRedisAddrs(raw string) []string {
 	return out
 }
 
-// buildRedisURL assembles a redis:// URL from split host/port/password.
-func buildRedisURL(host string, port int, password string) string {
+// buildRedisURL assembles a redis:// URL from split host/port/db/password.
+func buildRedisURL(host string, port int, db int, password string) string {
 	if port == 0 {
 		port = 6379
 	}
 	u := &url.URL{
 		Scheme: "redis",
 		Host:   fmt.Sprintf("%s:%d", host, port),
-		Path:   "/0",
+		Path:   fmt.Sprintf("/%d", db),
 	}
 	if password != "" {
 		u.User = url.UserPassword("", password)

--- a/CubeOps/internal/nodemanagement/nodemetric/redis_metric_test.go
+++ b/CubeOps/internal/nodemanagement/nodemetric/redis_metric_test.go
@@ -4,12 +4,19 @@
 package nodemetric
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/config"
 )
 
 func TestWriteNodeMetric_NilPool(t *testing.T) {
@@ -91,6 +98,146 @@ func TestParseRedisAddrs(t *testing.T) {
 	if addrs[0] != "10.0.0.1:26379" {
 		t.Errorf("bare host should default to :26379, got %s", addrs[0])
 	}
+}
+
+func TestBuildRedisURLUsesConfiguredDatabase(t *testing.T) {
+	if got := buildRedisURL("redis.example", 6380, 7, "secret"); got != "redis://:secret@redis.example:6380/7" {
+		t.Fatalf("buildRedisURL() = %q, want configured database", got)
+	}
+	if got := buildRedisURL("redis.example", 0, 0, ""); got != "redis://redis.example:6379/0" {
+		t.Fatalf("buildRedisURL() default = %q, want database 0", got)
+	}
+}
+
+func TestResolveRedisConnectionPrefersURL(t *testing.T) {
+	cfg := &config.Config{
+		RedisURL:              "redis://url-user:url-pass@url.example:6380/7?pool_size=10",
+		RedisHost:             "split.example",
+		RedisPort:             6381,
+		RedisDB:               3,
+		RedisPassword:         "split-pass",
+		RedisMasterName:       "mymaster",
+		RedisSentinelNodes:    "sentinel.example:26379",
+		RedisSentinelPassword: "sentinel-pass",
+	}
+
+	gotURL, sentinel, err := resolveRedisConnection(cfg)
+	if err != nil {
+		t.Fatalf("resolveRedisConnection: %v", err)
+	}
+	if sentinel {
+		t.Fatal("resolveRedisConnection() selected Sentinel despite REDIS_URL")
+	}
+	if gotURL != cfg.RedisURL {
+		t.Fatalf("resolveRedisConnection() URL = %q, want unchanged %q", gotURL, cfg.RedisURL)
+	}
+}
+
+func TestDialSentinelSelectsConfiguredDatabase(t *testing.T) {
+	sentinelLn := listenTestRedis(t)
+	masterLn := listenTestRedis(t)
+	masterDB := make(chan int, 1)
+
+	go serveTestSentinel(t, sentinelLn, masterLn.Addr().(*net.TCPAddr).Port)
+	go serveTestMaster(t, masterLn, masterDB)
+
+	cfg := &config.Config{
+		RedisMasterName:    "mymaster",
+		RedisSentinelNodes: sentinelLn.Addr().String(),
+		RedisDB:            7,
+	}
+	conn, err := dialSentinel(cfg)
+	if err != nil {
+		t.Fatalf("dialSentinel: %v", err)
+	}
+	defer conn.Close()
+
+	select {
+	case got := <-masterDB:
+		if got != 7 {
+			t.Fatalf("master selected database %d, want 7", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for master SELECT")
+	}
+}
+
+func listenTestRedis(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	return ln
+}
+
+func serveTestSentinel(t *testing.T, ln net.Listener, masterPort int) {
+	t.Helper()
+	conn, err := ln.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	cmd, err := readTestRedisCommand(conn)
+	if err != nil || len(cmd) != 3 || strings.ToUpper(cmd[0]) != "SENTINEL" {
+		return
+	}
+	fmt.Fprintf(conn, "*2\r\n$9\r\n127.0.0.1\r\n$%d\r\n%d\r\n", len(strconv.Itoa(masterPort)), masterPort)
+}
+
+func serveTestMaster(t *testing.T, ln net.Listener, selectedDB chan<- int) {
+	t.Helper()
+	conn, err := ln.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	cmd, err := readTestRedisCommand(conn)
+	if err != nil || len(cmd) != 2 || strings.ToUpper(cmd[0]) != "SELECT" {
+		return
+	}
+	db, err := strconv.Atoi(cmd[1])
+	if err != nil {
+		return
+	}
+	selectedDB <- db
+	fmt.Fprint(conn, "+OK\r\n")
+}
+
+func readTestRedisCommand(r net.Conn) ([]string, error) {
+	br := bufio.NewReader(r)
+	line, err := br.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(line, "*") {
+		return nil, fmt.Errorf("unexpected RESP header %q", line)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(line[1:]))
+	if err != nil {
+		return nil, err
+	}
+	cmd := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		line, err = br.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		if !strings.HasPrefix(line, "$") {
+			return nil, fmt.Errorf("unexpected RESP bulk header %q", line)
+		}
+		length, err := strconv.Atoi(strings.TrimSpace(line[1:]))
+		if err != nil {
+			return nil, err
+		}
+		value := make([]byte, length+2)
+		if _, err := io.ReadFull(br, value); err != nil {
+			return nil, err
+		}
+		cmd = append(cmd, string(value[:length]))
+	}
+	return cmd, nil
 }
 
 func TestPing_NilPool(t *testing.T) {


### PR DESCRIPTION
## Motivation

When CubeMaster is configured to read node metrics from a non-zero Redis logical database, CubeOps still writes those metrics to DB 0 when it uses split Redis settings. CubeMaster therefore cannot see the metrics, causing scheduler metric updates to time out.

The same mismatch affects Sentinel connections because CubeOps does not select the configured logical database after discovering the Redis master.

## What Changed

* Add `redis_db` YAML and `REDIS_DB` environment configuration to CubeOps, defaulting to database `0`.
* Use the configured database for split standalone Redis connections.
* Use the configured database for Sentinel master connections.
* Treat `REDIS_URL` as the complete, highest-priority Redis connection configuration, including its database path, without combining it with Sentinel or split settings.
* Add focused coverage for Redis connection source priority, Sentinel master database selection, and YAML/environment precedence.
* Update CubeOps documentation.

## Validation

* `go test ./... -count=1` passed for CubeOps.
* CubeOps binaries built successfully.
* `REDIS_URL` priority and Sentinel database selection tests passed for 20 consecutive runs.
* Runtime Redis selection validation confirmed that a metric written with database `7` is readable from DB 7 and absent from DB 0.

## Scope

This PR is intentionally limited to CubeOps logical Redis database selection. It does not change the Helm chart or CubeMaster.

The chart already supports additional CubeOps environment variables through `cubeOps.env`, so Kubernetes installations can set `REDIS_DB` without adding a Chart-level `redis_db` value. CubeMaster continues using its existing `conf.yaml` Redis database configuration.
