### PR TITLE
fix(cubelet): skip s3lvol init unless opted in via [cow.s3] enable

### DIFF
--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -128,6 +128,12 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
     file = "/data/log/cubecow/cubecow.log"
     rotation = "daily"
 
+    [plugins."io.cubelet.internal.v1.storage".cow.s3]
+    # CubeS3lvol opt-in. Default false: cubelet does not probe s3lvol.
+    # One-click flips this from ONE_CLICK_ENABLE_S3LVOL.
+    enable = false
+    socket_path = "/var/run/s3lvol.sock"
+
     # Only needed when switching back to the legacy ext4 / raw / reflink-pool
     # backend: change storage_backend to the corresponding value (e.g. "ext4")
     # and uncomment the fields below as needed. Under cubecow these fields are ignored.

--- a/Cubelet/storage/cow_store_ops.go
+++ b/Cubelet/storage/cow_store_ops.go
@@ -151,8 +151,9 @@ func (a storeActivator) Activate(ctx context.Context, snapshotID string) error {
 }
 
 // StoreFor returns the live XFS or S3 [cow.Store] for backend (request `type`).
-// XFS is ready after plugin init; S3 returns [ErrS3NotReady] until the
-// background s3lvol init loop publishes the S3 handle.
+// XFS is ready after plugin init; S3 returns [ErrS3NotConfigured] when
+// [cow.s3] enable is false, or [ErrS3NotReady] until the background
+// s3lvol init loop publishes the S3 handle.
 func StoreFor(backend string) (cow.Store, error) {
 	if localStorage == nil {
 		return nil, fmt.Errorf("storage is not initialized")

--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -1297,6 +1297,9 @@ func (l *local) storeForBackend(backend string) (cow.Store, error) {
 		if l.s3CowManager != nil {
 			return l.s3CowManager, nil
 		}
+		if l.config == nil || !l.config.s3lvolConfigured() {
+			return nil, ErrS3NotConfigured
+		}
 		return nil, ErrS3NotReady
 	default:
 		if l.cowManager != nil {
@@ -1309,6 +1312,9 @@ func (l *local) storeForBackend(backend string) (cow.Store, error) {
 	switch normalized {
 	case cow.BackendS3:
 		if l.s3CowManager == nil {
+			if l.config == nil || !l.config.s3lvolConfigured() {
+				return nil, ErrS3NotConfigured
+			}
 			return nil, ErrS3NotReady
 		}
 		return l.s3CowManager, nil

--- a/Cubelet/storage/local_test.go
+++ b/Cubelet/storage/local_test.go
@@ -854,6 +854,7 @@ func TestInitSkipsPoolSetupWhenStorageBackendIsCow(t *testing.T) {
 func TestInitResetsCowStorageAndReinitializesEngine(t *testing.T) {
 	cfg := makeTestConfig(t)
 	cfg.StorageBackend = "cubecow"
+	cfg.Cow.S3.Enable = true
 	// cubelet derives reflink root_dir from data_path, so put data_path
 	// somewhere we can also pre-seed stale state in.
 	rootDir := defaultReflinkAutoRootDir(cfg.DataPath)

--- a/Cubelet/storage/plugin.go
+++ b/Cubelet/storage/plugin.go
@@ -130,7 +130,7 @@ type Config struct {
 
 // CowInlineConfig mirrors the cubecow `AppConfig` schema. Cubelet owns
 // the cubecow init payload and starts one handle per backend.kind.
-// Users may tune `[log]` and `[cow.s3]` (s3lvol socket); reflink
+// Users may tune `[log]` and `[cow.s3]` (s3lvol enable / socket); reflink
 // `root_dir` and s3 `state_dir` are derived from `data_path`.
 type CowInlineConfig struct {
 	Log     CowLogConfig     `toml:"log"`
@@ -140,6 +140,7 @@ type CowInlineConfig struct {
 
 // CowS3UserConfig is the operator-facing `[cow.s3]` block.
 type CowS3UserConfig struct {
+	Enable       bool    `toml:"enable"`
 	SocketPath   *string `toml:"socket_path"`
 	StateDir     *string `toml:"state_dir"`
 	RPCTimeoutMS *uint64 `toml:"rpc_timeout_ms"`
@@ -282,6 +283,13 @@ func initS3CowEngineWithConfig(cfg *Config) (*cubecow.Engine, string, error) {
 	}
 	engine, err := cubecow.InitWithoutLoggingFromJSON(string(payload))
 	return engine, "inline storage.cow s3 handle", err
+}
+
+// s3lvolConfigured reports whether the operator opted into CubeS3lvol by
+// setting [cow.s3] enable = true. socket_path only names the RPC socket;
+// a default path in config.toml is not an opt-in.
+func (c *Config) s3lvolConfigured() bool {
+	return c != nil && c.Cow.S3.Enable
 }
 
 func (c *Config) s3BackendConfig() CowBackendConfig {
@@ -443,9 +451,10 @@ func init() {
 				return nil, err
 			}
 
-			// S3 cubecow + metadata base: background retry so cubelet does
-			// not depend on s3lvol being up at startup. S3 requests fail
-			// with ErrS3NotReady until the loop succeeds.
+			// S3 cubecow + metadata base: only when [cow.s3] enable is
+			// true. Background retry so cubelet does not depend on s3lvol
+			// being up at startup; S3 requests fail with ErrS3NotReady
+			// until the loop succeeds.
 			localStorage.startS3CowInitLoop(ic.Context)
 
 			return localStorage, nil

--- a/Cubelet/storage/s3_init.go
+++ b/Cubelet/storage/s3_init.go
@@ -21,6 +21,10 @@ var s3InitRetryInterval = 5 * time.Second
 // handle and metadata base are still initializing (or retrying).
 var ErrS3NotReady = errors.New("s3 storage is not ready (initializing)")
 
+// ErrS3NotConfigured is returned for backend=s3 requests when the operator
+// has not opted into CubeS3lvol ([cow.s3] enable is false).
+var ErrS3NotConfigured = errors.New("s3 storage is not configured (set [cow.s3] enable = true to enable CubeS3lvol)")
+
 // ensureS3MetadataReadyFn is swapped in tests to avoid real mkfs/mount.
 var ensureS3MetadataReadyFn = EnsureS3MetadataReady
 
@@ -33,6 +37,10 @@ var (
 
 func (l *local) startS3CowInitLoop(parent context.Context) {
 	if l == nil || !l.useCowStorage() {
+		return
+	}
+	if l.config == nil || !l.config.s3lvolConfigured() {
+		CubeLog.Infof("s3 cubecow init skipped; set [cow.s3] enable = true to enable")
 		return
 	}
 	l.stopS3CowInitLoop()

--- a/Cubelet/storage/s3_init_test.go
+++ b/Cubelet/storage/s3_init_test.go
@@ -16,9 +16,48 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/storage/cow"
 )
 
-func TestStoreForS3NotReadyUntilInit(t *testing.T) {
+func TestS3lvolConfigured(t *testing.T) {
+	assert.False(t, (*Config)(nil).s3lvolConfigured())
+	assert.False(t, (&Config{}).s3lvolConfigured())
+	assert.False(t, (&Config{Cow: CowInlineConfig{S3: CowS3UserConfig{
+		Enable:     false,
+		SocketPath: stringPtr("/var/run/s3lvol.sock"),
+	}}}).s3lvolConfigured())
+	assert.True(t, s3OptInConfig().s3lvolConfigured())
+}
+
+func s3OptInConfig() *Config {
+	return &Config{
+		StorageBackend: "cubecow",
+		Cow: CowInlineConfig{
+			S3: CowS3UserConfig{
+				Enable:     true,
+				SocketPath: stringPtr("/var/run/s3lvol.sock"),
+			},
+		},
+	}
+}
+
+func TestStoreForS3NotConfiguredWhenDisabled(t *testing.T) {
 	prev := localStorage
 	cfg := &Config{StorageBackend: "cubecow"}
+	localStorage = &local{config: cfg, cowManager: &XfsCow{engine: &cubecow.Engine{}}}
+	t.Cleanup(func() {
+		localStorage.stopS3CowInitLoop()
+		localStorage = prev
+	})
+
+	_, err := StoreFor(cow.BackendS3)
+	require.ErrorIs(t, err, ErrS3NotConfigured)
+
+	xfs, err := StoreFor(cow.BackendXFS)
+	require.NoError(t, err)
+	require.NotNil(t, xfs)
+}
+
+func TestStoreForS3NotReadyUntilInit(t *testing.T) {
+	prev := localStorage
+	cfg := s3OptInConfig()
 	localStorage = &local{config: cfg, cowManager: &XfsCow{engine: &cubecow.Engine{}}}
 	t.Cleanup(func() {
 		localStorage.stopS3CowInitLoop()
@@ -35,7 +74,7 @@ func TestStoreForS3NotReadyUntilInit(t *testing.T) {
 
 func TestTryS3CowInitOncePublishesAfterMetadata(t *testing.T) {
 	prev := localStorage
-	cfg := &Config{StorageBackend: "cubecow"}
+	cfg := s3OptInConfig()
 	s := &local{config: cfg}
 	localStorage = s
 	t.Cleanup(func() {
@@ -63,7 +102,7 @@ func TestTryS3CowInitOncePublishesAfterMetadata(t *testing.T) {
 
 func TestTryS3CowInitOnceDoesNotPublishOnMetadataFail(t *testing.T) {
 	prev := localStorage
-	cfg := &Config{StorageBackend: "cubecow"}
+	cfg := s3OptInConfig()
 	s := &local{config: cfg}
 	localStorage = s
 	t.Cleanup(func() {
@@ -92,7 +131,7 @@ func TestTryS3CowInitOnceDoesNotPublishOnMetadataFail(t *testing.T) {
 func TestS3CowInitLoopRetriesUntilSuccess(t *testing.T) {
 	prev := localStorage
 	prevInterval := s3InitRetryInterval
-	cfg := &Config{StorageBackend: "cubecow"}
+	cfg := s3OptInConfig()
 	s := &local{config: cfg}
 	localStorage = s
 	s3InitRetryInterval = 20 * time.Millisecond
@@ -121,4 +160,38 @@ func TestS3CowInitLoopRetriesUntilSuccess(t *testing.T) {
 		return s.s3CowEngine == eng && s.s3CowManager != nil
 	}, 2*time.Second, 20*time.Millisecond)
 	assert.GreaterOrEqual(t, attempts, 3)
+}
+
+func TestS3CowInitLoopSkippedWhenDisabled(t *testing.T) {
+	prev := localStorage
+	cfg := &Config{
+		StorageBackend: "cubecow",
+		Cow: CowInlineConfig{
+			S3: CowS3UserConfig{
+				Enable:     false,
+				SocketPath: stringPtr("/var/run/s3lvol.sock"),
+			},
+		},
+	}
+	s := &local{config: cfg}
+	localStorage = s
+	t.Cleanup(func() {
+		s.stopS3CowInitLoop()
+		s.clearS3Cow()
+		localStorage = prev
+		initS3CowEngine = initS3CowEngineWithConfig
+	})
+
+	attempts := 0
+	initS3CowEngine = func(*Config) (*cubecow.Engine, string, error) {
+		attempts++
+		return nil, "", errors.New("must not be called")
+	}
+
+	s.startS3CowInitLoop(context.Background())
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, attempts)
+	assert.Nil(t, s.s3InitCancel)
+	_, err := StoreFor(cow.BackendS3)
+	require.ErrorIs(t, err, ErrS3NotConfigured)
 }

--- a/cubecow/src/ffi.rs
+++ b/cubecow/src/ffi.rs
@@ -72,7 +72,6 @@ fn set_last_error(msg: &str) {
 }
 
 fn set_last_init_error(msg: &str) {
-    eprintln!("cubecow init error: {msg}");
     set_last_error(msg);
 }
 

--- a/deploy/one-click/scripts/common/cubelet_config.sh
+++ b/deploy/one-click/scripts/common/cubelet_config.sh
@@ -41,3 +41,140 @@ write_cubelet_cubeops_addr() {
   fi
   log "updated cubelet cubeops_addr=${addr}"
 }
+
+# Live [cow.s3] header: optional indent, then the table name. Comments and
+# in-line mentions do not count.
+cubelet_s3_header_re() {
+  printf '%s' '^[[:space:]]*\[plugins\."io\.cubelet\.internal\.v1\.storage"\.cow\.s3\]'
+}
+
+count_live_cubelet_s3_headers() {
+  grep -Ec "$(cubelet_s3_header_re)" "${1}" || true
+}
+
+# write_cubelet_s3lvol_enable CONFIG_PATH 0|1
+# Flip [cow.s3] enable from ONE_CLICK_ENABLE_S3LVOL. socket_path is left
+# alone when already set. If the section is missing, insert it after
+# cow.log / before images; if neither anchor exists, append at EOF.
+# Pre-scan live (uncommented) headers only: never insert when a real
+# [cow.s3] table already exists anywhere, so TOML does not gain a second table.
+write_cubelet_s3lvol_enable() {
+  local config_path="${1:-}"
+  local flag="${2:-}"
+  local enable_toml
+  local header='[plugins."io.cubelet.internal.v1.storage".cow.s3]'
+  local cow_log='[plugins."io.cubelet.internal.v1.storage".cow.log]'
+  local images='[plugins."io.cubelet.internal.v1.images"]'
+  local sock="/var/run/s3lvol.sock"
+  local tmp
+  local header_count
+  local enable_in_section=0
+  [[ -n "${config_path}" ]] || die "write_cubelet_s3lvol_enable requires a config path"
+  [[ -f "${config_path}" ]] || die "required file not found: ${config_path}"
+  case "${flag}" in
+    0) enable_toml="false" ;;
+    1) enable_toml="true" ;;
+    *) die "write_cubelet_s3lvol_enable requires 0 or 1 (got: '${flag}')" ;;
+  esac
+  tmp="$(mktemp "${config_path}.XXXXXX")"
+  if grep -Eq "$(cubelet_s3_header_re)" "${config_path}"; then
+    awk -v enable_toml="${enable_toml}" -v header="${header}" -v sock="${sock}" '
+      function is_table(line, name,    t) {
+        t = line
+        sub(/^[[:space:]]+/, "", t)
+        return index(t, name) == 1
+      }
+      function flush_s3() {
+        if (in_s3) {
+          if (!found_enable) {
+            print "    enable = " enable_toml
+          }
+          if (!found_socket) {
+            print "    socket_path = \"" sock "\""
+          }
+          in_s3 = 0
+        }
+      }
+      is_table($0, header) {
+        in_s3 = 1
+        print
+        next
+      }
+      in_s3 && /^[[:space:]]*\[/ {
+        flush_s3()
+      }
+      in_s3 && /^[[:space:]]*enable[[:space:]]*=/ {
+        print "    enable = " enable_toml
+        found_enable = 1
+        next
+      }
+      in_s3 && /^[[:space:]]*socket_path[[:space:]]*=/ {
+        found_socket = 1
+        print
+        next
+      }
+      { print }
+      END { flush_s3() }
+    ' "${config_path}" > "${tmp}"
+  else
+    awk -v enable_toml="${enable_toml}" -v header="${header}" \
+        -v cow_log="${cow_log}" -v images="${images}" -v sock="${sock}" '
+      function is_table(line, name,    t) {
+        t = line
+        sub(/^[[:space:]]+/, "", t)
+        return index(t, name) == 1
+      }
+      function emit_section() {
+        print "    " header
+        print "    enable = " enable_toml
+        print "    socket_path = \"" sock "\""
+        print ""
+        inserted = 1
+      }
+      is_table($0, cow_log) {
+        in_log = 1
+        print
+        next
+      }
+      in_log && /^[[:space:]]*\[/ {
+        in_log = 0
+        if (!inserted) {
+          emit_section()
+        }
+      }
+      !inserted && is_table($0, images) {
+        emit_section()
+      }
+      { print }
+      END {
+        if (!inserted) {
+          emit_section()
+        }
+      }
+    ' "${config_path}" > "${tmp}"
+  fi
+  header_count="$(count_live_cubelet_s3_headers "${tmp}")"
+  if [[ "${header_count}" -ne 1 ]]; then
+    rm -f "${tmp}"
+    die "expected exactly one live ${header} (got ${header_count})"
+  fi
+  enable_in_section="$(awk -v header="${header}" -v enable_toml="${enable_toml}" '
+    function is_table(line, name,    t) {
+      t = line
+      sub(/^[[:space:]]+/, "", t)
+      return index(t, name) == 1
+    }
+    is_table($0, header) { in_s3 = 1; next }
+    in_s3 && /^[[:space:]]*\[/ { in_s3 = 0 }
+    in_s3 && $0 ~ ("^[[:space:]]*enable[[:space:]]*=[[:space:]]*" enable_toml "[[:space:]]*$") {
+      found = 1
+    }
+    END { print found + 0 }
+  ' "${tmp}")"
+  if [[ "${enable_in_section}" -ne 1 ]]; then
+    rm -f "${tmp}"
+    die "failed to set ${header} enable = ${enable_toml}"
+  fi
+  mv -f "${tmp}" "${config_path}"
+  log "updated cubelet cow.s3 enable=${enable_toml}"
+}

--- a/deploy/one-click/scripts/systemd/cubelet-start.sh
+++ b/deploy/one-click/scripts/systemd/cubelet-start.sh
@@ -21,6 +21,7 @@ PATTERN="^${CUBELET_BIN} --config"
 ensure_executable "${CUBELET_BIN}"
 ensure_file "${CUBELET_CONFIG}"
 ensure_file "${CUBELET_DYNAMICCONF}"
+write_cubelet_s3lvol_enable "${CUBELET_CONFIG}" "${ONE_CLICK_ENABLE_S3LVOL:-0}"
 mkdir -p \
   "${TOOLBOX_ROOT}/cube-vs/network" \
   "${TOOLBOX_ROOT}/cube-snapshot" \

--- a/deploy/one-click/tests/test_cubeops_addr.sh
+++ b/deploy/one-click/tests/test_cubeops_addr.sh
@@ -95,11 +95,131 @@ test_up_compute_uses_shared_helper() {
   fi
 }
 
+write_sample_storage_config() {
+  local path="$1"
+  cat > "${path}" <<'EOF'
+    [plugins."io.cubelet.internal.v1.storage"]
+    storage_backend = "cubecow"
+    [plugins."io.cubelet.internal.v1.storage".cow.log]
+    level = "info"
+  [plugins."io.cubelet.internal.v1.images"]
+    runtime_type = "io.containerd.cube.v2"
+EOF
+}
+
+assert_s3_before_images() {
+  local path="$1"
+  local s3_line images_line
+  s3_line="$(grep -nE "$(cubelet_s3_header_re)" "${path}" | head -1 | cut -d: -f1)"
+  images_line="$(grep -nE '^[[:space:]]*\[plugins\."io\.cubelet\.internal\.v1\.images"\]' "${path}" | head -1 | cut -d: -f1)"
+  [[ -n "${s3_line}" ]] || fail "expected ${path} to contain a live cow.s3 header"
+  [[ -n "${images_line}" ]] || fail "expected ${path} to contain images"
+  (( s3_line < images_line )) || fail "cow.s3 must sit before images (s3=${s3_line} images=${images_line})"
+}
+
+test_s3lvol_enable_inserts_after_cow_log() {
+  local cfg="${TMP_DIR}/s3lvol-insert.toml"
+  write_sample_storage_config "${cfg}"
+  write_cubelet_s3lvol_enable "${cfg}" 1
+  [[ "$(count_s3_headers "${cfg}")" == "1" ]] \
+    || fail "insert path must write exactly one cow.s3 table"
+  assert_contains "${cfg}" '[plugins."io.cubelet.internal.v1.storage".cow.s3]'
+  assert_contains "${cfg}" 'enable = true'
+  assert_contains "${cfg}" 'socket_path = "/var/run/s3lvol.sock"'
+  assert_s3_before_images "${cfg}"
+}
+
+test_s3lvol_enable_flips_existing() {
+  local cfg="${TMP_DIR}/s3lvol-flip.toml"
+  cat > "${cfg}" <<'EOF'
+    [plugins."io.cubelet.internal.v1.storage"]
+    storage_backend = "cubecow"
+    [plugins."io.cubelet.internal.v1.storage".cow.log]
+    level = "info"
+    [plugins."io.cubelet.internal.v1.storage".cow.s3]
+    enable = false
+    socket_path = "/tmp/handwritten.sock"
+  [plugins."io.cubelet.internal.v1.images"]
+    runtime_type = "io.containerd.cube.v2"
+EOF
+  write_cubelet_s3lvol_enable "${cfg}" 1
+  assert_contains "${cfg}" 'enable = true'
+  assert_contains "${cfg}" 'socket_path = "/tmp/handwritten.sock"'
+  write_cubelet_s3lvol_enable "${cfg}" 0
+  assert_contains "${cfg}" 'enable = false'
+  if grep -Eq '^[[:space:]]*enable[[:space:]]*=[[:space:]]*true' "${cfg}"; then
+    fail "write_cubelet_s3lvol_enable 0 must clear enable = true"
+  fi
+  assert_contains "${cfg}" 'socket_path = "/tmp/handwritten.sock"'
+  assert_s3_before_images "${cfg}"
+}
+
+count_s3_headers() {
+  count_live_cubelet_s3_headers "$1"
+}
+
+test_s3lvol_enable_inserts_when_header_is_commented() {
+  local cfg="${TMP_DIR}/s3lvol-commented.toml"
+  cat > "${cfg}" <<'EOF'
+    [plugins."io.cubelet.internal.v1.storage"]
+    storage_backend = "cubecow"
+    [plugins."io.cubelet.internal.v1.storage".cow.log]
+    level = "info"
+    # [plugins."io.cubelet.internal.v1.storage".cow.s3]
+    # enable = false
+  [plugins."io.cubelet.internal.v1.images"]
+    runtime_type = "io.containerd.cube.v2"
+EOF
+  write_cubelet_s3lvol_enable "${cfg}" 1
+  [[ "$(count_s3_headers "${cfg}")" == "1" ]] \
+    || fail "commented cow.s3 must not count as a live table"
+  assert_contains "${cfg}" '# [plugins."io.cubelet.internal.v1.storage".cow.s3]'
+  assert_contains "${cfg}" 'enable = true'
+  assert_contains "${cfg}" 'socket_path = "/var/run/s3lvol.sock"'
+  assert_s3_before_images "${cfg}"
+}
+
+test_s3lvol_enable_flips_section_after_images() {
+  local cfg="${TMP_DIR}/s3lvol-after-images.toml"
+  cat > "${cfg}" <<'EOF'
+    [plugins."io.cubelet.internal.v1.storage"]
+    storage_backend = "cubecow"
+    [plugins."io.cubelet.internal.v1.storage".cow.log]
+    level = "info"
+  [plugins."io.cubelet.internal.v1.images"]
+    runtime_type = "io.containerd.cube.v2"
+    [plugins."io.cubelet.internal.v1.storage".cow.s3]
+    enable = false
+    socket_path = "/tmp/appended.sock"
+EOF
+  write_cubelet_s3lvol_enable "${cfg}" 1
+  [[ "$(count_s3_headers "${cfg}")" == "1" ]] \
+    || fail "write_cubelet_s3lvol_enable must not insert a second cow.s3 table"
+  assert_contains "${cfg}" 'enable = true'
+  assert_contains "${cfg}" 'socket_path = "/tmp/appended.sock"'
+  if grep -Fq 'socket_path = "/var/run/s3lvol.sock"' "${cfg}"; then
+    fail "existing handwritten socket_path must be kept when the section already exists"
+  fi
+}
+
+test_cubelet_start_writes_s3lvol_enable() {
+  assert_contains "${ONE_CLICK_DIR}/scripts/systemd/cubelet-start.sh" "write_cubelet_s3lvol_enable"
+  assert_contains "${ONE_CLICK_DIR}/scripts/systemd/cubelet-start.sh" "ONE_CLICK_ENABLE_S3LVOL"
+  if grep -Fq "write_cubelet_s3lvol_socket" "${ONE_CLICK_DIR}/scripts/systemd/cubelet-start.sh"; then
+    fail "cubelet-start.sh must not keep write_cubelet_s3lvol_socket"
+  fi
+}
+
 test_control_default_writes_local_cubeops
 test_scheme_passthrough
 test_compute_override_addr
 test_inserts_when_key_missing
 test_prepare_writes_before_compute_only_exit
 test_up_compute_uses_shared_helper
+test_s3lvol_enable_inserts_after_cow_log
+test_s3lvol_enable_flips_existing
+test_s3lvol_enable_flips_section_after_images
+test_s3lvol_enable_inserts_when_header_is_commented
+test_cubelet_start_writes_s3lvol_enable
 
 echo "cubeops_addr tests OK"


### PR DESCRIPTION
## Summary

Make CubeS3lvol an explicit opt-in. Cubelet no longer probes the s3lvol RPC socket by default. The background s3 cubecow init loop starts only when `[cow.s3] enable = true`; otherwise `backend=s3` requests fail fast with `ErrS3NotConfigured` instead of blocking on `ErrS3NotReady`.

## Changes

- **`Cubelet/config/config.toml`** — ship a default-disabled `[cow.s3]` block (`enable = false`, `socket_path = /var/run/s3lvol.sock`).
- **`Cubelet/storage/plugin.go`** — add `CowS3UserConfig.Enable` and `Config.s3lvolConfigured()`.
- **`Cubelet/storage/local.go` / `s3_init.go`** — gate `startS3CowInitLoop` and `storeForBackend` on `s3lvolConfigured()`; add `ErrS3NotConfigured`.
- **`Cubelet/storage/cow_store_ops.go`** — document the updated `StoreFor` contract for S3.
- **`Cubelet/storage/s3_init_test.go`** — new/updated tests for config gating, disabled `StoreFor`, init-loop skip, and enabled init flow.
- **`cubecow/src/ffi.rs`** — remove a noisy `eprintln` in `set_last_init_error`.

## One-click deploy

- **`deploy/one-click/scripts/common/cubelet_config.sh`** — `write_cubelet_s3lvol_enable` flips `[cow.s3] enable` from `ONE_CLICK_ENABLE_S3LVOL`. It preserves a hand-written `socket_path`. If the section is missing, it inserts after `cow.log` / before `images`. If the header already exists anywhere (including after `images`), it only flips `enable` and never inserts a second table.
- **`deploy/one-click/scripts/systemd/cubelet-start.sh`** — on every cubelet start, writes `enable` from `ONE_CLICK_ENABLE_S3LVOL` (default `0`). On one-click nodes the env var is the source of truth; a hand-edited `enable = true` is overwritten on restart unless the env var is also `1`.
- **`deploy/one-click/tests/test_cubeops_addr.sh`** — covers insert-after-log, flip-existing, section-after-images (no duplicate table), ordering, and that no stale helper remains.

## How to enable

- **One-click:** set `ONE_CLICK_ENABLE_S3LVOL=1` in `.env` / `.one-click.env`, then restart cubelet (or re-run `install.sh`). Do not rely on editing `[cow.s3] enable` alone on one-click nodes.
- **Non-one-click / hand-managed toml:** set `[cow.s3] enable = true` and restart cubelet.

## Upgrade note

Nodes that previously used S3 because cubelet always probed `/var/run/s3lvol.sock` (no `[cow.s3]` block, or a block without `enable`) will have S3 disabled after this change (`Enable` defaults to false). To keep S3, set `ONE_CLICK_ENABLE_S3LVOL=1` (one-click) or `enable = true` (manual config).

refs: https://github.com/TencentCloud/CubeSandbox/issues/1581