### PR TITLE
feat(cubemaster): support deleting snapshots while sandboxes are running

### DIFF
--- a/CubeAPI/src/handlers/templates.rs
+++ b/CubeAPI/src/handlers/templates.rs
@@ -276,6 +276,8 @@ pub async fn delete_template(
     // branch additionally exposes the operation id via a response header so
     // audit trails / debugging can still correlate the deletion with its
     // CubeMaster job, but no body is returned.
+    // Route by snapshot identity (snap- prefix or a live snapshot GET),
+    // not by whether GetSnapshot still exposes the row.
     if state.services.snapshots.has_snapshot(&template_id).await? {
         let resp = state.services.snapshots.delete(&template_id).await?;
         let mut headers = HeaderMap::new();

--- a/CubeAPI/src/routes.rs
+++ b/CubeAPI/src/routes.rs
@@ -487,9 +487,9 @@ mod tests {
 
     /// Verifies that `DELETE /templates/:id` is mounted on the long-budget
     /// router (240 s in production), not on the 30 s standard router, so that
-    /// CubeMaster's *synchronous* snapshot delete contract — which can
-    /// legitimately wait for cubelet LVM/metadata cleanup — is not cut short
-    /// by an HTTP timeout that fires while the master is still working.
+    /// CubeMaster's snapshot delete contract — which still waits for cubelet
+    /// cleanup when no sandbox holds a runtime ref — is not cut short by an
+    /// HTTP timeout that fires while the master is still working.
     ///
     /// Strategy: rebuild the same merge topology as `build_router` but with
     /// scaled-down durations (50 ms vs 5 s) and a slow handler that sleeps

--- a/CubeAPI/src/services/snapshots.rs
+++ b/CubeAPI/src/services/snapshots.rs
@@ -113,20 +113,12 @@ impl SnapshotService {
 
     // ── DELETE /templates/{templateID}  (when templateID is a snapshot id) ─
     //
-    // Relies on CubeMaster's *synchronous* `DELETE /cube/snapshot/{id}`
-    // contract: when the master returns `ret_code == 0`, the snapshot
-    // (replica + metadata + cubelet-side LVM/meta) is fully gone; when it
-    // errors, the operation either was rejected up-front or ran to a
-    // recorded failure.  We assert this invariant via
-    // `ensure_operation_ready(resp.status(), …)` — if master ever drifts
-    // back to handing us Pending/Running we want the caller to see it as
-    // an `Internal` error rather than silently returning success on an
-    // un-finished delete.
-    //
-    // The 240 s router timeout (see `routes::SNAPSHOT_LONG_ROUTE_TIMEOUT`)
-    // exists exactly so a slow cubelet cleanup does not get cut off by the
-    // 30 s default budget.  The snapshot API is synchronous — CubeAPI waits
-    // for a terminal state and does not expose a polling interface.
+    // Master returns `ret_code == 0` + `status == READY` once the snapshot is
+    // logically retired. Physical cleanup is synchronous only with no
+    // runtime refs; otherwise the row is tombstoned and bytes are reclaimed
+    // later. `ensure_operation_ready` rejects Pending/Running; CREATING /
+    // in-progress delete remain conflicts. The 240 s timeout covers the
+    // no-ref synchronous path.
 
     pub async fn delete(&self, snapshot_id: &str) -> AppResult<ApiDeleteSnapshotResponse> {
         let req = DeleteSnapshotRequest {
@@ -160,6 +152,11 @@ impl SnapshotService {
     }
 
     pub async fn has_snapshot(&self, snapshot_id: &str) -> AppResult<bool> {
+        // Identity, not visibility: a tombstoned snap- id is still a snapshot
+        // and must keep using DeleteSnapshot (idempotent), not DeleteTemplate.
+        if is_snapshot_identity(snapshot_id) {
+            return Ok(true);
+        }
         match self.cubemaster.get_snapshot(snapshot_id, false).await {
             Ok(resp) => {
                 resp.ret.as_result().map_err(internal_error)?;
@@ -493,6 +490,10 @@ fn snapshot_names(resource: &SnapshotResource) -> Vec<String> {
     vec![resource.snapshot_id.clone()]
 }
 
+fn is_snapshot_identity(id: &str) -> bool {
+    id.trim().starts_with("snap-")
+}
+
 fn owned_or_fallback(value: String, fallback: &str) -> String {
     if value.trim().is_empty() {
         fallback.to_string()
@@ -520,6 +521,15 @@ mod tests {
             created_at: None,
             updated_at: None,
         }
+    }
+
+    #[test]
+    fn snapshot_identity_uses_snap_prefix() {
+        assert!(is_snapshot_identity("snap-c85fc2cb8bc04831bd75f551"));
+        assert!(is_snapshot_identity("  snap-abc"));
+        assert!(!is_snapshot_identity("tpl-abc"));
+        assert!(!is_snapshot_identity(""));
+        assert!(!is_snapshot_identity("snapshot-1"));
     }
 
     #[test]

--- a/CubeDB/migrate/migrate_postgres_test.go
+++ b/CubeDB/migrate/migrate_postgres_test.go
@@ -106,9 +106,10 @@ func assertPGHeadSchema(t *testing.T, db *sql.DB) {
 			table: "t_cube_template_definition",
 			columns: []string{
 				"kind", "origin_sandbox_id", "origin_node_id",
-				"display_name", "storage_backend", "retain",
+				"display_name", "storage_backend",
 				"rootfs_size_bytes_at_snapshot", "rootfs_artifact_id",
 			},
+			absent: []string{"retain"},
 			indexes: []string{
 				"idx_template_kind_status",
 				"idx_snapshot_origin_sandbox",
@@ -157,6 +158,7 @@ func assertPGHeadSchema(t *testing.T, db *sql.DB) {
 				"snapshot_id", "origin_sandbox_id", "origin_node_id",
 				"backend", "remote_status", "request_json", "export_uuids",
 			},
+			absent: []string{"retain"},
 			indexes: []string{
 				"uniq_cube_snapshot_id",
 				"idx_cube_snapshot_origin_sandbox",

--- a/CubeDB/migrate/migrate_test.go
+++ b/CubeDB/migrate/migrate_test.go
@@ -217,8 +217,12 @@ func TestRun_RerunsAfterVersionMissingAtHeadSchema(t *testing.T) {
 	if err := migrate.Run(ctx, db, "mysql", testSessionLocker()); err != nil {
 		t.Fatalf("initial migrate.Run: %v", err)
 	}
-	if _, err := db.ExecContext(ctx, `DELETE FROM goose_db_version WHERE version_id = 2`); err != nil {
-		t.Fatalf("delete version 2: %v", err)
+	// 0002 is frozen and still ADD IF MISSING the unused retain column on
+	// t_cube_template_definition. 20260902140000 drops that dead column
+	// (never written or read). Replaying 0002 without also replaying the
+	// drop would reintroduce retain and fail assertHeadSchema.
+	if _, err := db.ExecContext(ctx, `DELETE FROM goose_db_version WHERE version_id IN (2, 20260902140000)`); err != nil {
+		t.Fatalf("delete version 2 and drop-retain: %v", err)
 	}
 	if err := migrate.Run(ctx, db, "mysql", testSessionLocker()); err != nil {
 		t.Fatalf("rerun migrate.Run at HEAD schema without version 2: %v", err)
@@ -356,9 +360,10 @@ func assertHeadSchema(t *testing.T, db *sql.DB) {
 			table: "t_cube_template_definition",
 			columns: []string{
 				"kind", "origin_sandbox_id", "origin_node_id",
-				"display_name", "storage_backend", "retain",
+				"display_name", "storage_backend",
 				"rootfs_size_bytes_at_snapshot",
 			},
+			absent: []string{"retain"},
 			indexes: []string{
 				"idx_template_kind_status",
 				"idx_snapshot_origin_sandbox",
@@ -407,6 +412,7 @@ func assertHeadSchema(t *testing.T, db *sql.DB) {
 				"snapshot_id", "origin_sandbox_id", "origin_node_id",
 				"backend", "remote_status", "request_json", "export_uuids",
 			},
+			absent: []string{"retain"},
 			indexes: []string{
 				"uniq_cube_snapshot_id",
 				"idx_cube_snapshot_origin_sandbox",

--- a/CubeDB/migrate/migrations/mysql/20260902140000_drop_snapshot_retain.sql
+++ b/CubeDB/migrate/migrations/mysql/20260902140000_drop_snapshot_retain.sql
@@ -1,0 +1,31 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Drop the unused retain column from snapshot and template definition
+-- tables. It was never written or consumed by control-plane logic.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260902140000_drop_retain', 60);
+
+CALL cubemaster_drop_column_if_exists('t_cube_snapshot', 'retain');
+CALL cubemaster_drop_column_if_exists('t_cube_template_definition', 'retain');
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260902140000_drop_retain');
+
+-- +goose Down
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260902140000_drop_retain', 60);
+
+CALL cubemaster_add_column_if_missing(
+  't_cube_snapshot',
+  'retain',
+  "tinyint(1) NOT NULL DEFAULT 0"
+);
+CALL cubemaster_add_column_if_missing(
+  't_cube_template_definition',
+  'retain',
+  "tinyint(1) NOT NULL DEFAULT 0 COMMENT 'retain snapshot from gc' AFTER `storage_backend`"
+);
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260902140000_drop_retain');

--- a/CubeDB/migrate/migrations/postgres/20260902140000_drop_snapshot_retain.sql
+++ b/CubeDB/migrate/migrations/postgres/20260902140000_drop_snapshot_retain.sql
@@ -1,0 +1,24 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Drop the unused retain column from snapshot and template definition
+-- tables. It was never written or consumed by control-plane logic.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+SELECT cubemaster_acquire_migration_lock('cubemaster_migration_20260902140000_drop_retain', 60);
+
+SELECT cubemaster_drop_column_if_exists('t_cube_snapshot', 'retain');
+SELECT cubemaster_drop_column_if_exists('t_cube_template_definition', 'retain');
+
+SELECT pg_advisory_unlock(hashtext('cubemaster_migration_20260902140000_drop_retain'));
+
+-- +goose Down
+
+SELECT cubemaster_acquire_migration_lock('cubemaster_migration_20260902140000_drop_retain', 60);
+
+SELECT cubemaster_add_column_if_missing('t_cube_snapshot', 'retain', 'boolean NOT NULL DEFAULT false');
+SELECT cubemaster_add_column_if_missing('t_cube_template_definition', 'retain', 'boolean NOT NULL DEFAULT false');
+
+SELECT pg_advisory_unlock(hashtext('cubemaster_migration_20260902140000_drop_retain'));

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/snapshot.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/snapshot.go
@@ -58,7 +58,6 @@ type snapshotResource struct {
 	StorageBackend            string                      `json:"storage_backend,omitempty"`
 	Backend                   string                      `json:"backend,omitempty"`
 	RemoteStatus              string                      `json:"remote_status,omitempty"`
-	Retain                    bool                        `json:"retain,omitempty"`
 	RootfsSizeBytesAtSnapshot uint64                      `json:"rootfs_size_bytes_at_snapshot,omitempty"`
 	LastError                 string                      `json:"last_error,omitempty"`
 	CreatedAt                 string                      `json:"created_at,omitempty"`

--- a/CubeMaster/pkg/base/db/models/snapshot.go
+++ b/CubeMaster/pkg/base/db/models/snapshot.go
@@ -24,7 +24,6 @@ type SnapshotRecord struct {
 	Version                   string `json:"version" gorm:"column:version"`
 	Status                    string `json:"status" gorm:"column:status"`
 	LastError                 string `json:"last_error" gorm:"column:last_error"`
-	Retain                    bool   `json:"retain" gorm:"column:retain"`
 	RootfsSizeBytesAtSnapshot uint64 `json:"rootfs_size_bytes_at_snapshot" gorm:"column:rootfs_size_bytes_at_snapshot"`
 	OriginHostFactsJSON       string `json:"origin_host_facts_json" gorm:"column:origin_host_facts_json"`
 	RequestJSON               string `json:"request_json" gorm:"column:request_json"`

--- a/CubeMaster/pkg/base/db/models/template.go
+++ b/CubeMaster/pkg/base/db/models/template.go
@@ -20,7 +20,6 @@ type TemplateDefinition struct {
 	OriginNodeID              string `json:"origin_node_id" gorm:"column:origin_node_id"`
 	DisplayName               string `json:"display_name" gorm:"column:display_name"`
 	StorageBackend            string `json:"storage_backend" gorm:"column:storage_backend"`
-	Retain                    bool   `json:"retain" gorm:"column:retain"`
 	RootfsSizeBytesAtSnapshot uint64 `json:"rootfs_size_bytes_at_snapshot" gorm:"column:rootfs_size_bytes_at_snapshot"`
 	RootfsArtifactID          string `json:"rootfs_artifact_id" gorm:"column:rootfs_artifact_id"`
 	OriginHostFactsJSON       string `json:"origin_host_facts_json" gorm:"column:origin_host_facts_json"`

--- a/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
@@ -32,6 +32,7 @@ var (
 	resolveTemplateReadyReplicaFn   = templatecenter.ResolveTemplateReadyReplica
 	getSnapshotRestoreSourceFn      = templatecenter.GetSnapshotRestoreSource
 	decideRestorePlacementFn        = restoreplace.Decide
+	ensureSnapshotReadyForNewUseFn  = templatecenter.EnsureSnapshotReadyForNewUse
 )
 
 func getCubeboxReqTemplate() (*types.CreateCubeSandboxReq, error) {
@@ -583,6 +584,9 @@ func constrainSnapshotCreateScope(ctx context.Context, snapshotID string, reqInO
 // keys are explicitly deleted so any stale value supplied by the caller
 // cannot reach the cubelet.
 func bindSnapshotCreateReplica(ctx context.Context, snapshotID string, reqInOut *types.CreateCubeSandboxReq) error {
+	if err := ensureSnapshotReadyForNewUseFn(ctx, snapshotID); err != nil {
+		return err
+	}
 	if src, err := getSnapshotRestoreSourceFn(ctx, snapshotID); err == nil && src != nil {
 		return bindSnapshotCreateReplicaWithPlacement(ctx, snapshotID, reqInOut, src)
 	} else if err != nil && !errors.Is(err, templatecenter.ErrSnapshotNotFound) &&

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot.go
@@ -123,7 +123,6 @@ type snapshotResource struct {
 	StorageBackend            string                         `json:"storage_backend,omitempty"`
 	Backend                   string                         `json:"backend,omitempty"`
 	RemoteStatus              string                         `json:"remote_status,omitempty"`
-	Retain                    bool                           `json:"retain,omitempty"`
 	RootfsSizeBytesAtSnapshot uint64                         `json:"rootfs_size_bytes_at_snapshot,omitempty"`
 	LastError                 string                         `json:"last_error,omitempty"`
 	CreatedAt                 string                         `json:"created_at,omitempty"`
@@ -615,30 +614,13 @@ func getSnapshot(r *http.Request, rt *CubeLog.RequestTrace, snapshotID string) i
 	}
 }
 
-// deleteSnapshot fronts `DELETE /cube/snapshot/{snapshot_id}` and is part of
-// the *synchronous* snapshot contract: the HTTP response is not produced
-// until the underlying snapshot-delete job has reached a terminal status
-// (READY on success, FAILED on error).  Specifically:
+// deleteSnapshot fronts `DELETE /cube/snapshot/{snapshot_id}`.
 //
-//   - Inputs are validated, then `templatecenter.DeleteSnapshot` runs the
-//     full delete pipeline (replica cleanup via cubelet, metadata removal,
-//     cache invalidation) inside a context capped at
-//     `templatecenter.SnapshotOperationTimeout()` (15 min).
-//   - `extendSnapshotWriteDeadline(w)` widens the HTTP write deadline to
-//     `SnapshotOperationTimeout + 30s` so the server-side write does not
-//     fire before the synchronous wait completes.
-//   - `executeSnapshotDeleteJob` -> `finalizeSynchronousSnapshotJob` only
-//     returns a non-error `info` when the job row is `Ready`; any other
-//     terminal state (`Failed`, missing) becomes an error and is mapped to
-//     a 4xx/5xx ret code.  Pending/Running can never escape this handler.
-//
-// Callers may therefore treat a successful response as "snapshot definitely
-// removed" and a non-success response as "the operation either ran to
-// failure or was rejected before starting" — there is no middle "still
-// running, please poll" outcome.  `GET /cube/operation/{operation_id}` is
-// kept around purely for human audit; programmatic clients have no reason
-// to poll.  The snapshot API is synchronous — CubeAPI waits for a
-// terminal state and does not expose a polling interface to callers.
+// Success means the snapshot is logically retired: List/Get hide it and it
+// can no longer create or roll back. With no runtime refs, physical cleanup
+// is also synchronous (15 min cap); otherwise the row is tombstoned and
+// bytes are reclaimed later. CREATING / DELETING / active job → conflict;
+// no polling path.
 func deleteSnapshot(r *http.Request, rt *CubeLog.RequestTrace, snapshotID string) interface{} {
 	if snapshotID == "" {
 		return &operationResponse{
@@ -800,7 +782,6 @@ func snapshotResourceFromInfo(info *templatecenter.SnapshotInfo) *snapshotResour
 		StorageBackend:            firstNonEmptyTrimmed(info.Backend, info.StorageBackend),
 		Backend:                   firstNonEmptyTrimmed(info.Backend, info.StorageBackend),
 		RemoteStatus:              info.RemoteStatus,
-		Retain:                    info.Retain,
 		RootfsSizeBytesAtSnapshot: info.RootfsSizeBytesAtSnapshot,
 		LastError:                 info.LastError,
 		CreatedAt:                 info.CreatedAt,

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
@@ -6,6 +6,7 @@ package cube
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -316,12 +317,20 @@ func TestConstrainSnapshotCreateScopeIntersectsRequestedScope(t *testing.T) {
 	assert.Equal(t, []string{"node-b"}, req.DistributionScope)
 }
 
+func stubSnapshotReadyForNewUse(t *testing.T) {
+	t.Helper()
+	orig := ensureSnapshotReadyForNewUseFn
+	ensureSnapshotReadyForNewUseFn = func(ctx context.Context, snapshotID string) error { return nil }
+	t.Cleanup(func() { ensureSnapshotReadyForNewUseFn = orig })
+}
+
 // TestBindSnapshotCreateReplicaInjectsRuntimeAnnotations verifies the v4
 // contract: master sets only the logical snapshot id + attached_at
 // annotations, never the physical memory_vol/memory_dev. Any stale physical
 // annotation present in the caller-supplied request must be stripped so it
 // cannot reach the cubelet.
 func TestBindSnapshotCreateReplicaInjectsRuntimeAnnotations(t *testing.T) {
+	stubSnapshotReadyForNewUse(t)
 	origResolveSnapshotReadyNodeScopeFn := resolveSnapshotReadyNodeScopeFn
 	origResolveSnapshotReadyReplicaFn := resolveSnapshotReadyReplicaFn
 	t.Cleanup(func() {
@@ -353,6 +362,7 @@ func TestBindSnapshotCreateReplicaInjectsRuntimeAnnotations(t *testing.T) {
 }
 
 func TestBindSnapshotCreateReplicaCrossNodeWhenOriginCannotSchedule(t *testing.T) {
+	stubSnapshotReadyForNewUse(t)
 	origSource := getSnapshotRestoreSourceFn
 	origDecide := decideRestorePlacementFn
 	t.Cleanup(func() {
@@ -394,6 +404,7 @@ func TestBindSnapshotCreateReplicaCrossNodeWhenOriginCannotSchedule(t *testing.T
 }
 
 func TestBindSnapshotCreateReplicaKeepsOriginWhenPlacementSaysOrigin(t *testing.T) {
+	stubSnapshotReadyForNewUse(t)
 	origSource := getSnapshotRestoreSourceFn
 	origDecide := decideRestorePlacementFn
 	origReplica := resolveSnapshotReadyReplicaFn
@@ -431,6 +442,7 @@ func TestBindSnapshotCreateReplicaKeepsOriginWhenPlacementSaysOrigin(t *testing.
 }
 
 func TestBindSnapshotCreateReplicaXFSIgnoresExportUUIDs(t *testing.T) {
+	stubSnapshotReadyForNewUse(t)
 	origSource := getSnapshotRestoreSourceFn
 	origDecide := decideRestorePlacementFn
 	origReplica := resolveSnapshotReadyReplicaFn
@@ -463,6 +475,20 @@ func TestBindSnapshotCreateReplicaXFSIgnoresExportUUIDs(t *testing.T) {
 	assert.Equal(t, []string{"node-a"}, req.DistributionScope)
 	assert.Empty(t, req.Annotations[constants.CubeAnnotationSnapshotRemoteUUIDs])
 	assert.Empty(t, req.Annotations[constants.CubeAnnotationSnapshotAllowNonLocal])
+}
+
+func TestBindSnapshotCreateReplicaRejectsTombstone(t *testing.T) {
+	orig := ensureSnapshotReadyForNewUseFn
+	t.Cleanup(func() { ensureSnapshotReadyForNewUseFn = orig })
+	ensureSnapshotReadyForNewUseFn = func(ctx context.Context, snapshotID string) error {
+		return fmt.Errorf("%w: %s", templatecenter.ErrSnapshotNotFound, snapshotID)
+	}
+
+	req := &types.CreateCubeSandboxReq{Annotations: map[string]string{}}
+	err := bindSnapshotCreateReplica(context.Background(), "snap-deleted", req)
+	if !errors.Is(err, templatecenter.ErrSnapshotNotFound) {
+		t.Fatalf("error = %v, want ErrSnapshotNotFound", err)
+	}
 }
 
 // TestBindAppSnapshotTemplateReplicaRequiresReadyReplica verifies that even

--- a/CubeMaster/pkg/templatecenter/delete.go
+++ b/CubeMaster/pkg/templatecenter/delete.go
@@ -76,6 +76,12 @@ func DeleteTemplate(ctx context.Context, templateID, instanceType string) error 
 	if !isReady() {
 		return ErrTemplateStoreNotInitialized
 	}
+	if rec, err := getSnapshotRecord(ctx, templateID); err == nil && rec != nil {
+		_, err := DeleteSnapshot(ctx, uuid.NewString(), templateID, instanceType)
+		return err
+	} else if err != nil && !errors.Is(err, ErrSnapshotNotFound) {
+		return err
+	}
 	return withTemplateWriteLock(templateID, func() error {
 		targets, err := discoverTemplateCleanupTargets(ctx, templateID, instanceType)
 		if err != nil {

--- a/CubeMaster/pkg/templatecenter/delete_test.go
+++ b/CubeMaster/pkg/templatecenter/delete_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/pkgs/proto/services/cubebox/v1"
 	errorcodev1 "github.com/tencentcloud/CubeSandbox/pkgs/proto/services/errorcode/v1"
+	"gorm.io/gorm"
 )
 
 func TestDeleteTemplateWithTargetsAllowsJobOnlyCleanup(t *testing.T) {
@@ -433,6 +435,39 @@ func TestIsIgnorableArtifactDeleteMessage(t *testing.T) {
 	}
 	if isIgnorableArtifactDeleteMessage("node not found") {
 		t.Fatal("node not found should not be ignored")
+	}
+}
+
+func TestDeleteTemplateDelegatesTombstonedSnapshot(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted}, nil
+	})
+	delegated := false
+	patches.ApplyFunc(DeleteSnapshot, func(ctx context.Context, requestID, snapshotID, instanceType string) (*sandboxtypes.TemplateImageJobInfo, error) {
+		delegated = true
+		if snapshotID != "snap-tomb" {
+			t.Fatalf("snapshotID = %q", snapshotID)
+		}
+		return &sandboxtypes.TemplateImageJobInfo{Status: JobStatusReady}, nil
+	})
+	origReplica := runReplicaCleanup
+	t.Cleanup(func() { runReplicaCleanup = origReplica })
+	runReplicaCleanup = func(ctx context.Context, templateID string, locators []templateCleanupLocator, _ string) error {
+		t.Fatal("must not physically clean a snapshot via DeleteTemplate")
+		return nil
+	}
+
+	if err := DeleteTemplate(context.Background(), "snap-tomb", "cubebox"); err != nil {
+		t.Fatalf("DeleteTemplate: %v", err)
+	}
+	if !delegated {
+		t.Fatal("expected DeleteSnapshot")
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/snapshot_ops.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops.go
@@ -465,9 +465,12 @@ func RollbackSandboxToSnapshot(ctx context.Context, requestID, sandboxID, snapsh
 		rec, err := getSnapshotRecord(ctx, snapshotID)
 		if err != nil {
 			if errors.Is(err, ErrSnapshotNotFound) {
-				return fmt.Errorf("%w: %s", ErrSnapshotNotFound, snapshotID)
+				return wrapSnapshotNotFound(snapshotID)
 			}
 			return err
+		}
+		if snapshotRejectsNewUse(rec.Status) {
+			return wrapSnapshotNotFound(snapshotID)
 		}
 		if !strings.EqualFold(rec.Status, StatusReady) {
 			return fmt.Errorf("%w: snapshot %s is in status %s", ErrTemplateAttemptInProgress, snapshotID, rec.Status)
@@ -628,33 +631,27 @@ func runSnapshotRollbackJob(ctx context.Context, jobID, sandboxID, snapshotID, n
 	return nil
 }
 
-// DeleteSnapshot tears down a snapshot synchronously: it returns only when
-// the underlying delete job has settled into a terminal state (READY on
-// success, FAILED on error).  There is no "started, please poll" return
-// path — pending / running states are converted into errors by
-// `finalizeSynchronousSnapshotJob`.  The caller can therefore treat a nil
-// error as "snapshot is gone (replica + metadata + caches all cleaned)"
-// and a non-nil error as "delete either rejected up-front or ran to
-// failure".
+// DeleteSnapshot logically retires a snapshot immediately, then physically
+// removes it when it is safe to do so.
 //
-// Behaviour summary:
+//   - CREATING / DELETING / another active job still conflict (true
+//     "operation in progress").
+//   - Active runtime refs no longer block the caller: the row is tombstoned
+//     (`DELETED`) and a synthetic READY job is returned. New creates and
+//     rollbacks are rejected. Physical cleanup waits for registered refs
+//     and for a late register that wins the snapshot write lock before
+//     cleanup starts. A create RPC that has not returned yet is not waited
+//     on (same window as the pre-tombstone synchronous delete).
+//   - When no runtime refs remain, the existing synchronous delete job runs
+//     (replica cleanup + metadata drop). A nil error then means the bytes
+//     are gone. Physical-delete failure returns the row to `DELETED` so GC
+//     / a later DELETE can retry — it is not marked `FAILED`.
 //
-//   - Up-front guards (kind, status, in-use, active-job, active runtime
-//     refs) all run inside `withTemplateWriteLock`, so a duplicate request
-//     for the same `requestID` is idempotent: a re-arrived call either
-//     resumes the still-pending job or surfaces the prior terminal result.
-//   - The actual delete (`runSnapshotDeleteJob`) runs under a detached
-//     context produced by `synchronousSnapshotJobContext`, capped at
-//     `snapshotOperationTimeout` (15 min) so a stuck cubelet cannot wedge
-//     the master goroutine forever.  The wider request context is allowed
-//     to cancel the *response*, but the job itself is owned by master and
-//     completes (or fails) regardless.
-//   - On crash / restart, `reconcileSnapshotDefinitionTimeouts` will mark
-//     definitions left in `deleting` past the timeout as `failed`, and the
-//     next `DeleteSnapshot` call for the same id will re-attempt cleanly.
-//
-// The snapshot API is synchronous — CubeAPI waits for a terminal state
-// and does not expose a polling interface to callers.
+// Duplicate requestIDs remain idempotent: a still-pending job is resumed,
+// a tombstone-only call is re-returned as READY. Repeat DELETE is
+// idempotent only while the row is still DELETED. DELETING still
+// conflicts as in-progress; after physical cleanup the row is gone and
+// DELETE returns not found.
 func DeleteSnapshot(ctx context.Context, requestID, snapshotID, instanceType string) (*sandboxtypes.TemplateImageJobInfo, error) {
 	if !isReady() {
 		return nil, ErrTemplateStoreNotInitialized
@@ -664,6 +661,7 @@ func DeleteSnapshot(ctx context.Context, requestID, snapshotID, instanceType str
 	}
 	var jobID string
 	reusedExistingJob := false
+	tombstoned := false
 	var existingRequest snapshotDeleteJobRequest
 	if err := withSnapshotWriteLocks([]string{
 		snapshotResourceLockKey(snapshotID),
@@ -689,7 +687,7 @@ func DeleteSnapshot(ctx context.Context, requestID, snapshotID, instanceType str
 		rec, err := getSnapshotRecord(ctx, snapshotID)
 		if err != nil {
 			if errors.Is(err, ErrSnapshotNotFound) {
-				return fmt.Errorf("%w: %s", ErrSnapshotNotFound, snapshotID)
+				return wrapSnapshotNotFound(snapshotID)
 			}
 			return err
 		}
@@ -718,53 +716,30 @@ func DeleteSnapshot(ctx context.Context, requestID, snapshotID, instanceType str
 				log.G(ctx).Warnf("snapshot %s still has active sandbox(es) referencing it; proceeding with delete (rootfs is reflink/CoW-derived and memory vol remains accessible to running hypervisors)", snapshotID)
 			}
 		}
-		if activeRefs, err := ListActiveSnapshotRuntimeRefs(ctx, snapshotID); err != nil {
-			return err
-		} else if len(activeRefs) > 0 {
-			return fmt.Errorf("%w: snapshot %s still has %d active runtime ref(s): %s", ErrTemplateAttemptInProgress, snapshotID, len(activeRefs), formatSnapshotRuntimeRefConsumers(activeRefs))
-		}
-		attemptNo, retryOfJobID, err := nextSnapshotAttempt(ctx, snapshotID)
+		n, err := countActiveSnapshotRuntimeRefsFn(ctx, snapshotID)
 		if err != nil {
 			return err
 		}
-		payload, err := json.Marshal(snapshotDeleteJobRequest{
-			RequestID:  requestID,
-			SnapshotID: snapshotID,
-			NodeID:     rec.OriginNodeID,
-		})
-		if err != nil {
-			return err
-		}
-		jobID = uuid.NewString()
-		record := &models.TemplateImageJob{
-			JobID:        jobID,
-			TemplateID:   snapshotID,
-			RequestID:    requestID,
-			ResourceType: JobResourceTypeSnapshot,
-			ResourceID:   snapshotID,
-			AttemptNo:    attemptNo,
-			RetryOfJobID: retryOfJobID,
-			Operation:    JobOperationSnapshotDelete,
-			NodeID:       rec.OriginNodeID,
-			InstanceType: instanceType,
-			Status:       JobStatusPending,
-			Phase:        JobPhaseDeleting,
-			Progress:     0,
-			RequestJSON:  string(payload),
-		}
-		return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			if err := tx.Table(constants.SnapshotTableName).
-				Where("snapshot_id = ?", snapshotID).
-				Updates(map[string]any{
-					"status":     StatusDeleting,
-					"updated_at": gorm.Expr("CURRENT_TIMESTAMP"),
-				}).Error; err != nil {
-				return err
+		if n > 0 {
+			if !snapshotIsTombstoned(rec.Status) {
+				if err := tombstoneSnapshotRecord(ctx, snapshotID); err != nil {
+					return err
+				}
 			}
-			return tx.Table(constants.TemplateImageJobTableName).Create(record).Error
-		})
+			tombstoned = true
+			return nil
+		}
+		id, err := insertSnapshotDeleteJob(ctx, requestID, snapshotID, rec.OriginNodeID, instanceType)
+		if err != nil {
+			return err
+		}
+		jobID = id
+		return nil
 	}); err != nil {
 		return nil, err
+	}
+	if tombstoned {
+		return syntheticTombstoneJobInfo(requestID, snapshotID), nil
 	}
 	info, err := GetTemplateImageJobInfo(ctx, jobID)
 	if err != nil {
@@ -794,6 +769,9 @@ func runSnapshotDeleteJob(ctx context.Context, jobID, snapshotID string) error {
 	if err != nil {
 		return failSnapshotDeleteJob(ctx, jobID, snapshotID, err)
 	}
+	if err := abortSnapshotDeleteIfRefsReappeared(ctx, jobID, snapshotID); err != nil {
+		return err
+	}
 	if err := runReplicaCleanup(ctx, snapshotID, locators, cleanupBackendFromTargets(targets)); err != nil {
 		return failSnapshotDeleteJob(ctx, jobID, snapshotID, err)
 	}
@@ -808,6 +786,32 @@ func runSnapshotDeleteJob(ctx context.Context, jobID, snapshotID string) error {
 	}
 	success = true
 	return nil
+}
+
+// abortSnapshotDeleteIfRefsReappeared re-counts runtime refs under the
+// snapshot write lock immediately before physical cleanup. A late
+// in-flight create that registered after the row flipped to DELETING
+// must send the job back to DELETED instead of unlinking bytes.
+func abortSnapshotDeleteIfRefsReappeared(ctx context.Context, jobID, snapshotID string) error {
+	var n int64
+	if err := withSnapshotWriteLocks([]string{snapshotResourceLockKey(snapshotID)}, func() error {
+		count, err := countActiveSnapshotRuntimeRefsFn(ctx, snapshotID)
+		if err != nil {
+			return err
+		}
+		n = count
+		return nil
+	}); err != nil {
+		return failSnapshotDeleteJob(ctx, jobID, snapshotID, err)
+	}
+	if n <= 0 {
+		return nil
+	}
+	cause := fmt.Errorf("snapshot %s grew %d runtime ref(s) before physical cleanup", snapshotID, n)
+	if err := failSnapshotDeleteJob(ctx, jobID, snapshotID, cause); err != nil {
+		return err
+	}
+	return cause
 }
 
 func failSnapshotCreateJob(ctx context.Context, jobID, snapshotID, nodeIP, snapshotPath string, commitRsp *cubeboxv1.CommitSandboxResponse, cause error, backend string) error {
@@ -840,18 +844,28 @@ func failSnapshotCreateJob(ctx context.Context, jobID, snapshotID, nodeIP, snaps
 	return errors.Join(defErr, jobErr)
 }
 
+var withStoreTx = func(ctx context.Context, fn func(*gorm.DB) error) error {
+	if !isReady() {
+		return ErrTemplateStoreNotInitialized
+	}
+	return store.db.WithContext(ctx).Transaction(fn)
+}
+
 func failSnapshotDeleteJob(ctx context.Context, jobID, snapshotID string, cause error) error {
-	defErr := updateSnapshotFields(ctx, snapshotID, map[string]any{
-		"status":     StatusFailed,
-		"last_error": cause.Error(),
+	return withStoreTx(ctx, func(tx *gorm.DB) error {
+		if err := updateSnapshotFieldsTx(tx, snapshotID, map[string]any{
+			"status":     StatusDeleted,
+			"last_error": cause.Error(),
+		}); err != nil {
+			return err
+		}
+		return updateTemplateImageJobTx(tx, jobID, map[string]any{
+			"status":        JobStatusFailed,
+			"phase":         JobPhaseDeleting,
+			"progress":      100,
+			"error_message": cause.Error(),
+		})
 	})
-	jobErr := updateTemplateImageJob(ctx, jobID, map[string]any{
-		"status":        JobStatusFailed,
-		"phase":         JobPhaseDeleting,
-		"progress":      100,
-		"error_message": cause.Error(),
-	})
-	return errors.Join(defErr, jobErr)
 }
 
 func failSnapshotRollbackJob(ctx context.Context, jobID, phase string, resultPayload []byte, cause error) error {
@@ -917,19 +931,12 @@ func marshalSnapshotRollbackRequest(requestID, sandboxID, snapshotID, nodeID, no
 	return string(payload), nil
 }
 
-func formatSnapshotRuntimeRefConsumers(refs []SnapshotRuntimeRefInfo) string {
-	consumers := make([]string, 0, len(refs))
-	for _, item := range refs {
-		consumer := strings.TrimSpace(item.SandboxID)
-		if node := firstNonEmpty(item.NodeID, item.NodeIP); node != "" {
-			consumer = firstNonEmpty(consumer, "<unknown>") + "@" + node
-		}
-		consumers = append(consumers, firstNonEmpty(consumer, "<unknown>"))
-	}
-	return strings.Join(consumers, ", ")
-}
-
 func getSnapshotReadyReplica(ctx context.Context, snapshotID, preferredNodeID string) (ReplicaStatus, error) {
+	if rec, err := getSnapshotRecord(ctx, snapshotID); err == nil && rec != nil && snapshotRejectsNewUse(rec.Status) {
+		return ReplicaStatus{}, ErrTemplateHasNoReadyReplica
+	} else if err != nil && !errors.Is(err, ErrSnapshotNotFound) && !errors.Is(err, ErrTemplateStoreNotInitialized) {
+		return ReplicaStatus{}, err
+	}
 	replicas, err := ListReplicas(ctx, snapshotID)
 	if err != nil {
 		return ReplicaStatus{}, err
@@ -1151,7 +1158,6 @@ func createDefinitionTx(ctx context.Context, tx *gorm.DB, templateID string, sto
 		OriginHostFactsJSON:       opts.OriginHostFactsJSON,
 		DisplayName:               opts.DisplayName,
 		StorageBackend:            opts.StorageBackend,
-		Retain:                    opts.Retain,
 		RootfsSizeBytesAtSnapshot: opts.RootfsSizeBytesAtSnapshot,
 		RootfsArtifactID:          rootfsArtifactIDFromCreateRequest(storedReq),
 		RequestJSON:               string(payload),

--- a/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
@@ -638,13 +638,7 @@ func TestValidateSnapshotMetricsRejectsMissingKeys(t *testing.T) {
 	}
 }
 
-// TestDeleteSnapshotBlocksWhenRuntimeRefsExist verifies that the active
-// runtime binding table is the current-state authority: deleting a snapshot
-// that is still attached to a sandbox must fail with a conflict.
-//
-// The legacy template in-use precheck remains warning-only, but active runtime
-// refs are authoritative and must prevent reaching nextSnapshotAttempt.
-func TestDeleteSnapshotBlocksWhenRuntimeRefsExist(t *testing.T) {
+func TestDeleteSnapshotTombstonesWhenRuntimeRefsExist(t *testing.T) {
 	oldDB := store.db
 	store.db = &gorm.DB{}
 	defer func() { store.db = oldDB }()
@@ -652,13 +646,18 @@ func TestDeleteSnapshotBlocksWhenRuntimeRefsExist(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
+	var tombstoneStatus string
 	patches.ApplyFunc(getTemplateImageJobByRequestID, func(ctx context.Context, requestID string) (*models.TemplateImageJob, error) {
 		return nil, gorm.ErrRecordNotFound
 	})
 	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		status := StatusReady
+		if tombstoneStatus != "" {
+			status = tombstoneStatus
+		}
 		return &models.SnapshotRecord{
 			SnapshotID: snapshotID,
-			Status:     StatusReady,
+			Status:     status,
 		}, nil
 	})
 	patches.ApplyFunc(getActiveSnapshotJobByResourceID, func(ctx context.Context, resourceID string) (*models.TemplateImageJob, error) {
@@ -676,35 +675,76 @@ func TestDeleteSnapshotBlocksWhenRuntimeRefsExist(t *testing.T) {
 			}},
 		}, nil
 	})
-	// The legacy template in-use precheck is still warning-only.
 	patches.ApplyFunc(isTemplateInUse, func(ctx context.Context, templateID, instanceType string) (bool, error) {
 		return true, nil
 	})
-	patches.ApplyFunc(ListActiveSnapshotRuntimeRefs, func(ctx context.Context, snapshotID string) ([]SnapshotRuntimeRefInfo, error) {
-		return []SnapshotRuntimeRefInfo{{
-			SnapshotID: snapshotID,
-			SandboxID:  "sb-active",
-			NodeID:     "node-a",
-		}}, nil
+	origCount := countActiveSnapshotRuntimeRefsFn
+	t.Cleanup(func() { countActiveSnapshotRuntimeRefsFn = origCount })
+	countActiveSnapshotRuntimeRefsFn = func(ctx context.Context, snapshotID string) (int64, error) {
+		return 1, nil
+	}
+	patches.ApplyFunc(updateSnapshotFields, func(ctx context.Context, snapshotID string, values map[string]any) error {
+		if status, ok := values["status"].(string); ok {
+			tombstoneStatus = status
+		}
+		return nil
 	})
+	patches.ApplyFunc(invalidateTemplateCaches, func(templateID string) {})
 
-	sentinel := errors.New("sentinel: reached nextSnapshotAttempt past runtime-ref guard")
+	sentinel := errors.New("sentinel: reached nextSnapshotAttempt past tombstone path")
 	patches.ApplyFunc(nextSnapshotAttempt, func(ctx context.Context, snapshotID string) (int32, string, error) {
 		return 0, "", sentinel
 	})
 
-	_, err := DeleteSnapshot(context.Background(), "req-delete", "snap-in-use", "cubebox")
-	if err == nil {
-		t.Fatal("DeleteSnapshot returned nil error; expected active runtime refs to block deletion")
+	info, err := DeleteSnapshot(context.Background(), "req-delete", "snap-in-use", "cubebox")
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned error: %v", err)
 	}
 	if errors.Is(err, sentinel) {
 		t.Fatalf("DeleteSnapshot reached nextSnapshotAttempt despite active runtime refs: %v", err)
 	}
-	if !errors.Is(err, ErrTemplateAttemptInProgress) {
-		t.Fatalf("DeleteSnapshot error = %v, want ErrTemplateAttemptInProgress", err)
+	if info == nil || info.Status != JobStatusReady {
+		t.Fatalf("job info = %#v, want READY tombstone", info)
 	}
-	if !strings.Contains(err.Error(), "active runtime ref") {
-		t.Fatalf("DeleteSnapshot error = %q, want active runtime ref message", err.Error())
+	if tombstoneStatus != StatusDeleted {
+		t.Fatalf("status = %q, want %q", tombstoneStatus, StatusDeleted)
+	}
+}
+
+func TestDeleteSnapshotWithZeroRefsStartsPhysicalDelete(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(getTemplateImageJobByRequestID, func(ctx context.Context, requestID string) (*models.TemplateImageJob, error) {
+		return nil, gorm.ErrRecordNotFound
+	})
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusReady, OriginNodeID: "node-a"}, nil
+	})
+	patches.ApplyFunc(getActiveSnapshotJobByResourceID, func(ctx context.Context, resourceID string) (*models.TemplateImageJob, error) {
+		return nil, gorm.ErrRecordNotFound
+	})
+	patches.ApplyFunc(discoverTemplateCleanupTargets, func(ctx context.Context, templateID, instanceType string) (*templateCleanupTargets, error) {
+		return &templateCleanupTargets{InstanceType: "cubebox"}, nil
+	})
+	origCount := countActiveSnapshotRuntimeRefsFn
+	t.Cleanup(func() { countActiveSnapshotRuntimeRefsFn = origCount })
+	countActiveSnapshotRuntimeRefsFn = func(ctx context.Context, snapshotID string) (int64, error) {
+		return 0, nil
+	}
+
+	sentinel := errors.New("sentinel: reached nextSnapshotAttempt for zero-ref delete")
+	patches.ApplyFunc(nextSnapshotAttempt, func(ctx context.Context, snapshotID string) (int32, string, error) {
+		return 0, "", sentinel
+	})
+
+	_, err := DeleteSnapshot(context.Background(), "req-delete", "snap-idle", "cubebox")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("DeleteSnapshot error = %v, want zero-ref physical delete sentinel", err)
 	}
 }
 
@@ -732,6 +772,11 @@ func TestRunSnapshotDeleteJobCleansTemplateJobs(t *testing.T) {
 		return nil, nil
 	})
 	patches.ApplyFunc(invalidateTemplateCaches, func(templateID string) {})
+	origCount := countActiveSnapshotRuntimeRefsFn
+	t.Cleanup(func() { countActiveSnapshotRuntimeRefsFn = origCount })
+	countActiveSnapshotRuntimeRefsFn = func(ctx context.Context, snapshotID string) (int64, error) {
+		return 0, nil
+	}
 	runReplicaCleanup = func(ctx context.Context, templateID string, locators []templateCleanupLocator, _ string) error {
 		return nil
 	}
@@ -751,6 +796,56 @@ func TestRunSnapshotDeleteJobCleansTemplateJobs(t *testing.T) {
 	}
 	if !jobsCleaned {
 		t.Fatal("expected runTemplateJobCleanup to be called")
+	}
+}
+
+func TestRunSnapshotDeleteJobAbortsWhenRefsReappeared(t *testing.T) {
+	origReplicaCleanup := runReplicaCleanup
+	t.Cleanup(func() { runReplicaCleanup = origReplicaCleanup })
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var status string
+	origTx := withStoreTx
+	t.Cleanup(func() { withStoreTx = origTx })
+	withStoreTx = func(ctx context.Context, fn func(*gorm.DB) error) error {
+		return fn(&gorm.DB{})
+	}
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, fields map[string]any) error {
+		return nil
+	})
+	patches.ApplyFunc(updateTemplateImageJobTx, func(tx *gorm.DB, jobID string, fields map[string]any) error {
+		return nil
+	})
+	patches.ApplyFunc(discoverTemplateCleanupTargets, func(ctx context.Context, templateID, instanceType string) (*templateCleanupTargets, error) {
+		return &templateCleanupTargets{}, nil
+	})
+	patches.ApplyFunc(snapshotDeleteLocators, func(targets *templateCleanupTargets) ([]templateCleanupLocator, error) {
+		return nil, nil
+	})
+	patches.ApplyFunc(updateSnapshotFieldsTx, func(tx *gorm.DB, snapshotID string, values map[string]any) error {
+		if s, ok := values["status"].(string); ok {
+			status = s
+		}
+		return nil
+	})
+	origCount := countActiveSnapshotRuntimeRefsFn
+	t.Cleanup(func() { countActiveSnapshotRuntimeRefsFn = origCount })
+	countActiveSnapshotRuntimeRefsFn = func(ctx context.Context, snapshotID string) (int64, error) {
+		return 1, nil
+	}
+	runReplicaCleanup = func(ctx context.Context, templateID string, locators []templateCleanupLocator, _ string) error {
+		t.Fatal("must not physically clean up when a runtime ref reappeared")
+		return nil
+	}
+
+	err := runSnapshotDeleteJob(context.Background(), "job-del", "snap-late-ref")
+	if err == nil {
+		t.Fatal("expected abort when refs reappeared")
+	}
+	if status != StatusDeleted {
+		t.Fatalf("status = %q, want %q", status, StatusDeleted)
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/snapshot_reconciler.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_reconciler.go
@@ -84,6 +84,17 @@ func failedReplicaStatus(replica models.TemplateReplica, message string) Replica
 	return status
 }
 
+// stampReplicaPresenceFailed marks a missing local catalog entry FAILED.
+// The snapshot row is CAS-updated only while still READY/FAILED so a
+// concurrent tombstone is not overwritten.
+func stampReplicaPresenceFailed(ctx context.Context, snapshotID string, model models.TemplateReplica, msg string) {
+	_ = UpsertReplica(ctx, snapshotID, model.InstanceType, failedReplicaStatus(model, msg))
+	_, _ = updateSnapshotFieldsIfStatusIn(ctx, snapshotID, map[string]any{
+		"status":     StatusFailed,
+		"last_error": msg,
+	}, StatusReady, StatusFailed)
+}
+
 var (
 	snapshotReconcilerOnce sync.Once
 	snapshotStorageCache   = struct {
@@ -125,6 +136,9 @@ func runSnapshotReconcilerPass(ctx context.Context) {
 	}
 	if err := reconcileSnapshotRuntimeRefs(ctx); err != nil {
 		logger.Warnf("reconcile snapshot runtime refs failed: %v", err)
+	}
+	if err := reconcileSnapshotTombstones(ctx); err != nil {
+		logger.Warnf("reconcile snapshot tombstones failed: %v", err)
 	}
 	if err := refreshSnapshotStorageMetrics(ctx); err != nil {
 		logger.Warnf("refresh snapshot storage metrics failed: %v", err)
@@ -181,22 +195,75 @@ func reconcileSnapshotDefinitionTimeouts(ctx context.Context) error {
 		return err
 	}
 	for _, rec := range rows {
-		active, err := getActiveSnapshotJobByResourceID(ctx, rec.SnapshotID)
-		if err == nil && active != nil {
-			continue
-		}
-		if err != nil && !errorsIsRecordNotFound(err) {
-			return err
-		}
-		lastError := fmt.Sprintf("snapshot %s remained in %s beyond %s", rec.SnapshotID, rec.Status, snapshotOperationTimeout)
-		if err := updateSnapshotFields(ctx, rec.SnapshotID, map[string]any{
-			"status":     StatusFailed,
-			"last_error": lastError,
-		}); err != nil {
+		if err := reclaimTimedOutSnapshotRecord(ctx, rec); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// shouldReclaimStaleSnapshotDeleteJob is true when a DELETING row is held
+// by an expired SNAPSHOT_DELETE job (typical after a master crash between
+// insertSnapshotDeleteJob and execute). Fresh jobs and CREATING stay skipped.
+func snapshotDeleteJobIsStale(job *models.TemplateImageJob) bool {
+	if job == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(job.Operation), JobOperationSnapshotDelete) {
+		return false
+	}
+	if job.UpdatedAt.IsZero() {
+		return false
+	}
+	return time.Since(job.UpdatedAt) >= snapshotOperationTimeout
+}
+
+func shouldReclaimStaleSnapshotDeleteJob(rec models.SnapshotRecord, job *models.TemplateImageJob) bool {
+	if !strings.EqualFold(strings.TrimSpace(rec.Status), StatusDeleting) {
+		return false
+	}
+	return snapshotDeleteJobIsStale(job)
+}
+
+func shouldFailStaleDeleteJobOnTombstone(rec models.SnapshotRecord, job *models.TemplateImageJob) bool {
+	if !snapshotIsTombstoned(rec.Status) {
+		return false
+	}
+	return snapshotDeleteJobIsStale(job)
+}
+
+// reclaimTimedOutSnapshotRecord returns a stuck CREATING/DELETING row to a
+// terminal-or-retryable status. A live active job still wins, except a stale
+// SNAPSHOT_DELETE job which is failed so the tombstone reconciler can retry.
+func reclaimTimedOutSnapshotRecord(ctx context.Context, rec models.SnapshotRecord) error {
+	active, err := getActiveSnapshotJobByResourceID(ctx, rec.SnapshotID)
+	if err != nil && !errorsIsRecordNotFound(err) {
+		return err
+	}
+	if active != nil {
+		if !shouldReclaimStaleSnapshotDeleteJob(rec, active) {
+			return nil
+		}
+		if err := updateTemplateImageJob(ctx, active.JobID, map[string]any{
+			"status":        JobStatusFailed,
+			"error_message": fmt.Sprintf("stale snapshot delete job %s exceeded %s", active.JobID, snapshotOperationTimeout),
+		}); err != nil {
+			return err
+		}
+	}
+	lastError := fmt.Sprintf("snapshot %s remained in %s beyond %s", rec.SnapshotID, rec.Status, snapshotOperationTimeout)
+	if active != nil {
+		lastError = fmt.Sprintf("snapshot %s remained in %s beyond %s with stale delete job %s", rec.SnapshotID, rec.Status, snapshotOperationTimeout, active.JobID)
+	}
+	// Stuck DELETING returns to DELETED so the tombstone reconciler can retry.
+	status := StatusFailed
+	if strings.EqualFold(rec.Status, StatusDeleting) {
+		status = StatusDeleted
+	}
+	return updateSnapshotFields(ctx, rec.SnapshotID, map[string]any{
+		"status":     status,
+		"last_error": lastError,
+	})
 }
 
 func reconcileSnapshotReplicaPresence(ctx context.Context) error {
@@ -205,7 +272,7 @@ func reconcileSnapshotReplicaPresence(ctx context.Context) error {
 	defer setSnapshotOrphanGauge(orphanCount)
 	var rows []models.SnapshotRecord
 	if err := store.db.WithContext(ctx).Table(constants.SnapshotTableName).
-		Where("status IN ?", []string{StatusReady, StatusFailed, StatusDeleting}).
+		Where("status IN ?", []string{StatusReady, StatusFailed}).
 		Find(&rows).Error; err != nil {
 		return err
 	}
@@ -278,11 +345,7 @@ func reconcileSnapshotReplicaPresence(ctx context.Context) error {
 				if rsp.GetSnapshot() == nil || strings.TrimSpace(rsp.GetSnapshot().GetSnapshotID()) == "" {
 					orphanCount++
 					msg := fmt.Sprintf("snapshot %s missing from local catalog on node %s", rec.SnapshotID, firstNonEmpty(replica.NodeID, hostIP))
-					_ = UpsertReplica(ctx, rec.SnapshotID, model.InstanceType, failedReplicaStatus(model, msg))
-					_ = updateSnapshotFields(ctx, rec.SnapshotID, map[string]any{
-						"status":     StatusFailed,
-						"last_error": msg,
-					})
+					stampReplicaPresenceFailed(ctx, rec.SnapshotID, model, msg)
 				}
 			case cubeleterrorcode.ErrorCode_PreConditionFailed:
 				orphanCount++
@@ -291,11 +354,7 @@ func reconcileSnapshotReplicaPresence(ctx context.Context) error {
 					NodeID: model.NodeID,
 					NodeIP: model.NodeIP,
 				}}, snapshotBackend)
-				_ = UpsertReplica(ctx, rec.SnapshotID, model.InstanceType, failedReplicaStatus(model, msg))
-				_ = updateSnapshotFields(ctx, rec.SnapshotID, map[string]any{
-					"status":     StatusFailed,
-					"last_error": msg,
-				})
+				stampReplicaPresenceFailed(ctx, rec.SnapshotID, model, msg)
 			default:
 				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("snapshot %s reconcile on node %s returned ret=%d %s", rec.SnapshotID, firstNonEmpty(replica.NodeID, hostIP), retCode, retMsg))
 			}
@@ -338,23 +397,9 @@ func reconcileSnapshotRuntimeRefs(ctx context.Context) error {
 				observed = append(observed, ref)
 				continue
 			}
-			templateID := ""
-			if item != nil {
-				templateID = strings.TrimSpace(item.TemplateID)
+			if ref, ok := snapshotRuntimeRefFromTemplateID(ctx, item); ok {
+				observed = append(observed, ref)
 			}
-			if templateID == "" {
-				continue
-			}
-			kind, err := GetTemplateKind(ctx, templateID)
-			if err != nil || !strings.EqualFold(kind, TemplateKindSnapshot) {
-				continue
-			}
-			observed = append(observed, SnapshotRuntimeRefInfo{
-				SnapshotID: templateID,
-				SandboxID:  item.SandboxID,
-				NodeID:     item.HostID,
-				NodeIP:     item.HostIP,
-			})
 		}
 		if err := RefreshSnapshotRuntimeRefsFromNode(ctx, nodeID, nodeIP, observed); err != nil {
 			reconcileErr = err

--- a/CubeMaster/pkg/templatecenter/snapshot_reconciler_test.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_reconciler_test.go
@@ -325,3 +325,253 @@ func TestReconcileSnapshotReplicaPresenceSkipsS3(t *testing.T) {
 	require.Equal(t, 0, probes)
 	require.Empty(t, *updated)
 }
+
+func TestReconcileSnapshotReplicaPresenceDoesNotOverwriteTombstone(t *testing.T) {
+	for _, raced := range []string{StatusDeleted, StatusDeleting} {
+		t.Run(raced, func(t *testing.T) {
+			casCalls := 0
+			unguardedFailed := false
+			patches := gomonkey.NewPatches()
+			t.Cleanup(patches.Reset)
+			patches.ApplyFunc(cubelet.GetCubeletAddr, func(hostIP string) string {
+				return hostIP
+			})
+			patches.ApplyFunc(updateSnapshotFieldsIfStatusIn, func(ctx context.Context, snapshotID string, values map[string]any, statuses ...string) (bool, error) {
+				casCalls++
+				if snapshotID != "snap-1" {
+					t.Fatalf("snapshotID = %q", snapshotID)
+				}
+				if values["status"] != StatusFailed {
+					t.Fatalf("CAS status = %v, want FAILED", values["status"])
+				}
+				if len(statuses) != 2 || statuses[0] != StatusReady || statuses[1] != StatusFailed {
+					t.Fatalf("CAS allowed statuses = %v, want READY, FAILED", statuses)
+				}
+				return false, nil
+			})
+			patches.ApplyFunc(updateSnapshotFields, func(ctx context.Context, snapshotID string, values map[string]any) error {
+				if values["status"] == StatusFailed {
+					unguardedFailed = true
+				}
+				return nil
+			})
+
+			_ = stubReconcilerDB(t,
+				models.SnapshotRecord{
+					SnapshotID:   "snap-1",
+					Status:       StatusReady,
+					Backend:      constants.SnapshotBackendXFS,
+					InstanceType: "cubebox",
+					OriginNodeID: "node-a",
+					OriginNodeIP: "10.0.0.8",
+				},
+				models.TemplateReplica{
+					TemplateID:   "snap-1",
+					NodeID:       "node-a",
+					NodeIP:       "10.0.0.8",
+					InstanceType: "cubebox",
+					Status:       ReplicaStatusReady,
+					Phase:        ReplicaPhaseReady,
+				})
+
+			origProbe := getLocalSnapshotOnCubelet
+			t.Cleanup(func() { getLocalSnapshotOnCubelet = origProbe })
+			getLocalSnapshotOnCubelet = func(ctx context.Context, addr string,
+				req *cubeboxv1.GetLocalSnapshotRequest) (*cubeboxv1.GetLocalSnapshotResponse, error) {
+				return &cubeboxv1.GetLocalSnapshotResponse{
+					Ret: &errorcodev1.Ret{RetCode: errorcodev1.ErrorCode_Success},
+				}, nil
+			}
+
+			require.NoError(t, reconcileSnapshotReplicaPresence(context.Background()))
+			require.Equal(t, 1, casCalls, "replica-presence must CAS FAILED against READY/FAILED")
+			require.False(t, unguardedFailed, "must not write FAILED through unguarded updateSnapshotFields after a %s race", raced)
+		})
+	}
+}
+
+func staleDeleteJob(status string) *models.TemplateImageJob {
+	job := &models.TemplateImageJob{
+		JobID:     "job-stale-delete",
+		Operation: JobOperationSnapshotDelete,
+		Status:    status,
+	}
+	job.UpdatedAt = time.Now().Add(-snapshotOperationTimeout - time.Minute)
+	return job
+}
+
+func TestShouldReclaimStaleSnapshotDeleteJob(t *testing.T) {
+	deleting := models.SnapshotRecord{SnapshotID: "snap-1", Status: StatusDeleting}
+	creating := models.SnapshotRecord{SnapshotID: "snap-1", Status: StatusCreating}
+
+	if !shouldReclaimStaleSnapshotDeleteJob(deleting, staleDeleteJob(JobStatusPending)) {
+		t.Fatal("DELETING + stale pending SNAPSHOT_DELETE must reclaim")
+	}
+	if !shouldReclaimStaleSnapshotDeleteJob(deleting, staleDeleteJob(JobStatusRunning)) {
+		t.Fatal("DELETING + stale running SNAPSHOT_DELETE must reclaim")
+	}
+
+	fresh := staleDeleteJob(JobStatusPending)
+	fresh.UpdatedAt = time.Now()
+	if shouldReclaimStaleSnapshotDeleteJob(deleting, fresh) {
+		t.Fatal("fresh delete job must not reclaim")
+	}
+	if shouldReclaimStaleSnapshotDeleteJob(creating, staleDeleteJob(JobStatusPending)) {
+		t.Fatal("CREATING must not reclaim a stale job")
+	}
+
+	createJob := staleDeleteJob(JobStatusPending)
+	createJob.Operation = JobOperationSnapshotCreate
+	if shouldReclaimStaleSnapshotDeleteJob(deleting, createJob) {
+		t.Fatal("non-delete job must not reclaim")
+	}
+	if shouldReclaimStaleSnapshotDeleteJob(deleting, nil) {
+		t.Fatal("nil job must not reclaim")
+	}
+}
+
+func TestShouldFailStaleDeleteJobOnTombstone(t *testing.T) {
+	deleted := models.SnapshotRecord{SnapshotID: "snap-1", Status: StatusDeleted}
+	deleting := models.SnapshotRecord{SnapshotID: "snap-1", Status: StatusDeleting}
+
+	if !shouldFailStaleDeleteJobOnTombstone(deleted, staleDeleteJob(JobStatusPending)) {
+		t.Fatal("DELETED + stale pending SNAPSHOT_DELETE must fail the job")
+	}
+	if shouldFailStaleDeleteJobOnTombstone(deleting, staleDeleteJob(JobStatusPending)) {
+		t.Fatal("DELETING is handled by the timeout reclaim path, not this helper")
+	}
+	fresh := staleDeleteJob(JobStatusRunning)
+	fresh.UpdatedAt = time.Now()
+	if shouldFailStaleDeleteJobOnTombstone(deleted, fresh) {
+		t.Fatal("fresh delete job on a tombstone must not be failed")
+	}
+}
+
+func TestFailStaleDeleteJobOnTombstoneMarksJobFailed(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	job := staleDeleteJob(JobStatusPending)
+	var failed map[string]any
+	patches.ApplyFunc(getActiveSnapshotJobByResourceID, func(ctx context.Context, resourceID string) (*models.TemplateImageJob, error) {
+		return job, nil
+	})
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+		failed = values
+		return nil
+	})
+
+	err := failStaleDeleteJobOnTombstone(context.Background(), models.SnapshotRecord{
+		SnapshotID: "snap-split",
+		Status:     StatusDeleted,
+	})
+	require.NoError(t, err)
+	require.Equal(t, JobStatusFailed, failed["status"])
+	require.Contains(t, failed["error_message"], "on tombstone")
+}
+
+func TestReclaimTimedOutSnapshotRecordStaleDeleteJob(t *testing.T) {
+	for _, jobStatus := range []string{JobStatusPending, JobStatusRunning} {
+		t.Run(jobStatus, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			job := staleDeleteJob(jobStatus)
+			var failedJob map[string]any
+			var snapFields map[string]any
+			patches.ApplyFunc(getActiveSnapshotJobByResourceID, func(ctx context.Context, resourceID string) (*models.TemplateImageJob, error) {
+				return job, nil
+			})
+			patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+				failedJob = values
+				return nil
+			})
+			patches.ApplyFunc(updateSnapshotFields, func(ctx context.Context, snapshotID string, values map[string]any) error {
+				snapFields = values
+				return nil
+			})
+
+			err := reclaimTimedOutSnapshotRecord(context.Background(), models.SnapshotRecord{
+				SnapshotID: "snap-stuck",
+				Status:     StatusDeleting,
+			})
+			require.NoError(t, err)
+			require.Equal(t, JobStatusFailed, failedJob["status"])
+			require.Equal(t, StatusDeleted, snapFields["status"])
+			require.Contains(t, snapFields["last_error"], "stale delete job")
+		})
+	}
+}
+
+func TestReclaimTimedOutSnapshotRecordSkipsFreshDeleteJob(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	job := staleDeleteJob(JobStatusPending)
+	job.UpdatedAt = time.Now()
+	patches.ApplyFunc(getActiveSnapshotJobByResourceID, func(ctx context.Context, resourceID string) (*models.TemplateImageJob, error) {
+		return job, nil
+	})
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+		t.Fatal("must not fail a fresh delete job")
+		return nil
+	})
+	patches.ApplyFunc(updateSnapshotFields, func(ctx context.Context, snapshotID string, values map[string]any) error {
+		t.Fatal("must not rewrite snapshot while a fresh delete job is active")
+		return nil
+	})
+
+	err := reclaimTimedOutSnapshotRecord(context.Background(), models.SnapshotRecord{
+		SnapshotID: "snap-live",
+		Status:     StatusDeleting,
+	})
+	require.NoError(t, err)
+}
+
+func TestReclaimTimedOutSnapshotRecordSkipsCreatingWithStaleJob(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(getActiveSnapshotJobByResourceID, func(ctx context.Context, resourceID string) (*models.TemplateImageJob, error) {
+		return staleDeleteJob(JobStatusPending), nil
+	})
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+		t.Fatal("CREATING must not fail a stale job")
+		return nil
+	})
+	patches.ApplyFunc(updateSnapshotFields, func(ctx context.Context, snapshotID string, values map[string]any) error {
+		t.Fatal("CREATING + active job must keep the existing skip path")
+		return nil
+	})
+
+	err := reclaimTimedOutSnapshotRecord(context.Background(), models.SnapshotRecord{
+		SnapshotID: "snap-creating",
+		Status:     StatusCreating,
+	})
+	require.NoError(t, err)
+}
+
+func TestReclaimTimedOutSnapshotRecordNoJob(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var snapFields map[string]any
+	patches.ApplyFunc(getActiveSnapshotJobByResourceID, func(ctx context.Context, resourceID string) (*models.TemplateImageJob, error) {
+		return nil, gorm.ErrRecordNotFound
+	})
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+		t.Fatal("must not touch a job when none is active")
+		return nil
+	})
+	patches.ApplyFunc(updateSnapshotFields, func(ctx context.Context, snapshotID string, values map[string]any) error {
+		snapFields = values
+		return nil
+	})
+
+	err := reclaimTimedOutSnapshotRecord(context.Background(), models.SnapshotRecord{
+		SnapshotID: "snap-no-job",
+		Status:     StatusDeleting,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusDeleted, snapFields["status"])
+}

--- a/CubeMaster/pkg/templatecenter/snapshot_runtime_ref.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_runtime_ref.go
@@ -151,6 +151,11 @@ func AcquireSnapshotRuntimeRef(ctx context.Context, ref SnapshotRuntimeRefInfo) 
 	return AttachSnapshotRuntimeBinding(ctx, ref, "attached runtime ref")
 }
 
+var (
+	acquireSnapshotRuntimeRefFn      = AcquireSnapshotRuntimeRef
+	countActiveSnapshotRuntimeRefsFn = CountActiveSnapshotRuntimeRefs
+)
+
 func AttachSnapshotRuntimeBinding(ctx context.Context, ref SnapshotRuntimeRefInfo, reason string) error {
 	if !isReady() {
 		return ErrTemplateStoreNotInitialized
@@ -481,6 +486,9 @@ func RefreshSnapshotRuntimeRefsFromNode(ctx context.Context, nodeID, nodeIP stri
 			if _, ok := observedKeys[snapshotRuntimeBindingKey(item.SandboxID, item.BindingType)]; ok {
 				continue
 			}
+			if retainUnobservedTombstoneRuntimeRef(ctx, item) {
+				continue
+			}
 			if err := detachObservedSnapshotRuntimeBindingTx(tx, item, "runtime ref not observed on node", now); err != nil {
 				return err
 			}
@@ -531,6 +539,40 @@ func SnapshotRuntimeRefFromSandboxBriefData(sandbox *sandboxtypes.SandboxBriefDa
 	return ref, ref.SnapshotID != ""
 }
 
+// snapshotRuntimeRefFromTemplateID observes a live sandbox as bound to a
+// snapshot when its TemplateID still has a t_cube_snapshot row, including
+// tombstones. GetTemplateKind is the create-path API and skips tombstones.
+func snapshotRuntimeRefFromTemplateID(ctx context.Context, sandbox *sandboxtypes.SandboxBriefData) (SnapshotRuntimeRefInfo, bool) {
+	if sandbox == nil {
+		return SnapshotRuntimeRefInfo{}, false
+	}
+	templateID := strings.TrimSpace(sandbox.TemplateID)
+	if templateID == "" {
+		return SnapshotRuntimeRefInfo{}, false
+	}
+	rec, err := getSnapshotRecord(ctx, templateID)
+	if err != nil || rec == nil {
+		return SnapshotRuntimeRefInfo{}, false
+	}
+	return SnapshotRuntimeRefInfo{
+		SnapshotID: templateID,
+		SandboxID:  sandbox.SandboxID,
+		NodeID:     sandbox.HostID,
+		NodeIP:     sandbox.HostIP,
+	}, true
+}
+
+// retainUnobservedTombstoneRuntimeRef keeps an existing ref when the snapshot
+// is already retired and the sandbox still exists on master. Lost annotations
+// must not detach the last ref and trigger physical delete.
+func retainUnobservedTombstoneRuntimeRef(ctx context.Context, item models.SnapshotRuntimeActive) bool {
+	rec, err := getSnapshotRecord(ctx, item.SnapshotID)
+	if err != nil || rec == nil || !snapshotRejectsNewUse(rec.Status) {
+		return false
+	}
+	return sandboxExistsOnMasterFn(ctx, item.SandboxID)
+}
+
 func snapshotRuntimeRefFromAnnotationMap(sandboxID, nodeID, nodeIP string, annotations map[string]string) SnapshotRuntimeRefInfo {
 	// v5: the physical memory_vol annotation no longer exists. The ref's
 	// MemoryVol is populated only from the rollback RPC response (see
@@ -569,18 +611,9 @@ func parseSnapshotRuntimeRefTime(raw string) (time.Time, bool) {
 // registering the ref - callers should fail fast if the snapshot is not
 // actually consumable.
 func RegisterSnapshotRuntimeRefForCreatedSandbox(ctx context.Context, snapshotID, sandboxID, nodeID, nodeIP string) error {
-	snapshotID = strings.TrimSpace(snapshotID)
-	if snapshotID == "" {
-		return nil
-	}
-	if _, err := getSnapshotReadyReplica(ctx, snapshotID, nodeID); err != nil {
+	return acquireCreatedSandboxRuntimeRef(ctx, snapshotID, sandboxID, nodeID, nodeIP, func() error {
+		_, err := getSnapshotReadyReplica(ctx, snapshotID, nodeID)
 		return err
-	}
-	return AcquireSnapshotRuntimeRef(ctx, SnapshotRuntimeRefInfo{
-		SnapshotID: snapshotID,
-		SandboxID:  sandboxID,
-		NodeID:     nodeID,
-		NodeIP:     nodeIP,
 	})
 }
 
@@ -599,17 +632,37 @@ func RegisterSnapshotRuntimeRefForCreatedSandboxWithReplica(
 	snapshotID, sandboxID, nodeID, nodeIP string,
 	replica ReplicaStatus,
 ) error {
+	return acquireCreatedSandboxRuntimeRef(ctx, snapshotID, sandboxID, nodeID, nodeIP, func() error {
+		return validateSnapshotReadyReplica(replica)
+	})
+}
+
+// acquireCreatedSandboxRuntimeRef records a sandbox↔snapshot binding.
+// DELETED / DELETING skip validation so a create that bound before
+// retire can still register. The snapshot write lock serializes this
+// with DeleteSnapshot / finalize count-then-DELETING. Cleanup waits for
+// refs registered before physical delete starts; a create RPC that has
+// not finished yet is the same window as the pre-tombstone sync delete.
+func acquireCreatedSandboxRuntimeRef(ctx context.Context, snapshotID, sandboxID, nodeID, nodeIP string, validate func() error) error {
 	snapshotID = strings.TrimSpace(snapshotID)
 	if snapshotID == "" {
 		return nil
 	}
-	if err := validateSnapshotReadyReplica(replica); err != nil {
-		return err
-	}
-	return AcquireSnapshotRuntimeRef(ctx, SnapshotRuntimeRefInfo{
-		SnapshotID: snapshotID,
-		SandboxID:  sandboxID,
-		NodeID:     nodeID,
-		NodeIP:     nodeIP,
+	return withSnapshotWriteLocks([]string{snapshotResourceLockKey(snapshotID)}, func() error {
+		allowInFlight := false
+		if rec, err := getSnapshotRecord(ctx, snapshotID); err == nil && rec != nil {
+			allowInFlight = snapshotRejectsNewUse(rec.Status)
+		}
+		if !allowInFlight {
+			if err := validate(); err != nil {
+				return err
+			}
+		}
+		return acquireSnapshotRuntimeRefFn(ctx, SnapshotRuntimeRefInfo{
+			SnapshotID: snapshotID,
+			SandboxID:  sandboxID,
+			NodeID:     nodeID,
+			NodeIP:     nodeIP,
+		})
 	})
 }

--- a/CubeMaster/pkg/templatecenter/snapshot_table.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_table.go
@@ -50,9 +50,33 @@ func updateSnapshotFields(ctx context.Context, snapshotID string, values map[str
 	if !isReady() {
 		return ErrTemplateStoreNotInitialized
 	}
+	return updateSnapshotFieldsTx(store.db.WithContext(ctx), snapshotID, values)
+}
+
+func updateSnapshotFieldsTx(tx *gorm.DB, snapshotID string, values map[string]any) error {
 	values["updated_at"] = gorm.Expr("CURRENT_TIMESTAMP")
-	return store.db.WithContext(ctx).Table(constants.SnapshotTableName).
+	return tx.Table(constants.SnapshotTableName).
 		Where("snapshot_id = ?", snapshotID).Updates(values).Error
+}
+
+// updateSnapshotFieldsIfStatusIn writes only when the row is still in one of
+// statuses. Used by replica-presence so a concurrent tombstone / physical
+// delete is not overwritten with FAILED.
+func updateSnapshotFieldsIfStatusIn(ctx context.Context, snapshotID string, values map[string]any, statuses ...string) (bool, error) {
+	if !isReady() {
+		return false, ErrTemplateStoreNotInitialized
+	}
+	if len(statuses) == 0 {
+		return false, nil
+	}
+	values["updated_at"] = gorm.Expr("CURRENT_TIMESTAMP")
+	result := store.db.WithContext(ctx).Table(constants.SnapshotTableName).
+		Where("snapshot_id = ? AND status IN ?", snapshotID, statuses).
+		Updates(values)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected > 0, nil
 }
 
 func createSnapshotTx(ctx context.Context, tx *gorm.DB, snapshotID string, storedReq *sandboxtypes.CreateCubeSandboxReq, instanceType, version string, rec *models.SnapshotRecord) error {
@@ -99,7 +123,6 @@ func snapshotInfoFromRecord(rec *models.SnapshotRecord, replicas []ReplicaStatus
 		StorageBackend:            rec.Backend,
 		Backend:                   rec.Backend,
 		RemoteStatus:              rec.RemoteStatus,
-		Retain:                    rec.Retain,
 		RootfsSizeBytesAtSnapshot: rec.RootfsSizeBytesAtSnapshot,
 		LastError:                 rec.LastError,
 		CreatedAt:                 formatUTCRFC3339(rec.CreatedAt),
@@ -167,6 +190,9 @@ func GetSnapshotRestoreSource(ctx context.Context, snapshotID string) (*RestoreS
 	rec, err := getSnapshotRecord(ctx, snapshotID)
 	if err != nil {
 		return nil, err
+	}
+	if snapshotRejectsNewUse(rec.Status) {
+		return nil, wrapSnapshotNotFound(snapshotID)
 	}
 	return &RestoreSource{
 		SnapshotID:          rec.SnapshotID,

--- a/CubeMaster/pkg/templatecenter/snapshot_tombstone.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_tombstone.go
@@ -1,0 +1,337 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxspec"
+	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"gorm.io/gorm"
+)
+
+const (
+	snapshotOrphanRuntimeRefTTL = 24 * time.Hour
+	snapshotTombstoneRequestID  = "tombstone-finalize:"
+)
+
+var (
+	sandboxExistsOnMasterFn = sandboxExistsOnMaster
+	snapshotNow             = time.Now
+)
+
+func snapshotIsTombstoned(status string) bool {
+	return strings.EqualFold(strings.TrimSpace(status), StatusDeleted)
+}
+
+func snapshotRejectsNewUse(status string) bool {
+	return snapshotIsTombstoned(status) || strings.EqualFold(strings.TrimSpace(status), StatusDeleting)
+}
+
+func wrapSnapshotNotFound(snapshotID string) error {
+	return fmt.Errorf("%w: %s", ErrSnapshotNotFound, snapshotID)
+}
+
+// EnsureSnapshotReadyForNewUse gates create/rollback binding on a still-
+// consumable snapshot. The read lock orders the READY check against a
+// concurrent DeleteSnapshot / finalize write lock.
+func EnsureSnapshotReadyForNewUse(ctx context.Context, snapshotID string) error {
+	snapshotID = strings.TrimSpace(snapshotID)
+	if snapshotID == "" {
+		return ErrSnapshotNotFound
+	}
+	return withTemplateReadLock(snapshotResourceLockKey(snapshotID), func() error {
+		rec, err := getSnapshotRecord(ctx, snapshotID)
+		if err != nil {
+			return err
+		}
+		if snapshotRejectsNewUse(rec.Status) {
+			return wrapSnapshotNotFound(snapshotID)
+		}
+		if !strings.EqualFold(strings.TrimSpace(rec.Status), StatusReady) {
+			return fmt.Errorf("%w: snapshot %s is in status %s", ErrTemplateAttemptInProgress, snapshotID, rec.Status)
+		}
+		return nil
+	})
+}
+
+func tombstoneSnapshotRecord(ctx context.Context, snapshotID string) error {
+	if err := updateSnapshotFields(ctx, snapshotID, map[string]any{
+		"status":     StatusDeleted,
+		"last_error": "",
+	}); err != nil {
+		return err
+	}
+	invalidateTemplateCaches(snapshotID)
+	return nil
+}
+
+func syntheticTombstoneJobInfo(requestID, snapshotID string) *sandboxtypes.TemplateImageJobInfo {
+	return &sandboxtypes.TemplateImageJobInfo{
+		JobID:        firstNonEmpty(strings.TrimSpace(requestID), uuid.NewString()),
+		RequestID:    strings.TrimSpace(requestID),
+		TemplateID:   snapshotID,
+		ResourceType: JobResourceTypeSnapshot,
+		ResourceID:   snapshotID,
+		Operation:    JobOperationSnapshotDelete,
+		Status:       JobStatusReady,
+		Phase:        JobPhaseReady,
+		Progress:     100,
+	}
+}
+
+func markSnapshotDeleteFailed(ctx context.Context, snapshotID, message string) error {
+	return updateSnapshotFields(ctx, snapshotID, map[string]any{
+		"status":     StatusDeleted,
+		"last_error": message,
+	})
+}
+
+func sandboxExistsOnMaster(ctx context.Context, sandboxID string) bool {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return false
+	}
+	if localcache.GetSandboxCache(sandboxID) != nil {
+		return true
+	}
+	if _, ok := localcache.GetSandboxProxyMap(ctx, sandboxID); ok {
+		return true
+	}
+	if _, err := sandboxspec.Get(ctx, sandboxID); err == nil {
+		return true
+	} else if errors.Is(err, sandboxspec.ErrSandboxSpecNotFound) {
+		return false
+	}
+	// Spec store / DB error: fail closed so a blip cannot expire a live ref.
+	return true
+}
+
+func listSnapshotRecordsByStatus(ctx context.Context, statuses ...string) ([]models.SnapshotRecord, error) {
+	if !isReady() {
+		return nil, ErrTemplateStoreNotInitialized
+	}
+	if len(statuses) == 0 {
+		return nil, nil
+	}
+	var rows []models.SnapshotRecord
+	if err := store.db.WithContext(ctx).Table(constants.SnapshotTableName).
+		Where("status IN ?", statuses).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func expireOrphanSnapshotRuntimeRefs(ctx context.Context) error {
+	rows, err := listSnapshotRecordsByStatus(ctx, StatusDeleted)
+	if err != nil {
+		return err
+	}
+	return expireOrphanSnapshotRuntimeRefsOn(ctx, rows)
+}
+
+// expireOrphanSnapshotRuntimeRefsOn detaches refs whose sandbox is gone from
+// master AND whose last observation exceeds the TTL. Both are required: a
+// live sandbox always keeps its ref, and the TTL guards against transient
+// cache misses (S3 cleanup deactivates before unlinking, bypassing EBUSY).
+func expireOrphanSnapshotRuntimeRefsOn(ctx context.Context, rows []models.SnapshotRecord) error {
+	now := snapshotNow()
+	var expireErr error
+	for _, rec := range rows {
+		refs, listErr := ListActiveSnapshotRuntimeRefs(ctx, rec.SnapshotID)
+		if listErr != nil {
+			expireErr = errors.Join(expireErr, listErr)
+			continue
+		}
+		for _, ref := range refs {
+			if sandboxExistsOnMasterFn(ctx, ref.SandboxID) {
+				continue
+			}
+			observed := ref.AttachedAt
+			if ref.LastSeenAt != nil && !ref.LastSeenAt.IsZero() {
+				observed = *ref.LastSeenAt
+			}
+			if observed.IsZero() || now.Sub(observed) < snapshotOrphanRuntimeRefTTL {
+				continue
+			}
+			if err := DetachSnapshotRuntimeBinding(ctx, ref.SandboxID, ref.BindingType, "orphan runtime ref expired"); err != nil {
+				expireErr = errors.Join(expireErr, err)
+			}
+		}
+	}
+	return expireErr
+}
+
+// maybeFinalizeTombstone starts physical cleanup when a tombstoned snapshot
+// has no remaining runtime refs. Execution is asynchronous so destroy hooks
+// stay cheap; the 5min reconciler retries if the goroutine is lost.
+func maybeFinalizeTombstone(ctx context.Context, snapshotID string) {
+	snapshotID = strings.TrimSpace(snapshotID)
+	if snapshotID == "" {
+		return
+	}
+	jobID, err := beginTombstonePhysicalCleanup(ctx, snapshotID)
+	if err != nil {
+		log.G(ctx).Warnf("begin tombstone physical cleanup for %s failed: %v", snapshotID, err)
+		return
+	}
+	if jobID == "" {
+		return
+	}
+	go func() {
+		jobCtx, cancel := synchronousSnapshotJobContext(context.Background(), "snapshot_tombstone_finalize", map[string]any{
+			"job_id":      jobID,
+			"snapshot_id": snapshotID,
+		})
+		defer cancel()
+		info, err := GetTemplateImageJobInfo(jobCtx, jobID)
+		if err != nil {
+			log.G(jobCtx).Warnf("load tombstone delete job %s failed: %v", jobID, err)
+			return
+		}
+		if _, err := executeSnapshotDeleteJob(jobCtx, info, snapshotID); err != nil {
+			log.G(jobCtx).Warnf("tombstone physical cleanup for %s failed: %v", snapshotID, err)
+		}
+	}()
+}
+
+// beginTombstonePhysicalCleanup starts physical delete for a tombstoned
+// snapshot with no remaining refs. Returns "" if gone, not tombstoned,
+// still referenced, or already has an active job.
+func beginTombstonePhysicalCleanup(ctx context.Context, snapshotID string) (string, error) {
+	var jobID string
+	err := withSnapshotWriteLocks([]string{snapshotResourceLockKey(snapshotID)}, func() error {
+		rec, err := getSnapshotRecord(ctx, snapshotID)
+		if err != nil {
+			if errors.Is(err, ErrSnapshotNotFound) {
+				return nil
+			}
+			return err
+		}
+		if !snapshotIsTombstoned(rec.Status) {
+			return nil
+		}
+		n, err := countActiveSnapshotRuntimeRefsFn(ctx, snapshotID)
+		if err != nil {
+			return err
+		}
+		if n > 0 {
+			return nil
+		}
+		if _, err := getActiveSnapshotJobByResourceID(ctx, snapshotID); err == nil {
+			return nil
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		id, err := insertSnapshotDeleteJob(ctx, snapshotTombstoneRequestID+uuid.NewString(), snapshotID, rec.OriginNodeID, rec.InstanceType)
+		if err != nil {
+			return err
+		}
+		jobID = id
+		return nil
+	})
+	return jobID, err
+}
+
+func insertSnapshotDeleteJob(ctx context.Context, requestID, snapshotID, originNodeID, instanceType string) (string, error) {
+	attemptNo, retryOfJobID, err := nextSnapshotAttempt(ctx, snapshotID)
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(snapshotDeleteJobRequest{
+		RequestID:  requestID,
+		SnapshotID: snapshotID,
+		NodeID:     originNodeID,
+	})
+	if err != nil {
+		return "", err
+	}
+	jobID := uuid.NewString()
+	record := &models.TemplateImageJob{
+		JobID:        jobID,
+		TemplateID:   snapshotID,
+		RequestID:    requestID,
+		ResourceType: JobResourceTypeSnapshot,
+		ResourceID:   snapshotID,
+		AttemptNo:    attemptNo,
+		RetryOfJobID: retryOfJobID,
+		Operation:    JobOperationSnapshotDelete,
+		NodeID:       originNodeID,
+		InstanceType: instanceType,
+		Status:       JobStatusPending,
+		Phase:        JobPhaseDeleting,
+		Progress:     0,
+		RequestJSON:  string(payload),
+	}
+	if err := store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Table(constants.SnapshotTableName).
+			Where("snapshot_id = ?", snapshotID).
+			Updates(map[string]any{
+				"status":     StatusDeleting,
+				"updated_at": gorm.Expr("CURRENT_TIMESTAMP"),
+			}).Error; err != nil {
+			return err
+		}
+		return tx.Table(constants.TemplateImageJobTableName).Create(record).Error
+	}); err != nil {
+		return "", err
+	}
+	return jobID, nil
+}
+
+// reconcileSnapshotTombstones expires orphan refs and finalizes drained
+// tombstones, sharing one list of DELETED rows.
+func reconcileSnapshotTombstones(ctx context.Context) error {
+	rows, err := listSnapshotRecordsByStatus(ctx, StatusDeleted)
+	if err != nil {
+		return err
+	}
+	expireErr := expireOrphanSnapshotRuntimeRefsOn(ctx, rows)
+	if failErr := failStaleDeleteJobsOnTombstones(ctx, rows); failErr != nil {
+		return errors.Join(expireErr, failErr)
+	}
+	for _, rec := range rows {
+		maybeFinalizeTombstone(ctx, rec.SnapshotID)
+	}
+	return expireErr
+}
+
+// failStaleDeleteJobsOnTombstones marks a leftover PENDING/RUNNING
+// SNAPSHOT_DELETE job FAILED when the row is already DELETED and the job
+// is past the operation timeout. That split state blocks finalize forever.
+func failStaleDeleteJobsOnTombstones(ctx context.Context, rows []models.SnapshotRecord) error {
+	var failErr error
+	for _, rec := range rows {
+		if err := failStaleDeleteJobOnTombstone(ctx, rec); err != nil {
+			failErr = errors.Join(failErr, err)
+		}
+	}
+	return failErr
+}
+
+func failStaleDeleteJobOnTombstone(ctx context.Context, rec models.SnapshotRecord) error {
+	active, err := getActiveSnapshotJobByResourceID(ctx, rec.SnapshotID)
+	if err != nil && !errorsIsRecordNotFound(err) {
+		return err
+	}
+	if active == nil || !shouldFailStaleDeleteJobOnTombstone(rec, active) {
+		return nil
+	}
+	return updateTemplateImageJob(ctx, active.JobID, map[string]any{
+		"status":        JobStatusFailed,
+		"error_message": fmt.Sprintf("stale snapshot delete job %s exceeded %s on tombstone", active.JobID, snapshotOperationTimeout),
+	})
+}

--- a/CubeMaster/pkg/templatecenter/snapshot_tombstone_test.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_tombstone_test.go
@@ -1,0 +1,631 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/types"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxspec"
+	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	gormmysql "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+func TestMatchesSnapshotRecordListOptionsHidesTombstone(t *testing.T) {
+	if matchesSnapshotRecordListOptions(&models.SnapshotRecord{Status: StatusDeleted}, ListSnapshotsOptions{}) {
+		t.Fatal("DELETED snapshots must be hidden from default list")
+	}
+	if matchesSnapshotRecordListOptions(&models.SnapshotRecord{Status: StatusDeleting}, ListSnapshotsOptions{}) {
+		t.Fatal("DELETING snapshots must be hidden from default list")
+	}
+	if !matchesSnapshotRecordListOptions(&models.SnapshotRecord{Status: StatusReady}, ListSnapshotsOptions{}) {
+		t.Fatal("READY snapshots must remain listed")
+	}
+	if !matchesSnapshotRecordListOptions(&models.SnapshotRecord{Status: StatusDeleted}, ListSnapshotsOptions{Status: StatusDeleted}) {
+		t.Fatal("explicit status filter should still match DELETED")
+	}
+}
+
+func TestGetSnapshotInfoHidesTombstone(t *testing.T) {
+	for _, status := range []string{StatusDeleted, StatusDeleting} {
+		t.Run(status, func(t *testing.T) {
+			oldDB := store.db
+			store.db = &gorm.DB{}
+			defer func() { store.db = oldDB }()
+
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+				return &models.SnapshotRecord{SnapshotID: snapshotID, Status: status}, nil
+			})
+
+			_, err := GetSnapshotInfo(context.Background(), "snap-gone", false)
+			if !errors.Is(err, ErrSnapshotNotFound) {
+				t.Fatalf("GetSnapshotInfo(%s) error = %v, want ErrSnapshotNotFound", status, err)
+			}
+		})
+	}
+}
+
+func TestGetSnapshotRestoreSourceRejectsTombstone(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted}, nil
+	})
+
+	_, err := GetSnapshotRestoreSource(context.Background(), "snap-gone")
+	if !errors.Is(err, ErrSnapshotNotFound) {
+		t.Fatalf("GetSnapshotRestoreSource error = %v, want ErrSnapshotNotFound", err)
+	}
+}
+
+func TestRollbackSandboxToSnapshotRejectsTombstone(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getTemplateImageJobByRequestID, func(ctx context.Context, requestID string) (*models.TemplateImageJob, error) {
+		return nil, gorm.ErrRecordNotFound
+	})
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted, OriginSandboxID: "sb-1"}, nil
+	})
+
+	_, err := RollbackSandboxToSnapshot(context.Background(), "req-rb", "sb-1", "snap-gone", "cubebox", "")
+	if !errors.Is(err, ErrSnapshotNotFound) {
+		t.Fatalf("RollbackSandboxToSnapshot error = %v, want ErrSnapshotNotFound", err)
+	}
+}
+
+func TestEnsureSnapshotReadyForNewUseRejectsTombstone(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted}, nil
+	})
+
+	err := EnsureSnapshotReadyForNewUse(context.Background(), "snap-gone")
+	if !errors.Is(err, ErrSnapshotNotFound) {
+		t.Fatalf("EnsureSnapshotReadyForNewUse error = %v, want ErrSnapshotNotFound", err)
+	}
+}
+
+func TestRegisterSnapshotRuntimeRefAllowsTombstoneAcquire(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted}, nil
+	})
+	origAcquire := acquireSnapshotRuntimeRefFn
+	t.Cleanup(func() { acquireSnapshotRuntimeRefFn = origAcquire })
+	acquired := false
+	acquireSnapshotRuntimeRefFn = func(ctx context.Context, ref SnapshotRuntimeRefInfo) error {
+		acquired = true
+		if ref.SnapshotID != "snap-tomb" || ref.SandboxID != "sb-1" {
+			t.Fatalf("unexpected acquire %#v", ref)
+		}
+		return nil
+	}
+	patches.ApplyFunc(getSnapshotReadyReplica, func(ctx context.Context, snapshotID, preferredNodeID string) (ReplicaStatus, error) {
+		t.Fatal("tombstoned register must skip ready-replica check")
+		return ReplicaStatus{}, nil
+	})
+
+	if err := RegisterSnapshotRuntimeRefForCreatedSandbox(context.Background(), "snap-tomb", "sb-1", "node-a", "10.0.0.1"); err != nil {
+		t.Fatalf("RegisterSnapshotRuntimeRefForCreatedSandbox: %v", err)
+	}
+	if !acquired {
+		t.Fatal("expected acquire on tombstoned snapshot")
+	}
+}
+
+func TestRegisterSnapshotRuntimeRefAllowsDeletingAcquire(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleting}, nil
+	})
+	origAcquire := acquireSnapshotRuntimeRefFn
+	t.Cleanup(func() { acquireSnapshotRuntimeRefFn = origAcquire })
+	acquired := false
+	acquireSnapshotRuntimeRefFn = func(ctx context.Context, ref SnapshotRuntimeRefInfo) error {
+		acquired = true
+		return nil
+	}
+	patches.ApplyFunc(getSnapshotReadyReplica, func(ctx context.Context, snapshotID, preferredNodeID string) (ReplicaStatus, error) {
+		t.Fatal("DELETING register must skip ready-replica check")
+		return ReplicaStatus{}, nil
+	})
+
+	if err := RegisterSnapshotRuntimeRefForCreatedSandbox(context.Background(), "snap-dying", "sb-1", "node-a", "10.0.0.1"); err != nil {
+		t.Fatalf("RegisterSnapshotRuntimeRefForCreatedSandbox: %v", err)
+	}
+	if !acquired {
+		t.Fatal("expected acquire on DELETING snapshot")
+	}
+}
+
+func TestRegisterSnapshotRuntimeRefReadyStillValidates(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusReady}, nil
+	})
+	origAcquire := acquireSnapshotRuntimeRefFn
+	t.Cleanup(func() { acquireSnapshotRuntimeRefFn = origAcquire })
+	acquireSnapshotRuntimeRefFn = func(ctx context.Context, ref SnapshotRuntimeRefInfo) error {
+		t.Fatal("READY register must not acquire after validate fails")
+		return nil
+	}
+	patches.ApplyFunc(getSnapshotReadyReplica, func(ctx context.Context, snapshotID, preferredNodeID string) (ReplicaStatus, error) {
+		return ReplicaStatus{}, errors.New("no ready replica")
+	})
+
+	err := RegisterSnapshotRuntimeRefForCreatedSandbox(context.Background(), "snap-ready", "sb-1", "node-a", "10.0.0.1")
+	if err == nil {
+		t.Fatal("READY register must run validate")
+	}
+}
+
+func TestFailSnapshotDeleteJobReturnsTombstone(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	origTx := withStoreTx
+	t.Cleanup(func() { withStoreTx = origTx })
+	withStoreTx = func(ctx context.Context, fn func(*gorm.DB) error) error {
+		return fn(store.db)
+	}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var status string
+	patches.ApplyFunc(updateSnapshotFieldsTx, func(tx *gorm.DB, snapshotID string, values map[string]any) error {
+		if s, ok := values["status"].(string); ok {
+			status = s
+		}
+		return nil
+	})
+	patches.ApplyFunc(updateTemplateImageJobTx, func(tx *gorm.DB, jobID string, values map[string]any) error {
+		return nil
+	})
+
+	if err := failSnapshotDeleteJob(context.Background(), "job-1", "snap-1", errors.New("cubelet busy")); err != nil {
+		t.Fatalf("failSnapshotDeleteJob: %v", err)
+	}
+	if status != StatusDeleted {
+		t.Fatalf("status = %q, want %q", status, StatusDeleted)
+	}
+}
+
+func TestFailSnapshotDeleteJobRollsBackWhenJobUpdateFails(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	origTx := withStoreTx
+	t.Cleanup(func() { withStoreTx = origTx })
+	snapWritten := false
+	withStoreTx = func(ctx context.Context, fn func(*gorm.DB) error) error {
+		if err := fn(store.db); err != nil {
+			snapWritten = false
+			return err
+		}
+		return nil
+	}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(updateSnapshotFieldsTx, func(tx *gorm.DB, snapshotID string, values map[string]any) error {
+		snapWritten = true
+		return nil
+	})
+	patches.ApplyFunc(updateTemplateImageJobTx, func(tx *gorm.DB, jobID string, values map[string]any) error {
+		return errors.New("job write failed")
+	})
+
+	err := failSnapshotDeleteJob(context.Background(), "job-1", "snap-1", errors.New("cubelet busy"))
+	if err == nil {
+		t.Fatal("expected failSnapshotDeleteJob to return the job write error")
+	}
+	if snapWritten {
+		t.Fatal("snapshot row must not stay DELETED when the job update fails")
+	}
+}
+
+func TestBeginTombstonePhysicalCleanupRequiresZeroRefs(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted}, nil
+	})
+	origCount := countActiveSnapshotRuntimeRefsFn
+	t.Cleanup(func() { countActiveSnapshotRuntimeRefsFn = origCount })
+	countActiveSnapshotRuntimeRefsFn = func(ctx context.Context, snapshotID string) (int64, error) {
+		return 1, nil
+	}
+	patches.ApplyFunc(nextSnapshotAttempt, func(ctx context.Context, snapshotID string) (int32, string, error) {
+		t.Fatal("must not start delete job while refs remain")
+		return 0, "", nil
+	})
+
+	jobID, err := beginTombstonePhysicalCleanup(context.Background(), "snap-1")
+	if err != nil {
+		t.Fatalf("beginTombstonePhysicalCleanup: %v", err)
+	}
+	if jobID != "" {
+		t.Fatalf("jobID = %q, want empty while refs remain", jobID)
+	}
+}
+
+func TestExpireOrphanSnapshotRuntimeRefsRequiresMissingSandboxAndTTL(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	origExists := sandboxExistsOnMasterFn
+	origNow := snapshotNow
+	t.Cleanup(func() {
+		sandboxExistsOnMasterFn = origExists
+		snapshotNow = origNow
+	})
+
+	seen := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	snapshotNow = func() time.Time { return seen.Add(snapshotOrphanRuntimeRefTTL + time.Hour) }
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(listSnapshotRecordsByStatus, func(ctx context.Context, statuses ...string) ([]models.SnapshotRecord, error) {
+		return []models.SnapshotRecord{{SnapshotID: "snap-1", Status: StatusDeleted}}, nil
+	})
+	patches.ApplyFunc(ListActiveSnapshotRuntimeRefs, func(ctx context.Context, snapshotID string) ([]SnapshotRuntimeRefInfo, error) {
+		return []SnapshotRuntimeRefInfo{{
+			SnapshotID: snapshotID,
+			SandboxID:  "sb-missing",
+			LastSeenAt: &seen,
+		}}, nil
+	})
+
+	sandboxExistsOnMasterFn = func(ctx context.Context, sandboxID string) bool { return true }
+	detached := false
+	patches.ApplyFunc(DetachSnapshotRuntimeBinding, func(ctx context.Context, sandboxID, bindingType, reason string) error {
+		detached = true
+		return nil
+	})
+	if err := expireOrphanSnapshotRuntimeRefs(context.Background()); err != nil {
+		t.Fatalf("expire while sandbox exists: %v", err)
+	}
+	if detached {
+		t.Fatal("must not expire refs while the sandbox still exists on master")
+	}
+
+	sandboxExistsOnMasterFn = func(ctx context.Context, sandboxID string) bool { return false }
+	snapshotNow = func() time.Time { return seen.Add(time.Hour) }
+	if err := expireOrphanSnapshotRuntimeRefs(context.Background()); err != nil {
+		t.Fatalf("expire before TTL: %v", err)
+	}
+	if detached {
+		t.Fatal("must not expire refs before last_seen TTL")
+	}
+
+	snapshotNow = func() time.Time { return seen.Add(snapshotOrphanRuntimeRefTTL + time.Hour) }
+	if err := expireOrphanSnapshotRuntimeRefs(context.Background()); err != nil {
+		t.Fatalf("expire after TTL: %v", err)
+	}
+	if !detached {
+		t.Fatal("expected orphan ref detach after TTL when sandbox is gone")
+	}
+}
+
+func TestGetTemplateKindSkipsTombstone(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getCachedTemplateKind, func(templateID string) (string, bool) {
+		return "", false
+	})
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted}, nil
+	})
+	patches.ApplyFunc(GetDefinition, func(ctx context.Context, templateID string) (*models.TemplateDefinition, error) {
+		return nil, ErrTemplateNotFound
+	})
+
+	_, err := GetTemplateKind(context.Background(), "snap-gone")
+	if err == nil {
+		t.Fatal("GetTemplateKind should not treat a tombstoned snapshot as a live snapshot")
+	}
+	if !errors.Is(err, ErrTemplateNotFound) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("GetTemplateKind error = %v, want not found", err)
+	}
+}
+
+func TestSnapshotRuntimeRefFromTemplateIDIncludesTombstone(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted}, nil
+	})
+
+	ref, ok := snapshotRuntimeRefFromTemplateID(context.Background(), &sandboxtypes.SandboxBriefData{
+		SandboxID:  "sb-1",
+		TemplateID: "snap-tomb",
+		HostID:     "node-a",
+		HostIP:     "10.0.0.1",
+	})
+	if !ok {
+		t.Fatal("tombstoned snapshot row must still be observed from TemplateID")
+	}
+	if ref.SnapshotID != "snap-tomb" || ref.SandboxID != "sb-1" {
+		t.Fatalf("ref = %+v", ref)
+	}
+}
+
+func TestRetainUnobservedTombstoneRuntimeRef(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	origExists := sandboxExistsOnMasterFn
+	t.Cleanup(func() { sandboxExistsOnMasterFn = origExists })
+
+	item := models.SnapshotRuntimeActive{SnapshotID: "snap-1", SandboxID: "sb-1"}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	status := StatusDeleted
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: status}, nil
+	})
+
+	sandboxExistsOnMasterFn = func(ctx context.Context, sandboxID string) bool { return true }
+	if !retainUnobservedTombstoneRuntimeRef(context.Background(), item) {
+		t.Fatal("tombstone + sandbox on master must keep the unobserved ref")
+	}
+
+	status = StatusDeleting
+	if !retainUnobservedTombstoneRuntimeRef(context.Background(), item) {
+		t.Fatal("DELETING + sandbox on master must keep the unobserved ref")
+	}
+
+	sandboxExistsOnMasterFn = func(ctx context.Context, sandboxID string) bool { return false }
+	if retainUnobservedTombstoneRuntimeRef(context.Background(), item) {
+		t.Fatal("tombstone + sandbox gone must still allow detach")
+	}
+
+	status = StatusReady
+	sandboxExistsOnMasterFn = func(ctx context.Context, sandboxID string) bool { return true }
+	if retainUnobservedTombstoneRuntimeRef(context.Background(), item) {
+		t.Fatal("READY snapshot must not skip detach-on-unobserved")
+	}
+}
+
+func TestSandboxExistsOnMasterFailClosedOnSpecError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(localcache.GetSandboxCache, func(sandboxID string) *localcache.SandboxCache {
+		return nil
+	})
+	patches.ApplyFunc(localcache.GetSandboxProxyMap, func(ctx context.Context, sandboxID string) (*types.SandboxProxyMap, bool) {
+		return nil, false
+	})
+	patches.ApplyFunc(sandboxspec.Get, func(ctx context.Context, sandboxID string) (*sandboxtypes.CreateCubeSandboxReq, error) {
+		return nil, errors.New("spec db unavailable")
+	})
+
+	if !sandboxExistsOnMaster(context.Background(), "sb-spec-err") {
+		t.Fatal("spec store error must fail closed and treat the sandbox as still present")
+	}
+}
+
+func TestGetTemplateInfoHidesTombstoneDespiteDefinition(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(GetDefinition, func(ctx context.Context, templateID string) (*models.TemplateDefinition, error) {
+		return &models.TemplateDefinition{TemplateID: templateID, Kind: TemplateKindSnapshot, Status: StatusReady}, nil
+	})
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted}, nil
+	})
+	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
+		t.Fatal("must not list replicas for a tombstoned snapshot")
+		return nil, nil
+	})
+
+	_, err := GetTemplateInfo(context.Background(), "snap-gone")
+	if !errors.Is(err, ErrTemplateNotFound) {
+		t.Fatalf("GetTemplateInfo error = %v, want ErrTemplateNotFound", err)
+	}
+}
+
+func TestListTemplatesHidesTombstonedDefinition(t *testing.T) {
+	oldDB := store.db
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(hiddenSnapshotIDs, func(ctx context.Context) (map[string]struct{}, error) {
+		return map[string]struct{}{"snap-tomb": {}}, nil
+	})
+
+	store.db = stubListTemplatesDB(t,
+		[]models.TemplateDefinition{
+			{TemplateID: "snap-tomb", Kind: TemplateKindSnapshot, Status: StatusReady},
+			{TemplateID: "tpl-live", Status: StatusReady},
+		},
+		nil,
+	)
+
+	out, listErr := ListTemplates(context.Background())
+	if listErr != nil {
+		t.Fatalf("ListTemplates: %v", listErr)
+	}
+	ids := make([]string, 0, len(out))
+	foundLive := false
+	for _, item := range out {
+		ids = append(ids, item.TemplateID)
+		if item.TemplateID == "snap-tomb" {
+			t.Fatalf("tombstoned definition leaked into ListTemplates: %v", ids)
+		}
+		if item.TemplateID == "tpl-live" {
+			foundLive = true
+		}
+	}
+	if !foundLive {
+		t.Fatalf("live template missing from ListTemplates: %v", ids)
+	}
+}
+
+func TestGetTemplateInfoHidesTombstoneDespiteCreateJob(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(GetDefinition, func(ctx context.Context, templateID string) (*models.TemplateDefinition, error) {
+		return nil, ErrTemplateNotFound
+	})
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted}, nil
+	})
+	patches.ApplyFunc(getLatestTemplateImageJobByTemplateID, func(ctx context.Context, templateID string) (*models.TemplateImageJob, error) {
+		t.Fatal("job fallback must not resurrect a tombstoned snapshot")
+		return &models.TemplateImageJob{TemplateID: templateID, Status: JobStatusReady}, nil
+	})
+
+	_, err := GetTemplateInfo(context.Background(), "snap-gone")
+	if !errors.Is(err, ErrTemplateNotFound) {
+		t.Fatalf("GetTemplateInfo error = %v, want ErrTemplateNotFound", err)
+	}
+}
+
+func TestGetTemplateRequestRejectsTombstone(t *testing.T) {
+	invalidateTemplateCaches("snap-gone-req")
+	defer invalidateTemplateCaches("snap-gone-req")
+
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(getSnapshotRecord, func(ctx context.Context, snapshotID string) (*models.SnapshotRecord, error) {
+		return &models.SnapshotRecord{SnapshotID: snapshotID, Status: StatusDeleted, RequestJSON: `{}`}, nil
+	})
+
+	_, err := GetTemplateRequest(context.Background(), "snap-gone-req")
+	if !errors.Is(err, ErrTemplateNotFound) {
+		t.Fatalf("GetTemplateRequest error = %v, want ErrTemplateNotFound", err)
+	}
+}
+
+func TestHiddenSnapshotIDsIncludesDeletedAndDeleting(t *testing.T) {
+	oldDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = oldDB }()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(listSnapshotRecordsByStatus, func(ctx context.Context, statuses ...string) ([]models.SnapshotRecord, error) {
+		if len(statuses) != 2 || statuses[0] != StatusDeleted || statuses[1] != StatusDeleting {
+			t.Fatalf("statuses = %v, want DELETED, DELETING", statuses)
+		}
+		return []models.SnapshotRecord{
+			{SnapshotID: "snap-tomb", Status: StatusDeleted},
+			{SnapshotID: "snap-dying", Status: StatusDeleting},
+		}, nil
+	})
+
+	ids, err := hiddenSnapshotIDs(context.Background())
+	if err != nil {
+		t.Fatalf("hiddenSnapshotIDs: %v", err)
+	}
+	if _, ok := ids["snap-tomb"]; !ok {
+		t.Fatal("missing snap-tomb")
+	}
+	if _, ok := ids["snap-dying"]; !ok {
+		t.Fatal("missing snap-dying")
+	}
+	if _, ok := ids["snap-ready"]; ok {
+		t.Fatal("READY snapshot must not be hidden from job fallback")
+	}
+}
+
+func stubListTemplatesDB(t *testing.T, defs []models.TemplateDefinition, jobs []models.TemplateImageJob) *gorm.DB {
+	t.Helper()
+	sqlDB, err := sql.Open("mysql", "root:root@tcp(127.0.0.1:3306)/unused?parseTime=true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := gorm.Open(gormmysql.New(gormmysql.Config{
+		Conn:                      sqlDB,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{DryRun: true, DisableAutomaticPing: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Callback().Query().Replace("gorm:query", func(tx *gorm.DB) {
+		switch dest := tx.Statement.Dest.(type) {
+		case *[]models.TemplateDefinition:
+			*dest = append([]models.TemplateDefinition(nil), defs...)
+		case *[]models.TemplateImageJob:
+			*dest = append([]models.TemplateImageJob(nil), jobs...)
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}

--- a/CubeMaster/pkg/templatecenter/snapshot_view.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_view.go
@@ -34,7 +34,6 @@ type SnapshotInfo struct {
 	StorageBackend            string                             `json:"storage_backend,omitempty"`
 	Backend                   string                             `json:"backend,omitempty"`
 	RemoteStatus              string                             `json:"remote_status,omitempty"`
-	Retain                    bool                               `json:"retain,omitempty"`
 	RootfsSizeBytesAtSnapshot uint64                             `json:"rootfs_size_bytes_at_snapshot,omitempty"`
 	LastError                 string                             `json:"last_error,omitempty"`
 	CreatedAt                 string                             `json:"created_at,omitempty"`
@@ -111,12 +110,13 @@ func ListSnapshots(ctx context.Context, opts *ListSnapshotsOptions) ([]SnapshotI
 }
 
 func GetSnapshotInfo(ctx context.Context, snapshotID string, includeRequest bool) (*SnapshotInfo, error) {
-	rec, err := getSnapshotRecord(ctx, strings.TrimSpace(snapshotID))
+	snapshotID = strings.TrimSpace(snapshotID)
+	rec, err := getSnapshotRecord(ctx, snapshotID)
 	if err != nil {
-		if errors.Is(err, ErrTemplateNotFound) {
-			return nil, ErrSnapshotNotFound
-		}
 		return nil, err
+	}
+	if snapshotRejectsNewUse(rec.Status) {
+		return nil, wrapSnapshotNotFound(snapshotID)
 	}
 	var createReq *sandboxtypes.CreateCubeSandboxReq
 	if includeRequest {
@@ -161,11 +161,13 @@ func GetTemplateKind(ctx context.Context, templateID string) (string, error) {
 	if kind, ok := getCachedTemplateKind(id); ok {
 		return kind, nil
 	}
-	if rec, err := getSnapshotRecord(ctx, id); err == nil && rec != nil {
+	rec, snapErr := getSnapshotRecord(ctx, id)
+	if snapErr != nil && !errors.Is(snapErr, ErrSnapshotNotFound) && !errors.Is(snapErr, ErrTemplateStoreNotInitialized) {
+		return "", snapErr
+	}
+	if rec != nil && !snapshotRejectsNewUse(rec.Status) {
 		setTemplateKindCache(id, TemplateKindSnapshot)
 		return TemplateKindSnapshot, nil
-	} else if err != nil && !errors.Is(err, ErrSnapshotNotFound) && !errors.Is(err, ErrTemplateStoreNotInitialized) {
-		return "", err
 	}
 	if rec, err := pausesnap.GetBySnapshotID(ctx, id); err == nil && rec != nil {
 		setTemplateKindCache(id, pausesnap.KindPauseSnapshot)
@@ -343,13 +345,9 @@ func matchesSnapshotRecordListOptions(rec *models.SnapshotRecord, opts ListSnaps
 		return false
 	}
 	if opts.Status != "" {
-		if !strings.EqualFold(strings.TrimSpace(rec.Status), opts.Status) {
-			return false
-		}
-	} else if strings.EqualFold(strings.TrimSpace(rec.Status), StatusDeleting) {
-		return false
+		return strings.EqualFold(strings.TrimSpace(rec.Status), opts.Status)
 	}
-	return true
+	return !snapshotRejectsNewUse(rec.Status)
 }
 
 func decodeSnapshotNextToken(token string) (int, error) {

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -47,6 +47,7 @@ const (
 	StatusFailed         = "FAILED"
 	StatusCreating       = "CREATING"
 	StatusDeleting       = "DELETING"
+	StatusDeleted        = "DELETED"
 
 	TemplateKindTemplate = "template"
 	TemplateKindSnapshot = "snapshot"
@@ -135,7 +136,6 @@ type TemplateInfo struct {
 	DisplayName               string          `json:"display_name,omitempty"`
 	StorageBackend            string          `json:"storage_backend,omitempty"`
 	Backend                   string          `json:"backend,omitempty"`
-	Retain                    bool            `json:"retain,omitempty"`
 	RootfsSizeBytesAtSnapshot uint64          `json:"rootfs_size_bytes_at_snapshot,omitempty"`
 	LastError                 string          `json:"last_error,omitempty"`
 	CreatedAt                 string          `json:"created_at,omitempty"`
@@ -166,7 +166,6 @@ func templateInfoFromDefinition(def models.TemplateDefinition) TemplateInfo {
 		DisplayName:               def.DisplayName,
 		StorageBackend:            def.StorageBackend,
 		Backend:                   def.StorageBackend,
-		Retain:                    def.Retain,
 		RootfsSizeBytesAtSnapshot: def.RootfsSizeBytesAtSnapshot,
 		LastError:                 def.LastError,
 	}
@@ -184,7 +183,6 @@ type definitionCreateOptions struct {
 	OriginHostFactsJSON       string
 	DisplayName               string
 	StorageBackend            string
-	Retain                    bool
 	RootfsSizeBytesAtSnapshot uint64
 }
 
@@ -211,11 +209,19 @@ func ListTemplates(ctx context.Context) ([]TemplateInfo, error) {
 		latestJobByTemplateID[job.TemplateID] = job
 	}
 
+	hiddenIDs, err := hiddenSnapshotIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	out := make([]TemplateInfo, 0, len(defs))
 	for _, def := range defs {
 		// Pause-produced snaps are internal Resume artifacts (Kind=pause_snapshot).
 		// Keep them out of template/snapshot list surfaces.
 		if strings.EqualFold(strings.TrimSpace(def.Kind), pausesnap.KindPauseSnapshot) {
+			continue
+		}
+		if _, skip := hiddenIDs[def.TemplateID]; skip {
 			continue
 		}
 		imageInfo := extractImageInfoFromRequestJSON(def.RequestJSON)
@@ -238,10 +244,44 @@ func ListTemplates(ctx context.Context) ([]TemplateInfo, error) {
 		if _, ok := seen[job.TemplateID]; ok {
 			continue
 		}
+		if _, skip := hiddenIDs[job.TemplateID]; skip {
+			continue
+		}
 		out = append(out, templateInfoFromJob(&job))
 		seen[job.TemplateID] = struct{}{}
 	}
 	return out, nil
+}
+
+// hiddenSnapshotIDs returns DELETED/DELETING snapshot IDs so ListTemplates
+// can omit leftover definition or job rows for the same id.
+func hiddenSnapshotIDs(ctx context.Context) (map[string]struct{}, error) {
+	rows, err := listSnapshotRecordsByStatus(ctx, StatusDeleted, StatusDeleting)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]struct{}, len(rows))
+	for _, rec := range rows {
+		out[rec.SnapshotID] = struct{}{}
+	}
+	return out, nil
+}
+
+// errIfHiddenSnapshot returns ErrTemplateNotFound when a snapshot row exists
+// and rejects new use. Missing rows and an uninitialized store are ignored
+// so definition/job fallbacks still run.
+func errIfHiddenSnapshot(ctx context.Context, templateID string) error {
+	rec, err := getSnapshotRecord(ctx, templateID)
+	if err != nil {
+		if errors.Is(err, ErrSnapshotNotFound) || errors.Is(err, ErrTemplateStoreNotInitialized) {
+			return nil
+		}
+		return err
+	}
+	if rec != nil && snapshotRejectsNewUse(rec.Status) {
+		return ErrTemplateNotFound
+	}
+	return nil
 }
 
 func Init(ctx context.Context) error {
@@ -275,8 +315,17 @@ func Init(ctx context.Context) error {
 
 func configureSnapshotRuntimeRefHooks() {
 	releaseBySandboxID := func(ctx context.Context, sandboxID string) error {
+		// Look up the ref before releasing so we can trigger the tombstone
+		// finalizer for that snapshot afterward.
+		ref, refErr := GetActiveSnapshotRuntimeRefBySandbox(ctx, sandboxID)
+		if refErr != nil && !errors.Is(refErr, gorm.ErrRecordNotFound) {
+			log.G(ctx).Warnf("lookup snapshot runtime ref before destroy release failed: %v", refErr)
+		}
 		errReleasingRefs := ReleaseSnapshotRuntimeRefsBySandbox(ctx, sandboxID, snapshotRuntimeRefReleasedByDestroy)
 		errDeletingSpec := sandboxspec.Delete(ctx, sandboxID)
+		if ref != nil && strings.TrimSpace(ref.SnapshotID) != "" {
+			maybeFinalizeTombstone(ctx, ref.SnapshotID)
+		}
 		if errReleasingRefs != nil && errDeletingSpec != nil {
 			return errors.Join(errReleasingRefs, errDeletingSpec)
 		}
@@ -810,14 +859,17 @@ func UpdateDefinitionStatus(ctx context.Context, templateID, status, lastError s
 }
 
 func GetTemplateInfo(ctx context.Context, templateID string) (*TemplateInfo, error) {
-	def, err := GetDefinition(ctx, templateID)
-	if err != nil {
-		if !errors.Is(err, ErrTemplateNotFound) {
-			return nil, err
-		}
+	def, defErr := GetDefinition(ctx, templateID)
+	if defErr != nil && !errors.Is(defErr, ErrTemplateNotFound) {
+		return nil, defErr
+	}
+	if err := errIfHiddenSnapshot(ctx, templateID); err != nil {
+		return nil, err
+	}
+	if defErr != nil {
 		job, jobErr := getLatestTemplateImageJobByTemplateID(ctx, templateID)
 		if jobErr != nil {
-			return nil, err
+			return nil, defErr
 		}
 		info := templateInfoFromJob(job)
 		return &info, nil
@@ -1513,6 +1565,9 @@ func GetTemplateRequest(ctx context.Context, templateID string) (*sandboxtypes.C
 		err := withTemplateReadLock(templateID, func() error {
 			dbStart := time.Now()
 			if rec, snapErr := getSnapshotRecord(ctx, templateID); snapErr == nil && rec != nil {
+				if snapshotRejectsNewUse(rec.Status) {
+					return ErrTemplateNotFound
+				}
 				reportTemplateMetric(ctx, constants.MySQL, store.dbAddr, constants.ActionTemplateGetDefinition, time.Since(dbStart), 0)
 				parsed, err := requestFromSnapshotJSON(rec.RequestJSON)
 				if err != nil {


### PR DESCRIPTION
### Background

Close #1621 

`DELETE /cube/snapshot/{id}` used to fail with a conflict while any sandbox still held a runtime reference to the snapshot, so a snapshot could only be deleted after every consuming sandbox was destroyed. A long-lived sandbox therefore pinned snapshots indefinitely, and callers had no way to express "delete it as soon as nothing needs it".

This PR decouples logical deletion from physical reclamation with a **tombstone-based two-phase delete**: the logical delete always succeeds, and physical cleanup runs once the last runtime reference is gone.

### Design

1. **Logical retire (tombstone).** When active runtime refs remain, `DeleteSnapshot` marks the row `DELETED` and returns a synthetic `READY` job, keeping the API surface synchronous and idempotent (a repeated DELETE re-returns READY). A tombstoned snapshot disappears from List/Get and rejects new sandbox creates, rollbacks, and restore-source lookups.
2. **Physical finalize.** When the last runtime ref detaches (sandbox destroy hook), the existing snapshot-delete job runs asynchronously to clean replicas and metadata. The periodic snapshot reconciler retries lost finalizations and expires orphan refs — a ref is only expired when the sandbox is gone from master **and** it has been unobserved beyond a 24 h TTL, so a transient cache miss cannot drop a live ref.
3. **In-flight create safety.** A sandbox whose create bound just before the tombstone still records its runtime ref, so cleanup waits for it. Ready-replica validation is skipped only for that already-bound case.
4. **Failure semantics.** A physical-delete failure returns the row to `DELETED` (retryable by the reconciler or a repeated DELETE) instead of `FAILED`; replica-presence failures now use a compare-and-set update so they never overwrite a concurrent tombstone; a row stuck in `DELETING` past the operation timeout returns to `DELETED` for retry.

### Other changes

- **CubeAPI routing:** `has_snapshot` routes `snap-*` ids to the snapshot delete path by identity rather than row visibility, so a tombstoned snapshot keeps being deleted idempotently instead of falling through to template deletion.
- **`DeleteTemplate` delegation:** deleting a template id that is actually a snapshot row now delegates to `DeleteSnapshot`, so both delete paths behave identically.
- **Schema cleanup:** drop the `retain` column from `t_cube_snapshot` and `t_cube_template_definition` — it was never written or consumed by control-plane logic. Goose migrations for MySQL and Postgres, guarded by the usual migration advisory locks; the Down migration restores the column.

### Testing

- New `snapshot_tombstone_test.go` (18 cases) covering tombstone visibility (List / Get / template kind / template info / request), rejection of new use (create / rollback / restore source), ref-count gating of physical cleanup, orphan-ref expiry requiring both a missing sandbox and TTL, fail-closed sandbox lookups, and tombstone-preserving failure paths.
- Updated existing tests for the `DeleteSnapshot` tombstone path, runtime-ref registration for in-flight creates, reconciler drain, replica-presence compare-and-set, and CubeAPI `snap-*` identity routing.
- Migration schema assertions updated: `retain` must be absent at head schema for both MySQL and Postgres.

### Compatibility / upgrade notes

- `DELETED` is a new snapshot status; all pre-existing statuses keep their previous handling. When no runtime refs remain, the delete path is unchanged and still fully synchronous.
- The `retain` column drop is safe for the control plane (never read or written); the Down migration restores the column if a rollback is ever needed.
