### PR TITLE
Security optimizations for virtiofsd

### DIFF
--- a/hypervisor/virtiofsd/src/filesystem.rs
+++ b/hypervisor/virtiofsd/src/filesystem.rs
@@ -1225,6 +1225,15 @@ pub trait FileSystem {
     fn get_root_ino(&self) -> io::Result<u64> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
+
+    /// Whether the filesystem has `readdirplus` support enabled.
+    ///
+    /// When this returns `false`, the server should reject any `readdirplus` FUSE request
+    /// (returning an empty reply) to guard against guests that bypass the negotiated
+    /// capabilities and issue forged `readdirplus` requests directly.
+    fn readdirplus_enabled(&self) -> bool {
+        false
+    }
 }
 
 /// Allow filesystem's state to be serialized for migration.

--- a/hypervisor/virtiofsd/src/passthrough/mod.rs
+++ b/hypervisor/virtiofsd/src/passthrough/mod.rs
@@ -397,7 +397,7 @@ impl Default for Config {
             proc_mountinfo_rawfd: None,
             announce_submounts: false,
             inode_file_handles: Default::default(),
-            readdirplus: true,
+            readdirplus: false,
             allow_direct_io: false,
             killpriv_v2: false,
             posix_acl: false,
@@ -1362,6 +1362,10 @@ impl FileSystem for PassthroughFs {
         let st = statx(&path_fd, None)?;
 
         Ok(st.st.st_ino)
+    }
+
+    fn readdirplus_enabled(&self) -> bool {
+        self.cfg.readdirplus
     }
 
     fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {

--- a/hypervisor/virtiofsd/src/passthrough/read_only.rs
+++ b/hypervisor/virtiofsd/src/passthrough/read_only.rs
@@ -441,6 +441,10 @@ impl FileSystem for PassthroughFsRo {
 
         Ok(st.st.st_ino)
     }
+
+    fn readdirplus_enabled(&self) -> bool {
+        self.0.readdirplus_enabled()
+    }
 }
 
 impl SerializableFileSystem for PassthroughFsRo {

--- a/hypervisor/virtiofsd/src/server.rs
+++ b/hypervisor/virtiofsd/src/server.rs
@@ -1387,6 +1387,14 @@ impl<F: FileSystem + Sync> Server<F> {
             );
         }
 
+        // If `readdirplus` is not enabled in the filesystem configuration, reject any
+        // `readdirplus` FUSE request by returning an empty reply.  This prevents a
+        // malicious guest from bypassing the negotiated capabilities and issuing forged
+        // `readdirplus` requests directly.
+        if !self.fs.readdirplus_enabled() {
+            return reply_readdir(0, in_header.unique, w);
+        }
+
         // Skip over enough bytes for the header.
         let unique = in_header.unique;
         let mut cursor = w.split_at(size_of::<OutHeader>()).unwrap();

--- a/hypervisor/virtiofsd/src/server.rs
+++ b/hypervisor/virtiofsd/src/server.rs
@@ -391,6 +391,14 @@ impl<F: FileSystem + Sync> Server<F> {
         }
     }
 
+    // When an allow-dir whitelist is configured, the FUSE root is a synthetic, filtered directory:
+    // the guest may only traverse into whitelisted entries (LOOKUP) and list them (READDIR/
+    // READDIRPLUS). It must never create, delete, rename, link, or change metadata directly on the
+    // real backend root. Returns true when `nodeid` is that filtered root so callers reject the op.
+    fn is_filtered_root(&self, nodeid: u64) -> bool {
+        nodeid == ROOT_ID && !self.root_filter.as_ref().lock().unwrap().is_empty()
+    }
+
     fn lookup(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
         let namelen = (in_header.len as usize)
             .checked_sub(size_of::<InHeader>())
@@ -468,6 +476,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn setattr(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let setattr_in: SetattrIn = r.read_obj().map_err(Error::DecodeMessage)?;
 
         let handle = if setattr_in.valid & FATTR_FH != 0 {
@@ -514,6 +530,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn symlink(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         // Unfortunately the name and linkname are encoded one after another and
         // separated by a nul character.
         let len = (in_header.len as usize)
@@ -549,6 +573,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn mknod(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let MknodIn {
             mode, rdev, umask, ..
         } = r.read_obj().map_err(Error::DecodeMessage)?;
@@ -586,6 +618,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn mkdir(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let MkdirIn { mode, umask } = r.read_obj().map_err(Error::DecodeMessage)?;
 
         let remaining_len = (in_header.len as usize)
@@ -620,6 +660,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn unlink(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let namelen = (in_header.len as usize)
             .checked_sub(size_of::<InHeader>())
             .ok_or(Error::InvalidHeaderLength)?;
@@ -638,6 +686,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn rmdir(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let namelen = (in_header.len as usize)
             .checked_sub(size_of::<InHeader>())
             .ok_or(Error::InvalidHeaderLength)?;
@@ -664,6 +720,16 @@ impl<F: FileSystem + Sync> Server<F> {
         mut r: Reader,
         w: Writer,
     ) -> Result<usize> {
+        // Reject renames whose source (`in_header.nodeid`) or destination (`newdir`) parent is the
+        // filtered root, so the guest can neither remove from nor create in the real backend root.
+        if self.is_filtered_root(in_header.nodeid) || self.is_filtered_root(newdir) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let buflen = (in_header.len as usize)
             .checked_sub(size_of::<InHeader>())
             .and_then(|l| l.checked_sub(msg_size))
@@ -710,6 +776,15 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn link(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        // `in_header.nodeid` is the destination parent; deny hardlinks into the filtered root.
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let LinkIn { oldnodeid } = r.read_obj().map_err(Error::DecodeMessage)?;
 
         let namelen = (in_header.len as usize)
@@ -944,6 +1019,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn setxattr(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let options = FsOptions::from_bits_truncate(self.options.load(Ordering::Relaxed));
         let (
             SetxattrIn {
@@ -1073,6 +1156,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn removexattr(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let namelen = (in_header.len as usize)
             .checked_sub(size_of::<InHeader>())
             .ok_or(Error::InvalidHeaderLength)?;
@@ -1530,6 +1621,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     fn create(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        if self.is_filtered_root(in_header.nodeid) {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EACCES),
+                in_header.unique,
+                w,
+            );
+        }
+
         let CreateIn {
             flags,
             mode,


### PR DESCRIPTION
virtiofsd: reject root mutations when an allow-dir filter is set
virtiofsd: reject forged readdirplus requests when disabled