### PR TITLE
fix(shim): restore RPC log forward after template create

### DIFF
--- a/CubeShim/shim/src/common/utils.rs
+++ b/CubeShim/shim/src/common/utils.rs
@@ -341,9 +341,10 @@ impl Utils {
             Err(e) => Err(format!("resolve ivshmem path failed:{}", e)),
         };
 
-        // delete host init logs. Task.Delete on a live shim is not enough:
-        // after a crash containerd reaps via the delete subcommand, which
-        // must drop /data/cubelet/log/<id> here.
+        // Regular-sandbox host logs. Template builds write under
+        // /data/log/template and never create this dir, so this is a no-op
+        // for app_snapshot_create. Task.Delete on a live shim is not enough:
+        // after a crash containerd reaps via the delete subcommand.
         let ret_logdir = crate::container::remove_sandbox_log_dir_sync(sandbox_id);
 
         let mut err_msg = String::new();

--- a/CubeShim/shim/src/common/utils.rs
+++ b/CubeShim/shim/src/common/utils.rs
@@ -341,6 +341,11 @@ impl Utils {
             Err(e) => Err(format!("resolve ivshmem path failed:{}", e)),
         };
 
+        // delete host init logs. Task.Delete on a live shim is not enough:
+        // after a crash containerd reaps via the delete subcommand, which
+        // must drop /data/cubelet/log/<id> here.
+        let ret_logdir = crate::container::remove_sandbox_log_dir_sync(sandbox_id);
+
         let mut err_msg = String::new();
         if let Err(e) = ret_vmdir {
             err_msg = err_msg + e.as_str();
@@ -351,6 +356,10 @@ impl Utils {
         }
 
         if let Err(e) = ret_ivshmem {
+            err_msg = err_msg + e.as_str();
+        }
+
+        if let Err(e) = ret_logdir {
             err_msg = err_msg + e.as_str();
         }
 

--- a/CubeShim/shim/src/container/exec.rs
+++ b/CubeShim/shim/src/container/exec.rs
@@ -4,9 +4,10 @@
 
 use super::ContainerState;
 use crate::log::Log;
-use crate::{debugf, errf, infof};
+use crate::{debugf, errf, infof, warnf};
 use oci_spec::runtime::Process;
 use protoc::{agent, agent_ttrpc};
+use std::time::Duration;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use ttrpc::context;
@@ -373,12 +374,20 @@ impl Exec {
                 res = client.read_stdout(ctx.clone(), &req) => {
                     match res {
                         Err(e) => {
-                            debugf!(log, "init log: read stdout failed:{}", e);
-                            return;
+                            warnf!(log, "init log: read stdout failed:{}, retry", e);
+                            tokio::time::sleep(Duration::from_millis(200)).await;
+                            continue;
                         }
                         Ok(rsp) => {
+                            if rsp.data.is_empty() {
+                                continue;
+                            }
                             if let Err(e) = file.write_all(&rsp.data).await {
                                 infof!(log, "init log: write stdout failed:{}", e);
+                                return;
+                            }
+                            if let Err(e) = file.flush().await {
+                                infof!(log, "init log: flush stdout failed:{}", e);
                                 return;
                             }
                         }
@@ -439,12 +448,20 @@ impl Exec {
                 res = client.read_stderr(ctx.clone(), &req) => {
                     match res {
                         Err(e) => {
-                            debugf!(log, "init log: read stderr failed:{}", e);
-                            return;
+                            warnf!(log, "init log: read stderr failed:{}, retry", e);
+                            tokio::time::sleep(Duration::from_millis(200)).await;
+                            continue;
                         }
                         Ok(rsp) => {
+                            if rsp.data.is_empty() {
+                                continue;
+                            }
                             if let Err(e) = file.write_all(&rsp.data).await {
                                 infof!(log, "init log: write stderr failed:{}", e);
+                                return;
+                            }
+                            if let Err(e) = file.flush().await {
+                                infof!(log, "init log: flush stderr failed:{}", e);
                                 return;
                             }
                         }

--- a/CubeShim/shim/src/container/mod.rs
+++ b/CubeShim/shim/src/container/mod.rs
@@ -135,6 +135,44 @@ fn validate_log_path_component(id: &str) -> CResult<()> {
     Ok(())
 }
 
+/// Host directory for regular-sandbox init logs. Template builds stay under
+/// `/data/log/template`. cubecli reads this path without entering a mount ns.
+pub const SANDBOX_LOG_ROOT: &str = "/data/cubelet/log";
+
+pub fn sandbox_log_dir(sandbox_id: &str) -> CResult<PathBuf> {
+    validate_log_path_component(sandbox_id)?;
+    Ok(PathBuf::from(SANDBOX_LOG_ROOT).join(sandbox_id))
+}
+
+pub async fn create_sandbox_log_paths(sandbox_id: &str) -> CResult<(String, String)> {
+    let dir = sandbox_log_dir(sandbox_id)?;
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| format!("create log dir {}: {}", dir.display(), e))?;
+    Ok((
+        dir.join("stdout").to_string_lossy().into_owned(),
+        dir.join("stderr").to_string_lossy().into_owned(),
+    ))
+}
+
+/// Sync cleanup used by the shim `delete` subcommand (`clean_sandbox_resource`)
+/// so a crashed shim still drops `/data/cubelet/log/<id>` when containerd
+/// reaps the leftover task.
+pub fn remove_sandbox_log_dir_sync(sandbox_id: &str) -> CResult<()> {
+    let dir = sandbox_log_dir(sandbox_id)?;
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("del {} failed:{}", dir.display(), e)),
+    }
+}
+
+pub async fn remove_sandbox_log_dir(sandbox_id: &str, log: &Log) {
+    if let Err(e) = remove_sandbox_log_dir_sync(sandbox_id) {
+        warnf!(log, "remove sandbox log dir: {}", e);
+    }
+}
+
 #[derive(Clone)]
 pub struct Container {
     sandbox_id: String,
@@ -151,8 +189,8 @@ pub struct Container {
     execs: Arc<Mutex<HashMap<String, Exec>>>,
     app_snapshot: bool,
     /// Background task forwarding container stdout/stderr to log files.
-    /// Template creation: /data/log/template/<id>/stdout|stderr (755 dir).
-    /// Normal sandbox: ./stdout and ./stderr relative to the bundle directory.
+    /// Template creation: /data/log/template/<id>/stdout|stderr.
+    /// Normal sandbox: /data/cubelet/log/<sandbox-id>/stdout|stderr.
     /// Clones share the task ownership so exactly one caller takes and awaits
     /// it; start/stop are serialized across clones by an internal semaphore.
     log_forward: LogForwardHandle,
@@ -510,12 +548,14 @@ impl Container {
         self.id == self.real_id
     }
 
-    /// Template creation writes stdout/stderr to regular files under
-    /// /data/log/template. Regular files cannot be registered with epoll, so
-    /// keep that path on the legacy RPC log forwarder even when passfd is the
-    /// sandbox default.
+    /// Passfd stays compiled in but is opt-in. Cubelet must set
+    /// `cube.use_passfd_io=true` and publish nonempty stdout/stderr paths.
+    /// Template builds and the default cubelet path keep the RPC log forwarder.
     fn passfd_io_enabled(&self) -> bool {
-        self.sb_conf.use_passfd_io && !self.sb_conf.app_snapshot_create
+        self.sb_conf.use_passfd_io
+            && !self.sb_conf.app_snapshot_create
+            && !self.info.stdout.is_empty()
+            && !self.info.stderr.is_empty()
     }
 
     pub async fn create_container(&mut self) -> CResult<()> {
@@ -641,8 +681,7 @@ impl Container {
     /// Spawn a background task that streams container stdout/stderr from the
     /// agent (via a fresh vsock connection) and appends them to log files.
     /// Template creation writes to `/data/log/template/<id>/stdout|stderr`;
-    /// normal sandbox restore writes to `./stdout` and `./stderr` relative
-    /// to the shim's current working directory (the bundle directory).
+    /// normal sandboxes write to `/data/cubelet/log/<sandbox-id>/stdout|stderr`.
     ///
     /// The task exits cleanly when `stop_log_forward` is called (pause /
     /// snapshot / kill / destroy): a watch cancel signal is sent first so the
@@ -675,7 +714,7 @@ impl Container {
 
         // Write log files:
         //   - template creation: /data/log/template/<id>/stdout|stderr
-        //   - sandbox (restore): current working directory (bundle dir)
+        //   - regular sandbox: /data/cubelet/log/<sandbox-id>/stdout|stderr
         let (stdout_path, stderr_path) = if self.sb_conf.app_snapshot_create {
             validate_log_path_component(&self.info.id)?;
             let log_dir = format!("/data/log/template/{}", self.info.id);
@@ -688,7 +727,7 @@ impl Container {
             // already restrictive enough for log files.
             (format!("{}/stdout", log_dir), format!("{}/stderr", log_dir))
         } else {
-            ("stdout".to_string(), "stderr".to_string())
+            create_sandbox_log_paths(&self.sandbox_id).await?
         };
 
         // Init log forwarding is separate from exec I/O relay (forward_std).
@@ -1294,5 +1333,33 @@ mod log_forward_tests {
             observed, 1,
             "stop must drain the task the start installed, not abort it"
         );
+    }
+}
+
+#[cfg(test)]
+mod sandbox_log_path_tests {
+    use super::{sandbox_log_dir, SANDBOX_LOG_ROOT};
+
+    #[test]
+    fn sandbox_log_dir_joins_root() {
+        let dir = sandbox_log_dir("aabbccddeeff00112233445566778899").unwrap();
+        assert_eq!(
+            dir,
+            std::path::Path::new(SANDBOX_LOG_ROOT).join("aabbccddeeff00112233445566778899")
+        );
+    }
+
+    #[test]
+    fn sandbox_log_dir_rejects_traversal() {
+        assert!(sandbox_log_dir("../etc").is_err());
+        assert!(sandbox_log_dir("a/b").is_err());
+        assert!(sandbox_log_dir("").is_err());
+    }
+
+    #[test]
+    fn remove_sandbox_log_dir_sync_rejects_traversal() {
+        assert!(super::remove_sandbox_log_dir_sync("../etc").is_err());
+        assert!(super::remove_sandbox_log_dir_sync("a/b").is_err());
+        assert!(super::remove_sandbox_log_dir_sync("").is_err());
     }
 }

--- a/CubeShim/shim/src/container/mod.rs
+++ b/CubeShim/shim/src/container/mod.rs
@@ -149,9 +149,21 @@ pub async fn create_sandbox_log_paths(sandbox_id: &str) -> CResult<(String, Stri
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|e| format!("create log dir {}: {}", dir.display(), e))?;
+    let stdout = dir.join("stdout");
+    let stderr = dir.join("stderr");
+    // Pause reaps the previous shim via binary delete and removes this
+    // directory. Resume is a new shim and must recreate the files.
+    for path in [&stdout, &stderr] {
+        tokio::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(path)
+            .await
+            .map_err(|e| format!("create log file {}: {}", path.display(), e))?;
+    }
     Ok((
-        dir.join("stdout").to_string_lossy().into_owned(),
-        dir.join("stderr").to_string_lossy().into_owned(),
+        stdout.to_string_lossy().into_owned(),
+        stderr.to_string_lossy().into_owned(),
     ))
 }
 

--- a/CubeShim/shim/src/sandbox/config.rs
+++ b/CubeShim/shim/src/sandbox/config.rs
@@ -525,15 +525,31 @@ mod tests {
         );
 
         annotations.insert("cube.use_passfd_io".to_string(), "true".to_string());
-        assert!(Config::new(&Some(annotations.clone())).unwrap().use_passfd_io);
+        assert!(
+            Config::new(&Some(annotations.clone()))
+                .unwrap()
+                .use_passfd_io
+        );
 
         annotations.insert("cube.use_passfd_io".to_string(), "TRUE".to_string());
-        assert!(Config::new(&Some(annotations.clone())).unwrap().use_passfd_io);
+        assert!(
+            Config::new(&Some(annotations.clone()))
+                .unwrap()
+                .use_passfd_io
+        );
 
         annotations.insert("cube.use_passfd_io".to_string(), "false".to_string());
-        assert!(!Config::new(&Some(annotations.clone())).unwrap().use_passfd_io);
+        assert!(
+            !Config::new(&Some(annotations.clone()))
+                .unwrap()
+                .use_passfd_io
+        );
 
         annotations.insert("cube.use_passfd_io".to_string(), "1".to_string());
-        assert!(!Config::new(&Some(annotations.clone())).unwrap().use_passfd_io);
+        assert!(
+            !Config::new(&Some(annotations.clone()))
+                .unwrap()
+                .use_passfd_io
+        );
     }
 }

--- a/CubeShim/shim/src/sandbox/config.rs
+++ b/CubeShim/shim/src/sandbox/config.rs
@@ -101,7 +101,7 @@ impl Default for Config {
             notify_snapshot_ret: false,
             app_snapshot_create: false,
             app_snapshot_restore: false,
-            use_passfd_io: true,
+            use_passfd_io: false,
             extra_kernel_params: Vec::new(),
         }
     }
@@ -182,10 +182,12 @@ impl Config {
             }
         };
 
+        // Opt-in only: cubelet must set cube.use_passfd_io=true. Missing or
+        // any other value keeps the legacy RPC log-forward path.
         let use_passfd_io = anno
             .get("cube.use_passfd_io")
-            .map(|v| !v.eq_ignore_ascii_case("false"))
-            .unwrap_or(true);
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
 
         let mut cube_vips = String::new();
         if let Some(v) = anno.get(ANNO_CUBE_VIPS) {
@@ -508,5 +510,30 @@ mod tests {
         assert!(ret.is_ok());
         let config = ret.unwrap();
         assert_eq!(config.extra_kernel_params, vec!["single=param".to_string()]);
+    }
+
+    #[test]
+    fn passfd_io_is_opt_in() {
+        let mut annotations = HashMap::<String, String>::new();
+        let res = r#"{"cpu": 1, "memory": 2048, "preserve_memory": 2048, "snap_memory": 2048}"#;
+        annotations.insert(ANNO_VM_RES.to_string(), res.to_string());
+
+        let config = Config::new(&Some(annotations.clone())).unwrap();
+        assert!(
+            !config.use_passfd_io,
+            "missing annotation must keep the legacy log-forward path"
+        );
+
+        annotations.insert("cube.use_passfd_io".to_string(), "true".to_string());
+        assert!(Config::new(&Some(annotations.clone())).unwrap().use_passfd_io);
+
+        annotations.insert("cube.use_passfd_io".to_string(), "TRUE".to_string());
+        assert!(Config::new(&Some(annotations.clone())).unwrap().use_passfd_io);
+
+        annotations.insert("cube.use_passfd_io".to_string(), "false".to_string());
+        assert!(!Config::new(&Some(annotations.clone())).unwrap().use_passfd_io);
+
+        annotations.insert("cube.use_passfd_io".to_string(), "1".to_string());
+        assert!(!Config::new(&Some(annotations.clone())).unwrap().use_passfd_io);
     }
 }

--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -1074,7 +1074,12 @@ impl SandBox {
             let mut containers = self.containers.lock().await;
             match containers.get_mut(id) {
                 Some(c) => c.clone(),
-                None => return Err(Error::NotFoundError(format!("not found container:{}", id))),
+                None => {
+                    if id == &self.id && !self.conf.app_snapshot_create {
+                        crate::container::remove_sandbox_log_dir(&self.id, &self.log).await;
+                    }
+                    return Err(Error::NotFoundError(format!("not found container:{}", id)));
+                }
             }
         };
         let (code, tm) = container
@@ -1085,6 +1090,11 @@ impl SandBox {
         let mut containers = self.containers.lock().await;
         if containers.remove(id).is_none() {
             warnf!(self.log, "remove container:{} failed from map", id);
+        }
+        // Live Task.Delete. Crash leftover is cleaned by the delete subcommand
+        // (`clean_sandbox_resource`). Pause-to-snapshot returns before here.
+        if id == &self.id && !self.conf.app_snapshot_create {
+            crate::container::remove_sandbox_log_dir(&self.id, &self.log).await;
         }
         Ok((code, tm))
     }

--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -1075,9 +1075,13 @@ impl SandBox {
             match containers.get_mut(id) {
                 Some(c) => c.clone(),
                 None => {
-                    if id == &self.id && !self.conf.app_snapshot_create {
+                    let should_clean = id == &self.id && !self.conf.app_snapshot_create;
+                    drop(containers);
+                    if should_clean {
                         crate::container::remove_sandbox_log_dir(&self.id, &self.log).await;
                     }
+                    // Keep NotFound: cubelet already treats it as success on
+                    // destroy. Changing the RPC contract is out of scope.
                     return Err(Error::NotFoundError(format!("not found container:{}", id)));
                 }
             }
@@ -1087,9 +1091,11 @@ impl SandBox {
             .await
             .map_err(|e| Error::Other(format!("{}", e)))?;
 
-        let mut containers = self.containers.lock().await;
-        if containers.remove(id).is_none() {
-            warnf!(self.log, "remove container:{} failed from map", id);
+        {
+            let mut containers = self.containers.lock().await;
+            if containers.remove(id).is_none() {
+                warnf!(self.log, "remove container:{} failed from map", id);
+            }
         }
         // Live Task.Delete. Crash leftover is cleaned by the delete subcommand
         // (`clean_sandbox_resource`). Pause-to-snapshot returns before here.

--- a/CubeShim/shim/src/service/srv.rs
+++ b/CubeShim/shim/src/service/srv.rs
@@ -66,6 +66,8 @@ impl Shim for Service {
             let _ = fs::remove_file(sk_file.as_str());
         }
 
+        // Binary delete: also removes /data/cubelet/log/<id> so a crashed
+        // shim does not leak host log files until a later live Task.Delete.
         utils::Utils::clean_sandbox_resource(&self.id).map_err(Error::Other)?;
 
         Ok(api::DeleteResponse::new())

--- a/Cubelet/cmd/cubecli/commands/cubebox/logs.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/logs.go
@@ -224,7 +224,7 @@ func readBundleLog(sandboxID, stream string, all bool, tailN, headN int) error {
 	f, err := openNoFollow(logPath, cubeletStateDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("log file not found: %s (also tried %s)\n(sandbox may not exist or log forwarding may not be enabled)", filepath.Join(sandboxlog.Dir, sandboxID, stream), logPath)
+			return fmt.Errorf("log file not found at %s (host) or %s (legacy bundle)\n(sandbox may not exist or log forwarding may not be enabled)", filepath.Join(sandboxlog.Dir, sandboxID, stream), logPath)
 		}
 		return fmt.Errorf("open %s: %w", logPath, err)
 	}
@@ -310,10 +310,6 @@ func openHostSandboxLog(sandboxID, stream string) (*os.File, string, error) {
 // openSandboxLogFrom tries the host log directory first, then the legacy
 // containerd bundle path. Used by unit tests; live cubecli splits the two
 // paths across host vs mount-namespace processes.
-func openSandboxLog(sandboxID, stream string) (*os.File, string, error) {
-	return openSandboxLogFrom(sandboxID, stream, sandboxlog.Dir, cubeletStateDir)
-}
-
 func openSandboxLogFrom(sandboxID, stream, newBase, oldBase string) (*os.File, string, error) {
 	newPath := filepath.Join(newBase, sandboxID, stream)
 	f, err := openNoFollow(newPath, newBase)
@@ -330,7 +326,7 @@ func openSandboxLogFrom(sandboxID, stream, newBase, oldBase string) (*os.File, s
 		return f, oldPath, nil
 	}
 	if os.IsNotExist(err) {
-		return nil, newPath, fmt.Errorf("log file not found: %s (also tried %s)\n(sandbox may not exist or log forwarding may not be enabled)", newPath, oldPath)
+		return nil, newPath, fmt.Errorf("log file not found at %s (host) or %s (legacy bundle)\n(sandbox may not exist or log forwarding may not be enabled)", newPath, oldPath)
 	}
 	return nil, oldPath, fmt.Errorf("open %s: %w", oldPath, err)
 }

--- a/Cubelet/cmd/cubecli/commands/cubebox/logs.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/logs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/cmd/cubecli/commands"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/sandboxid"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/sandboxlog"
 	"github.com/tencentcloud/CubeSandbox/pkgs/proto/services/cubebox/v1"
 )
 
@@ -41,17 +42,22 @@ const (
 //
 // Sandbox log files live at:
 //
-//	<cubeletStateDir>/<sandboxID>/stdout|stderr  (inside cubelet mount namespace)
+//	/data/cubelet/log/<sandboxID>/stdout|stderr  (host filesystem, no ns)
+//
+// If that file is missing, cubecli falls back to the pre-v0.7.1 bundle path
+// inside the cubelet mount namespace:
+//
+//	<cubeletStateDir>/<sandboxID>/stdout|stderr
 //
 // Template log files live at:
 //
 //	<templateLogDir>/<templateID>_0/stdout|stderr  (host filesystem, no ns needed)
 //
 // The "_0" suffix is the container index within the sandbox (currently always 0).
-// For sandbox logs the process re-execs itself with CUBEMNT=1 so the C
-// constructor in pkg/cubemnt/nsenter.c enters the mount namespace while still
-// single-threaded.  Template logs are on the host filesystem and need no
-// namespace entry.
+// Host `/data/cubelet/log` is tried first without entering a namespace. Only
+// the bundle fallback re-execs with CUBEMNT=1 so the C constructor in
+// pkg/cubemnt/nsenter.c enters the cubelet mount namespace while still
+// single-threaded.
 var LogsCommand = &cli.Command{
 	Name:  "logs",
 	Usage: "show container stdout/stderr log for a sandbox or template",
@@ -126,13 +132,14 @@ var LogsCommand = &cli.Command{
 			return readTemplateLog(id, stream, all, tailN, headN)
 		}
 
-		// Already inside the namespace: do the real work.
+		// Bundle fallback after CUBEMNT re-exec: only the legacy path is
+		// visible inside the cubelet mount namespace.
 		if os.Getenv(envLogsMode) == "1" {
-			return readLog(id, stream, all, tailN, headN)
+			return readBundleLog(id, stream, all, tailN, headN)
 		}
 
-		// Resolve short sandbox ID prefix to full 32-char ID before re-exec
-		// so the child process can locate the log directory directly.
+		// Resolve short sandbox ID prefix to full 32-char ID before opening
+		// files or re-exec so both paths use the canonical ID.
 		originalID := id
 		if !sandboxid.IsFullID(id) {
 			resolved, err := resolveLogsSandboxID(cliCtx, id)
@@ -140,6 +147,14 @@ var LogsCommand = &cli.Command{
 				return err
 			}
 			id = resolved
+		}
+
+		// Host path first: shim writes here, no mount namespace required.
+		if f, logPath, err := openHostSandboxLog(id, stream); err == nil {
+			defer f.Close()
+			return printLog(f, logPath, id, all, tailN, headN)
+		} else if !os.IsNotExist(err) {
+			return err
 		}
 
 		// Re-exec with CUBEMNT=1 so the C constructor enters the cubelet mount
@@ -203,23 +218,24 @@ func openNoFollow(path, base string) (*os.File, error) {
 	return os.NewFile(uintptr(fd), resolvedPath), nil
 }
 
-// readLog opens the log file for sandboxID/stream and prints lines according
-// to the requested mode. Must be called after entering the cubelet mount namespace.
-func readLog(sandboxID, stream string, all bool, tailN, headN int) error {
+// readBundleLog opens the legacy bundle log inside the cubelet mount namespace.
+func readBundleLog(sandboxID, stream string, all bool, tailN, headN int) error {
 	logPath := filepath.Join(cubeletStateDir, sandboxID, stream)
-
 	f, err := openNoFollow(logPath, cubeletStateDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("log file not found: %s\n(sandbox may not exist or log forwarding may not be enabled)", logPath)
+			return fmt.Errorf("log file not found: %s (also tried %s)\n(sandbox may not exist or log forwarding may not be enabled)", filepath.Join(sandboxlog.Dir, sandboxID, stream), logPath)
 		}
 		return fmt.Errorf("open %s: %w", logPath, err)
 	}
 	defer f.Close()
+	return printLog(f, logPath, sandboxID, all, tailN, headN)
+}
 
+func printLog(f *os.File, logPath, sandboxID string, all bool, tailN, headN int) error {
 	switch {
 	case all:
-		if _, err = io.Copy(os.Stdout, f); err != nil {
+		if _, err := io.Copy(os.Stdout, f); err != nil {
 			return fmt.Errorf("reading log for %s: %w", sandboxID, err)
 		}
 		return nil
@@ -277,6 +293,46 @@ func printTail(r io.Reader, logPath string, n int) error {
 		fmt.Println(buf[(start+i)%n])
 	}
 	return nil
+}
+
+func openHostSandboxLog(sandboxID, stream string) (*os.File, string, error) {
+	path := filepath.Join(sandboxlog.Dir, sandboxID, stream)
+	f, err := openNoFollow(path, sandboxlog.Dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, path, err
+		}
+		return nil, path, fmt.Errorf("open %s: %w", path, err)
+	}
+	return f, path, nil
+}
+
+// openSandboxLogFrom tries the host log directory first, then the legacy
+// containerd bundle path. Used by unit tests; live cubecli splits the two
+// paths across host vs mount-namespace processes.
+func openSandboxLog(sandboxID, stream string) (*os.File, string, error) {
+	return openSandboxLogFrom(sandboxID, stream, sandboxlog.Dir, cubeletStateDir)
+}
+
+func openSandboxLogFrom(sandboxID, stream, newBase, oldBase string) (*os.File, string, error) {
+	newPath := filepath.Join(newBase, sandboxID, stream)
+	f, err := openNoFollow(newPath, newBase)
+	if err == nil {
+		return f, newPath, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, newPath, fmt.Errorf("open %s: %w", newPath, err)
+	}
+
+	oldPath := filepath.Join(oldBase, sandboxID, stream)
+	f, err = openNoFollow(oldPath, oldBase)
+	if err == nil {
+		return f, oldPath, nil
+	}
+	if os.IsNotExist(err) {
+		return nil, newPath, fmt.Errorf("log file not found: %s (also tried %s)\n(sandbox may not exist or log forwarding may not be enabled)", newPath, oldPath)
+	}
+	return nil, oldPath, fmt.Errorf("open %s: %w", oldPath, err)
 }
 
 // resolveLogsSandboxID resolves a short sandbox ID prefix to the full 32-char

--- a/Cubelet/cmd/cubecli/commands/cubebox/logs_test.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/logs_test.go
@@ -5,6 +5,9 @@
 package cubebox
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -79,5 +82,66 @@ func TestReplacePositionalArgDoesNotModifyOriginal(t *testing.T) {
 	_ = replacePositionalArg(original, "aabbccdd", "aabbccddeeff00112233445566778899")
 	if original[2] != "aabbccdd" {
 		t.Fatalf("original slice was modified: got %q want %q", original[2], "aabbccdd")
+	}
+}
+
+func TestOpenSandboxLogFromPrefersNewPath(t *testing.T) {
+	newBase := t.TempDir()
+	oldBase := t.TempDir()
+	id := "aabbccddeeff00112233445566778899"
+	if err := os.MkdirAll(filepath.Join(newBase, id), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(oldBase, id), 0755); err != nil {
+		t.Fatal(err)
+	}
+	newFile := filepath.Join(newBase, id, "stdout")
+	oldFile := filepath.Join(oldBase, id, "stdout")
+	if err := os.WriteFile(newFile, []byte("new\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldFile, []byte("old\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, path, err := openSandboxLogFrom(id, "stdout", newBase, oldBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if path != newFile {
+		t.Fatalf("path=%q want %q", path, newFile)
+	}
+}
+
+func TestOpenSandboxLogFromFallsBackToBundle(t *testing.T) {
+	newBase := t.TempDir()
+	oldBase := t.TempDir()
+	id := "aabbccddeeff00112233445566778899"
+	if err := os.MkdirAll(filepath.Join(oldBase, id), 0755); err != nil {
+		t.Fatal(err)
+	}
+	oldFile := filepath.Join(oldBase, id, "stdout")
+	if err := os.WriteFile(oldFile, []byte("old\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, path, err := openSandboxLogFrom(id, "stdout", newBase, oldBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if path != oldFile {
+		t.Fatalf("path=%q want %q", path, oldFile)
+	}
+}
+
+func TestOpenSandboxLogFromMissingBoth(t *testing.T) {
+	_, _, err := openSandboxLogFrom("aabbccddeeff00112233445566778899", "stdout", t.TempDir(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected missing log error")
+	}
+	if !strings.Contains(err.Error(), "log file not found") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/Cubelet/pkg/sandboxlog/sandboxlog.go
+++ b/Cubelet/pkg/sandboxlog/sandboxlog.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Package sandboxlog holds the host path where the shim writes init logs.
+//
+// Regular (non-template) sandboxes:
+//
+//	/data/cubelet/log/<sandbox-id>/stdout
+//	/data/cubelet/log/<sandbox-id>/stderr
+//
+// The shim creates and deletes these files. cubecli reads them on the host
+// filesystem (no mount-namespace entry). Template-build logs stay under
+// /data/log/template.
+package sandboxlog
+
+// Dir is the host directory for sandbox init logs. Not configurable.
+const Dir = "/data/cubelet/log"

--- a/agent/rustjail/src/process.rs
+++ b/agent/rustjail/src/process.rs
@@ -671,6 +671,24 @@ impl Process {
         Some(reader)
     }
 
+    /// After snapshot restore, cached Tokio `PipeStream` wrappers still point
+    /// at the pre-snapshot reactor. Dup the log-pipe read ends and drop the
+    /// cache so the next `read_stdout` / `read_stderr` attaches cleanly.
+    /// The write ends inherited by the init process are unchanged.
+    pub fn reset_log_stream_readers(&mut self) -> result::Result<(), String> {
+        if let Some(fd) = self.parent_stdout {
+            let dup = unistd::dup(fd).map_err(|e| format!("dup parent_stdout: {:?}", e))?;
+            self.parent_stdout = Some(dup);
+        }
+        if let Some(fd) = self.parent_stderr {
+            let dup = unistd::dup(fd).map_err(|e| format!("dup parent_stderr: {:?}", e))?;
+            self.parent_stderr = Some(dup);
+        }
+        self.readers.clear();
+        self.writers.clear();
+        Ok(())
+    }
+
     pub fn get_writer(&mut self, stream_type: StreamType) -> Option<Writer> {
         if let Some(writer) = self.writers.get(&stream_type) {
             return Some(writer.clone());
@@ -781,5 +799,25 @@ mod tests {
         assert!(process.parent_stdin.is_none());
         assert!(process.parent_stdout.is_none());
         assert!(process.parent_stderr.is_none());
+    }
+
+    #[test]
+    fn test_reset_log_stream_readers_keeps_pipe_readable() {
+        let (r, w) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
+        let logger = Logger::root(slog::Discard, o!("source" => "unit-test"));
+        let mut process = Process::new(&logger, &OCIProcess::default(), "reset-io", true, 32)
+            .unwrap();
+        process.parent_stdout = Some(r);
+        process.reset_log_stream_readers().unwrap();
+        assert!(process.readers.is_empty());
+        assert!(process.writers.is_empty());
+        let new_fd = process.parent_stdout.expect("duped stdout");
+        assert_ne!(new_fd, r);
+        unistd::write(w, b"x").unwrap();
+        let mut buf = [0u8; 1];
+        assert_eq!(unistd::read(new_fd, &mut buf).unwrap(), 1);
+        assert_eq!(&buf, b"x");
+        let _ = unistd::close(w);
+        let _ = unistd::close(new_fd);
     }
 }

--- a/agent/rustjail/src/process.rs
+++ b/agent/rustjail/src/process.rs
@@ -805,8 +805,8 @@ mod tests {
     fn test_reset_log_stream_readers_keeps_pipe_readable() {
         let (r, w) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
         let logger = Logger::root(slog::Discard, o!("source" => "unit-test"));
-        let mut process = Process::new(&logger, &OCIProcess::default(), "reset-io", true, 32)
-            .unwrap();
+        let mut process =
+            Process::new(&logger, &OCIProcess::default(), "reset-io", true, 32).unwrap();
         process.parent_stdout = Some(r);
         process.reset_log_stream_readers().unwrap();
         assert!(process.readers.is_empty());

--- a/agent/src/rpc.rs
+++ b/agent/src/rpc.rs
@@ -195,6 +195,13 @@ impl AgentService {
                     info!(sl!(), "reconnecting passfd for restored container {}", id);
                     process.reconnect_passfd(io).await?;
                 }
+                process
+                    .reset_log_stream_readers()
+                    .map_err(|e| anyhow!(e))?;
+                info!(
+                    sl!(),
+                    "reset log-forward readers for restored container {}", id
+                );
 
                 process.pid
             };

--- a/agent/src/rpc.rs
+++ b/agent/src/rpc.rs
@@ -195,9 +195,7 @@ impl AgentService {
                     info!(sl!(), "reconnecting passfd for restored container {}", id);
                     process.reconnect_passfd(io).await?;
                 }
-                process
-                    .reset_log_stream_readers()
-                    .map_err(|e| anyhow!(e))?;
+                process.reset_log_stream_readers().map_err(|e| anyhow!(e))?;
                 info!(
                     sl!(),
                     "reset log-forward readers for restored container {}", id

--- a/tests/e2e/sdk_compat/cases/framework/test_sandbox_logs.py
+++ b/tests/e2e/sdk_compat/cases/framework/test_sandbox_logs.py
@@ -103,10 +103,18 @@ def test_host_log_paths():
     assert sandbox_logs.template_log_dir("tpl-example").name == "tpl-example_0"
 
 
+def test_guest_envd_health_cmd():
+    assert "127.0.0.1:49983/health" in sandbox_logs.GUEST_ENVD_HEALTH_CMD
+    assert "cube-e2e-log" in sandbox_logs.guest_envd_probe_cmd("/cube-e2e-log")
+
+
 def test_contains_envd_access_log():
     assert not sandbox_logs.contains_envd_access_log("")
     assert sandbox_logs.contains_envd_access_log('GET /health HTTP/1.1" 200')
     assert sandbox_logs.contains_envd_access_log("POST /process.Process/Start")
+    assert sandbox_logs.contains_envd_access_log("Uvicorn running on http://0.0.0.0:49999")
+    assert sandbox_logs.contains_envd_access_log("cube-e2e-log-deadbeef")
+    assert sandbox_logs.count_envd_access('GET /health\nPOST /process.Process/Start\n') == 2
 
 
 def test_count_envd_rpc():

--- a/tests/e2e/sdk_compat/cases/framework/test_sandbox_logs.py
+++ b/tests/e2e/sdk_compat/cases/framework/test_sandbox_logs.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hermetic tests for single-node cubecli log helpers."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from framework import sandbox_logs
+
+
+pytestmark = pytest.mark.framework
+
+
+def test_parse_ops_node_count_array():
+    assert sandbox_logs.parse_ops_node_count([{"id": "a"}, {"id": "b"}]) == 2
+    assert sandbox_logs.parse_ops_node_count([]) == 0
+
+
+def test_parse_ops_node_count_wrapped():
+    assert sandbox_logs.parse_ops_node_count({"data": [{"id": "a"}]}) == 1
+    assert sandbox_logs.parse_ops_node_count({"nodes": []}) == 0
+    assert sandbox_logs.parse_ops_node_count({"items": [{}, {}, {}]}) == 3
+
+
+def test_parse_ops_node_count_rejects_unknown():
+    assert sandbox_logs.parse_ops_node_count({"ok": True}) is None
+    assert sandbox_logs.parse_ops_node_count("1") is None
+    assert sandbox_logs.parse_ops_node_count(None) is None
+
+
+def test_parse_master_nodes_scanned():
+    text = "NODE_SCOPE       all\nNODES_SCANNED    1/1\nSANDBOX_COUNT    0\n"
+    assert sandbox_logs.parse_master_nodes_scanned(text) == 1
+    assert sandbox_logs.parse_master_nodes_scanned("NODES_SCANNED    2/3") == 3
+    assert sandbox_logs.parse_master_nodes_scanned("no such line") is None
+    assert sandbox_logs.parse_master_nodes_scanned("NODES_SCANNED    bogus") is None
+
+
+def test_cubecli_logs_argv_sandbox_and_template():
+    assert sandbox_logs.cubecli_logs_argv(
+        "/opt/cubecli",
+        "aabbccdd",
+        address="/data/cubelet/cubelet.sock",
+    ) == [
+        "/opt/cubecli",
+        "--address",
+        "/data/cubelet/cubelet.sock",
+        "logs",
+        "--all",
+        "aabbccdd",
+    ]
+    assert sandbox_logs.cubecli_logs_argv(
+        "/opt/cubecli",
+        "tpl-example",
+        address="/data/cubelet/cubelet.sock",
+        template=True,
+        stream="stderr",
+    ) == [
+        "/opt/cubecli",
+        "logs",
+        "--tpl",
+        "--stderr",
+        "--all",
+        "tpl-example",
+    ]
+
+
+def test_resolve_cubecli_prefers_env(tmp_path):
+    cubecli = tmp_path / "cubecli"
+    cubecli.write_text("#!/bin/sh\n", encoding="utf-8")
+    cubecli.chmod(0o755)
+    assert sandbox_logs.resolve_cubecli({"CUBECLI": str(cubecli)}) == str(cubecli)
+    assert sandbox_logs.resolve_cubecli({"CUBECLI": str(tmp_path / "missing")}) is None
+
+
+def test_skip_unless_single_node_skips_cluster():
+    runner = mock.Mock(
+        return_value=mock.Mock(returncode=0, stdout='[{"id":"a"},{"id":"b"}]')
+    )
+    with (
+        mock.patch.object(sandbox_logs.shutil, "which", return_value="/bin/cubeopscli"),
+        pytest.raises(pytest.skip.Exception, match="single-node only"),
+    ):
+        sandbox_logs.skip_unless_single_node_cubecli(runner=runner)
+
+
+def test_skip_unless_single_node_skips_unknown_topology():
+    runner = mock.Mock(return_value=mock.Mock(returncode=1, stdout=""))
+    with (
+        mock.patch.object(sandbox_logs.shutil, "which", return_value=None),
+        pytest.raises(pytest.skip.Exception, match="could not determine"),
+    ):
+        sandbox_logs.skip_unless_single_node_cubecli(env={}, runner=runner)
+
+
+def test_host_log_paths():
+    stdout, stderr = sandbox_logs.host_log_paths("aabbccddeeff00112233445566778899")
+    assert stdout == sandbox_logs.host_log_dir("aabbccddeeff00112233445566778899") / "stdout"
+    assert stderr.name == "stderr"
+    assert sandbox_logs.template_log_dir("tpl-example").name == "tpl-example_0"
+
+
+def test_contains_envd_access_log():
+    assert not sandbox_logs.contains_envd_access_log("")
+    assert sandbox_logs.contains_envd_access_log('GET /health HTTP/1.1" 200')
+    assert sandbox_logs.contains_envd_access_log("POST /process.Process/Start")
+
+
+def test_count_envd_rpc():
+    assert sandbox_logs.count_envd_rpc("") == 0
+    text = (
+        'INFO:     10.0.0.1:1 - "POST /process.Process/Start HTTP/1.1" 200 OK\n'
+        'INFO:     10.0.0.1:2 - "POST /process.Process/Start HTTP/1.1" 200 OK\n'
+    )
+    assert sandbox_logs.count_envd_rpc(text) == 2
+
+
+def test_skip_unless_single_node_skips_missing_cubecli(tmp_path):
+    sock = tmp_path / "cubelet.sock"
+    sock.write_text("", encoding="utf-8")
+    runner = mock.Mock(return_value=mock.Mock(returncode=0, stdout='[{"id":"n1"}]'))
+    env = {
+        "CUBECLI": str(tmp_path / "missing"),
+        "CUBELET_ADDRESS": str(sock),
+        "CUBEOPSCLI": "/bin/cubeopscli",
+    }
+    with pytest.raises(pytest.skip.Exception, match="cubecli is not available"):
+        sandbox_logs.skip_unless_single_node_cubecli(env=env, runner=runner)
+
+
+def test_skip_unless_single_node_returns_paths(tmp_path):
+    cubecli = tmp_path / "cubecli"
+    cubecli.write_text("#!/bin/sh\n", encoding="utf-8")
+    cubecli.chmod(0o755)
+    sock = tmp_path / "cubelet.sock"
+    sock.write_text("", encoding="utf-8")
+    env = {
+        "CUBECLI": str(cubecli),
+        "CUBELET_ADDRESS": str(sock),
+        "CUBEOPSCLI": "/bin/cubeopscli",
+    }
+    runner = mock.Mock(return_value=mock.Mock(returncode=0, stdout='[{"id":"n1"}]'))
+    got_cli, got_addr = sandbox_logs.skip_unless_single_node_cubecli(
+        env=env, runner=runner
+    )
+    assert got_cli == str(cubecli)
+    assert got_addr == str(sock)

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_sandbox_envd_logs.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_sandbox_envd_logs.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single-node cubecli checks for envd init logs.
+
+SDK ``commands.run`` hits envd's ``/process.Process/Start`` RPC. envd prints
+that path in its access log; ``cubecli logs`` must show it after create,
+resume, snapshot, and rollback. Template-build logs stay under
+``/data/log/template`` and are read with ``cubecli logs --tpl``. Multi-node
+clusters skip: cubecli can only see the local Cubelet's files.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.capabilities import COMMANDS, PAUSE_RESUME, ROLLBACK_CLONE
+from framework.cleanup import safe_kill
+from framework.lifecycle import (
+    wait_until_data_plane_ready,
+    wait_until_paused,
+    wait_until_running,
+)
+from framework.sandbox_logs import (
+    HOST_LOG_ROOT,
+    TEMPLATE_ENVD_MARKER,
+    assert_host_logs_present,
+    contains_envd_access_log,
+    host_log_dir,
+    read_cubecli_logs,
+    skip_unless_single_node_cubecli,
+    template_log_dir,
+    trigger_envd,
+    wait_for_envd_rpc,
+    wait_host_logs_absent,
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.lifecycle,
+    pytest.mark.p1,
+]
+
+
+def _require_cubesandbox(sdk_backend: str) -> None:
+    if sdk_backend != "cubesandbox":
+        pytest.skip("cubecli envd-log checks only apply to the cubesandbox backend")
+
+
+@pytest.fixture
+def cubecli_logs_target(sdk_backend: str) -> tuple[str, str]:
+    _require_cubesandbox(sdk_backend)
+    return skip_unless_single_node_cubecli()
+
+
+def _trigger_and_wait(
+    adapter,
+    cubecli: str,
+    address: str,
+    *,
+    command_timeout: int,
+    wait_timeout: float,
+    min_count: int,
+) -> str:
+    trigger_envd(adapter, timeout=command_timeout)
+    return wait_for_envd_rpc(
+        cubecli,
+        adapter.sandbox_id,
+        address=address,
+        timeout=wait_timeout,
+        min_count=min_count,
+    )
+
+
+@pytest.mark.requires_capability(COMMANDS)
+def test_create_envd_rpc_visible_in_cubecli_logs(
+    sdk_sandbox,
+    sdk_e2e_config,
+    cubecli_logs_target,
+):
+    cubecli, address = cubecli_logs_target
+    assert_host_logs_present(sdk_sandbox.sandbox_id)
+    logs = _trigger_and_wait(
+        sdk_sandbox,
+        cubecli,
+        address,
+        command_timeout=sdk_e2e_config.command_timeout,
+        wait_timeout=sdk_e2e_config.command_timeout,
+        min_count=1,
+    )
+    assert contains_envd_access_log(logs)
+    sandbox_id = sdk_sandbox.sandbox_id
+    cleanup_errors = safe_kill(sdk_sandbox, sdk_e2e_config)
+    assert not cleanup_errors, f"sandbox cleanup failed: {cleanup_errors!r}"
+    wait_host_logs_absent(sandbox_id, timeout=sdk_e2e_config.default_timeout)
+
+
+@pytest.mark.requires_capability(COMMANDS)
+@pytest.mark.requires_capability(PAUSE_RESUME)
+def test_resume_appends_envd_rpc_to_cubecli_logs(
+    sdk_sandbox,
+    sdk_e2e_config,
+    cubecli_logs_target,
+):
+    cubecli, address = cubecli_logs_target
+    _trigger_and_wait(
+        sdk_sandbox,
+        cubecli,
+        address,
+        command_timeout=sdk_e2e_config.command_timeout,
+        wait_timeout=sdk_e2e_config.command_timeout,
+        min_count=1,
+    )
+    assert_host_logs_present(sdk_sandbox.sandbox_id)
+
+    sdk_sandbox.pause(timeout=sdk_e2e_config.default_timeout)
+    wait_until_paused(sdk_sandbox, timeout=sdk_e2e_config.default_timeout)
+    resumed = sdk_sandbox.resume_or_connect(timeout=sdk_e2e_config.default_timeout)
+    try:
+        wait_until_running(resumed, timeout=sdk_e2e_config.default_timeout)
+        wait_until_data_plane_ready(
+            resumed,
+            timeout=sdk_e2e_config.default_timeout,
+            command_timeout=sdk_e2e_config.command_timeout,
+        )
+        assert resumed.sandbox_id == sdk_sandbox.sandbox_id
+        assert_host_logs_present(resumed.sandbox_id)
+        logs = _trigger_and_wait(
+            resumed,
+            cubecli,
+            address,
+            command_timeout=sdk_e2e_config.command_timeout,
+            wait_timeout=sdk_e2e_config.command_timeout,
+            min_count=1,
+        )
+        assert contains_envd_access_log(logs)
+    finally:
+        resumed.close()
+
+
+@pytest.mark.requires_capability(COMMANDS)
+@pytest.mark.requires_capability(ROLLBACK_CLONE)
+def test_snapshot_rollback_keeps_envd_cubecli_logs(
+    sdk_sandbox,
+    sdk_e2e_config,
+    cubecli_logs_target,
+):
+    cubecli, address = cubecli_logs_target
+    _trigger_and_wait(
+        sdk_sandbox,
+        cubecli,
+        address,
+        command_timeout=sdk_e2e_config.command_timeout,
+        wait_timeout=sdk_e2e_config.command_timeout,
+        min_count=1,
+    )
+    assert_host_logs_present(sdk_sandbox.sandbox_id)
+
+    snapshot_id = None
+    cleanup_errors = []
+    cleanup_error = None
+    try:
+        snapshot_id = sdk_sandbox.create_snapshot()
+        _trigger_and_wait(
+            sdk_sandbox,
+            cubecli,
+            address,
+            command_timeout=sdk_e2e_config.command_timeout,
+            wait_timeout=sdk_e2e_config.command_timeout,
+            min_count=1,
+        )
+        assert_host_logs_present(sdk_sandbox.sandbox_id)
+
+        sdk_sandbox.rollback(snapshot_id)
+        wait_until_data_plane_ready(
+            sdk_sandbox,
+            timeout=sdk_e2e_config.default_timeout,
+            command_timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_host_logs_present(sdk_sandbox.sandbox_id)
+        logs = _trigger_and_wait(
+            sdk_sandbox,
+            cubecli,
+            address,
+            command_timeout=sdk_e2e_config.command_timeout,
+            wait_timeout=sdk_e2e_config.command_timeout,
+            min_count=1,
+        )
+        assert contains_envd_access_log(logs)
+    finally:
+        cleanup_errors.extend(safe_kill(sdk_sandbox, sdk_e2e_config))
+        if snapshot_id:
+            try:
+                from cases.lifecycle.test_rollback_clone import (
+                    _delete_snapshot_after_runtime_release,
+                )
+
+                _delete_snapshot_after_runtime_release(
+                    sdk_sandbox,
+                    snapshot_id,
+                    timeout=sdk_e2e_config.default_timeout,
+                )
+            except Exception as exc:  # noqa: BLE001 - do not mask the test failure
+                cleanup_error = exc
+    assert not cleanup_errors, f"sandbox cleanup failed: {cleanup_errors!r}"
+    assert cleanup_error is None, (
+        f"snapshot cleanup failed for {snapshot_id}: {cleanup_error}"
+    )
+
+
+def test_template_envd_output_in_cubecli_tpl_logs(
+    sdk_backend,
+    sdk_e2e_config,
+    cubecli_logs_target,
+):
+    _require_cubesandbox(sdk_backend)
+    if not sdk_e2e_config.cube_template_id:
+        pytest.skip("set CUBE_TEMPLATE_ID for template envd log checks")
+    cubecli, _address = cubecli_logs_target
+    logs = read_cubecli_logs(
+        cubecli,
+        sdk_e2e_config.cube_template_id,
+        template=True,
+    )
+    if TEMPLATE_ENVD_MARKER not in logs:
+        logs = logs + "\n" + read_cubecli_logs(
+            cubecli,
+            sdk_e2e_config.cube_template_id,
+            template=True,
+            stream="stderr",
+        )
+    assert TEMPLATE_ENVD_MARKER in logs, (
+        f"expected {TEMPLATE_ENVD_MARKER!r} in cubecli logs --tpl, got {logs!r}"
+    )
+
+
+@pytest.mark.requires_capability(COMMANDS)
+@pytest.mark.requires_capability(ROLLBACK_CLONE)
+def test_snapshot_start_envd_rpc_visible_in_cubecli_logs(
+    sdk_sandbox,
+    sdk_e2e_config,
+    cubecli_logs_target,
+):
+    from adapters.cubesandbox_adapter import CubeSandboxAdapter
+    from cases.lifecycle.test_rollback_clone import (
+        _delete_snapshot_after_runtime_release,
+    )
+
+    cubecli, address = cubecli_logs_target
+    _trigger_and_wait(
+        sdk_sandbox,
+        cubecli,
+        address,
+        command_timeout=sdk_e2e_config.command_timeout,
+        wait_timeout=sdk_e2e_config.command_timeout,
+        min_count=1,
+    )
+    snapshot_id = None
+    child = None
+    cleanup_error = None
+    try:
+        snapshot_id = sdk_sandbox.create_snapshot()
+        child = CubeSandboxAdapter.create(
+            sdk_e2e_config,
+            create_options={"template": snapshot_id},
+        )
+        wait_until_running(child, timeout=sdk_e2e_config.default_timeout)
+        wait_until_data_plane_ready(
+            child,
+            timeout=sdk_e2e_config.default_timeout,
+            command_timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_host_logs_present(child.sandbox_id)
+        logs = _trigger_and_wait(
+            child,
+            cubecli,
+            address,
+            command_timeout=sdk_e2e_config.command_timeout,
+            wait_timeout=sdk_e2e_config.command_timeout,
+            min_count=1,
+        )
+        assert contains_envd_access_log(logs)
+        child_id = child.sandbox_id
+        child_errors = safe_kill(child, sdk_e2e_config)
+        child = None
+        assert not child_errors, f"snapshot-start sandbox cleanup failed: {child_errors!r}"
+        wait_host_logs_absent(child_id, timeout=sdk_e2e_config.default_timeout)
+    finally:
+        if child is not None:
+            safe_kill(child, sdk_e2e_config)
+        if snapshot_id:
+            try:
+                _delete_snapshot_after_runtime_release(
+                    sdk_sandbox,
+                    snapshot_id,
+                    timeout=sdk_e2e_config.default_timeout,
+                )
+            except Exception as exc:  # noqa: BLE001 - do not mask the test failure
+                cleanup_error = exc
+    assert cleanup_error is None, (
+        f"snapshot cleanup failed for {snapshot_id}: {cleanup_error}"
+    )
+
+
+def test_template_build_writes_cubecli_tpl_logs(
+    sdk_backend,
+    sdk_e2e_config,
+    cubecli_logs_target,
+):
+    _require_cubesandbox(sdk_backend)
+    from cubesandbox import Config, Template
+    from cubesandbox._exceptions import ApiError, TemplateNotFoundError
+    from cases.templates.test_alias import (
+        DEFAULT_IMAGE,
+        DEFAULT_WRITABLE_LAYER_SIZE,
+        _delete_with_retry,
+        _wait_for_ready,
+    )
+    from framework.build_throttle import template_build_slot
+
+    cubecli, _address = cubecli_logs_target
+    cfg = Config(api_url=sdk_e2e_config.cube_api_url)
+    created_id = None
+    try:
+        with template_build_slot(label="envd_logs_template_build"):
+            job = Template.build(
+                image=DEFAULT_IMAGE,
+                writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE,
+                config=cfg,
+            )
+            created_id = job.template_id
+            _wait_for_ready(created_id, cfg, timeout=600)
+        logs = read_cubecli_logs(cubecli, created_id, template=True)
+        if TEMPLATE_ENVD_MARKER not in logs:
+            logs = logs + "\n" + read_cubecli_logs(
+                cubecli,
+                created_id,
+                template=True,
+                stream="stderr",
+            )
+        assert TEMPLATE_ENVD_MARKER in logs, (
+            f"expected {TEMPLATE_ENVD_MARKER!r} in cubecli logs --tpl "
+            f"after template build, got {logs!r}"
+        )
+        assert template_log_dir(created_id).is_dir(), (
+            f"missing template log dir {template_log_dir(created_id)}"
+        )
+    finally:
+        if created_id:
+            try:
+                _delete_with_retry(created_id, cfg)
+            except (ApiError, TemplateNotFoundError):
+                pass
+
+
+def test_cubecli_reads_host_log_without_mntns(cubecli_logs_target):
+    import shutil
+
+    cubecli, address = cubecli_logs_target
+    sandbox_id = "aabbccddeeff00112233445566778899"
+    directory = host_log_dir(sandbox_id)
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "stdout").write_text("host-path-compat-marker\n")
+        (directory / "stderr").write_text("")
+        logs = read_cubecli_logs(cubecli, sandbox_id, address=address)
+        assert "host-path-compat-marker" in logs
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+def test_cubecli_missing_log_mentions_host_and_bundle(cubecli_logs_target):
+    cubecli, address = cubecli_logs_target
+    sandbox_id = "ffffffffffffffffffffffffffffffff"
+    with pytest.raises(AssertionError) as exc:
+        read_cubecli_logs(cubecli, sandbox_id, address=address)
+    message = str(exc.value)
+    assert "log file not found" in message
+    assert HOST_LOG_ROOT in message
+    assert sandbox_id in message

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_sandbox_envd_logs.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_sandbox_envd_logs.py
@@ -3,11 +3,11 @@
 
 """Single-node cubecli checks for envd init logs.
 
-SDK ``commands.run`` hits envd's ``/process.Process/Start`` RPC. envd prints
-that path in its access log; ``cubecli logs`` must show it after create,
-resume, snapshot, and rollback. Template-build logs stay under
-``/data/log/template`` and are read with ``cubecli logs --tpl``. Multi-node
-clusters skip: cubecli can only see the local Cubelet's files.
+Tests GET envd ``/health`` so the access log writes to init stdout;
+``cubecli logs`` must show that after create, resume, snapshot, and
+rollback. Template-build logs stay under ``/data/log/template`` and are
+read with ``cubecli logs --tpl``. Multi-node clusters skip: cubecli can
+only see the local Cubelet's files.
 """
 
 from __future__ import annotations
@@ -32,6 +32,7 @@ from framework.sandbox_logs import (
     template_log_dir,
     trigger_envd,
     wait_for_envd_rpc,
+    wait_for_host_log_contains,
     wait_host_logs_absent,
 )
 
@@ -63,13 +64,14 @@ def _trigger_and_wait(
     wait_timeout: float,
     min_count: int,
 ) -> str:
-    trigger_envd(adapter, timeout=command_timeout)
+    marker = trigger_envd(adapter, timeout=command_timeout)
     return wait_for_envd_rpc(
         cubecli,
         adapter.sandbox_id,
         address=address,
         timeout=wait_timeout,
         min_count=min_count,
+        needles=(marker,),
     )
 
 
@@ -119,20 +121,26 @@ def test_resume_appends_envd_rpc_to_cubecli_logs(
     resumed = sdk_sandbox.resume_or_connect(timeout=sdk_e2e_config.default_timeout)
     try:
         wait_until_running(resumed, timeout=sdk_e2e_config.default_timeout)
+        assert resumed.sandbox_id == sdk_sandbox.sandbox_id
+        assert_host_logs_present(resumed.sandbox_id)
         wait_until_data_plane_ready(
             resumed,
             timeout=sdk_e2e_config.default_timeout,
             command_timeout=sdk_e2e_config.command_timeout,
         )
-        assert resumed.sandbox_id == sdk_sandbox.sandbox_id
-        assert_host_logs_present(resumed.sandbox_id)
-        logs = _trigger_and_wait(
-            resumed,
+        marker = trigger_envd(resumed, timeout=sdk_e2e_config.command_timeout)
+        wait_for_host_log_contains(
+            resumed.sandbox_id,
+            marker,
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        logs = wait_for_envd_rpc(
             cubecli,
-            address,
-            command_timeout=sdk_e2e_config.command_timeout,
-            wait_timeout=sdk_e2e_config.command_timeout,
+            resumed.sandbox_id,
+            address=address,
+            timeout=sdk_e2e_config.command_timeout,
             min_count=1,
+            needles=(marker,),
         )
         assert contains_envd_access_log(logs)
     finally:
@@ -173,19 +181,25 @@ def test_snapshot_rollback_keeps_envd_cubecli_logs(
         assert_host_logs_present(sdk_sandbox.sandbox_id)
 
         sdk_sandbox.rollback(snapshot_id)
+        assert_host_logs_present(sdk_sandbox.sandbox_id)
         wait_until_data_plane_ready(
             sdk_sandbox,
             timeout=sdk_e2e_config.default_timeout,
             command_timeout=sdk_e2e_config.command_timeout,
         )
-        assert_host_logs_present(sdk_sandbox.sandbox_id)
-        logs = _trigger_and_wait(
-            sdk_sandbox,
+        marker = trigger_envd(sdk_sandbox, timeout=sdk_e2e_config.command_timeout)
+        wait_for_host_log_contains(
+            sdk_sandbox.sandbox_id,
+            marker,
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        logs = wait_for_envd_rpc(
             cubecli,
-            address,
-            command_timeout=sdk_e2e_config.command_timeout,
-            wait_timeout=sdk_e2e_config.command_timeout,
+            sdk_sandbox.sandbox_id,
+            address=address,
+            timeout=sdk_e2e_config.command_timeout,
             min_count=1,
+            needles=(marker,),
         )
         assert contains_envd_access_log(logs)
     finally:

--- a/tests/e2e/sdk_compat/env.example
+++ b/tests/e2e/sdk_compat/env.example
@@ -126,3 +126,9 @@ SDK_E2E_REPORT_DIR=reports/sdk-dual
 # Override the local CubeSandbox Python SDK path when testing an unreleased
 # checkout or a custom SDK build.
 # CUBE_PYTHON_SDK_PATH=/path/to/CubeSandbox/sdk/python
+
+# Node-local cubecli envd-log checks (cases/lifecycle/test_sandbox_envd_logs.py).
+# Single-node only: multi-node clusters skip. Defaults look for cubecli next to
+# Cubelet and the Cubelet unix socket; override when the binaries live elsewhere.
+# CUBECLI=/usr/local/services/cubetoolbox/Cubelet/bin/cubecli
+# CUBELET_ADDRESS=/data/cubelet/cubelet.sock

--- a/tests/e2e/sdk_compat/framework/sandbox_logs.py
+++ b/tests/e2e/sdk_compat/framework/sandbox_logs.py
@@ -1,0 +1,334 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Node-local cubecli log helpers for single-node envd init-log checks.
+
+``cubecli logs`` reads ``/data/cubelet/log`` on the host, then the legacy
+bundle path inside the Cubelet mount namespace. That only works when the
+pytest process is on the same host as Cubelet, so these helpers refuse to
+run on a multi-node cluster (skip) and skip when cubecli or the Cubelet
+socket is missing.
+
+Sandbox checks trigger envd through the SDK process API
+(``commands.run`` → ``/process.Process/Start``) and then look for that RPC
+in the captured envd access log. Template-build checks read envd's own
+startup line via ``cubecli logs --tpl``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+DEFAULT_CUBECLI = "/usr/local/services/cubetoolbox/Cubelet/bin/cubecli"
+DEFAULT_CUBELET_ADDRESS = "/data/cubelet/cubelet.sock"
+HOST_LOG_ROOT = "/data/cubelet/log"
+TEMPLATE_LOG_ROOT = "/data/log/template"
+
+CLUSTER_SKIP_REASON = (
+    "cubecli init-log checks are single-node only; skipping on a multi-node cluster"
+)
+UNKNOWN_TOPOLOGY_SKIP_REASON = (
+    "could not determine the Cubelet node count; "
+    "refusing to guess this is a single-node deployment"
+)
+CUBECLI_SKIP_REASON = (
+    "cubecli is not available on this host; set CUBECLI to the cubecli binary"
+)
+SOCKET_SKIP_REASON = (
+    "Cubelet address is not present on this host; "
+    "set CUBELET_ADDRESS when cubecli lives next to Cubelet"
+)
+
+# envd / code images print this on the template-build console.
+TEMPLATE_ENVD_MARKER = "envd started"
+
+# SDK commands.run hits envd's Connect RPC; some envd builds echo that path,
+# others only log HTTP probes such as GET /health on the same access log.
+ENVD_PROCESS_RPC = "process.Process/Start"
+ENVD_ACCESS_MARKERS = (ENVD_PROCESS_RPC, "/health")
+
+
+def resolve_cubecli(env: dict[str, str] | None = None) -> str | None:
+    values = os.environ if env is None else env
+    explicit = (values.get("CUBECLI") or "").strip()
+    if explicit:
+        return explicit if _is_executable(explicit) else None
+    if _is_executable(DEFAULT_CUBECLI):
+        return DEFAULT_CUBECLI
+    return shutil.which("cubecli")
+
+
+def resolve_cubelet_address(env: dict[str, str] | None = None) -> str:
+    values = os.environ if env is None else env
+    return (values.get("CUBELET_ADDRESS") or DEFAULT_CUBELET_ADDRESS).strip()
+
+
+def parse_ops_node_count(payload: object) -> int | None:
+    if isinstance(payload, list):
+        return len(payload)
+    if isinstance(payload, dict):
+        for key in ("data", "nodes", "items"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return len(value)
+    return None
+
+
+def parse_master_nodes_scanned(text: str) -> int | None:
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] == "NODES_SCANNED" and "/" in parts[1]:
+            total = parts[1].split("/", 1)[1]
+            if total.isdigit():
+                return int(total)
+    return None
+
+
+def discover_node_count(
+    *,
+    env: dict[str, str] | None = None,
+    runner: Any = subprocess.run,
+) -> int | None:
+    """Return the registered Cubelet count, or None when it cannot be proven."""
+    values = os.environ if env is None else env
+    ops = (values.get("CUBEOPSCLI") or "").strip() or shutil.which("cubeopscli")
+    if ops:
+        try:
+            proc = runner(
+                [ops, "node", "list", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            proc = None
+        if proc is not None and proc.returncode == 0 and proc.stdout.strip():
+            try:
+                count = parse_ops_node_count(json.loads(proc.stdout))
+            except json.JSONDecodeError:
+                count = None
+            if count is not None:
+                return count
+
+    master = (values.get("CUBEMASTERCLI") or "").strip() or shutil.which(
+        "cubemastercli"
+    )
+    if not master:
+        master = shutil.which("cubemaster")
+    if not master:
+        return None
+    try:
+        proc = runner(
+            [master, "list", "--all", "--size", "1"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    return parse_master_nodes_scanned(proc.stdout)
+
+
+def cubecli_logs_argv(
+    cubecli: str,
+    target_id: str,
+    *,
+    address: str | None = None,
+    template: bool = False,
+    stream: str = "stdout",
+    all_lines: bool = True,
+) -> list[str]:
+    cmd = [cubecli]
+    if address and not template:
+        cmd.extend(["--address", address])
+    cmd.append("logs")
+    if template:
+        cmd.append("--tpl")
+    if stream == "stderr":
+        cmd.append("--stderr")
+    if all_lines:
+        cmd.append("--all")
+    cmd.append(target_id)
+    return cmd
+
+
+def skip_unless_single_node_cubecli(
+    *,
+    env: dict[str, str] | None = None,
+    runner: Any = subprocess.run,
+) -> tuple[str, str]:
+    """Return ``(cubecli, address)`` or skip this test.
+
+    Cluster (node count > 1) and unknown topology skip rather than fail, so
+    the shared sdk_compat suite stays green on multi-node runners.
+    """
+    count = discover_node_count(env=env, runner=runner)
+    if count is None:
+        pytest.skip(UNKNOWN_TOPOLOGY_SKIP_REASON)
+    if count > 1:
+        pytest.skip(CLUSTER_SKIP_REASON)
+
+    cubecli = resolve_cubecli(env)
+    if cubecli is None:
+        pytest.skip(CUBECLI_SKIP_REASON)
+
+    address = resolve_cubelet_address(env)
+    if not os.path.exists(address):
+        pytest.skip(SOCKET_SKIP_REASON)
+    return cubecli, address
+
+
+def read_cubecli_logs(
+    cubecli: str,
+    target_id: str,
+    *,
+    address: str | None = None,
+    template: bool = False,
+    stream: str = "stdout",
+    timeout: float = 30,
+) -> str:
+    argv = cubecli_logs_argv(
+        cubecli,
+        target_id,
+        address=address,
+        template=template,
+        stream=stream,
+        all_lines=True,
+    )
+    proc = subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"cubecli logs failed rc={proc.returncode} argv={argv!r} "
+            f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+    return proc.stdout
+
+
+def trigger_envd(adapter, *, timeout: int) -> None:
+    """Hit envd so it prints an access log for ``process.Process/Start``."""
+    from framework.assertions import assert_command_ok
+
+    result = adapter.run_command("true", timeout=timeout)
+    assert_command_ok(result)
+
+
+def read_cubecli_logs_both(
+    cubecli: str,
+    target_id: str,
+    *,
+    address: str | None = None,
+    template: bool = False,
+    timeout: float = 30,
+) -> str:
+    stdout = read_cubecli_logs(
+        cubecli,
+        target_id,
+        address=address,
+        template=template,
+        stream="stdout",
+        timeout=timeout,
+    )
+    stderr = read_cubecli_logs(
+        cubecli,
+        target_id,
+        address=address,
+        template=template,
+        stream="stderr",
+        timeout=timeout,
+    )
+    return stdout + "\n" + stderr
+
+
+def count_envd_rpc(logs: str, needle: str = ENVD_PROCESS_RPC) -> int:
+    return logs.count(needle)
+
+
+def contains_envd_access_log(logs: str) -> bool:
+    return any(marker in logs for marker in ENVD_ACCESS_MARKERS)
+
+
+def wait_for_envd_rpc(
+    cubecli: str,
+    sandbox_id: str,
+    *,
+    address: str,
+    timeout: float,
+    min_count: int = 1,
+    interval: float = 0.5,
+) -> str:
+    from framework.lifecycle import wait_until
+
+    last = ""
+
+    def _seen() -> bool:
+        nonlocal last
+        last = read_cubecli_logs_both(cubecli, sandbox_id, address=address)
+        if min_count <= 1:
+            return contains_envd_access_log(last)
+        return count_envd_rpc(last) >= min_count
+
+    try:
+        wait_until(
+            _seen,
+            timeout=timeout,
+            interval=interval,
+            description=(
+                "cubecli logs to contain envd access output "
+                f"({', '.join(ENVD_ACCESS_MARKERS)})"
+            ),
+        )
+    except AssertionError as exc:
+        raise AssertionError(f"{exc}; last cubecli logs={last!r}") from exc
+    return last
+
+
+def host_log_dir(sandbox_id: str) -> Path:
+    return Path(HOST_LOG_ROOT) / sandbox_id
+
+
+def host_log_paths(sandbox_id: str) -> tuple[Path, Path]:
+    directory = host_log_dir(sandbox_id)
+    return directory / "stdout", directory / "stderr"
+
+
+def assert_host_logs_present(sandbox_id: str) -> None:
+    stdout, stderr = host_log_paths(sandbox_id)
+    assert stdout.is_file(), f"missing host stdout log {stdout}"
+    assert stderr.is_file(), f"missing host stderr log {stderr}"
+
+
+def wait_host_logs_absent(sandbox_id: str, *, timeout: float = 30) -> None:
+    from framework.lifecycle import wait_until
+
+    directory = host_log_dir(sandbox_id)
+    wait_until(
+        lambda: not directory.exists(),
+        timeout=timeout,
+        interval=0.5,
+        description=f"host log dir {directory} to be removed",
+    )
+
+
+def template_log_dir(template_id: str) -> Path:
+    return Path(TEMPLATE_LOG_ROOT) / f"{template_id}_0"
+
+
+def _is_executable(path: str) -> bool:
+    return os.path.isfile(path) and os.access(path, os.X_OK)

--- a/tests/e2e/sdk_compat/framework/sandbox_logs.py
+++ b/tests/e2e/sdk_compat/framework/sandbox_logs.py
@@ -9,10 +9,9 @@ pytest process is on the same host as Cubelet, so these helpers refuse to
 run on a multi-node cluster (skip) and skip when cubecli or the Cubelet
 socket is missing.
 
-Sandbox checks trigger envd through the SDK process API
-(``commands.run`` → ``/process.Process/Start``) and then look for that RPC
-in the captured envd access log. Template-build checks read envd's own
-startup line via ``cubecli logs --tpl``.
+Sandbox checks GET envd ``/health`` from inside the guest so the access
+log writes a new line to init stdout. Template-build checks read envd's
+own startup line via ``cubecli logs --tpl``.
 """
 
 from __future__ import annotations
@@ -49,10 +48,38 @@ SOCKET_SKIP_REASON = (
 # envd / code images print this on the template-build console.
 TEMPLATE_ENVD_MARKER = "envd started"
 
-# SDK commands.run hits envd's Connect RPC; some envd builds echo that path,
-# others only log HTTP probes such as GET /health on the same access log.
+# envd access-log needles. Some images log GET /health or Process/Start;
+# the current code image prints uvicorn's bind line. trigger_envd also
+# writes cube-e2e-log-<hex> to init stdout so cubecli can see a unique line.
 ENVD_PROCESS_RPC = "process.Process/Start"
-ENVD_ACCESS_MARKERS = (ENVD_PROCESS_RPC, "/health")
+ENVD_E2E_MARKER_PREFIX = "cube-e2e-log-"
+ENVD_ACCESS_MARKERS = (
+    ENVD_PROCESS_RPC,
+    "/health",
+    "Uvicorn running",
+    ENVD_E2E_MARKER_PREFIX,
+)
+ENVD_HEALTH_PORT = 49983
+ENVD_HEALTH_PATH = "/health"
+GUEST_ENVD_HEALTH_CMD = (
+    "python3 -c "
+    "\"import urllib.request; "
+    f"urllib.request.urlopen('http://127.0.0.1:{ENVD_HEALTH_PORT}{ENVD_HEALTH_PATH}')\""
+)
+
+
+def guest_envd_probe_cmd(path: str) -> str:
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return (
+        "python3 -c "
+        "\"import urllib.request,urllib.error\n"
+        f"req=urllib.request.Request('http://127.0.0.1:{ENVD_HEALTH_PORT}{path}')\n"
+        "try:\n"
+        "    urllib.request.urlopen(req)\n"
+        "except urllib.error.HTTPError:\n"
+        "    pass\""
+    )
 
 
 def resolve_cubecli(env: dict[str, str] | None = None) -> str | None:
@@ -221,12 +248,21 @@ def read_cubecli_logs(
     return proc.stdout
 
 
-def trigger_envd(adapter, *, timeout: int) -> None:
-    """Hit envd so it prints an access log for ``process.Process/Start``."""
+def trigger_envd(adapter, *, timeout: int) -> str:
+    """GET envd /health and write a unique marker to init stdout.
+
+    Resume recreates host log files; /health alone may not flush a new
+    access-log line, so the marker is also written to ``/proc/1/fd/1``.
+    """
     from framework.assertions import assert_command_ok
 
-    result = adapter.run_command("true", timeout=timeout)
-    assert_command_ok(result)
+    marker = f"cube-e2e-log-{os.urandom(6).hex()}"
+    assert_command_ok(adapter.run_command(GUEST_ENVD_HEALTH_CMD, timeout=timeout))
+    assert_command_ok(adapter.run_command(guest_envd_probe_cmd(f"/{marker}"), timeout=timeout))
+    assert_command_ok(
+        adapter.run_command(f"printf '%s\\n' '{marker}' > /proc/1/fd/1", timeout=timeout)
+    )
+    return marker
 
 
 def read_cubecli_logs_both(
@@ -260,8 +296,85 @@ def count_envd_rpc(logs: str, needle: str = ENVD_PROCESS_RPC) -> int:
     return logs.count(needle)
 
 
+def count_envd_access(logs: str) -> int:
+    return sum(logs.count(marker) for marker in ENVD_ACCESS_MARKERS)
+
+
 def contains_envd_access_log(logs: str) -> bool:
     return any(marker in logs for marker in ENVD_ACCESS_MARKERS)
+
+
+def host_stdout_size(sandbox_id: str) -> int:
+    path = host_log_paths(sandbox_id)[0]
+    try:
+        return path.stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+def wait_for_host_log_growth(
+    sandbox_id: str,
+    *,
+    before_size: int,
+    timeout: float,
+    interval: float = 0.5,
+) -> int:
+    from framework.lifecycle import wait_until
+
+    last = before_size
+
+    def _grew() -> bool:
+        nonlocal last
+        last = host_stdout_size(sandbox_id)
+        return last > before_size
+
+    try:
+        wait_until(
+            _grew,
+            timeout=timeout,
+            interval=interval,
+            description=(
+                f"host stdout log to grow past {before_size} bytes "
+                f"for {sandbox_id}"
+            ),
+        )
+    except AssertionError as exc:
+        raise AssertionError(
+            f"{exc}; stdout_size={last} before={before_size}"
+        ) from exc
+    return last
+
+
+def wait_for_host_log_contains(
+    sandbox_id: str,
+    needle: str,
+    *,
+    timeout: float,
+    interval: float = 0.5,
+) -> str:
+    from framework.lifecycle import wait_until
+
+    last = ""
+    path = host_log_paths(sandbox_id)[0]
+
+    def _has() -> bool:
+        nonlocal last
+        try:
+            last = path.read_text(errors="replace")
+        except FileNotFoundError:
+            last = ""
+        return needle in last
+
+    try:
+        wait_until(
+            _has,
+            timeout=timeout,
+            interval=interval,
+            description=f"host stdout to contain {needle!r} for {sandbox_id}",
+        )
+    except AssertionError as exc:
+        raise AssertionError(f"{exc}; stdout={last!r}") from exc
+    return last
 
 
 def wait_for_envd_rpc(
@@ -272,17 +385,19 @@ def wait_for_envd_rpc(
     timeout: float,
     min_count: int = 1,
     interval: float = 0.5,
+    needles: tuple[str, ...] | None = None,
 ) -> str:
     from framework.lifecycle import wait_until
 
     last = ""
+    required = needles or ENVD_ACCESS_MARKERS
 
     def _seen() -> bool:
         nonlocal last
         last = read_cubecli_logs_both(cubecli, sandbox_id, address=address)
-        if min_count <= 1:
-            return contains_envd_access_log(last)
-        return count_envd_rpc(last) >= min_count
+        if needles:
+            return all(needle in last for needle in needles)
+        return count_envd_access(last) >= min_count
 
     try:
         wait_until(
@@ -291,7 +406,7 @@ def wait_for_envd_rpc(
             interval=interval,
             description=(
                 "cubecli logs to contain envd access output "
-                f"({', '.join(ENVD_ACCESS_MARKERS)})"
+                f"({', '.join(required)})"
             ),
         )
     except AssertionError as exc:


### PR DESCRIPTION
## Summary
- Keep passfd compiled in but opt-in (`cube.use_passfd_io=true` plus nonempty stdout/stderr). Default sandboxes use the original RPC log forwarder again, which is what template restore needs after #728.
- Shim creates `/data/cubelet/log/<sandbox-id>/stdout|stderr` and removes that directory on binary delete (`delete_shim` / `clean_sandbox_resource`), so a crashed shim does not leak files.
- `cubecli logs` reads the host path first without entering a mount namespace, then falls back to the legacy bundle path. Template logs stay under `/data/log/template` and `--tpl`.

Fixes #1598

## Test plan
- [ ] Rebuild a template that pins the new shim (old templates keep their pinned component).
- [ ] Create a sandbox from that template; `cubecli logs` shows envd init output and `/data/cubelet/log/<id>/stdout|stderr` exist.
- [ ] `cubecli logs --tpl` still reads template-build logs.
- [ ] Pause/resume and snapshot rollback keep readable sandbox logs.
- [ ] Destroy/kill removes `/data/cubelet/log/<id>`.
- [ ] Missing host file still falls back to the bundle path (or reports both paths).


Made with [Cursor](https://cursor.com)