### PR TITLE
feat(cube-bench): add seeded workload generator and A/B compare report

### DIFF
--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -195,8 +195,9 @@ queue metrics in one `compare` run.
 > load has degenerated to bursts, and the `queue_delay_*`/`dispatch_*` metrics
 > describe the client's semaphore rather than the offered schedule. The JSON
 > export marks such runs with `dispatch_saturated: 1` in `summary`; `compare`
-> pops that marker out of the metric rows and prints a warning for the
-> affected group instead. Two readings of the marker to keep in mind: it
+> pops that marker, drops the untrustworthy `queue_delay_*`/`dispatch_*` keys
+> from the flagged group (their rows render "—" and stay out of the verdict
+> lists), and prints a warning naming the group instead. Two readings of the marker to keep in mind: it
 > cannot distinguish client under-provisioning from a slow server create path
 > (a create-latency spike holds slots just as long) — check `create.p95`
 > before blaming `--concurrency` — and a transient burst delaying >5% of
@@ -207,7 +208,7 @@ queue metrics in one `compare` run.
 > approaches the `time.Sleep` granularity, where even healthy runs can exceed
 > it — treat the marker as advisory there. An early TUI quit instead exports
 > `partial: 1` in `summary` (suppressing the saturation marker), which
-> `compare` surfaces as a note in the same way.
+> `compare` surfaces as a note and covers with the same key exclusion.
 
 ### Trace file schema
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -167,11 +167,17 @@ instead. Don't mix cube-bench's `queue_delay_*` with schedsim's scheduler-side
 queue metrics in one `compare` run.
 
 > **Concurrency for lifetime-bearing presets.** A worker slot is held for the
-> full sandbox lifetime (create → lifetime sleep → delete), so the steady-state
-> number of live sandboxes ≈ `rate × mean lifetime`. Set `--concurrency` at
-> least that high (e.g. `burst`: 50 req/s × ~65 s ≈ 3250) or the dispatcher
-> stalls on the semaphore and the requested `--rate` is not honored; the tool
-> prints a startup warning when it detects this.
+> full sandbox lifetime (create → lifetime sleep → delete). The lifetime sleep
+> starts only after the create response returns (the client cannot know the
+> sandbox ID earlier), so the effective residence per sandbox is
+> `create + lifetime + delete` and the steady-state number of live sandboxes ≈
+> `rate × (mean create + mean lifetime + mean delete)`. The `rate × mean
+> lifetime` rule of thumb is fine for the ≥ 10 s preset lifetimes but
+> underestimates for ad-hoc sub-second lifetimes where create/delete time is
+> comparable. Set `--concurrency` at least that high (e.g. `burst`: 50 req/s ×
+> ~65 s ≈ 3250) or the dispatcher stalls on the semaphore and the requested
+> `--rate` is not honored; the tool prints a startup warning when it detects
+> this.
 
 ### Trace file schema
 
@@ -189,6 +195,11 @@ Requests are sorted by `arrival_ms`; `cpu_millis`/`mem_mib` come from the
   "requests": [{"seq": 0, "arrival_ms": 0, "template_id": "tpl-small", "cpu_millis": 1000, "mem_mib": 2048, "lifetime_ms": 53210}]
 }
 ```
+
+`lifetime_ms` is the planned hold time measured from create completion (the
+client sleeps it after the create response returns); true sandbox residence is
+`create + lifetime + delete`, so trace replayers modeling occupancy should add
+the create/delete tail themselves.
 
 ### Comparing runs (A/B report)
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -345,15 +345,18 @@ Caveats when reading verdicts:
   compare like with like.
 - **Mismatched pacing config across the groups is flagged.** When the two
   groups were run with different `concurrency`/`rate_per_sec`/`lifetime_*`
-  values (per-group de-duplicated; a missing key is not a mismatch), the
-  report prints a note that `queue_delay_*`/`dispatch_*` verdicts on such a
-  pair are client-config artifacts — rerun both sides under the same pacing
-  flags before trusting those rows.
-- **Dry-run exports are marked and flagged.** Scheduled exports carry
-  `config.dry_run`, surfaced in the report's config highlights; any group
-  whose export is a dry-run gets a warning that its latencies are synthesized
-  (lifetime sleeps clamped to 25ms, errors drawn from `--dry-error-rate`), so
-  verdicts over them describe the simulator, not a scheduler or a real API.
+  values (per-group de-duplicated; a missing key is not a mismatch) and at
+  least one side actually carries `queue_delay_*`/`dispatch_*` rows, the
+  report prints a note that those verdicts are client-config artifacts —
+  rerun both sides under the same pacing flags before trusting those rows.
+  A legacy-vs-legacy pair (no dispatch rows anywhere) never raises it.
+- **Dry-run exports are marked and flagged.** Scheduled exports always carry
+  `config.dry_run`, and legacy dry-run exports opt into the same marker
+  (legacy real runs keep the exact pre-scheduled export shape); the key is
+  surfaced in the report's config highlights, and any group whose export is
+  a dry-run gets a warning that its latencies are synthesized (lifetime
+  sleeps clamped to 25ms, errors drawn from `--dry-error-rate`), so verdicts
+  over them describe the simulator, not a scheduler or a real API.
 - **Rounds files flatten only each round's `summary`.** Round-level stat
   blocks outside `summary` are dropped; today's only rounds producer
   (schedsim) carries just `seed` + `summary` per round, so nothing is lost

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -68,7 +68,7 @@ All env vars can be overridden by the corresponding flag.
 | `--rate` | `0` | Poisson arrival rate in requests/sec (`<=0` = as fast as possible) |
 | `--lifetime` | *(none)* | Per-sandbox lifetime in seconds: `min,max` (uniform); client DELETEs when lifetime expires |
 | `--templates` | *(none)* | Template pool: comma-separated `templateID[:weight[:cpuMillis:memMiB]]` (weight default 1) |
-| `--dump-trace` | *(none)* | Write the pre-generated request sequence to a JSON trace file, then run normally |
+| `--dump-trace` | *(none)* | Write the pre-generated request sequence to a JSON trace file, then run normally (requires a scheduled workload) |
 
 Without any scheduling flag (`--workload`/`--rate`/`--lifetime`/`--templates`)
 the tool behaves exactly as before: all requests fire at once and each sandbox
@@ -135,6 +135,12 @@ weighted random template picks. Each create body carries the picked
 client issues the DELETE itself when the lifetime expires. The report and JSON
 export add queue-delay percentiles (scheduled vs actual start) and per-template
 create counts/success rates.
+
+> **Concurrency for lifetime-bearing presets.** A worker slot is held for the
+> full sandbox lifetime (create → lifetime sleep → delete), so the steady-state
+> number of live sandboxes ≈ `rate × mean lifetime`. Set `--concurrency` at
+> least that high (e.g. `burst`: 50 req/s × ~65 s ≈ 3250) or the dispatcher
+> stalls on the semaphore and the requested `--rate` is not honored.
 
 ### Trace file schema
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -116,8 +116,11 @@ export CUBE_TEMPLATE_ID=<your-template-id>
 
 # Dry-run a preset and keep the exact request sequence as a trace file
 # (dry-run clamps the per-sandbox lifetime sleep to 25ms, so even burst
-# finishes in seconds at the default concurrency)
-./bin/cube-bench --dry-run --workload burst --no-tui \
+# finishes in seconds; dry occupancy is still ~0.137s per request, so burst
+# at 50/s needs ~7 slots — pass -c 8 to keep the run clear of the startup
+# warning and the dispatch_saturated marker, though the written trace is
+# identical either way)
+./bin/cube-bench --dry-run --workload burst --no-tui -c 8 \
   -o report.json --dump-trace trace.json
 # The same trace can then be replayed by an external scheduling simulator.
 ```
@@ -177,8 +180,11 @@ queue metrics in one `compare` run.
 > `rate × (mean create + mean lifetime + mean delete)`. The `rate × mean
 > lifetime` rule of thumb is fine for the ≥ 10 s preset lifetimes but
 > underestimates for ad-hoc sub-second lifetimes where create/delete time is
-> comparable. Set `--concurrency` at least that high (e.g. `burst`: 50 req/s ×
-> ~65 s ≈ 3250) or the dispatcher stalls on the semaphore and the requested
+> comparable — so the numeric startup check only runs when the mean lifetime
+> is ≥ 1 s; shorter holds get a qualitative warning instead of a
+> precise-looking threshold. Set `--concurrency` at least that high (e.g.
+> `burst`: 50 req/s × ~65 s ≈ 3250) or the dispatcher stalls on the semaphore
+> and the requested
 > `--rate` is not honored; the tool prints a startup warning when it detects
 > this, and at the end of a run it also measures the realized queue-delay p95
 > against the mean inter-arrival time (1000/rate) and warns when p95 exceeds

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -115,6 +115,8 @@ export CUBE_TEMPLATE_ID=<your-template-id>
 ./bin/cube-bench -t <template-id> --rate 20 --lifetime 5,30 -n 200 -c 400
 
 # Dry-run a preset and keep the exact request sequence as a trace file
+# (dry-run clamps the per-sandbox lifetime sleep to 25ms, so even burst
+# finishes in seconds at the default concurrency)
 ./bin/cube-bench --dry-run --workload burst --no-tui \
   -o report.json --dump-trace trace.json
 # The same trace can then be replayed by an external scheduling simulator.
@@ -222,7 +224,15 @@ bad-when-rising rates such as `restart_rate`/`preempt_rate`/`evict_rate`/
 It accepts both cube-bench exports (`summary` plus the top-level
 `create`/`delete` stat blocks are flattened recursively) and schedsim reports
 (each entry of a top-level `rounds` array counts as one sample), so
-real-cluster runs and simulator runs can be compared with the same command. A
+real-cluster runs and simulator runs can be compared with the same command.
+
+Metrics pair by exact flattened key, so a cross-tool run only compares what
+both tools emit: between a cube-bench export and a schedsim report that is
+essentially `success_rate` — cube-bench measures the client side, schedsim the
+scheduler side, and one-sided keys (cube-bench's `create.*`/`delete.*` blocks
+and `queue_delay_*`; schedsim's `sched_latency_*`, `cpu_alloc_rate`, ...)
+correctly render as "—". Same-tool A/B (cube-bench vs cube-bench, schedsim vs
+schedsim) is where the full metric set lines up. A
 metric is flagged in the conclusions when the verdict direction matches,
 |Δ%| ≥ 5%, and — whenever both sides have n ≥ 2 — the delta exceeds the
 combined CI half-widths, so small-sample noise is not flagged as a verdict.
@@ -303,8 +313,10 @@ contract still receives `metadata` as strings:
 - Built-in `--network-policy rules` mode for create-with-rules latency
 - Dark/light/auto theme detection
 - JSON report export (`-o report.json`)
-- Dry-run mode for testing without a CubeSandbox server (scheduled mode is
-  seed-reproducible in dry-run too)
+- Dry-run mode for testing without a CubeSandbox server (in scheduled mode the
+  request sequence and the synthetic create/delete latencies are
+  seed-reproducible; wall-clock timing metrics — `queue_delay_*`,
+  `dispatch_window_s`/`dispatch_qps` — are not)
 
 ## Clean up
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -228,7 +228,10 @@ artifact, not a regression.
 
 `--dump-trace FILE` writes the pre-generated sequence before the run starts.
 Requests are sorted by `arrival_ms`; `cpu_millis`/`mem_mib` come from the
-`--templates` spec annotations (`0` when not annotated):
+`--templates` spec annotations (`0` when not annotated). One trace request is
+exactly one scheduler attempt: replaying consumers (e.g. schedsim) must not
+requeue or retry a rejected request — app-level retries are out of the
+contract's scope, and cube-bench itself issues one create per sequence entry:
 
 ```json
 {

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -215,8 +215,13 @@ real-cluster runs and simulator runs can be compared with the same command. A
 metric is flagged in the conclusions when the verdict direction matches,
 |Δ%| ≥ 5%, and — whenever both sides have n ≥ 2 — the delta exceeds the
 combined CI half-widths, so small-sample noise is not flagged as a verdict.
+When the baseline mean is exactly 0 (Δ% undefined), the test falls back to
+the absolute delta — still CI-gated when possible — so a 0 → 0.5
+`error_rate` catastrophe is flagged rather than silently dropped.
+Directionless metrics join the "No direction" list only when the same
+magnitude test (without the CI gate) marks the delta notable.
 
-Two caveats when reading verdicts:
+Caveats when reading verdicts:
 
 - **Single-sample sides are not CI-gated.** With n=1 on either side there is
   no interval to compare against, so every |Δ%| ≥ 5% is flagged; one file per
@@ -231,7 +236,7 @@ Per-metric aggregation only counts samples that actually contain the key, so
 when the two groups mix export shapes (e.g. a `create-only` file next to
 `create-delete` files) a row's effective n can be smaller than the group
 header's sample count; the report prints a note under the table when that
-happens.
+happens and annotates affected conclusion rows with the reduced n.
 
 ### Network policies
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -140,7 +140,8 @@ create counts/success rates.
 > full sandbox lifetime (create → lifetime sleep → delete), so the steady-state
 > number of live sandboxes ≈ `rate × mean lifetime`. Set `--concurrency` at
 > least that high (e.g. `burst`: 50 req/s × ~65 s ≈ 3250) or the dispatcher
-> stalls on the semaphore and the requested `--rate` is not honored.
+> stalls on the semaphore and the requested `--rate` is not honored; the tool
+> prints a startup warning when it detects this.
 
 ### Trace file schema
 
@@ -162,9 +163,11 @@ Requests are sorted by `arrival_ms`; `cpu_millis`/`mem_mib` come from the
 ### Comparing runs (A/B report)
 
 `compare` reads the JSON exports of two experiment groups (multiple seeds per
-side) and renders a Markdown report: per-metric mean ± 95% CI, absolute and
-relative change, and an improved/regressed verdict based on a built-in
-direction table (latency/error/cv/fragmentation lower-is-better;
+side) and renders a Markdown report: per-metric mean ± 95% CI (Student-t
+quantiles — a normal z badly understates the interval at a handful of seeds),
+absolute and relative change, and an improved/regressed verdict based on a
+built-in direction table (latency/error/cv/fragmentation lower-is-better,
+including cube-bench's own `create.*`/`delete.*` stat blocks;
 rates/jain/throughput higher-is-better):
 
 ```bash
@@ -174,11 +177,13 @@ rates/jain/throughput higher-is-better):
                          -o compare.md
 ```
 
-It accepts both cube-bench exports (`summary` is flattened recursively) and
-schedsim reports (each entry of a top-level `rounds` array counts as one
-sample), so real-cluster runs and simulator runs can be compared with the same
-command. A metric is flagged in the conclusions when the verdict direction
-matches and |Δ%| ≥ 5%.
+It accepts both cube-bench exports (`summary` plus the top-level
+`create`/`delete` stat blocks are flattened recursively) and schedsim reports
+(each entry of a top-level `rounds` array counts as one sample), so
+real-cluster runs and simulator runs can be compared with the same command. A
+metric is flagged in the conclusions when the verdict direction matches,
+|Δ%| ≥ 5%, and — whenever both sides have n ≥ 2 — the delta exceeds the
+combined CI half-widths, so small-sample noise is not flagged as a verdict.
 
 ### Network policies
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -102,13 +102,17 @@ export CUBE_TEMPLATE_ID=<your-template-id>
 ./bin/cube-bench --dry-run --theme light -c 10 -n 100
 
 # Scheduled workload presets (Poisson arrivals + per-sandbox lifetimes)
-./bin/cube-bench --workload burst -t <template-id>
-./bin/cube-bench --workload template_storm -t <template-id> --seed 7
-./bin/cube-bench --workload mixed_spec \
+# NOTE: pass --concurrency explicitly — a worker slot is held for the full
+# sandbox lifetime, so honoring the preset rate needs ≈ rate x mean lifetime
+# slots (burst ≈ 3250, template_storm ≈ 1800); the default -c 5 stalls the
+# dispatcher and the run degrades to ASAP pacing (the tool warns at startup).
+./bin/cube-bench --workload burst -t <template-id> -c 3500
+./bin/cube-bench --workload template_storm -t <template-id> --seed 7 -c 2000
+./bin/cube-bench --workload mixed_spec -c 2000 \
   --templates 'tpl-1c2g:6:1000:2048,tpl-2c4g:3:2000:4096,tpl-8c16g:1:8000:16384'
 
 # Ad-hoc schedule without a preset: 20 req/s Poisson, 5-30s lifetimes
-./bin/cube-bench -t <template-id> --rate 20 --lifetime 5,30 -n 200
+./bin/cube-bench -t <template-id> --rate 20 --lifetime 5,30 -n 200 -c 400
 
 # Dry-run a preset and keep the exact request sequence as a trace file
 ./bin/cube-bench --dry-run --workload burst --no-tui \
@@ -131,10 +135,14 @@ In scheduled mode the whole request sequence is **pre-generated** from `--seed`
 (same seed ⇒ identical sequence): Poisson inter-arrival times
 (`Exp(λ)`, first request at t=0), uniform lifetimes in `[min,max]`, and
 weighted random template picks. Each create body carries the picked
-`templateID` and `timeout = lifetime + 60s` as a server-side fallback TTL; the
-client issues the DELETE itself when the lifetime expires. (The TTL is set in
-`create-only` mode too — intentional, so lifetime-bearing presets don't leak
-sandboxes when the client never DELETEs.) The report and JSON
+`templateID` and `timeout = trunc(lifetime) + 60s` as a server-side fallback
+TTL; the client issues the DELETE itself when the lifetime expires. (The TTL
+is set in `create-only` mode too — intentional, so lifetime-bearing presets
+don't leak sandboxes when the client never DELETEs.) Two caveats on the
+fallback: `timeout` is an *idle* timeout (see `docs/guide/lifecycle.md`), so
+it only acts as a wall-clock cap because the bench never touches a sandbox
+after create; and the seconds truncation makes the effective value up to 1s
+shorter than `lifetime + 60s`. The report and JSON
 export add queue-delay percentiles (scheduled vs actual start) and per-template
 create counts/success rates.
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -67,7 +67,7 @@ All env vars can be overridden by the corresponding flag.
 | `--workload` | *(none)* | Workload preset: `burst`, `template_storm`, `mixed_spec` (empty = legacy mode) |
 | `--rate` | `0` | Poisson arrival rate in requests/sec (`<=0` = as fast as possible) |
 | `--lifetime` | *(none)* | Per-sandbox lifetime in seconds: `min,max` (uniform); client DELETEs when lifetime expires |
-| `--templates` | *(none)* | Template pool: comma-separated `templateID[:weight[:cpuMillis:memMiB]]` (weight default 1) |
+| `--templates` | *(none)* | Template pool: comma-separated `templateID[:weight[:cpuMillis:memMiB]]` (weight default 1). Replaces `-t` for the generated pool (non-additive); warmup and the legacy fallback body still use `-t` |
 | `--dump-trace` | *(none)* | Write the pre-generated request sequence to a JSON trace file, then run normally (requires a scheduled workload) |
 
 Without any scheduling flag (`--workload`/`--rate`/`--lifetime`/`--templates`)
@@ -239,8 +239,9 @@ correctly render as "—". Same-tool A/B (cube-bench vs cube-bench, schedsim vs
 schedsim) is where the full metric set lines up. A
 metric is flagged in the conclusions when the verdict direction matches,
 |Δ%| ≥ 5%, and — whenever both sides have n ≥ 2 — the delta exceeds the
-95% CI of the difference (√(ci_base² + ci_cand²), the standard combination
-for two independent means), so small-sample noise is not flagged as a
+95% CI of the difference (√(ci_base² + ci_cand²); exact when both sides share
+the same degrees of freedom, otherwise a mild and generally conservative
+approximation), so small-sample noise is not flagged as a
 verdict.
 When the baseline mean is exactly 0 (Δ% undefined), the test falls back to
 the absolute delta — still CI-gated when possible — so a 0 → 0.5
@@ -252,8 +253,9 @@ Caveats when reading verdicts:
 
 - **Single-sample sides are not CI-gated.** With n=1 on either side there is
   no interval to compare against, so every |Δ%| ≥ 5% is flagged; one file per
-  side therefore produces verdicts that are pure single-run noise. Use
-  multiple seeds per side for decisions.
+  side therefore produces verdicts that are pure single-run noise. The report
+  prints a notice under the experiment-setup table whenever a group has n < 2.
+  Use multiple seeds per side for decisions.
 - **Δ% has no floor.** It is relative to the baseline mean, so near-zero
   baselines (e.g. `error_rate` ≈ 0.001) produce enormous percentages that
   always clear the 5% bar. Read them alongside the absolute Δ, which is shown

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -67,7 +67,7 @@ All env vars can be overridden by the corresponding flag.
 | `--workload` | *(none)* | Workload preset: `burst`, `template_storm`, `mixed_spec` (empty = legacy mode) |
 | `--rate` | `0` | Poisson arrival rate in requests/sec (`<=0` = as fast as possible) |
 | `--lifetime` | *(none)* | Per-sandbox lifetime in seconds: `min,max` (uniform); client DELETEs when lifetime expires |
-| `--templates` | *(none)* | Template pool: comma-separated `templateID[:weight[:cpuMillis:memMiB]]` (weight default 1). Replaces `-t` for the generated pool (non-additive); warmup and the legacy fallback body still use `-t` |
+| `--templates` | *(none)* | Template pool: comma-separated `templateID[:weight[:cpuMillis:memMiB]]` (weight default 1; duplicate IDs rejected — combine their weights). Replaces `-t` for the generated pool (non-additive); warmup and the legacy fallback body still use `-t` |
 | `--dump-trace` | *(none)* | Write the pre-generated request sequence to a JSON trace file, then run normally (requires a scheduled workload) |
 
 Without any scheduling flag (`--workload`/`--rate`/`--lifetime`/`--templates`)
@@ -154,7 +154,9 @@ lifetime-bearing workload likewise carry a TTL, keyed to `lifetime_max`.) Two
 caveats on the fallback: `timeout` is an *idle* timeout (see
 `docs/guide/lifecycle.md`), so it only acts as a wall-clock cap because the
 bench never touches a sandbox after create; and the seconds truncation makes
-the effective value up to 1s shorter than `lifetime + 60s`. The report and JSON
+the effective value up to 1s shorter than `lifetime + 60s` — for a sub-second
+lifetime `trunc(lifetime)` is 0, so an abandoned run's backstop is exactly
+60s no matter how short the intended hold. The report and JSON
 export add queue-delay percentiles (scheduled vs actual start) and per-template
 create counts/success rates — where `per_template.<id>.created` counts
 full-cycle successes (`r.Err == ""`), mirroring the top-level `successful`: in

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -140,11 +140,12 @@ weighted random template picks. Each create body carries the picked
 `templateID` and `timeout = trunc(lifetime) + 60s` as a server-side fallback
 TTL; the client issues the DELETE itself when the lifetime expires. (The TTL
 is set in `create-only` mode too — intentional, so lifetime-bearing presets
-don't leak sandboxes when the client never DELETEs.) Two caveats on the
-fallback: `timeout` is an *idle* timeout (see `docs/guide/lifecycle.md`), so
-it only acts as a wall-clock cap because the bench never touches a sandbox
-after create; and the seconds truncation makes the effective value up to 1s
-shorter than `lifetime + 60s`. The report and JSON
+don't leak sandboxes when the client never DELETEs; `--warmup` requests on a
+lifetime-bearing workload likewise carry a TTL, keyed to `lifetime_max`.) Two
+caveats on the fallback: `timeout` is an *idle* timeout (see
+`docs/guide/lifecycle.md`), so it only acts as a wall-clock cap because the
+bench never touches a sandbox after create; and the seconds truncation makes
+the effective value up to 1s shorter than `lifetime + 60s`. The report and JSON
 export add queue-delay percentiles (scheduled vs actual start) and per-template
 create counts/success rates.
 
@@ -183,7 +184,10 @@ queue metrics in one `compare` run.
 > against the mean inter-arrival time (1000/rate) and warns when p95 exceeds
 > it — at that point the dispatcher has fallen permanently behind, the offered
 > load has degenerated to bursts, and the `queue_delay_*`/`dispatch_*` metrics
-> describe the client's semaphore rather than the offered schedule.
+> describe the client's semaphore rather than the offered schedule. The JSON
+> export marks such runs with `dispatch_saturated: 1` in `summary`; `compare`
+> pops that marker out of the metric rows and prints a warning for the
+> affected group instead.
 
 ### Trace file schema
 
@@ -271,7 +275,14 @@ Caveats when reading verdicts:
   baseline mean is exactly 0, significance falls back to the absolute delta,
   so with tight CIs on both sides even a 0 → 1e-9 movement is flagged as
   Improved/Regressed. That is statistically real but usually immaterial —
-  judge from the absolute Δ shown next to the verdict.
+  judge from the absolute Δ shown next to the verdict; affected conclusion
+  rows carry a "zero baseline" marker in the report.
+- **Identical values across seeds yield zero-width CIs.** When every seed
+  produces the same value (common for integer-millisecond percentiles), the
+  per-side CI is exactly 0 and the difference-CI noise gate never engages —
+  any |Δ%| ≥ 5% is flagged regardless of whether the difference would
+  survive real variance. Read zero-width CIs as "no variance measured", not
+  "no variance exists".
 - **Mixed scheduled/legacy shapes share key names with different meanings.**
   When one group is a scheduled-mode export and the other is not,
   `total_time_s` is the dispatch window on one side and the whole-run wall

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -132,9 +132,29 @@ In scheduled mode the whole request sequence is **pre-generated** from `--seed`
 (`Exp(λ)`, first request at t=0), uniform lifetimes in `[min,max]`, and
 weighted random template picks. Each create body carries the picked
 `templateID` and `timeout = lifetime + 60s` as a server-side fallback TTL; the
-client issues the DELETE itself when the lifetime expires. The report and JSON
+client issues the DELETE itself when the lifetime expires. (The TTL is set in
+`create-only` mode too — intentional, so lifetime-bearing presets don't leak
+sandboxes when the client never DELETEs.) The report and JSON
 export add queue-delay percentiles (scheduled vs actual start) and per-template
 create counts/success rates.
+
+**Throughput metrics in scheduled mode.** `total_time_s`/`throughput_qps`
+measure the *whole run*, which ends only when the last sandbox is DELETEd —
+i.e. they include the lifetime tail and are diluted by the workload's own
+lifetime distribution. The JSON export therefore also reports
+`dispatch_window_s` (wall-clock span of the dispatch loop, first to last
+request release) and `dispatch_qps` (requests released per second of that
+window), which reflect the arrival-side throughput the scheduler actually saw.
+For A/B comparisons of scheduler behavior, prefer `dispatch_qps`;
+`throughput_qps` answers "how fast did the whole experiment finish".
+
+Also note that `queue_delay_*` percentiles are **client-side dispatch delay**
+(time the local dispatcher spent blocked on the concurrency semaphore, plus
+sleep overshoot) — a self-check that the generator isn't throttling itself,
+and ~0 when the concurrency guidance below is followed. They are *not*
+scheduler-side queueing; scheduler queueing shows up in `create.*` latency
+instead. Don't mix cube-bench's `queue_delay_*` with schedsim's scheduler-side
+queue metrics in one `compare` run.
 
 > **Concurrency for lifetime-bearing presets.** A worker slot is held for the
 > full sandbox lifetime (create → lifetime sleep → delete), so the steady-state
@@ -184,6 +204,23 @@ real-cluster runs and simulator runs can be compared with the same command. A
 metric is flagged in the conclusions when the verdict direction matches,
 |Δ%| ≥ 5%, and — whenever both sides have n ≥ 2 — the delta exceeds the
 combined CI half-widths, so small-sample noise is not flagged as a verdict.
+
+Two caveats when reading verdicts:
+
+- **Single-sample sides are not CI-gated.** With n=1 on either side there is
+  no interval to compare against, so every |Δ%| ≥ 5% is flagged; one file per
+  side therefore produces verdicts that are pure single-run noise. Use
+  multiple seeds per side for decisions.
+- **Δ% has no floor.** It is relative to the baseline mean, so near-zero
+  baselines (e.g. `error_rate` ≈ 0.001) produce enormous percentages that
+  always clear the 5% bar. Read them alongside the absolute Δ, which is shown
+  next to them.
+
+Per-metric aggregation only counts samples that actually contain the key, so
+when the two groups mix export shapes (e.g. a `create-only` file next to
+`create-delete` files) a row's effective n can be smaller than the group
+header's sample count; the report prints a note under the table when that
+happens.
 
 ### Network policies
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -145,6 +145,8 @@ lifetime distribution. The JSON export therefore also reports
 `dispatch_window_s` (wall-clock span of the dispatch loop, first to last
 request release) and `dispatch_qps` (requests released per second of that
 window), which reflect the arrival-side throughput the scheduler actually saw.
+Both keys are emitted only for rate-paced runs (`--rate > 0`): without pacing
+the "window" is just the client's release burst and the rate is meaningless.
 For A/B comparisons of scheduler behavior, prefer `dispatch_qps`;
 `throughput_qps` answers "how fast did the whole experiment finish".
 
@@ -187,8 +189,9 @@ side) and renders a Markdown report: per-metric mean ± 95% CI (Student-t
 quantiles — a normal z badly understates the interval at a handful of seeds),
 absolute and relative change, and an improved/regressed verdict based on a
 built-in direction table (latency/error/cv/fragmentation lower-is-better,
-including cube-bench's own `create.*`/`delete.*` stat blocks;
-rates/jain/throughput higher-is-better):
+including cube-bench's own `create.*`/`delete.*` stat blocks and
+bad-when-rising rates such as `restart_rate`/`preempt_rate`/`evict_rate`/
+`retry_rate`; other rates/jain/throughput higher-is-better):
 
 ```bash
 ./bin/cube-bench compare --baseline default1.json,default2.json,default3.json \

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -63,6 +63,16 @@ All env vars can be overridden by the corresponding flag.
 | `--dry-latency` | `80,30` | Dry-run latency: `mean,stddev` in ms |
 | `--dry-error-rate` | `0.02` | Simulated error rate (0.0–1.0) |
 | `--no-tui` | `false` | Disable interactive TUI |
+| `--seed` | `42` | Random seed for the pre-generated request sequence |
+| `--workload` | *(none)* | Workload preset: `burst`, `template_storm`, `mixed_spec` (empty = legacy mode) |
+| `--rate` | `0` | Poisson arrival rate in requests/sec (`<=0` = as fast as possible) |
+| `--lifetime` | *(none)* | Per-sandbox lifetime in seconds: `min,max` (uniform); client DELETEs when lifetime expires |
+| `--templates` | *(none)* | Template pool: comma-separated `templateID[:weight[:cpuMillis:memMiB]]` (weight default 1) |
+| `--dump-trace` | *(none)* | Write the pre-generated request sequence to a JSON trace file, then run normally |
+
+Without any scheduling flag (`--workload`/`--rate`/`--lifetime`/`--templates`)
+the tool behaves exactly as before: all requests fire at once and each sandbox
+is deleted immediately after creation.
 
 ### Examples
 
@@ -90,7 +100,79 @@ export CUBE_TEMPLATE_ID=<your-template-id>
 
 # Light terminal theme
 ./bin/cube-bench --dry-run --theme light -c 10 -n 100
+
+# Scheduled workload presets (Poisson arrivals + per-sandbox lifetimes)
+./bin/cube-bench --workload burst -t <template-id>
+./bin/cube-bench --workload template_storm -t <template-id> --seed 7
+./bin/cube-bench --workload mixed_spec \
+  --templates 'tpl-1c2g:6:1000:2048,tpl-2c4g:3:2000:4096,tpl-8c16g:1:8000:16384'
+
+# Ad-hoc schedule without a preset: 20 req/s Poisson, 5-30s lifetimes
+./bin/cube-bench -t <template-id> --rate 20 --lifetime 5,30 -n 200
+
+# Dry-run a preset and keep the exact request sequence as a trace file
+./bin/cube-bench --dry-run --workload burst --no-tui \
+  -o report.json --dump-trace trace.json
+# The same trace can then be replayed by an external scheduling simulator.
 ```
+
+### Workload presets
+
+A preset only supplies flag **defaults** — any flag you pass explicitly wins
+(e.g. `--workload burst -n 20` keeps `total=20`).
+
+| Preset | total | rate (req/s) | lifetime (s) | templates |
+|---|---|---|---|---|
+| `burst` | 500 | 50 | 10–120 | single (`-t`) |
+| `template_storm` | 300 | 30 | 30–90 | single (`-t`) |
+| `mixed_spec` | 400 | 10 | 30–300 | **requires `--templates`** with ≥2 entries, e.g. weights `6:3:1` for 1C2G/2C4G/8C16G |
+
+In scheduled mode the whole request sequence is **pre-generated** from `--seed`
+(same seed ⇒ identical sequence): Poisson inter-arrival times
+(`Exp(λ)`, first request at t=0), uniform lifetimes in `[min,max]`, and
+weighted random template picks. Each create body carries the picked
+`templateID` and `timeout = lifetime + 60s` as a server-side fallback TTL; the
+client issues the DELETE itself when the lifetime expires. The report and JSON
+export add queue-delay percentiles (scheduled vs actual start) and per-template
+create counts/success rates.
+
+### Trace file schema
+
+`--dump-trace FILE` writes the pre-generated sequence before the run starts.
+Requests are sorted by `arrival_ms`; `cpu_millis`/`mem_mib` come from the
+`--templates` spec annotations (`0` when not annotated):
+
+```json
+{
+  "workload": "burst",
+  "seed": 42,
+  "generated_at": "RFC3339",
+  "params": {"rate_per_sec": 50, "lifetime_min_s": 10, "lifetime_max_s": 120, "total": 500},
+  "templates": [{"template_id": "tpl-small", "weight": 1, "cpu_millis": 1000, "mem_mib": 2048}],
+  "requests": [{"seq": 0, "arrival_ms": 0, "template_id": "tpl-small", "cpu_millis": 1000, "mem_mib": 2048, "lifetime_ms": 53210}]
+}
+```
+
+### Comparing runs (A/B report)
+
+`compare` reads the JSON exports of two experiment groups (multiple seeds per
+side) and renders a Markdown report: per-metric mean ± 95% CI, absolute and
+relative change, and an improved/regressed verdict based on a built-in
+direction table (latency/error/cv/fragmentation lower-is-better;
+rates/jain/throughput higher-is-better):
+
+```bash
+./bin/cube-bench compare --baseline default1.json,default2.json,default3.json \
+                         --candidate new1.json,new2.json,new3.json \
+                         --baseline-name default --candidate-name burst-spread \
+                         -o compare.md
+```
+
+It accepts both cube-bench exports (`summary` is flattened recursively) and
+schedsim reports (each entry of a top-level `rounds` array counts as one
+sample), so real-cluster runs and simulator runs can be compared with the same
+command. A metric is flagged in the conclusions when the verdict direction
+matches and |Δ%| ≥ 5%.
 
 ### Network policies
 
@@ -133,13 +215,21 @@ contract still receives `metadata` as strings:
 ## Features
 
 - Goroutine pool with configurable concurrency
-- Live TUI dashboard: progress bar, real-time QPS, rolling operation log
+- Scheduler benchmark workload generator: seeded Poisson arrivals, per-sandbox
+  lifetimes (client-side DELETE + server-side `timeout` TTL), weighted
+  multi-template mixes, and three presets (`burst`, `template_storm`,
+  `mixed_spec`)
+- Trace dump (`--dump-trace`) for replaying the exact same sequence in a
+  scheduling simulator
+- Live TUI dashboard: progress bar, real-time QPS, in-flight estimate, rolling
+  operation log
 - Final report: percentile table (P50/P95/P99), latency histogram, sparkline,
-  and letter grade (S/A/B/C/D)
+  queue-delay percentiles (scheduled mode), and letter grade (S/A/B/C/D)
 - Built-in `--network-policy rules` mode for create-with-rules latency
 - Dark/light/auto theme detection
 - JSON report export (`-o report.json`)
-- Dry-run mode for testing without a CubeSandbox server
+- Dry-run mode for testing without a CubeSandbox server (scheduled mode is
+  seed-reproducible in dry-run too)
 
 ## Clean up
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -174,7 +174,12 @@ sleep overshoot) — a self-check that the generator isn't throttling itself,
 and ~0 when the concurrency guidance below is followed. They are *not*
 scheduler-side queueing; scheduler queueing shows up in `create.*` latency
 instead. Don't mix cube-bench's `queue_delay_*` with schedsim's scheduler-side
-queue metrics in one `compare` run.
+queue metrics in one `compare` run. And because the delay is a function of the
+client's own pacing and `--concurrency`, only compare `queue_delay_*` rows
+between runs with identical pacing and concurrency — an unpaced run (no
+`--rate`) releases every request at once and never trips the saturation
+marker, so its `queue_delay_*` rows against a paced run are a client-config
+artifact, not a regression.
 
 > **Concurrency for lifetime-bearing presets.** A worker slot is held for the
 > full sandbox lifetime (create → lifetime sleep → delete). The lifetime sleep
@@ -211,7 +216,10 @@ queue metrics in one `compare` run.
 > approaches the `time.Sleep` granularity, where even healthy runs can exceed
 > it — treat the marker as advisory there. An early TUI quit instead exports
 > `partial: 1` in `summary` (suppressing the saturation marker), which
-> `compare` surfaces as a note and covers with the same key exclusion.
+> `compare` surfaces as a note and covers with the same key exclusion, plus
+> the truncated `per_template.*` blocks (they aggregate only the results
+> consumed before the quit; a saturated run keeps them — they reflect what
+> actually ran).
 
 ### Trace file schema
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -201,7 +201,13 @@ queue metrics in one `compare` run.
 > (a create-latency spike holds slots just as long) — check `create.p95`
 > before blaming `--concurrency` — and a transient burst delaying >5% of
 > arrivals past the mean gap trips the whole-run marker even when the run
-> otherwise honored pace.
+> otherwise honored pace. The marker is only computed with ≥20 dispatched
+> requests (below that the p95 IS the maximum delay, so a single hiccup would
+> trip it), and at rates of several hundred req/s the mean inter-arrival
+> approaches the `time.Sleep` granularity, where even healthy runs can exceed
+> it — treat the marker as advisory there. An early TUI quit instead exports
+> `partial: 1` in `summary` (suppressing the saturation marker), which
+> `compare` surfaces as a note in the same way.
 
 ### Trace file schema
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -215,11 +215,15 @@ artifact, not a regression.
 > trip it), and at rates of several hundred req/s the mean inter-arrival
 > approaches the `time.Sleep` granularity, where even healthy runs can exceed
 > it — treat the marker as advisory there. An early TUI quit stops the
-> dispatcher from releasing further requests (released ones still run their
-> create/lifetime/delete cycle out; the per-request server-side `timeout` is
-> the backstop for anything abandoned) and exports
-> `partial: 1` in `summary` (suppressing the saturation marker), which
-> `compare` surfaces as a note and covers with the same key exclusion, plus
+> dispatcher from releasing further requests and exports
+> `partial: 1` in `summary` (suppressing the saturation marker). Released
+> requests are best-effort: the process does not wait for them after a quit,
+> so a worker killed mid create/delete can strand a sandbox — the per-request
+> server-side `timeout` (set only for lifetime-bearing runs) is the backstop.
+> The partial marker — which legacy-mode exports also carry on an early
+> quit, so the JSON never disagrees with the console note — is surfaced by
+> `compare` as a note and covers the flagged group with the dispatch-key
+> exclusion, plus
 > the truncated `per_template.*` blocks (they aggregate only the results
 > consumed before the quit; a saturated run keeps them — they reflect what
 > actually ran).

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -72,7 +72,11 @@ All env vars can be overridden by the corresponding flag.
 
 Without any scheduling flag (`--workload`/`--rate`/`--lifetime`/`--templates`)
 the tool behaves exactly as before: all requests fire at once and each sandbox
-is deleted immediately after creation.
+is deleted immediately after creation. Conversely, any one of those flags
+alone is enough to enter scheduled mode — including `--templates` by itself,
+which then also changes the JSON export shape (per-request
+`template_id`/`scheduled_arrival_ms`, `queue_delay_*`/`dispatch_*` aggregates,
+and `per_template.*` blocks appear even without `--rate` or `--lifetime`).
 
 ### Examples
 

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -179,7 +179,11 @@ queue metrics in one `compare` run.
 > comparable. Set `--concurrency` at least that high (e.g. `burst`: 50 req/s ×
 > ~65 s ≈ 3250) or the dispatcher stalls on the semaphore and the requested
 > `--rate` is not honored; the tool prints a startup warning when it detects
-> this.
+> this, and at the end of a run it also measures the realized queue-delay p95
+> against the mean inter-arrival time (1000/rate) and warns when p95 exceeds
+> it — at that point the dispatcher has fallen permanently behind, the offered
+> load has degenerated to bursts, and the `queue_delay_*`/`dispatch_*` metrics
+> describe the client's semaphore rather than the offered schedule.
 
 ### Trace file schema
 
@@ -201,7 +205,10 @@ Requests are sorted by `arrival_ms`; `cpu_millis`/`mem_mib` come from the
 `lifetime_ms` is the planned hold time measured from create completion (the
 client sleeps it after the create response returns); true sandbox residence is
 `create + lifetime + delete`, so trace replayers modeling occupancy should add
-the create/delete tail themselves.
+the create/delete tail themselves. `arrival_ms` and `lifetime_ms` are integer
+milliseconds — at rates above ~1000/s sub-millisecond arrival spacing is
+truncated, and the authoritative replay order is `seq`, not the truncated
+timestamps.
 
 Note on `seq` numbering: scheduled mode (and the trace contract) numbers
 requests 0..N-1, while the legacy non-scheduled export numbers `raw[].seq`
@@ -265,6 +272,18 @@ Caveats when reading verdicts:
   so with tight CIs on both sides even a 0 → 1e-9 movement is flagged as
   Improved/Regressed. That is statistically real but usually immaterial —
   judge from the absolute Δ shown next to the verdict.
+- **Mixed scheduled/legacy shapes share key names with different meanings.**
+  When one group is a scheduled-mode export and the other is not,
+  `total_time_s` is the dispatch window on one side and the whole-run wall
+  clock on the other, and `throughput_qps` inherits that difference — their
+  Δ rows are not meaningful. The report detects the shape mix (via the
+  scheduled-only `queue_delay_*`/`dispatch_window_s`/`per_template.*` keys)
+  and prints a notice under the experiment-setup table; compare like with
+  like.
+- **Rounds files flatten only each round's `summary`.** Round-level stat
+  blocks outside `summary` are dropped; today's only rounds producer
+  (schedsim) carries just `seed` + `summary` per round, so nothing is lost
+  in practice.
 
 Per-metric aggregation only counts samples that actually contain the key, so
 when the two groups mix export shapes (e.g. a `create-only` file next to

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -150,7 +150,9 @@ caveats on the fallback: `timeout` is an *idle* timeout (see
 bench never touches a sandbox after create; and the seconds truncation makes
 the effective value up to 1s shorter than `lifetime + 60s`. The report and JSON
 export add queue-delay percentiles (scheduled vs actual start) and per-template
-create counts/success rates.
+create counts/success rates — where `per_template.<id>.created` counts
+full-cycle successes (`r.Err == ""`), mirroring the top-level `successful`: in
+`create-delete` mode a sandbox whose delete failed counts as *not* created.
 
 **Throughput metrics in scheduled mode.** `total_time_s`/`throughput_qps`
 measure the *whole run*, which ends only when the last sandbox is DELETEd —
@@ -181,8 +183,9 @@ queue metrics in one `compare` run.
 > lifetime` rule of thumb is fine for the ≥ 10 s preset lifetimes but
 > underestimates for ad-hoc sub-second lifetimes where create/delete time is
 > comparable — so the numeric startup check only runs when the mean lifetime
-> is ≥ 1 s; shorter holds get a qualitative warning instead of a
-> precise-looking threshold. Set `--concurrency` at least that high (e.g.
+> is ≥ 1 s (and is a lower bound even there: it prices the lifetime hold but
+> not the create/delete tail); shorter holds get a qualitative note instead of
+> a precise-looking threshold. Set `--concurrency` at least that high (e.g.
 > `burst`: 50 req/s × ~65 s ≈ 3250) or the dispatcher stalls on the semaphore
 > and the requested
 > `--rate` is not honored; the tool prints a startup warning when it detects
@@ -193,7 +196,12 @@ queue metrics in one `compare` run.
 > describe the client's semaphore rather than the offered schedule. The JSON
 > export marks such runs with `dispatch_saturated: 1` in `summary`; `compare`
 > pops that marker out of the metric rows and prints a warning for the
-> affected group instead.
+> affected group instead. Two readings of the marker to keep in mind: it
+> cannot distinguish client under-provisioning from a slow server create path
+> (a create-latency spike holds slots just as long) — check `create.p95`
+> before blaming `--concurrency` — and a transient burst delaying >5% of
+> arrivals past the mean gap trips the whole-run marker even when the run
+> otherwise honored pace.
 
 ### Trace file schema
 
@@ -289,14 +297,14 @@ Caveats when reading verdicts:
   any |Δ%| ≥ 5% is flagged regardless of whether the difference would
   survive real variance. Read zero-width CIs as "no variance measured", not
   "no variance exists".
-- **Mixed scheduled/legacy shapes share key names with different meanings.**
-  When one group is a scheduled-mode export and the other is not,
-  `total_time_s` is the dispatch window on one side and the whole-run wall
-  clock on the other, and `throughput_qps` inherits that difference — their
-  Δ rows are not meaningful. The report detects the shape mix (via the
-  scheduled-only `queue_delay_*`/`dispatch_window_s`/`per_template.*` keys)
-  and prints a notice under the experiment-setup table; compare like with
-  like.
+- **Mixed scheduled/legacy shapes share key names spanning different
+  windows.** When one group is a scheduled-mode export and the other is not,
+  `total_time_s`/`throughput_qps` include per-sandbox lifetime tails on the
+  scheduled side (the run ends at the last lifetime DELETE) while the legacy
+  side ends at the last immediate delete — their Δ rows are not meaningful.
+  The report detects the shape mix (via the scheduled-only
+  `queue_delay_*`/`dispatch_window_s`/`per_template.*` keys) and prints a
+  notice under the experiment-setup table; compare like with like.
 - **Rounds files flatten only each round's `summary`.** Round-level stat
   blocks outside `summary` are dropped; today's only rounds producer
   (schedsim) carries just `seed` + `summary` per round, so nothing is lost

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -225,7 +225,9 @@ artifact, not a regression.
 > `partial: 1` in `summary` (suppressing the saturation marker). Released
 > requests are best-effort: the process does not wait for them after a quit,
 > so a worker killed mid create/delete can strand a sandbox — the per-request
-> server-side `timeout` (set only for lifetime-bearing runs) is the backstop.
+> server-side `timeout` (set only for lifetime-bearing runs) is the backstop,
+> and a rate-paced `create-delete` run without `--lifetime` prints a startup
+> NOTE precisely because it has none.
 > The partial marker — which legacy-mode exports also carry on an early
 > quit, so the JSON never disagrees with the console note — is surfaced by
 > `compare` as a note and covers the flagged group with the dispatch-key
@@ -336,9 +338,22 @@ Caveats when reading verdicts:
   `total_time_s`/`throughput_qps` include per-sandbox lifetime tails on the
   scheduled side (the run ends at the last lifetime DELETE) while the legacy
   side ends at the last immediate delete — their Δ rows are not meaningful.
-  The report detects the shape mix (via the scheduled-only
-  `queue_delay_*`/`dispatch_window_s`/`per_template.*` keys) and prints a
-  notice under the experiment-setup table; compare like with like.
+  The report detects the shape mix (via the scheduled-only `workload` config
+  key, which survives the partial/saturated key drop, falling back to the
+  `queue_delay_*`/`dispatch_window_s`/`per_template.*` summary keys for
+  config-less files) and prints a notice under the experiment-setup table;
+  compare like with like.
+- **Mismatched pacing config across the groups is flagged.** When the two
+  groups were run with different `concurrency`/`rate_per_sec`/`lifetime_*`
+  values (per-group de-duplicated; a missing key is not a mismatch), the
+  report prints a note that `queue_delay_*`/`dispatch_*` verdicts on such a
+  pair are client-config artifacts — rerun both sides under the same pacing
+  flags before trusting those rows.
+- **Dry-run exports are marked and flagged.** Scheduled exports carry
+  `config.dry_run`, surfaced in the report's config highlights; any group
+  whose export is a dry-run gets a warning that its latencies are synthesized
+  (lifetime sleeps clamped to 25ms, errors drawn from `--dry-error-rate`), so
+  verdicts over them describe the simulator, not a scheduler or a real API.
 - **Rounds files flatten only each round's `summary`.** Round-level stat
   blocks outside `summary` are dropped; today's only rounds producer
   (schedsim) carries just `seed` + `summary` per round, so nothing is lost

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -203,6 +203,10 @@ client sleeps it after the create response returns); true sandbox residence is
 `create + lifetime + delete`, so trace replayers modeling occupancy should add
 the create/delete tail themselves.
 
+Note on `seq` numbering: scheduled mode (and the trace contract) numbers
+requests 0..N-1, while the legacy non-scheduled export numbers `raw[].seq`
+1..N — expect a one-off shift when diffing raw entries across modes.
+
 ### Comparing runs (A/B report)
 
 `compare` reads the JSON exports of two experiment groups (multiple seeds per
@@ -235,7 +239,9 @@ correctly render as "—". Same-tool A/B (cube-bench vs cube-bench, schedsim vs
 schedsim) is where the full metric set lines up. A
 metric is flagged in the conclusions when the verdict direction matches,
 |Δ%| ≥ 5%, and — whenever both sides have n ≥ 2 — the delta exceeds the
-combined CI half-widths, so small-sample noise is not flagged as a verdict.
+95% CI of the difference (√(ci_base² + ci_cand²), the standard combination
+for two independent means), so small-sample noise is not flagged as a
+verdict.
 When the baseline mean is exactly 0 (Δ% undefined), the test falls back to
 the absolute delta — still CI-gated when possible — so a 0 → 0.5
 `error_rate` catastrophe is flagged rather than silently dropped.
@@ -252,6 +258,11 @@ Caveats when reading verdicts:
   baselines (e.g. `error_rate` ≈ 0.001) produce enormous percentages that
   always clear the 5% bar. Read them alongside the absolute Δ, which is shown
   next to them.
+- **The zero-baseline fallback has no magnitude floor either.** When the
+  baseline mean is exactly 0, significance falls back to the absolute delta,
+  so with tight CIs on both sides even a 0 → 1e-9 movement is flagged as
+  Improved/Regressed. That is statistically real but usually immaterial —
+  judge from the absolute Δ shown next to the verdict.
 
 Per-metric aggregation only counts samples that actually contain the key, so
 when the two groups mix export shapes (e.g. a `create-only` file next to

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -214,7 +214,10 @@ artifact, not a regression.
 > requests (below that the p95 IS the maximum delay, so a single hiccup would
 > trip it), and at rates of several hundred req/s the mean inter-arrival
 > approaches the `time.Sleep` granularity, where even healthy runs can exceed
-> it — treat the marker as advisory there. An early TUI quit instead exports
+> it — treat the marker as advisory there. An early TUI quit stops the
+> dispatcher from releasing further requests (released ones still run their
+> create/lifetime/delete cycle out; the per-request server-side `timeout` is
+> the backstop for anything abandoned) and exports
 > `partial: 1` in `summary` (suppressing the saturation marker), which
 > `compare` surfaces as a note and covers with the same key exclusion, plus
 > the truncated `per_template.*` blocks (they aggregate only the results

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -361,6 +361,13 @@ Caveats when reading verdicts:
   blocks outside `summary` are dropped; today's only rounds producer
   (schedsim) carries just `seed` + `summary` per round, so nothing is lost
   in practice.
+- **A group that mixes producers is flagged.** cube-bench exports
+  (client-side measurements) and schedsim rounds files (simulator reports)
+  on the SAME side of an A/B blend two measurement domains into one mean/CI;
+  the report prints a warning naming the group. Split producers into
+  separate comparisons — the endorsed cross-tool shape is one producer per
+  side (e.g. schedsim rounds as baseline vs cube-bench runs as candidate),
+  reading only the semantically shared keys.
 
 Per-metric aggregation only counts samples that actually contain the key, so
 when the two groups mix export shapes (e.g. a `create-only` file next to

--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -103,12 +103,14 @@ export CUBE_TEMPLATE_ID=<your-template-id>
 
 # Scheduled workload presets (Poisson arrivals + per-sandbox lifetimes)
 # NOTE: pass --concurrency explicitly — a worker slot is held for the full
-# sandbox lifetime, so honoring the preset rate needs ≈ rate x mean lifetime
-# slots (burst ≈ 3250, template_storm ≈ 1800); the default -c 5 stalls the
+# sandbox lifetime, so honoring the preset rate needs ≈ min(rate x mean
+# lifetime, total) slots (burst ≈ 500, template_storm ≈ 300, mixed_spec ≈ 400:
+# each preset's arrival window is shorter than its minimum lifetime, so nearly
+# the whole run is in flight at once); the default -c 5 stalls the
 # dispatcher and the run degrades to ASAP pacing (the tool warns at startup).
-./bin/cube-bench --workload burst -t <template-id> -c 3500
-./bin/cube-bench --workload template_storm -t <template-id> --seed 7 -c 2000
-./bin/cube-bench --workload mixed_spec -c 2000 \
+./bin/cube-bench --workload burst -t <template-id> -c 600
+./bin/cube-bench --workload template_storm -t <template-id> --seed 7 -c 350
+./bin/cube-bench --workload mixed_spec -c 450 \
   --templates 'tpl-1c2g:6:1000:2048,tpl-2c4g:3:2000:4096,tpl-8c16g:1:8000:16384'
 
 # Ad-hoc schedule without a preset: 20 req/s Poisson, 5-30s lifetimes
@@ -186,7 +188,8 @@ queue metrics in one `compare` run.
 > is ≥ 1 s (and is a lower bound even there: it prices the lifetime hold but
 > not the create/delete tail); shorter holds get a qualitative note instead of
 > a precise-looking threshold. Set `--concurrency` at least that high (e.g.
-> `burst`: 50 req/s × ~65 s ≈ 3250) or the dispatcher stalls on the semaphore
+> `burst`: min(50 req/s × ~65 s, 500 requests) ≈ 500) or the dispatcher stalls
+> on the semaphore
 > and the requested
 > `--rate` is not honored; the tool prints a startup warning when it detects
 > this, and at the end of a run it also measures the realized queue-delay p95

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -98,7 +98,9 @@ func runCompare(args []string, stdout io.Writer) error {
 	}
 	fmt.Fprint(stdout, report)
 	if output != "" {
-		fmt.Fprintf(stdout, "\nReport saved to %s\n", output)
+		// The confirmation is not part of the report; keep it off the report
+		// stream so `compare -o x.md > report.md` redirections stay clean.
+		fmt.Fprintf(os.Stderr, "Report saved to %s\n", output)
 	}
 	return nil
 }
@@ -621,6 +623,11 @@ func renderComparison(c *comparison) string {
 	fmt.Fprintf(&b, "| baseline | %s | %d | %d |\n", c.baseline.name, len(c.baseline.files), len(c.baseline.samples))
 	fmt.Fprintf(&b, "| candidate | %s | %d | %d |\n", c.candidate.name, len(c.candidate.files), len(c.candidate.samples))
 	b.WriteString("\n")
+	if len(c.baseline.samples) < 2 || len(c.candidate.samples) < 2 {
+		b.WriteString("> **Note:** at least one group has n < 2, so verdicts in this report are NOT " +
+			"CI-gated — every |Δ%| ≥ 5% row is flagged, including single-run noise. " +
+			"Use multiple seeds per side for decisions.\n\n")
+	}
 	writeFileList(&b, "baseline", c.baseline)
 	writeFileList(&b, "candidate", c.candidate)
 	if line := configHighlights("baseline", c.baseline); line != "" {

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -1,0 +1,654 @@
+package main
+
+// compare.go implements `cube-bench compare`, an A/B comparison report
+// generator for scheduling-policy experiments. It reads two groups of
+// cube-bench or simulator JSON exports (each file contributes one sample, or
+// one sample per entry of a non-empty top-level "rounds" array), aggregates
+// every numeric metric across samples (mean/stddev/95% CI), and renders a
+// markdown report with per-metric deltas and improvement/regression verdicts.
+//
+// The entry point is runCompare; wiring it into the CLI is a one-liner in
+// main.go:
+//
+//	if len(os.Args) > 1 && os.Args[1] == "compare" {
+//		if err := runCompare(os.Args[2:], os.Stdout); err != nil {
+//			fmt.Fprintln(os.Stderr, "ERROR:", err)
+//			os.Exit(1)
+//		}
+//		return
+//	}
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const compareUsage = `Usage: cube-bench compare --baseline f1.json,f2.json --candidate g1.json,g2.json [flags]
+
+Generates an A/B comparison report from two groups of cube-bench or
+simulator JSON exports. Each file contributes one sample, or one sample per
+entry when it carries a non-empty top-level "rounds" array.
+
+Flags:
+  --baseline files        Comma-separated baseline result files (required)
+  --candidate files       Comma-separated candidate result files (required)
+  --baseline-name name    Label for the baseline group (default "baseline")
+  --candidate-name name   Label for the candidate group (default "candidate")
+  -o, --output file       Also write the markdown report to this file
+`
+
+// runCompare is the testable entry point of the compare subcommand: it parses
+// args (without touching the global flag set), writes the markdown report to
+// stdout, and optionally also to the file given via -o/--output.
+func runCompare(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("compare", flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // errors are returned, not printed
+
+	var baselineList, candidateList, baselineName, candidateName, output string
+	fs.StringVar(&baselineList, "baseline", "", "Comma-separated baseline result files")
+	fs.StringVar(&candidateList, "candidate", "", "Comma-separated candidate result files")
+	fs.StringVar(&baselineName, "baseline-name", "baseline", "Label for the baseline group")
+	fs.StringVar(&candidateName, "candidate-name", "candidate", "Label for the candidate group")
+	fs.StringVar(&output, "o", "", "Also write the markdown report to this file")
+	fs.StringVar(&output, "output", "", "Also write the markdown report to this file")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Fprint(stdout, compareUsage)
+			return nil
+		}
+		return fmt.Errorf("compare: %w", err)
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("compare: unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+
+	baselinePaths := splitCommaList(baselineList)
+	candidatePaths := splitCommaList(candidateList)
+	if len(baselinePaths) == 0 || len(candidatePaths) == 0 {
+		return errors.New("compare: both --baseline and --candidate file lists are required")
+	}
+
+	baseline, err := loadSampleGroup(baselineName, baselinePaths)
+	if err != nil {
+		return err
+	}
+	candidate, err := loadSampleGroup(candidateName, candidatePaths)
+	if err != nil {
+		return err
+	}
+
+	cmp := buildComparison(baseline, candidate, time.Now().UTC())
+	report := renderComparison(cmp)
+
+	if output != "" {
+		if err := os.WriteFile(output, []byte(report), 0644); err != nil {
+			return fmt.Errorf("compare: write report %s: %w", output, err)
+		}
+	}
+	fmt.Fprint(stdout, report)
+	if output != "" {
+		fmt.Fprintf(stdout, "\nReport saved to %s\n", output)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Input parsing: files -> samples
+// ---------------------------------------------------------------------------
+
+// sampleFile is one input JSON file: its config block plus the metric samples
+// it contributes (one per round when a non-empty "rounds" array is present,
+// otherwise a single sample from the top-level "summary").
+type sampleFile struct {
+	path      string
+	config    map[string]any
+	samples   []map[string]float64
+	viaRounds bool
+}
+
+// sampleGroup is one side of the comparison (baseline or candidate).
+type sampleGroup struct {
+	name    string
+	files   []*sampleFile
+	samples []map[string]float64
+}
+
+func splitCommaList(raw string) []string {
+	var out []string
+	for _, p := range strings.Split(raw, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func loadSampleGroup(name string, paths []string) (*sampleGroup, error) {
+	g := &sampleGroup{name: name}
+	for _, p := range paths {
+		f, err := loadSampleFile(p)
+		if err != nil {
+			return nil, err
+		}
+		g.files = append(g.files, f)
+		g.samples = append(g.samples, f.samples...)
+	}
+	return g, nil
+}
+
+func loadSampleFile(path string) (*sampleFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("compare: read %s: %w", path, err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("compare: parse %s: %w", path, err)
+	}
+
+	f := &sampleFile{path: path}
+	if cfg, ok := root["config"].(map[string]any); ok {
+		f.config = cfg
+	}
+
+	// A non-empty top-level "rounds" array turns the file into one sample
+	// per round; otherwise the top-level "summary" is the single sample.
+	if rounds, ok := root["rounds"].([]any); ok && len(rounds) > 0 {
+		f.viaRounds = true
+		for i, r := range rounds {
+			rm, ok := r.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("compare: %s: rounds[%d] is not an object", path, i)
+			}
+			sample, err := flattenSummaryValue(rm["summary"])
+			if err != nil {
+				return nil, fmt.Errorf("compare: %s: rounds[%d]: %w", path, i, err)
+			}
+			f.samples = append(f.samples, sample)
+		}
+		return f, nil
+	}
+
+	sample, err := flattenSummaryValue(root["summary"])
+	if err != nil {
+		return nil, fmt.Errorf("compare: %s: %w", path, err)
+	}
+	f.samples = []map[string]float64{sample}
+	return f, nil
+}
+
+func flattenSummaryValue(v any) (map[string]float64, error) {
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil, errors.New("missing or non-object \"summary\"")
+	}
+	out := make(map[string]float64)
+	flattenMetrics(obj, "", out)
+	return out, nil
+}
+
+// flattenMetrics walks obj recursively and records every numeric leaf under a
+// dotted key (e.g. "create.p95_ms"). Non-numeric leaves (strings, booleans,
+// arrays, nulls) are skipped.
+func flattenMetrics(obj map[string]any, prefix string, out map[string]float64) {
+	for k, v := range obj {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		switch t := v.(type) {
+		case map[string]any:
+			flattenMetrics(t, key, out)
+		case float64:
+			out[key] = t
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation across samples
+// ---------------------------------------------------------------------------
+
+type metricStats struct {
+	n      int
+	mean   float64
+	stdDev float64 // sample standard deviation (n-1 denominator)
+	ci     float64 // half-width of the 95% confidence interval
+	hasCI  bool    // false when n < 2
+}
+
+func aggregateSamples(samples []map[string]float64) map[string]metricStats {
+	values := make(map[string][]float64)
+	for _, s := range samples {
+		for k, v := range s {
+			values[k] = append(values[k], v)
+		}
+	}
+	out := make(map[string]metricStats, len(values))
+	for k, vs := range values {
+		st := metricStats{n: len(vs), mean: sampleMean(vs), stdDev: sampleStdDev(vs)}
+		if st.n >= 2 {
+			st.ci = 1.96 * st.stdDev / math.Sqrt(float64(st.n))
+			st.hasCI = true
+		}
+		out[k] = st
+	}
+	return out
+}
+
+func sampleMean(vs []float64) float64 {
+	if len(vs) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, v := range vs {
+		sum += v
+	}
+	return sum / float64(len(vs))
+}
+
+func sampleStdDev(vs []float64) float64 {
+	if len(vs) < 2 {
+		return 0
+	}
+	// Shortcut for zero variance: identical inputs must yield exactly 0,
+	// otherwise inexact binary fractions (e.g. 0.05) leave an epsilon
+	// residue that renders as 9.6168e-18 in reports.
+	allEqual := true
+	for _, v := range vs[1:] {
+		if v != vs[0] {
+			allEqual = false
+			break
+		}
+	}
+	if allEqual {
+		return 0
+	}
+	m := sampleMean(vs)
+	sum := 0.0
+	for _, v := range vs {
+		d := v - m
+		sum += d * d
+	}
+	return math.Sqrt(sum / float64(len(vs)-1))
+}
+
+// ---------------------------------------------------------------------------
+// Metric direction table
+// ---------------------------------------------------------------------------
+
+type direction int
+
+const (
+	dirNA direction = iota
+	dirLowerBetter
+	dirHigherBetter
+)
+
+// Direction rules. Keys are lower-cased first. "substring" entries match
+// anywhere in the key; "token" entries must match a whole key segment (the
+// key split on non-alphanumeric characters), so "strategy" does not match
+// "rate" and "discovery" does not match "cv". Lower-better rules win when a
+// key matches both families, hence "error_rate" is lower-better while
+// "success_rate" is higher-better.
+var (
+	lowerBetterSubstrings  = []string{"latency", "delay", "duration", "error", "failure", "fragment", "herd"}
+	lowerBetterTokens      = []string{"cv"}
+	higherBetterSubstrings = []string{"jain", "throughput"}
+	higherBetterTokens     = []string{"rate", "qps"}
+)
+
+func metricDirection(key string) direction {
+	k := strings.ToLower(key)
+	tokens := strings.FieldsFunc(k, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	if directionMatches(k, tokens, lowerBetterSubstrings, lowerBetterTokens) {
+		return dirLowerBetter
+	}
+	if directionMatches(k, tokens, higherBetterSubstrings, higherBetterTokens) {
+		return dirHigherBetter
+	}
+	return dirNA
+}
+
+func directionMatches(key string, tokens, substrings, exactTokens []string) bool {
+	for _, s := range substrings {
+		if strings.Contains(key, s) {
+			return true
+		}
+	}
+	for _, tok := range tokens {
+		for _, e := range exactTokens {
+			if tok == e {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Comparison model
+// ---------------------------------------------------------------------------
+
+type verdict string
+
+const (
+	verdictImproved  verdict = "improved"
+	verdictRegressed verdict = "regressed"
+	verdictSame      verdict = "same"
+	verdictNoDir     verdict = "n/a"
+	verdictMissing   verdict = "—" // metric absent on one side
+)
+
+type compareRow struct {
+	key     string
+	group   string
+	base    metricStats
+	hasBase bool
+	cand    metricStats
+	hasCand bool
+	delta   float64 // candidate mean - baseline mean
+	pct     float64 // delta / baseline mean * 100
+	hasPct  bool    // false when baseline mean is 0 or a side is missing
+	dir     direction
+	verdict verdict
+}
+
+type comparison struct {
+	baseline  *sampleGroup
+	candidate *sampleGroup
+	rows      []*compareRow // sorted by (group, key)
+	generated time.Time
+}
+
+func buildComparison(baseline, candidate *sampleGroup, generated time.Time) *comparison {
+	baseAgg := aggregateSamples(baseline.samples)
+	candAgg := aggregateSamples(candidate.samples)
+
+	keySet := make(map[string]struct{}, len(baseAgg)+len(candAgg))
+	for k := range baseAgg {
+		keySet[k] = struct{}{}
+	}
+	for k := range candAgg {
+		keySet[k] = struct{}{}
+	}
+	keys := make([]string, 0, len(keySet))
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		gi, gj := groupPrefix(keys[i]), groupPrefix(keys[j])
+		if gi != gj {
+			return gi < gj
+		}
+		return keys[i] < keys[j]
+	})
+
+	cmp := &comparison{baseline: baseline, candidate: candidate, generated: generated}
+	for _, k := range keys {
+		row := &compareRow{key: k, group: groupPrefix(k), dir: metricDirection(k)}
+		if st, ok := baseAgg[k]; ok {
+			row.base, row.hasBase = st, true
+		}
+		if st, ok := candAgg[k]; ok {
+			row.cand, row.hasCand = st, true
+		}
+		if row.hasBase && row.hasCand {
+			row.delta = row.cand.mean - row.base.mean
+			if row.base.mean != 0 {
+				row.pct = row.delta / row.base.mean * 100
+				row.hasPct = true
+			}
+		}
+		row.verdict = compareVerdict(row)
+		cmp.rows = append(cmp.rows, row)
+	}
+	return cmp
+}
+
+func compareVerdict(r *compareRow) verdict {
+	switch {
+	case !r.hasBase || !r.hasCand:
+		return verdictMissing
+	case r.dir == dirNA:
+		return verdictNoDir
+	case r.delta > 0:
+		if r.dir == dirHigherBetter {
+			return verdictImproved
+		}
+		return verdictRegressed
+	case r.delta < 0:
+		if r.dir == dirLowerBetter {
+			return verdictImproved
+		}
+		return verdictRegressed
+	default:
+		return verdictSame
+	}
+}
+
+// groupPrefix groups metrics by their natural key prefix: the segment before
+// the first '.' or '_' (e.g. "create.p95_ms" -> "create", "queue_depth" ->
+// "queue"). Keys without a separator form their own group.
+func groupPrefix(key string) string {
+	if i := strings.IndexAny(key, "._"); i > 0 {
+		return key[:i]
+	}
+	return key
+}
+
+// conclusions splits rows into the report's conclusion lists: significant
+// improvements/regressions (verdict matches and |Δ%| >= 5%), plus metrics
+// without a known direction.
+func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
+	for _, r := range c.rows {
+		switch {
+		case (r.verdict == verdictImproved || r.verdict == verdictRegressed) && r.hasPct && math.Abs(r.pct) >= 5:
+			if r.verdict == verdictImproved {
+				improved = append(improved, r)
+			} else {
+				regressed = append(regressed, r)
+			}
+		case r.verdict == verdictNoDir:
+			noDir = append(noDir, r)
+		}
+	}
+	byImpact := func(rows []*compareRow) {
+		sort.Slice(rows, func(i, j int) bool {
+			ai, aj := math.Abs(rows[i].pct), math.Abs(rows[j].pct)
+			if ai != aj {
+				return ai > aj
+			}
+			return rows[i].key < rows[j].key
+		})
+	}
+	byImpact(improved)
+	byImpact(regressed)
+	return improved, regressed, noDir
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+func renderComparison(c *comparison) string {
+	var b strings.Builder
+
+	b.WriteString("# A/B Comparison Report\n\n")
+	fmt.Fprintf(&b, "Generated: %s\n\n", c.generated.Format("2006-01-02 15:04:05 UTC"))
+
+	b.WriteString("## Experiment Setup\n\n")
+	b.WriteString("| group | name | files | samples (n) |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	fmt.Fprintf(&b, "| baseline | %s | %d | %d |\n", c.baseline.name, len(c.baseline.files), len(c.baseline.samples))
+	fmt.Fprintf(&b, "| candidate | %s | %d | %d |\n", c.candidate.name, len(c.candidate.files), len(c.candidate.samples))
+	b.WriteString("\n")
+	writeFileList(&b, "baseline", c.baseline)
+	writeFileList(&b, "candidate", c.candidate)
+	if line := configHighlights("baseline", c.baseline); line != "" {
+		b.WriteString(line + "\n")
+	}
+	if line := configHighlights("candidate", c.candidate); line != "" {
+		b.WriteString(line + "\n")
+	}
+
+	b.WriteString("\n## Metric Comparison\n\n")
+	b.WriteString("Cells show the mean across samples; CI is the 95% confidence interval half-width (1.96·σ/√n), shown only when n ≥ 2. Δ = candidate − baseline.\n\n")
+	if len(c.rows) == 0 {
+		b.WriteString("- (no numeric metrics found)\n")
+	}
+	group := ""
+	for _, r := range c.rows {
+		if r.group != group {
+			if group != "" {
+				b.WriteString("\n")
+			}
+			fmt.Fprintf(&b, "### %s\n\n", r.group)
+			b.WriteString("| metric | baseline (mean±CI) | candidate (mean±CI) | Δ | Δ% | verdict |\n")
+			b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+			group = r.group
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s |\n",
+			r.key, statsCell(r.base, r.hasBase), statsCell(r.cand, r.hasCand),
+			deltaCell(r), pctCell(r), string(r.verdict))
+	}
+
+	improved, regressed, noDir := c.conclusions()
+	b.WriteString("\n## Conclusions\n\n")
+	b.WriteString("### Improved (|Δ%| ≥ 5%)\n\n")
+	writeConclusionList(&b, improved)
+	b.WriteString("\n### Regressed (|Δ%| ≥ 5%)\n\n")
+	writeConclusionList(&b, regressed)
+	b.WriteString("\n### No direction (n/a)\n\n")
+	writeConclusionList(&b, noDir)
+	b.WriteString("\n")
+	return b.String()
+}
+
+func writeFileList(b *strings.Builder, label string, g *sampleGroup) {
+	parts := make([]string, len(g.files))
+	for i, f := range g.files {
+		note := fmt.Sprintf("n=%d", len(f.samples))
+		if f.viaRounds {
+			note += " via rounds"
+		}
+		parts[i] = fmt.Sprintf("`%s` (%s)", f.path, note)
+	}
+	fmt.Fprintf(b, "- **%s files**: %s\n", label, strings.Join(parts, ", "))
+}
+
+// configHighlightKeys are the config fields surfaced in the report metadata
+// when present. Values are de-duplicated per group, so files that differ only
+// by seed render as e.g. "seed=1, 2, 3".
+var configHighlightKeys = []string{"seed", "seeds", "rounds", "workload", "profile", "version", "template", "mode"}
+
+func configHighlights(label string, g *sampleGroup) string {
+	var parts []string
+	for _, key := range configHighlightKeys {
+		seen := make(map[string]struct{})
+		var vals []string
+		for _, f := range g.files {
+			if f.config == nil {
+				continue
+			}
+			v, ok := f.config[key]
+			if !ok {
+				continue
+			}
+			s := formatConfigValue(v)
+			if _, dup := seen[s]; dup {
+				continue
+			}
+			seen[s] = struct{}{}
+			vals = append(vals, s)
+		}
+		if len(vals) > 0 {
+			parts = append(parts, key+"="+strings.Join(vals, ", "))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("- **%s config**: %s", label, strings.Join(parts, "; "))
+}
+
+func formatConfigValue(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(t)
+	default:
+		data, err := json.Marshal(t)
+		if err != nil {
+			return fmt.Sprint(t)
+		}
+		return string(data)
+	}
+}
+
+func writeConclusionList(b *strings.Builder, rows []*compareRow) {
+	if len(rows) == 0 {
+		b.WriteString("- (none)\n")
+		return
+	}
+	for _, r := range rows {
+		fmt.Fprintf(b, "- **%s**: %s (%s → %s)\n",
+			r.key, pctCell(r), formatNum(r.base.mean), formatNum(r.cand.mean))
+	}
+}
+
+func statsCell(st metricStats, ok bool) string {
+	if !ok {
+		return "—"
+	}
+	if !st.hasCI {
+		return formatNum(st.mean)
+	}
+	return formatNum(st.mean) + " ± " + formatNum(st.ci)
+}
+
+func deltaCell(r *compareRow) string {
+	if !r.hasBase || !r.hasCand {
+		return "—"
+	}
+	return signedNum(r.delta)
+}
+
+func pctCell(r *compareRow) string {
+	if !r.hasPct {
+		return "—"
+	}
+	return fmt.Sprintf("%+.1f%%", r.pct)
+}
+
+// formatNum renders integral values without decimals and everything else with
+// up to 5 significant digits.
+func formatNum(v float64) string {
+	if v == math.Trunc(v) && math.Abs(v) < 1e15 {
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	}
+	return strconv.FormatFloat(v, 'g', 5, 64)
+}
+
+func signedNum(v float64) string {
+	if v > 0 {
+		return "+" + formatNum(v)
+	}
+	return formatNum(v)
+}

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -640,10 +640,12 @@ func compareVerdict(r *compareRow) verdict {
 // the first '.' or '_' (e.g. "create.p95_ms" -> "create", "queue_depth" ->
 // "queue"). Keys without a separator form their own group. per_template keys
 // group by the template id instead, so a per-template comparison renders one
-// section per template rather than a single jumbled "per" table.
+// section per template rather than a single jumbled "per" table; the id is
+// delimited by the LAST dot (matching classifyKey), so ids containing dots
+// still group correctly.
 func groupPrefix(key string) string {
 	if rest, ok := strings.CutPrefix(key, "per_template."); ok {
-		if i := strings.Index(rest, "."); i > 0 {
+		if i := strings.LastIndex(rest, "."); i > 0 {
 			return "per_template." + rest[:i]
 		}
 		return key

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -246,12 +246,33 @@ func aggregateSamples(samples []map[string]float64) map[string]metricStats {
 	for k, vs := range values {
 		st := metricStats{n: len(vs), mean: sampleMean(vs), stdDev: sampleStdDev(vs)}
 		if st.n >= 2 {
-			st.ci = 1.96 * st.stdDev / math.Sqrt(float64(st.n))
+			st.ci = t95(st.n) * st.stdDev / math.Sqrt(float64(st.n))
 			st.hasCI = true
 		}
 		out[k] = st
 	}
 	return out
+}
+
+// t95 returns the two-sided 95% Student-t quantile for n samples (df = n-1).
+// The normal 1.96 badly understates the interval at the sample sizes this
+// tool is meant for — a handful of seed files per side (df=1: 12.706).
+var t95Table = []float64{
+	12.706, 4.303, 3.182, 2.776, 2.571, 2.447, 2.365, 2.306, 2.262, 2.228, // df 1-10
+	2.201, 2.179, 2.160, 2.145, 2.131, 2.120, 2.110, 2.101, 2.093, 2.086, // df 11-20
+	2.080, 2.074, 2.069, 2.064, 2.060, 2.056, 2.052, 2.048, 2.045, 2.042, // df 21-30
+}
+
+func t95(n int) float64 {
+	df := n - 1
+	switch {
+	case df < 1:
+		return 0
+	case df <= 30:
+		return t95Table[df-1]
+	default:
+		return 1.96
+	}
 }
 
 func sampleMean(vs []float64) float64 {
@@ -316,11 +337,30 @@ var (
 	higherBetterTokens     = []string{"rate", "qps"}
 )
 
+// cube-bench's own exported latency stat blocks ("create.p95", "delete.avg",
+// also the "_ms"-suffixed nested variants like "create.p95_ms") carry no
+// direction keyword. Classify any create/delete key that carries a stat-block
+// suffix as lower-better; "count" stays directionless.
+var (
+	statBlockGroups = map[string]bool{"create": true, "delete": true}
+	statBlockStats  = map[string]bool{
+		"min": true, "max": true, "avg": true, "std": true,
+		"p50": true, "p90": true, "p95": true, "p99": true,
+	}
+)
+
 func metricDirection(key string) direction {
 	k := strings.ToLower(key)
 	tokens := strings.FieldsFunc(k, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
+	if len(tokens) > 1 && statBlockGroups[tokens[0]] {
+		for _, tok := range tokens[1:] {
+			if statBlockStats[tok] {
+				return dirLowerBetter
+			}
+		}
+	}
 	if directionMatches(k, tokens, lowerBetterSubstrings, lowerBetterTokens) {
 		return dirLowerBetter
 	}
@@ -458,12 +498,18 @@ func groupPrefix(key string) string {
 }
 
 // conclusions splits rows into the report's conclusion lists: significant
-// improvements/regressions (verdict matches and |Δ%| >= 5%), plus metrics
+// improvements/regressions (verdict matches, |Δ%| >= 5%, and — when both
+// sides have n >= 2 — the delta must exceed the combined 95% CI half-widths,
+// so noise at small sample counts is not flagged as a verdict), plus metrics
 // without a known direction.
 func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
 	for _, r := range c.rows {
+		significant := r.hasPct && math.Abs(r.pct) >= 5
+		if significant && r.base.hasCI && r.cand.hasCI {
+			significant = math.Abs(r.delta) > r.base.ci+r.cand.ci
+		}
 		switch {
-		case (r.verdict == verdictImproved || r.verdict == verdictRegressed) && r.hasPct && math.Abs(r.pct) >= 5:
+		case (r.verdict == verdictImproved || r.verdict == verdictRegressed) && significant:
 			if r.verdict == verdictImproved {
 				improved = append(improved, r)
 			} else {
@@ -513,7 +559,7 @@ func renderComparison(c *comparison) string {
 	}
 
 	b.WriteString("\n## Metric Comparison\n\n")
-	b.WriteString("Cells show the mean across samples; CI is the 95% confidence interval half-width (1.96·σ/√n), shown only when n ≥ 2. Δ = candidate − baseline.\n\n")
+	b.WriteString("Cells show the mean across samples; CI is the 95% confidence interval half-width (Student-t t95·σ/√n), shown only when n ≥ 2. Δ = candidate − baseline. Verdicts are directional; the conclusion lists additionally require |Δ| beyond the combined CI half-widths when both sides have n ≥ 2.\n\n")
 	if len(c.rows) == 0 {
 		b.WriteString("- (no numeric metrics found)\n")
 	}
@@ -535,9 +581,9 @@ func renderComparison(c *comparison) string {
 
 	improved, regressed, noDir := c.conclusions()
 	b.WriteString("\n## Conclusions\n\n")
-	b.WriteString("### Improved (|Δ%| ≥ 5%)\n\n")
+	b.WriteString("### Improved (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)\n\n")
 	writeConclusionList(&b, improved)
-	b.WriteString("\n### Regressed (|Δ%| ≥ 5%)\n\n")
+	b.WriteString("\n### Regressed (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)\n\n")
 	writeConclusionList(&b, regressed)
 	b.WriteString("\n### No direction (n/a)\n\n")
 	writeConclusionList(&b, noDir)

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -161,10 +161,15 @@ func extractPartial(sample map[string]float64) bool {
 // from a sample whose run is flagged saturated or partial: those numbers
 // describe the client's semaphore or a truncated sample, not the offered
 // schedule, so they must not reach the metric tables or the verdict lists.
-// Affected rows render "—" and the group-level warning/note explains why.
-func dropUntrustworthyDispatchKeys(sample map[string]float64) {
+// A partial (early-quit) run additionally drops its per_template.* blocks:
+// they aggregate only the results consumed before the quit, so against a
+// full run they would read as spurious per-template regressions (a saturated
+// run keeps them — they reflect what actually ran). Affected rows render "—"
+// and the group-level warning/note explains why.
+func dropUntrustworthyDispatchKeys(sample map[string]float64, partial bool) {
 	for k := range sample {
-		if strings.HasPrefix(k, "queue_delay_") || strings.HasPrefix(k, "dispatch_") {
+		if strings.HasPrefix(k, "queue_delay_") || strings.HasPrefix(k, "dispatch_") ||
+			(partial && strings.HasPrefix(k, "per_template.")) {
 			delete(sample, k)
 		}
 	}
@@ -246,7 +251,7 @@ func loadSampleFile(path string) (*sampleFile, error) {
 			saturated := extractSaturated(sample)
 			partial := extractPartial(sample)
 			if saturated || partial {
-				dropUntrustworthyDispatchKeys(sample)
+				dropUntrustworthyDispatchKeys(sample, partial)
 			}
 			f.saturated = f.saturated || saturated
 			f.partial = f.partial || partial
@@ -269,7 +274,7 @@ func loadSampleFile(path string) (*sampleFile, error) {
 	f.saturated = extractSaturated(sample)
 	f.partial = extractPartial(sample)
 	if f.saturated || f.partial {
-		dropUntrustworthyDispatchKeys(sample)
+		dropUntrustworthyDispatchKeys(sample, f.partial)
 	}
 	f.samples = []map[string]float64{sample}
 	return f, nil

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -271,7 +271,19 @@ func t95(n int) float64 {
 	case df <= 30:
 		return t95Table[df-1]
 	default:
-		return 1.96
+		// Cornish–Fisher expansion of the two-sided 95% Student-t quantile
+		// around the normal value z=1.95996...: t ≈ z + g1/df + g2/df² +
+		// g3/df³ with g1=(z³+z)/4, g2=(5z⁵+16z³+3z)/96,
+		// g3=(3z⁷+19z⁵+17z³−15z)/384. Accurate to ~1e-4 for df > 30, where
+		// t has approached but not yet reached 1.96 (df=31: 2.0395,
+		// df=60: 2.0003, df=120: 1.9799).
+		const z = 1.959963986120195
+		v := float64(df)
+		z2, z3 := z*z, z*z*z
+		g1 := (z3 + z) / 4
+		g2 := (5*z3*z2 + 16*z3 + 3*z) / 96
+		g3 := (3*z3*z2*z2 + 19*z3*z2 + 17*z3 - 15*z) / 384
+		return z + g1/v + g2/(v*v) + g3/(v*v*v)
 	}
 }
 
@@ -329,9 +341,12 @@ const (
 // key split on non-alphanumeric characters), so "strategy" does not match
 // "rate" and "discovery" does not match "cv". Lower-better rules win when a
 // key matches both families, hence "error_rate" is lower-better while
-// "success_rate" is higher-better.
+// "success_rate" is higher-better. Scheduler-quality rates that are bad when
+// they rise (restart/preempt/evict/retry) are pinned lower-better explicitly —
+// the generic "rate" token alone would otherwise flag a growing restart_rate
+// as an improvement.
 var (
-	lowerBetterSubstrings  = []string{"latency", "delay", "duration", "error", "failure", "fragment", "herd"}
+	lowerBetterSubstrings  = []string{"latency", "delay", "duration", "error", "failure", "fragment", "herd", "restart", "preempt", "evict", "retry"}
 	lowerBetterTokens      = []string{"cv"}
 	higherBetterSubstrings = []string{"jain", "throughput"}
 	higherBetterTokens     = []string{"rate", "qps"}

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -420,13 +420,28 @@ var countTokens = map[string]bool{
 	"errors": true, "failures": true, "successful": true,
 }
 
+// classifyKey strips data-derived segments before direction/scale
+// classification. Today the only such segment is the template id in
+// per_template.<id>.<stat>: a user-chosen id like "sbx-errors" or
+// "herd-pool" must not flip the sibling stat's classification (a spurious
+// "errors" count token or "herd" lower-better substring).
+func classifyKey(key string) string {
+	const prefix = "per_template."
+	if rest, ok := strings.CutPrefix(key, prefix); ok {
+		if i := strings.LastIndex(rest, "."); i >= 0 {
+			return prefix + rest[i+1:]
+		}
+	}
+	return key
+}
+
 // isScaleCounter reports whether key is a raw scale counter: a bare count
 // token from countTokens, or the singular "count" of a create/delete stat
 // block (create.count/delete.count track how many cycles ran — scale, not
 // quality). "count" outside a stat block stays directional, so failure_count
 // keeps its lower-better verdict.
 func isScaleCounter(key string) bool {
-	k := strings.ToLower(key)
+	k := strings.ToLower(classifyKey(key))
 	tokens := strings.FieldsFunc(k, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
@@ -439,7 +454,7 @@ func isScaleCounter(key string) bool {
 }
 
 func metricDirection(key string) direction {
-	k := strings.ToLower(key)
+	k := strings.ToLower(classifyKey(key))
 	tokens := strings.FieldsFunc(k, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
@@ -581,8 +596,16 @@ func compareVerdict(r *compareRow) verdict {
 
 // groupPrefix groups metrics by their natural key prefix: the segment before
 // the first '.' or '_' (e.g. "create.p95_ms" -> "create", "queue_depth" ->
-// "queue"). Keys without a separator form their own group.
+// "queue"). Keys without a separator form their own group. per_template keys
+// group by the template id instead, so a per-template comparison renders one
+// section per template rather than a single jumbled "per" table.
 func groupPrefix(key string) string {
+	if rest, ok := strings.CutPrefix(key, "per_template."); ok {
+		if i := strings.Index(rest, "."); i > 0 {
+			return "per_template." + rest[:i]
+		}
+		return key
+	}
 	if i := strings.IndexAny(key, "._"); i > 0 {
 		return key[:i]
 	}

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -811,6 +811,9 @@ func renderComparison(c *comparison) string {
 	if line := configHighlights("candidate", c.candidate); line != "" {
 		b.WriteString(line + "\n")
 	}
+	if note := configMismatchNote(c.baseline, c.candidate); note != "" {
+		b.WriteString(note + "\n")
+	}
 
 	b.WriteString("\n## Metric Comparison\n\n")
 	b.WriteString("Cells show the mean across samples; CI is the 95% confidence interval half-width (Student-t t95·σ/√n), shown only when n ≥ 2. Δ = candidate − baseline. Verdicts are directional; the conclusion lists additionally require |Δ| beyond the 95% CI of the difference (√(ci_base² + ci_cand²)) when both sides have n ≥ 2. Δ% is relative to the baseline mean with no floor, so near-zero baselines (e.g. an error_rate ≈ 0) can produce enormous percentages — read them alongside the absolute Δ.\n\n")
@@ -897,6 +900,60 @@ func configHighlights(label string, g *sampleGroup) string {
 		return ""
 	}
 	return fmt.Sprintf("- **%s config**: %s", label, strings.Join(parts, "; "))
+}
+
+// configCompareKeys are the pacing/shape config fields where a silent
+// baseline-vs-candidate mismatch makes queue_delay_*/dispatch_* verdicts a
+// client-config artifact rather than a scheduler effect. Seeds are excluded
+// on purpose: they randomize the sequence, they do not pace it.
+var configCompareKeys = []string{"concurrency", "rate_per_sec", "lifetime_min_s", "lifetime_max_s"}
+
+// uniqueConfigValue returns the single de-duplicated value of key across the
+// group's files. ok is false when the key is missing everywhere or takes more
+// than one value inside the group — a ragged group is already surfaced by
+// configHighlights, and comparing one ragged side would be noise.
+func uniqueConfigValue(g *sampleGroup, key string) (string, bool) {
+	var val string
+	set := false
+	for _, f := range g.files {
+		if f.config == nil {
+			continue
+		}
+		v, ok := f.config[key]
+		if !ok {
+			continue
+		}
+		s := formatConfigValue(v)
+		if !set {
+			val, set = s, true
+			continue
+		}
+		if val != s {
+			return "", false
+		}
+	}
+	return val, set
+}
+
+// configMismatchNote flags a scheduled-vs-scheduled comparison whose two
+// groups were paced differently. Absence of a key on either side (legacy
+// exports) is not a mismatch; only two present, distinct values are.
+func configMismatchNote(base, cand *sampleGroup) string {
+	var diffs []string
+	for _, key := range configCompareKeys {
+		bv, bok := uniqueConfigValue(base, key)
+		cv, cok := uniqueConfigValue(cand, key)
+		if bok && cok && bv != cv {
+			diffs = append(diffs, fmt.Sprintf("%s (%s vs %s)", key, bv, cv))
+		}
+	}
+	if len(diffs) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("> **Note:** the two groups were run with mismatched client config (%s). "+
+		"`queue_delay_*`/`dispatch_*` verdicts on such a pair are client-config artifacts, not scheduler "+
+		"effects — rerun both sides under the same `--rate`/`--concurrency`/`--lifetime` before trusting "+
+		"those rows.", strings.Join(diffs, ", "))
 }
 
 func formatConfigValue(v any) string {

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -823,8 +823,8 @@ func renderComparison(c *comparison) string {
 		b.WriteString(note + "\n")
 	}
 	for _, g := range []*sampleGroup{c.baseline, c.candidate} {
-		if v, ok := uniqueConfigValue(g, "dry_run"); ok && v == "true" {
-			fmt.Fprintf(&b, "> **Warning:** %s is a dry-run export: its latencies are synthesized "+
+		if groupHasDryRun(g) {
+			fmt.Fprintf(&b, "> **Warning:** %s contains a dry-run export: its latencies are synthesized "+
 				"(lifetime sleeps clamped, errors drawn from --dry-error-rate), so verdicts on its rows "+
 				"describe the simulator, not a scheduler or a real API.\n", g.name)
 		}
@@ -949,6 +949,22 @@ func uniqueConfigValue(g *sampleGroup, key string) (string, bool) {
 		}
 	}
 	return val, set
+}
+
+// groupHasDryRun reports whether ANY file in the group is a dry-run export.
+// uniqueConfigValue would miss a mixed dry-run/real group (the key takes
+// more than one value), but aggregation blends synthetic and real latencies
+// into the same rows, so the warning must fire on any dry-run member.
+func groupHasDryRun(g *sampleGroup) bool {
+	for _, f := range g.files {
+		if f.config == nil {
+			continue
+		}
+		if v, ok := f.config["dry_run"]; ok && formatConfigValue(v) == "true" {
+			return true
+		}
+	}
+	return false
 }
 
 // configMismatchNote flags a scheduled-vs-scheduled comparison whose two

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -530,16 +530,20 @@ func groupPrefix(key string) string {
 
 // conclusions splits rows into the report's conclusion lists: significant
 // improvements/regressions (verdict matches, |Δ%| >= 5%, and — when both
-// sides have n >= 2 — the delta must exceed the combined 95% CI half-widths,
-// so noise at small sample counts is not flagged as a verdict), plus metrics
-// without a known direction.
+// sides have n >= 2 — the delta must exceed the 95% CI half-width of the
+// difference of the two independent means, √(ci_base² + ci_cand²), so noise
+// at small sample counts is not flagged as a verdict; summing the half-widths
+// instead would be over-conservative and hide genuine movements), plus
+// metrics without a known direction.
 //
 // When the baseline mean is exactly 0 the Δ% is undefined and hasPct is
 // false; the significance test then falls back to the absolute delta (still
 // CI-gated when possible), so a 0 -> 0.5 error_rate catastrophe is flagged
-// instead of silently dropped. Directionless rows join the n/a list only
-// when the same magnitude test (without the CI gate) says the delta is
-// notable, so trivial movements don't flood the section.
+// instead of silently dropped. The fallback has no magnitude floor: with
+// tight CIs on both sides even a 0 -> 1e-9 movement is flagged, so judge
+// materiality from the absolute Δ shown alongside. Directionless rows join
+// the n/a list only when the same magnitude test (without the CI gate) says
+// the delta is notable, so trivial movements don't flood the section.
 func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
 	for _, r := range c.rows {
 		significant := r.hasPct && math.Abs(r.pct) >= 5
@@ -548,7 +552,9 @@ func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
 		}
 		notable := significant
 		if significant && r.base.hasCI && r.cand.hasCI {
-			significant = math.Abs(r.delta) > r.base.ci+r.cand.ci
+			// 95% CI of the difference of two independent means: root-sum-of-
+			// squares of the per-side half-widths.
+			significant = math.Abs(r.delta) > math.Hypot(r.base.ci, r.cand.ci)
 		}
 		switch {
 		case (r.verdict == verdictImproved || r.verdict == verdictRegressed) && significant:
@@ -625,7 +631,7 @@ func renderComparison(c *comparison) string {
 	}
 
 	b.WriteString("\n## Metric Comparison\n\n")
-	b.WriteString("Cells show the mean across samples; CI is the 95% confidence interval half-width (Student-t t95·σ/√n), shown only when n ≥ 2. Δ = candidate − baseline. Verdicts are directional; the conclusion lists additionally require |Δ| beyond the combined CI half-widths when both sides have n ≥ 2. Δ% is relative to the baseline mean with no floor, so near-zero baselines (e.g. an error_rate ≈ 0) can produce enormous percentages — read them alongside the absolute Δ.\n\n")
+	b.WriteString("Cells show the mean across samples; CI is the 95% confidence interval half-width (Student-t t95·σ/√n), shown only when n ≥ 2. Δ = candidate − baseline. Verdicts are directional; the conclusion lists additionally require |Δ| beyond the 95% CI of the difference (√(ci_base² + ci_cand²)) when both sides have n ≥ 2. Δ% is relative to the baseline mean with no floor, so near-zero baselines (e.g. an error_rate ≈ 0) can produce enormous percentages — read them alongside the absolute Δ.\n\n")
 	if len(c.rows) == 0 {
 		b.WriteString("- (no numeric metrics found)\n")
 	}
@@ -654,9 +660,9 @@ func renderComparison(c *comparison) string {
 
 	improved, regressed, noDir := c.conclusions()
 	b.WriteString("\n## Conclusions\n\n")
-	b.WriteString("### Improved (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)\n\n")
+	b.WriteString("### Improved (|Δ%| ≥ 5%, beyond 95% CI of the difference when n ≥ 2)\n\n")
 	writeConclusionList(&b, c, improved)
-	b.WriteString("\n### Regressed (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)\n\n")
+	b.WriteString("\n### Regressed (|Δ%| ≥ 5%, beyond 95% CI of the difference when n ≥ 2)\n\n")
 	writeConclusionList(&b, c, regressed)
 	b.WriteString("\n### No direction (n/a, only |Δ%| ≥ 5% or newly-nonzero shown)\n\n")
 	writeConclusionList(&b, c, noDir)

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -705,8 +705,12 @@ func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
 			if ai != aj {
 				return ai > aj
 			}
-			// Zero-baseline rows have no Δ% (pct stays 0); rank them by the
-			// absolute delta instead of letting them sink to the bottom.
+			// Zero-baseline rows have no Δ% (pct stays 0), so they sort below
+			// every row with a defined Δ% — even a near-zero-baseline row
+			// whose huge percentage is an artifact of the no-floor Δ% math.
+			// The absolute-delta key only orders zero-baseline rows among
+			// themselves; their significance still comes from the absolute
+			// fallback in conclusions(), not from this ranking.
 			if di, dj := math.Abs(rows[i].delta), math.Abs(rows[j].delta); di != dj {
 				return di > dj
 			}

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -517,9 +517,20 @@ func groupPrefix(key string) string {
 // sides have n >= 2 — the delta must exceed the combined 95% CI half-widths,
 // so noise at small sample counts is not flagged as a verdict), plus metrics
 // without a known direction.
+//
+// When the baseline mean is exactly 0 the Δ% is undefined and hasPct is
+// false; the significance test then falls back to the absolute delta (still
+// CI-gated when possible), so a 0 -> 0.5 error_rate catastrophe is flagged
+// instead of silently dropped. Directionless rows join the n/a list only
+// when the same magnitude test (without the CI gate) says the delta is
+// notable, so trivial movements don't flood the section.
 func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
 	for _, r := range c.rows {
 		significant := r.hasPct && math.Abs(r.pct) >= 5
+		if r.hasBase && r.hasCand && !r.hasPct {
+			significant = r.delta != 0
+		}
+		notable := significant
 		if significant && r.base.hasCI && r.cand.hasCI {
 			significant = math.Abs(r.delta) > r.base.ci+r.cand.ci
 		}
@@ -530,7 +541,7 @@ func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
 			} else {
 				regressed = append(regressed, r)
 			}
-		case r.verdict == verdictNoDir:
+		case r.verdict == verdictNoDir && notable:
 			noDir = append(noDir, r)
 		}
 	}
@@ -631,7 +642,7 @@ func renderComparison(c *comparison) string {
 	writeConclusionList(&b, c, improved)
 	b.WriteString("\n### Regressed (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)\n\n")
 	writeConclusionList(&b, c, regressed)
-	b.WriteString("\n### No direction (n/a)\n\n")
+	b.WriteString("\n### No direction (n/a, only |Δ%| ≥ 5% or newly-nonzero shown)\n\n")
 	writeConclusionList(&b, c, noDir)
 	b.WriteString("\n")
 	return b.String()

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -157,6 +157,19 @@ func extractPartial(sample map[string]float64) bool {
 	return false
 }
 
+// dropUntrustworthyDispatchKeys removes the queue_delay_*/dispatch_* keys
+// from a sample whose run is flagged saturated or partial: those numbers
+// describe the client's semaphore or a truncated sample, not the offered
+// schedule, so they must not reach the metric tables or the verdict lists.
+// Affected rows render "—" and the group-level warning/note explains why.
+func dropUntrustworthyDispatchKeys(sample map[string]float64) {
+	for k := range sample {
+		if strings.HasPrefix(k, "queue_delay_") || strings.HasPrefix(k, "dispatch_") {
+			delete(sample, k)
+		}
+	}
+}
+
 // scheduledShape reports whether any sample in the group carries the keys a
 // scheduled-mode export adds to "summary" (queue_delay_p50_ms,
 // dispatch_window_s, or a per_template.* block). Scheduled and legacy runs
@@ -230,12 +243,13 @@ func loadSampleFile(path string) (*sampleFile, error) {
 			if err != nil {
 				return nil, fmt.Errorf("compare: %s: rounds[%d]: %w", path, i, err)
 			}
-			if extractSaturated(sample) {
-				f.saturated = true
+			saturated := extractSaturated(sample)
+			partial := extractPartial(sample)
+			if saturated || partial {
+				dropUntrustworthyDispatchKeys(sample)
 			}
-			if extractPartial(sample) {
-				f.partial = true
-			}
+			f.saturated = f.saturated || saturated
+			f.partial = f.partial || partial
 			f.samples = append(f.samples, sample)
 		}
 		return f, nil
@@ -254,6 +268,9 @@ func loadSampleFile(path string) (*sampleFile, error) {
 	}
 	f.saturated = extractSaturated(sample)
 	f.partial = extractPartial(sample)
+	if f.saturated || f.partial {
+		dropUntrustworthyDispatchKeys(sample)
+	}
 	f.samples = []map[string]float64{sample}
 	return f, nil
 }
@@ -839,7 +856,7 @@ func writeFileList(b *strings.Builder, label string, g *sampleGroup) {
 // configHighlightKeys are the config fields surfaced in the report metadata
 // when present. Values are de-duplicated per group, so files that differ only
 // by seed render as e.g. "seed=1, 2, 3".
-var configHighlightKeys = []string{"seed", "seeds", "rounds", "workload", "profile", "version", "template", "templates", "mode"}
+var configHighlightKeys = []string{"seed", "seeds", "rounds", "workload", "profile", "version", "template", "templates", "mode", "concurrency", "rate_per_sec", "lifetime_min_s", "lifetime_max_s"}
 
 func configHighlights(label string, g *sampleGroup) string {
 	var parts []string

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -410,12 +410,32 @@ var (
 // countTokens are whole-token names of raw scale counters, which track
 // workload size (-n, template mix), not the quality of the change under test.
 // They are excluded from direction inference so scale differences are not
-// flagged as regressions. These are exact tokens: "error_rate", "failure_rate"
-// and even "failure_count" stay directional — only bare plural count keys
-// (summary.errors, per_template.<id>.attempts, ...) match.
+// flagged as regressions, and from the conclusion lists so they are not
+// flagged as notable no-direction moves either. These are exact tokens:
+// "error_rate", "failure_rate" and even "failure_count" stay directional —
+// only bare plural count keys (summary.errors, per_template.<id>.attempts,
+// ...) match.
 var countTokens = map[string]bool{
 	"attempts": true, "created": true, "deleted": true,
 	"errors": true, "failures": true, "successful": true,
+}
+
+// isScaleCounter reports whether key is a raw scale counter: a bare count
+// token from countTokens, or the singular "count" of a create/delete stat
+// block (create.count/delete.count track how many cycles ran — scale, not
+// quality). "count" outside a stat block stays directional, so failure_count
+// keeps its lower-better verdict.
+func isScaleCounter(key string) bool {
+	k := strings.ToLower(key)
+	tokens := strings.FieldsFunc(k, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	for _, tok := range tokens {
+		if countTokens[tok] {
+			return true
+		}
+	}
+	return len(tokens) > 1 && statBlockGroups[tokens[0]] && tokens[len(tokens)-1] == "count"
 }
 
 func metricDirection(key string) direction {
@@ -423,10 +443,8 @@ func metricDirection(key string) direction {
 	tokens := strings.FieldsFunc(k, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
-	for _, tok := range tokens {
-		if countTokens[tok] {
-			return dirNA
-		}
+	if isScaleCounter(key) {
+		return dirNA
 	}
 	if len(tokens) > 1 && statBlockGroups[tokens[0]] {
 		for _, tok := range tokens[1:] {
@@ -577,7 +595,8 @@ func groupPrefix(key string) string {
 // difference of the two independent means, √(ci_base² + ci_cand²), so noise
 // at small sample counts is not flagged as a verdict; summing the half-widths
 // instead would be over-conservative and hide genuine movements), plus
-// metrics without a known direction.
+// metrics without a known direction. Raw scale counters (isScaleCounter) are
+// excluded from every list: they track workload size, not the change.
 //
 // When the baseline mean is exactly 0 the Δ% is undefined and hasPct is
 // false; the significance test then falls back to the absolute delta (still
@@ -589,6 +608,11 @@ func groupPrefix(key string) string {
 // the delta is notable, so trivial movements don't flood the section.
 func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
 	for _, r := range c.rows {
+		if isScaleCounter(r.key) {
+			// Scale counters track workload size, not the change under test;
+			// keep them out of every conclusion list regardless of magnitude.
+			continue
+		}
 		significant := r.hasPct && math.Abs(r.pct) >= 5
 		if r.hasBase && r.hasCand && !r.hasPct {
 			significant = r.delta != 0

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -953,8 +953,15 @@ func uniqueConfigValue(g *sampleGroup, key string) (string, bool) {
 
 // configMismatchNote flags a scheduled-vs-scheduled comparison whose two
 // groups were paced differently. Absence of a key on either side (legacy
-// exports) is not a mismatch; only two present, distinct values are.
+// exports) is not a mismatch; only two present, distinct values are. The
+// note only fires when at least one group actually carries
+// queue_delay_*/dispatch_* samples: those are the rows it talks about, and
+// pointing a legacy-vs-legacy reader (which has no such rows anywhere in the
+// report) at them is misleading.
 func configMismatchNote(base, cand *sampleGroup) string {
+	if !hasDispatchMetrics(base) && !hasDispatchMetrics(cand) {
+		return ""
+	}
 	var diffs []string
 	for _, key := range configCompareKeys {
 		bv, bok := uniqueConfigValue(base, key)
@@ -970,6 +977,21 @@ func configMismatchNote(base, cand *sampleGroup) string {
 		"`queue_delay_*`/`dispatch_*` verdicts on such a pair are client-config artifacts, not scheduler "+
 		"effects — rerun both sides under the same `--rate`/`--concurrency`/`--lifetime` before trusting "+
 		"those rows.", strings.Join(diffs, ", "))
+}
+
+// hasDispatchMetrics reports whether any sample in the group carries
+// queue_delay_*/dispatch_* keys — the rows configMismatchNote speaks about.
+// It runs after dropUntrustworthyDispatchKeys, so a saturated/partial group
+// whose dispatch keys were all dropped counts as not having them.
+func hasDispatchMetrics(g *sampleGroup) bool {
+	for _, s := range g.samples {
+		for k := range s {
+			if strings.HasPrefix(k, "queue_delay_") || strings.HasPrefix(k, "dispatch_") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func formatConfigValue(v any) string {

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -121,6 +121,9 @@ type sampleFile struct {
 	// that run's dispatcher fell behind pace, so its queue_delay_*/dispatch_*
 	// numbers describe the client semaphore, not the offered schedule.
 	saturated bool
+	// partial is set when any sample carried the partial marker: the run was
+	// quit early, so its aggregates cover a truncated sample.
+	partial bool
 }
 
 // sampleGroup is one side of the comparison (baseline or candidate).
@@ -129,6 +132,7 @@ type sampleGroup struct {
 	files     []*sampleFile
 	samples   []map[string]float64
 	saturated bool // any file in the group carried dispatch_saturated
+	partial   bool // any file in the group carried partial
 }
 
 // extractSaturated pops the dispatch_saturated marker out of a freshly loaded
@@ -137,6 +141,17 @@ type sampleGroup struct {
 func extractSaturated(sample map[string]float64) bool {
 	if sample["dispatch_saturated"] > 0 {
 		delete(sample, "dispatch_saturated")
+		return true
+	}
+	return false
+}
+
+// extractPartial pops the partial marker for the same reason: an early-quit
+// truncated export is a run-quality flag, not a comparison row. Reports
+// whether the marker was present.
+func extractPartial(sample map[string]float64) bool {
+	if sample["partial"] > 0 {
+		delete(sample, "partial")
 		return true
 	}
 	return false
@@ -178,6 +193,7 @@ func loadSampleGroup(name string, paths []string) (*sampleGroup, error) {
 		g.files = append(g.files, f)
 		g.samples = append(g.samples, f.samples...)
 		g.saturated = g.saturated || f.saturated
+		g.partial = g.partial || f.partial
 	}
 	return g, nil
 }
@@ -217,6 +233,9 @@ func loadSampleFile(path string) (*sampleFile, error) {
 			if extractSaturated(sample) {
 				f.saturated = true
 			}
+			if extractPartial(sample) {
+				f.partial = true
+			}
 			f.samples = append(f.samples, sample)
 		}
 		return f, nil
@@ -234,6 +253,7 @@ func loadSampleFile(path string) (*sampleFile, error) {
 		}
 	}
 	f.saturated = extractSaturated(sample)
+	f.partial = extractPartial(sample)
 	f.samples = []map[string]float64{sample}
 	return f, nil
 }
@@ -740,6 +760,19 @@ func renderComparison(c *comparison) string {
 			"permanently behind the requested pace, so their `queue_delay_*`/`dispatch_*` numbers describe the "+
 			"client's concurrency semaphore, not the offered schedule. Rerun with higher `--concurrency` before "+
 			"trusting verdicts on those keys.\n\n",
+			strings.Join(groups, " and "))
+	}
+	if c.baseline.partial || c.candidate.partial {
+		var groups []string
+		if c.baseline.partial {
+			groups = append(groups, "baseline ("+c.baseline.name+")")
+		}
+		if c.candidate.partial {
+			groups = append(groups, "candidate ("+c.candidate.name+")")
+		}
+		fmt.Fprintf(&b, "> **Note:** %s: exports marked `partial` — the runs were quit early, so their "+
+			"`queue_delay_*`/`dispatch_*`/`per_template.*` aggregates cover a truncated sample. Rerun to "+
+			"completion before trusting verdicts on those keys.\n\n",
 			strings.Join(groups, " and "))
 	}
 	writeFileList(&b, "baseline", c.baseline)

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -184,6 +184,13 @@ func loadSampleFile(path string) (*sampleFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("compare: %s: %w", path, err)
 	}
+	// cube-bench exports keep the create/delete latency stat blocks at the top
+	// level, outside "summary"; fold them in so latency percentiles comparable.
+	for _, k := range []string{"create", "delete"} {
+		if blk, ok := root[k].(map[string]any); ok {
+			flattenMetrics(blk, k, sample)
+		}
+	}
 	f.samples = []map[string]float64{sample}
 	return f, nil
 }

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -364,11 +364,27 @@ var (
 	}
 )
 
+// countTokens are whole-token names of raw scale counters, which track
+// workload size (-n, template mix), not the quality of the change under test.
+// They are excluded from direction inference so scale differences are not
+// flagged as regressions. These are exact tokens: "error_rate", "failure_rate"
+// and even "failure_count" stay directional — only bare plural count keys
+// (summary.errors, per_template.<id>.attempts, ...) match.
+var countTokens = map[string]bool{
+	"attempts": true, "created": true, "deleted": true,
+	"errors": true, "failures": true, "successful": true,
+}
+
 func metricDirection(key string) direction {
 	k := strings.ToLower(key)
 	tokens := strings.FieldsFunc(k, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
+	for _, tok := range tokens {
+		if countTokens[tok] {
+			return dirNA
+		}
+	}
 	if len(tokens) > 1 && statBlockGroups[tokens[0]] {
 		for _, tok := range tokens[1:] {
 			if statBlockStats[tok] {
@@ -663,7 +679,7 @@ func writeFileList(b *strings.Builder, label string, g *sampleGroup) {
 // configHighlightKeys are the config fields surfaced in the report metadata
 // when present. Values are de-duplicated per group, so files that differ only
 // by seed render as e.g. "seed=1, 2, 3".
-var configHighlightKeys = []string{"seed", "seeds", "rounds", "workload", "profile", "version", "template", "mode"}
+var configHighlightKeys = []string{"seed", "seeds", "rounds", "workload", "profile", "version", "template", "templates", "mode"}
 
 func configHighlights(label string, g *sampleGroup) string {
 	var parts []string

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -533,6 +533,30 @@ func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
 	return improved, regressed, noDir
 }
 
+// sampleCountNotes flags rows whose per-metric sample count differs from the
+// group sample count. Aggregation only accumulates values from samples that
+// contain the key, so heterogeneous exports (e.g. a create-only run next to
+// create-delete runs, or a legacy run without queue_delay_* next to a
+// scheduled one) shrink a row's n — and therefore its CI and whether the CI
+// noise-gate applies — relative to the group header.
+func (c *comparison) sampleCountNotes() []string {
+	var notes []string
+	baseN, candN := len(c.baseline.samples), len(c.candidate.samples)
+	for _, r := range c.rows {
+		baseShort := r.hasBase && r.base.n != baseN
+		candShort := r.hasCand && r.cand.n != candN
+		switch {
+		case baseShort && candShort:
+			notes = append(notes, fmt.Sprintf("- `%s`: n=%d of %d baseline, n=%d of %d candidate samples", r.key, r.base.n, baseN, r.cand.n, candN))
+		case baseShort:
+			notes = append(notes, fmt.Sprintf("- `%s`: n=%d of %d baseline samples", r.key, r.base.n, baseN))
+		case candShort:
+			notes = append(notes, fmt.Sprintf("- `%s`: n=%d of %d candidate samples", r.key, r.cand.n, candN))
+		}
+	}
+	return notes
+}
+
 // ---------------------------------------------------------------------------
 // Markdown rendering
 // ---------------------------------------------------------------------------
@@ -559,7 +583,7 @@ func renderComparison(c *comparison) string {
 	}
 
 	b.WriteString("\n## Metric Comparison\n\n")
-	b.WriteString("Cells show the mean across samples; CI is the 95% confidence interval half-width (Student-t t95·σ/√n), shown only when n ≥ 2. Δ = candidate − baseline. Verdicts are directional; the conclusion lists additionally require |Δ| beyond the combined CI half-widths when both sides have n ≥ 2.\n\n")
+	b.WriteString("Cells show the mean across samples; CI is the 95% confidence interval half-width (Student-t t95·σ/√n), shown only when n ≥ 2. Δ = candidate − baseline. Verdicts are directional; the conclusion lists additionally require |Δ| beyond the combined CI half-widths when both sides have n ≥ 2. Δ% is relative to the baseline mean with no floor, so near-zero baselines (e.g. an error_rate ≈ 0) can produce enormous percentages — read them alongside the absolute Δ.\n\n")
 	if len(c.rows) == 0 {
 		b.WriteString("- (no numeric metrics found)\n")
 	}
@@ -577,6 +601,13 @@ func renderComparison(c *comparison) string {
 		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s |\n",
 			r.key, statsCell(r.base, r.hasBase), statsCell(r.cand, r.hasCand),
 			deltaCell(r), pctCell(r), string(r.verdict))
+	}
+
+	if notes := c.sampleCountNotes(); len(notes) > 0 {
+		b.WriteString("\nSome metrics appear in fewer samples than the group header count (mixed export shapes); their n and CI cover only the samples that contain them:\n\n")
+		for _, note := range notes {
+			b.WriteString(note + "\n")
+		}
 	}
 
 	improved, regressed, noDir := c.conclusions()

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -175,12 +175,20 @@ func dropUntrustworthyDispatchKeys(sample map[string]float64, partial bool) {
 	}
 }
 
-// scheduledShape reports whether any sample in the group carries the keys a
-// scheduled-mode export adds to "summary" (queue_delay_p50_ms,
-// dispatch_window_s, or a per_template.* block). Scheduled and legacy runs
-// share key names such as total_time_s/throughput_qps with different windows
-// and meanings, so a baseline/candidate mix of the two shapes needs a warning.
+// scheduledShape reports whether the group looks like a scheduled-mode
+// export. The config block's "workload" key (written only in scheduled mode)
+// is the primary signal because it survives the saturated/partial key drop —
+// a partial scheduled run loses exactly the summary keys the fallback below
+// keys on, and must not be misread as legacy-shaped. The key scan remains as
+// the fallback for config-less files. Scheduled and legacy runs share key
+// names such as total_time_s/throughput_qps with different windows and
+// meanings, so a baseline/candidate mix of the two shapes needs a warning.
 func scheduledShape(g *sampleGroup) bool {
+	for _, f := range g.files {
+		if _, ok := f.config["workload"]; ok {
+			return true
+		}
+	}
 	for _, s := range g.samples {
 		for k := range s {
 			if k == "queue_delay_p50_ms" || k == "dispatch_window_s" || strings.HasPrefix(k, "per_template.") {
@@ -814,6 +822,13 @@ func renderComparison(c *comparison) string {
 	if note := configMismatchNote(c.baseline, c.candidate); note != "" {
 		b.WriteString(note + "\n")
 	}
+	for _, g := range []*sampleGroup{c.baseline, c.candidate} {
+		if v, ok := uniqueConfigValue(g, "dry_run"); ok && v == "true" {
+			fmt.Fprintf(&b, "> **Warning:** %s is a dry-run export: its latencies are synthesized "+
+				"(lifetime sleeps clamped, errors drawn from --dry-error-rate), so verdicts on its rows "+
+				"describe the simulator, not a scheduler or a real API.\n", g.name)
+		}
+	}
 
 	b.WriteString("\n## Metric Comparison\n\n")
 	b.WriteString("Cells show the mean across samples; CI is the 95% confidence interval half-width (Student-t t95·σ/√n), shown only when n ≥ 2. Δ = candidate − baseline. Verdicts are directional; the conclusion lists additionally require |Δ| beyond the 95% CI of the difference (√(ci_base² + ci_cand²)) when both sides have n ≥ 2. Δ% is relative to the baseline mean with no floor, so near-zero baselines (e.g. an error_rate ≈ 0) can produce enormous percentages — read them alongside the absolute Δ.\n\n")
@@ -832,7 +847,7 @@ func renderComparison(c *comparison) string {
 			group = r.group
 		}
 		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s |\n",
-			r.key, statsCell(r.base, r.hasBase), statsCell(r.cand, r.hasCand),
+			mdTableCell(r.key), statsCell(r.base, r.hasBase), statsCell(r.cand, r.hasCand),
 			deltaCell(r), pctCell(r), string(r.verdict))
 	}
 
@@ -870,7 +885,7 @@ func writeFileList(b *strings.Builder, label string, g *sampleGroup) {
 // configHighlightKeys are the config fields surfaced in the report metadata
 // when present. Values are de-duplicated per group, so files that differ only
 // by seed render as e.g. "seed=1, 2, 3".
-var configHighlightKeys = []string{"seed", "seeds", "rounds", "workload", "profile", "version", "template", "templates", "mode", "concurrency", "rate_per_sec", "lifetime_min_s", "lifetime_max_s"}
+var configHighlightKeys = []string{"seed", "seeds", "rounds", "workload", "profile", "version", "template", "templates", "mode", "concurrency", "rate_per_sec", "lifetime_min_s", "lifetime_max_s", "dry_run"}
 
 func configHighlights(label string, g *sampleGroup) string {
 	var parts []string
@@ -905,7 +920,8 @@ func configHighlights(label string, g *sampleGroup) string {
 // configCompareKeys are the pacing/shape config fields where a silent
 // baseline-vs-candidate mismatch makes queue_delay_*/dispatch_* verdicts a
 // client-config artifact rather than a scheduler effect. Seeds are excluded
-// on purpose: they randomize the sequence, they do not pace it.
+// on purpose: they randomize the sequence, they do not pace it. dry_run is
+// deliberately not here either — it gets its own stronger warning below.
 var configCompareKeys = []string{"concurrency", "rate_per_sec", "lifetime_min_s", "lifetime_max_s"}
 
 // uniqueConfigValue returns the single de-duplicated value of key across the
@@ -1007,6 +1023,13 @@ func writeConclusionList(b *strings.Builder, c *comparison, rows []*compareRow) 
 		fmt.Fprintf(b, "- **%s**: %s (%s → %s)%s%s\n",
 			r.key, pctCell(r), formatNum(r.base.mean), formatNum(r.cand.mean), c.rowCountNote(r), zeroBase)
 	}
+}
+
+// mdTableCell escapes the one character that would split a Markdown table
+// cell: template IDs embedded in per_template.* keys are operator-supplied
+// via --templates and not otherwise validated beyond non-empty/`:`-free.
+func mdTableCell(s string) string {
+	return strings.ReplaceAll(s, "|", "\\|")
 }
 
 func statsCell(st metricStats, ok bool) string {

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -126,6 +126,22 @@ type sampleGroup struct {
 	samples []map[string]float64
 }
 
+// scheduledShape reports whether any sample in the group carries the keys a
+// scheduled-mode export adds to "summary" (queue_delay_p50_ms,
+// dispatch_window_s, or a per_template.* block). Scheduled and legacy runs
+// share key names such as total_time_s/throughput_qps with different windows
+// and meanings, so a baseline/candidate mix of the two shapes needs a warning.
+func scheduledShape(g *sampleGroup) bool {
+	for _, s := range g.samples {
+		for k := range s {
+			if k == "queue_delay_p50_ms" || k == "dispatch_window_s" || strings.HasPrefix(k, "per_template.") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func splitCommaList(raw string) []string {
 	var out []string
 	for _, p := range strings.Split(raw, ",") {
@@ -166,6 +182,10 @@ func loadSampleFile(path string) (*sampleFile, error) {
 
 	// A non-empty top-level "rounds" array turns the file into one sample
 	// per round; otherwise the top-level "summary" is the single sample.
+	// Only each round's "summary" is flattened: round-level stat blocks
+	// (create/delete latency etc.) are dropped. That matches the current
+	// rounds producer (schedsim rounds carry just seed + summary); a future
+	// exporter that adds per-round stat blocks must extend this branch.
 	if rounds, ok := root["rounds"].([]any); ok && len(rounds) > 0 {
 		f.viaRounds = true
 		for i, r := range rounds {
@@ -627,6 +647,12 @@ func renderComparison(c *comparison) string {
 		b.WriteString("> **Note:** at least one group has n < 2, so verdicts in this report are NOT " +
 			"CI-gated — every |Δ%| ≥ 5% row is flagged, including single-run noise. " +
 			"Use multiple seeds per side for decisions.\n\n")
+	}
+	if scheduledShape(c.baseline) != scheduledShape(c.candidate) {
+		b.WriteString("> **Note:** one group is a scheduled-mode export and the other is not. Shared key " +
+			"names span different windows and meanings across the two modes — `total_time_s` is the dispatch " +
+			"window in scheduled mode but the wall-clock run in legacy mode, and `throughput_qps` derives " +
+			"from it — so cross-shape Δ on those keys is not meaningful. Compare like with like.\n\n")
 	}
 	writeFileList(&b, "baseline", c.baseline)
 	writeFileList(&b, "candidate", c.candidate)

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -628,11 +628,11 @@ func renderComparison(c *comparison) string {
 	improved, regressed, noDir := c.conclusions()
 	b.WriteString("\n## Conclusions\n\n")
 	b.WriteString("### Improved (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)\n\n")
-	writeConclusionList(&b, improved)
+	writeConclusionList(&b, c, improved)
 	b.WriteString("\n### Regressed (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)\n\n")
-	writeConclusionList(&b, regressed)
+	writeConclusionList(&b, c, regressed)
 	b.WriteString("\n### No direction (n/a)\n\n")
-	writeConclusionList(&b, noDir)
+	writeConclusionList(&b, c, noDir)
 	b.WriteString("\n")
 	return b.String()
 }
@@ -701,14 +701,32 @@ func formatConfigValue(v any) string {
 	}
 }
 
-func writeConclusionList(b *strings.Builder, rows []*compareRow) {
+// rowCountNote annotates a conclusion row when its per-metric sample count
+// is smaller than the group header count (mixed export shapes), so the
+// downgrade from CI-gated to pure |Δ%| is visible where the verdict lands.
+func (c *comparison) rowCountNote(r *compareRow) string {
+	baseN, candN := len(c.baseline.samples), len(c.candidate.samples)
+	var parts []string
+	if r.hasBase && r.base.n != baseN {
+		parts = append(parts, fmt.Sprintf("baseline n=%d/%d", r.base.n, baseN))
+	}
+	if r.hasCand && r.cand.n != candN {
+		parts = append(parts, fmt.Sprintf("candidate n=%d/%d", r.cand.n, candN))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, ", ") + ")"
+}
+
+func writeConclusionList(b *strings.Builder, c *comparison, rows []*compareRow) {
 	if len(rows) == 0 {
 		b.WriteString("- (none)\n")
 		return
 	}
 	for _, r := range rows {
-		fmt.Fprintf(b, "- **%s**: %s (%s → %s)\n",
-			r.key, pctCell(r), formatNum(r.base.mean), formatNum(r.cand.mean))
+		fmt.Fprintf(b, "- **%s**: %s (%s → %s)%s\n",
+			r.key, pctCell(r), formatNum(r.base.mean), formatNum(r.cand.mean), c.rowCountNote(r))
 	}
 }
 

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -486,19 +486,29 @@ func classifyKey(key string) string {
 }
 
 // isScaleCounter reports whether key is a raw scale counter: a bare count
-// token from countTokens, or the singular "count" of a create/delete stat
+// token from countTokens used AS the metric name — the whole key (errors),
+// a summary-namespaced key (summary.errors), or a per_template stat
+// (per_template.<id>.attempts, which classifyKey reduces to
+// per_template.attempts) — or the singular "count" of a create/delete stat
 // block (create.count/delete.count track how many cycles ran — scale, not
-// quality). "count" outside a stat block stays directional, so failure_count
-// keeps its lower-better verdict.
+// quality). A count token appearing as the tail of a qualified name does
+// NOT classify: restart_errors, evict_failures, sched_errors and
+// errors_total are "bad when they rise" signals the lower-better rules
+// deliberately cover, not workload-size counters. "count" outside a stat
+// block also stays directional, so failure_count keeps its lower-better
+// verdict.
 func isScaleCounter(key string) bool {
 	k := strings.ToLower(classifyKey(key))
 	tokens := strings.FieldsFunc(k, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
-	for _, tok := range tokens {
-		if countTokens[tok] {
-			return true
-		}
+	switch {
+	case len(tokens) == 1 && countTokens[tokens[0]]:
+		return true
+	case len(tokens) == 2 && tokens[0] == "summary" && countTokens[tokens[1]]:
+		return true
+	case len(tokens) == 3 && tokens[0] == "per" && tokens[1] == "template" && countTokens[tokens[2]]:
+		return true
 	}
 	return len(tokens) > 1 && statBlockGroups[tokens[0]] && tokens[len(tokens)-1] == "count"
 }
@@ -828,6 +838,11 @@ func renderComparison(c *comparison) string {
 				"(lifetime sleeps clamped, errors drawn from --dry-error-rate), so verdicts on its rows "+
 				"describe the simulator, not a scheduler or a real API.\n", g.name)
 		}
+		if groupMixesProducers(g) {
+			fmt.Fprintf(&b, "> **Warning:** %s mixes cube-bench exports (client-side measurements) with "+
+				"schedsim rounds files (simulator reports) in one group: both contribute samples to the same "+
+				"means and CIs while measuring different domains — split them into separate comparisons.\n", g.name)
+		}
 	}
 
 	b.WriteString("\n## Metric Comparison\n\n")
@@ -965,6 +980,23 @@ func groupHasDryRun(g *sampleGroup) bool {
 		}
 	}
 	return false
+}
+
+// groupMixesProducers reports whether the group blends files from different
+// producers — a cube-bench export and a schedsim rounds file. Their samples
+// aggregate into the same mean/CI rows but come from different measurement
+// domains (client-observed vs simulator-reported), so the blend is warned
+// about rather than silently trusted.
+func groupMixesProducers(g *sampleGroup) bool {
+	rounds, plain := false, false
+	for _, f := range g.files {
+		if f.viaRounds {
+			rounds = true
+		} else {
+			plain = true
+		}
+	}
+	return rounds && plain
 }
 
 // configMismatchNote flags a scheduled-vs-scheduled comparison whose two

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -117,13 +117,29 @@ type sampleFile struct {
 	config    map[string]any
 	samples   []map[string]float64
 	viaRounds bool
+	// saturated is set when any sample carried the dispatch_saturated marker:
+	// that run's dispatcher fell behind pace, so its queue_delay_*/dispatch_*
+	// numbers describe the client semaphore, not the offered schedule.
+	saturated bool
 }
 
 // sampleGroup is one side of the comparison (baseline or candidate).
 type sampleGroup struct {
-	name    string
-	files   []*sampleFile
-	samples []map[string]float64
+	name      string
+	files     []*sampleFile
+	samples   []map[string]float64
+	saturated bool // any file in the group carried dispatch_saturated
+}
+
+// extractSaturated pops the dispatch_saturated marker out of a freshly loaded
+// sample: it is a run-quality flag, not a metric, so it must warn rather than
+// appear as a comparison row. Reports whether the marker was present.
+func extractSaturated(sample map[string]float64) bool {
+	if sample["dispatch_saturated"] > 0 {
+		delete(sample, "dispatch_saturated")
+		return true
+	}
+	return false
 }
 
 // scheduledShape reports whether any sample in the group carries the keys a
@@ -161,6 +177,7 @@ func loadSampleGroup(name string, paths []string) (*sampleGroup, error) {
 		}
 		g.files = append(g.files, f)
 		g.samples = append(g.samples, f.samples...)
+		g.saturated = g.saturated || f.saturated
 	}
 	return g, nil
 }
@@ -197,6 +214,9 @@ func loadSampleFile(path string) (*sampleFile, error) {
 			if err != nil {
 				return nil, fmt.Errorf("compare: %s: rounds[%d]: %w", path, i, err)
 			}
+			if extractSaturated(sample) {
+				f.saturated = true
+			}
 			f.samples = append(f.samples, sample)
 		}
 		return f, nil
@@ -213,6 +233,7 @@ func loadSampleFile(path string) (*sampleFile, error) {
 			flattenMetrics(blk, k, sample)
 		}
 	}
+	f.saturated = extractSaturated(sample)
 	f.samples = []map[string]float64{sample}
 	return f, nil
 }
@@ -595,11 +616,17 @@ func (c *comparison) conclusions() (improved, regressed, noDir []*compareRow) {
 			if ai != aj {
 				return ai > aj
 			}
+			// Zero-baseline rows have no Δ% (pct stays 0); rank them by the
+			// absolute delta instead of letting them sink to the bottom.
+			if di, dj := math.Abs(rows[i].delta), math.Abs(rows[j].delta); di != dj {
+				return di > dj
+			}
 			return rows[i].key < rows[j].key
 		})
 	}
 	byImpact(improved)
 	byImpact(regressed)
+	byImpact(noDir)
 	return improved, regressed, noDir
 }
 
@@ -653,6 +680,20 @@ func renderComparison(c *comparison) string {
 			"names span different windows and meanings across the two modes — `total_time_s` is the dispatch " +
 			"window in scheduled mode but the wall-clock run in legacy mode, and `throughput_qps` derives " +
 			"from it — so cross-shape Δ on those keys is not meaningful. Compare like with like.\n\n")
+	}
+	if c.baseline.saturated || c.candidate.saturated {
+		var groups []string
+		if c.baseline.saturated {
+			groups = append(groups, "baseline ("+c.baseline.name+")")
+		}
+		if c.candidate.saturated {
+			groups = append(groups, "candidate ("+c.candidate.name+")")
+		}
+		fmt.Fprintf(&b, "> **Warning:** %s: runs marked `dispatch_saturated` — the dispatcher fell "+
+			"permanently behind the requested pace, so their `queue_delay_*`/`dispatch_*` numbers describe the "+
+			"client's concurrency semaphore, not the offered schedule. Rerun with higher `--concurrency` before "+
+			"trusting verdicts on those keys.\n\n",
+			strings.Join(groups, " and "))
 	}
 	writeFileList(&b, "baseline", c.baseline)
 	writeFileList(&b, "candidate", c.candidate)
@@ -791,8 +832,15 @@ func writeConclusionList(b *strings.Builder, c *comparison, rows []*compareRow) 
 		return
 	}
 	for _, r := range rows {
-		fmt.Fprintf(b, "- **%s**: %s (%s → %s)%s\n",
-			r.key, pctCell(r), formatNum(r.base.mean), formatNum(r.cand.mean), c.rowCountNote(r))
+		zeroBase := ""
+		if r.hasBase && !r.hasPct {
+			// Baseline mean exactly 0: Δ% is undefined and the verdict rests
+			// on the absolute delta with no magnitude floor — echo the caveat
+			// at the row so the report stands alone.
+			zeroBase = " *(zero baseline — judged on absolute Δ)*"
+		}
+		fmt.Fprintf(b, "- **%s**: %s (%s → %s)%s%s\n",
+			r.key, pctCell(r), formatNum(r.base.mean), formatNum(r.cand.mean), c.rowCountNote(r), zeroBase)
 	}
 }
 

--- a/examples/cube-bench/compare.go
+++ b/examples/cube-bench/compare.go
@@ -700,10 +700,10 @@ func renderComparison(c *comparison) string {
 			"Use multiple seeds per side for decisions.\n\n")
 	}
 	if scheduledShape(c.baseline) != scheduledShape(c.candidate) {
-		b.WriteString("> **Note:** one group is a scheduled-mode export and the other is not. Shared key " +
-			"names span different windows and meanings across the two modes — `total_time_s` is the dispatch " +
-			"window in scheduled mode but the wall-clock run in legacy mode, and `throughput_qps` derives " +
-			"from it — so cross-shape Δ on those keys is not meaningful. Compare like with like.\n\n")
+		b.WriteString("> **Note:** one group is a scheduled-mode export and the other is not. In scheduled " +
+			"mode `total_time_s`/`throughput_qps` include per-sandbox lifetime tails (the run ends at the last " +
+			"lifetime DELETE), while a legacy run ends at the last immediate delete — the shared keys span " +
+			"different windows, so cross-shape Δ on them is not meaningful. Compare like with like.\n\n")
 	}
 	if c.baseline.saturated || c.candidate.saturated {
 		var groups []string

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -366,6 +366,9 @@ func TestCompareGroupPrefix(t *testing.T) {
 		"per_template.tpl-a.success_rate": "per_template.tpl-a",
 		"per_template.tpl-b.success_rate": "per_template.tpl-b",
 		"per_template.tpl-a":              "per_template.tpl-a",
+		// ids containing dots group by the full id (last-dot split)
+		"per_template.pool.with.dots.error_rate": "per_template.pool.with.dots",
+		"per_template.pool.with.dots.created":    "per_template.pool.with.dots",
 	}
 	for key, want := range cases {
 		if got := groupPrefix(key); got != want {

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -470,3 +470,53 @@ func TestCompareFlagErrors(t *testing.T) {
 		t.Errorf("usage text should mention --baseline")
 	}
 }
+
+func TestSampleCountNotes(t *testing.T) {
+	// Heterogeneous exports: delete.p95_ms is absent from the second baseline
+	// sample, queue_depth is absent from the whole candidate side, and
+	// success_rate is present in every sample on both sides.
+	baseline := &sampleGroup{
+		name: "base",
+		samples: []map[string]float64{
+			{"success_rate": 0.9, "delete.p95_ms": 40, "queue_depth": 5},
+			{"success_rate": 0.92, "queue_depth": 6},
+		},
+	}
+	candidate := &sampleGroup{
+		name: "cand",
+		samples: []map[string]float64{
+			{"success_rate": 0.95, "delete.p95_ms": 30},
+			{"success_rate": 0.96, "delete.p95_ms": 28},
+		},
+	}
+	cmp := buildComparison(baseline, candidate, time.Now())
+
+	notes := cmp.sampleCountNotes()
+	if len(notes) != 1 {
+		t.Fatalf("sampleCountNotes len = %d, want 1: %v", len(notes), notes)
+	}
+	want := "- `delete.p95_ms`: n=1 of 2 baseline samples"
+	if notes[0] != want {
+		t.Errorf("note = %q, want %q", notes[0], want)
+	}
+
+	// Missing-on-one-side rows (verdictMissing) have no n on that side and
+	// must not produce a note for that side.
+	for _, note := range notes {
+		if strings.Contains(note, "queue_depth") || strings.Contains(note, "success_rate") {
+			t.Errorf("unexpected note %q", note)
+		}
+	}
+
+	// Homogeneous samples produce no notes at all.
+	same := &sampleGroup{
+		name: "same",
+		samples: []map[string]float64{
+			{"success_rate": 0.9},
+			{"success_rate": 0.91},
+		},
+	}
+	if got := buildComparison(same, same, time.Now()).sampleCountNotes(); len(got) != 0 {
+		t.Errorf("homogeneous comparison produced notes: %v", got)
+	}
+}

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -656,6 +656,37 @@ func TestCompareDispatchSaturatedWarning(t *testing.T) {
 	}
 }
 
+func TestComparePartialWarning(t *testing.T) {
+	dir := t.TempDir()
+
+	b1 := writeTempFile(t, dir, "base-partial.json", `{
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 500, "partial": 1}
+	}`)
+	c1 := writeTempFile(t, dir, "cand-clean.json", `{
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 3}
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c1, "-o", out}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	report := string(saved)
+
+	if !strings.Contains(report, "> **Note:** baseline (") {
+		t.Errorf("report missing the partial note naming the baseline group\n%s", report)
+	}
+	// Like dispatch_saturated, the marker is a run-quality flag and must not
+	// appear as a comparison row.
+	if strings.Contains(report, "| partial |") {
+		t.Errorf("partial leaked into the metric table\n%s", report)
+	}
+}
+
 func TestCompareNoDirSortedByImpact(t *testing.T) {
 	// Three directionless metrics: one small pct move, one large pct move, one
 	// zero-baseline row (no Δ%). Expect large pct first, then small pct, then

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -340,6 +340,12 @@ func TestMetricDirection(t *testing.T) {
 		{"create.count", dirNA}, // counts are not a quality signal
 		{"summary.errors", dirNA},
 		{"per_template.tpl-a.attempts", dirNA},
+		// A count token as the tail of a qualified name is NOT a scale
+		// counter: these are "bad when they rise" signals the lower-better
+		// substrings pin, and must not be silently excluded from verdicts.
+		{"restart_errors", dirLowerBetter},
+		{"evict_failures", dirLowerBetter},
+		{"errors_total", dirLowerBetter},
 		// Data-derived key segments must not flip classification: the
 		// template id in per_template.<id>.<stat> is user data.
 		{"per_template.sbx-errors.success_rate", dirHigherBetter},
@@ -495,6 +501,11 @@ func TestCompareEndToEnd(t *testing.T) {
 		"seed=1",
 		"workload=mixed",
 		"version=v2",
+		// Both groups deliberately mix a cube-bench export with rounds files
+		// to exercise multi-shape aggregation — and the report must flag
+		// exactly that blend instead of endorsing it.
+		"> **Warning:** default mixes cube-bench exports",
+		"> **Warning:** new-policy mixes cube-bench exports",
 	} {
 		if !strings.Contains(report, want) {
 			t.Errorf("report missing metadata %q", want)
@@ -752,6 +763,53 @@ func TestCompareConfigMismatchNote(t *testing.T) {
 	}
 	if strings.Contains(string(saved3), "client-config artifacts") {
 		t.Errorf("missing config keys treated as a mismatch\n%s", saved3)
+	}
+}
+
+func TestCompareMixedProducerWarning(t *testing.T) {
+	// Pure single-producer groups must not raise the mix warning; blending a
+	// cube-bench export with a schedsim rounds file in one group must.
+	dir := t.TempDir()
+
+	plain1 := writeTempFile(t, dir, "plain1.json", `{
+		"config": {"workload": "burst"},
+		"summary": {"success_rate": 0.9}
+	}`)
+	plain2 := writeTempFile(t, dir, "plain2.json", `{
+		"config": {"workload": "burst"},
+		"summary": {"success_rate": 0.91}
+	}`)
+	rounds1 := writeTempFile(t, dir, "rounds1.json", `{
+		"config": {"workload": "burst"},
+		"rounds": [{"seed": 1, "summary": {"success_rate": 0.95}}]
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	if err := runCompare([]string{"--baseline", plain1 + "," + plain2, "--candidate", rounds1, "-o", out}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if strings.Contains(string(saved), "mixes cube-bench exports") {
+		t.Errorf("pure groups got the producer-mix warning\n%s", saved)
+	}
+
+	out2 := filepath.Join(dir, "report2.md")
+	if err := runCompare([]string{"--baseline", plain1 + "," + rounds1, "--candidate", plain2, "-o", out2}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved2, err := os.ReadFile(out2)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(saved2), "> **Warning:** baseline mixes cube-bench exports") {
+		t.Errorf("mixed-producer baseline missing the warning\n%s", saved2)
+	}
+	if strings.Contains(string(saved2), "> **Warning:** candidate mixes cube-bench exports") {
+		t.Errorf("pure candidate got the producer-mix warning\n%s", saved2)
 	}
 }
 

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -667,3 +667,30 @@ func TestCompareNoDirSortedByImpact(t *testing.T) {
 			noDir[0].key, noDir[1].key, noDir[2].key)
 	}
 }
+
+func TestCompareScaleCountersNotConcluded(t *testing.T) {
+	// Different workload sizes (-n) move create.count by -40% and
+	// summary.errors likewise — pure scale noise that must not surface in any
+	// conclusion list, even the no-direction one.
+	baseline := &sampleGroup{name: "b", samples: []map[string]float64{
+		{"create.count": 100, "summary.errors": 5, "failure_count": 10},
+	}}
+	candidate := &sampleGroup{name: "c", samples: []map[string]float64{
+		{"create.count": 60, "summary.errors": 3, "failure_count": 20},
+	}}
+	cmp := buildComparison(baseline, candidate, time.Now().UTC())
+
+	improved, regressed, noDir := cmp.conclusions()
+	for _, list := range [][]*compareRow{improved, regressed, noDir} {
+		for _, r := range list {
+			if r.key == "create.count" || r.key == "summary.errors" {
+				t.Errorf("scale counter %s leaked into conclusions", r.key)
+			}
+		}
+	}
+	// failure_count is NOT a scale counter: "count" outside a create/delete
+	// stat block stays directional, so 10 -> 20 is a flagged regression.
+	if len(regressed) != 1 || regressed[0].key != "failure_count" {
+		t.Errorf("regressed = %v, want [failure_count]", regressed)
+	}
+}

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -690,6 +690,71 @@ func TestComparePartialWarning(t *testing.T) {
 	}
 }
 
+func TestCompareConfigMismatchNote(t *testing.T) {
+	dir := t.TempDir()
+
+	b1 := writeTempFile(t, dir, "base.json", `{
+		"config": {"rate_per_sec": 50, "concurrency": 64},
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 5}
+	}`)
+	c1 := writeTempFile(t, dir, "cand.json", `{
+		"config": {"rate_per_sec": 30, "concurrency": 64},
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 3}
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c1, "-o", out}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	report := string(saved)
+
+	if !strings.Contains(report, "rate_per_sec (50 vs 30)") {
+		t.Errorf("report missing the config-mismatch note\n%s", report)
+	}
+	// concurrency matched, so it must not be listed as a mismatch.
+	if strings.Contains(report, "concurrency (") {
+		t.Errorf("matched concurrency listed as a mismatch\n%s", report)
+	}
+
+	// Matching pacing config must not produce the note.
+	c2 := writeTempFile(t, dir, "cand-match.json", `{
+		"config": {"rate_per_sec": 50, "concurrency": 64},
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 3}
+	}`)
+	out2 := filepath.Join(dir, "report2.md")
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c2, "-o", out2}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved2, err := os.ReadFile(out2)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if strings.Contains(string(saved2), "client-config artifacts") {
+		t.Errorf("matching configs still produced the mismatch note\n%s", saved2)
+	}
+
+	// A legacy export without config keys is not a mismatch either.
+	c3 := writeTempFile(t, dir, "cand-legacy.json", `{
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 3}
+	}`)
+	out3 := filepath.Join(dir, "report3.md")
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c3, "-o", out3}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved3, err := os.ReadFile(out3)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if strings.Contains(string(saved3), "client-config artifacts") {
+		t.Errorf("missing config keys treated as a mismatch\n%s", saved3)
+	}
+}
+
 func TestLoadSampleFileDropsDispatchKeysWhenFlagged(t *testing.T) {
 	dir := t.TempDir()
 

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -203,6 +203,34 @@ func TestCompareStatsAggregate(t *testing.T) {
 	}
 }
 
+func TestT95(t *testing.T) {
+	// Table values (df <= 30) are exact; beyond the table the Cornish–Fisher
+	// expansion must track the true quantile instead of jumping to 1.96.
+	cases := []struct {
+		n    int
+		want float64
+		tol  float64
+	}{
+		{2, 12.706, 1e-12},
+		{31, 2.042, 1e-12},  // df=30, last table entry
+		{32, 2.0395, 1e-3},  // df=31: true 2.03951
+		{61, 2.0003, 1e-3},  // df=60: true 2.00030
+		{121, 1.9799, 1e-3}, // df=120: true 1.97993
+		{10000, 1.9602, 1e-3},
+	}
+	for _, tc := range cases {
+		if got := t95(tc.n); math.Abs(got-tc.want) > tc.tol {
+			t.Errorf("t95(%d) = %v, want ~%v", tc.n, got, tc.want)
+		}
+	}
+	// The quantile decreases monotonically in df.
+	for n := 2; n < 500; n++ {
+		if t95(n) < t95(n+1) {
+			t.Fatalf("t95 not monotonic: t95(%d)=%v < t95(%d)=%v", n, t95(n), n+1, t95(n+1))
+		}
+	}
+}
+
 func TestCompareZeroBaselinePct(t *testing.T) {
 	baseline := &sampleGroup{name: "b", samples: []map[string]float64{
 		{"restart_rate": 0, "sched_cv": 1, "only_base": 3},
@@ -229,8 +257,8 @@ func TestCompareZeroBaselinePct(t *testing.T) {
 	if got := pctCell(rr); got != "—" {
 		t.Errorf("pctCell = %q, want em dash", got)
 	}
-	if rr.verdict != verdictImproved {
-		t.Errorf("restart_rate verdict = %q, want improved (higher-better, delta>0)", rr.verdict)
+	if rr.verdict != verdictRegressed {
+		t.Errorf("restart_rate verdict = %q, want regressed (restart_* rates are lower-better, delta>0)", rr.verdict)
 	}
 
 	cv := rows["sched_cv"]
@@ -244,9 +272,9 @@ func TestCompareZeroBaselinePct(t *testing.T) {
 	}
 
 	// Rows without Δ% never enter the conclusions lists.
-	improved, _, _ := cmp.conclusions()
-	if len(improved) != 0 {
-		t.Errorf("conclusions improved = %v, want empty (restart_rate has no Δ%%)", improved)
+	improved, regressed, _ := cmp.conclusions()
+	if len(improved) != 0 || len(regressed) != 0 {
+		t.Errorf("conclusions improved=%v regressed=%v, want both empty (restart_rate has no Δ%%)", improved, regressed)
 	}
 }
 
@@ -274,6 +302,11 @@ func TestMetricDirection(t *testing.T) {
 		{"job_duration", dirLowerBetter},
 		{"error_rate", dirLowerBetter}, // lower rules beat "rate"
 		{"failure_count", dirLowerBetter},
+		{"restart_rate", dirLowerBetter},    // rising bad rates are regressions
+		{"preempt_rate", dirLowerBetter},    // even though "rate" is a
+		{"preemption_rate", dirLowerBetter}, // higher-better token
+		{"eviction_rate", dirLowerBetter},
+		{"retry_rate", dirLowerBetter},
 		{"sched_cv", dirLowerBetter},
 		{"queue_cv_ratio", dirLowerBetter},
 		{"fragmentation", dirLowerBetter},

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -755,6 +755,110 @@ func TestCompareConfigMismatchNote(t *testing.T) {
 	}
 }
 
+func TestCompareScheduledShapeUsesConfig(t *testing.T) {
+	// A partial scheduled export loses its queue_delay_*/per_template.* keys
+	// to the drop, so shape detection must come from the config block:
+	// partial-scheduled vs full-scheduled must NOT raise the cross-shape note.
+	dir := t.TempDir()
+
+	b1 := writeTempFile(t, dir, "base-partial-sched.json", `{
+		"config": {"workload": "custom", "rate_per_sec": 50},
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 500, "partial": 1, "per_template.tpl-a.created": 7}
+	}`)
+	c1 := writeTempFile(t, dir, "cand-full-sched.json", `{
+		"config": {"workload": "custom", "rate_per_sec": 50},
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 3}
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c1, "-o", out}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	report := string(saved)
+	if strings.Contains(report, "one group is a scheduled-mode export and the other is not") {
+		t.Errorf("partial scheduled group misread as legacy-shaped\n%s", report)
+	}
+	if !strings.Contains(report, "> **Note:** baseline (") {
+		t.Errorf("report missing the partial note\n%s", report)
+	}
+
+	// partial-scheduled vs legacy: the cross-shape warning must still fire.
+	c2 := writeTempFile(t, dir, "cand-legacy.json", `{
+		"summary": {"success_rate": 0.9, "total_time_s": 10}
+	}`)
+	out2 := filepath.Join(dir, "report2.md")
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c2, "-o", out2}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved2, err := os.ReadFile(out2)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(saved2), "one group is a scheduled-mode export and the other is not") {
+		t.Errorf("cross-shape note missing for partial-scheduled vs legacy\n%s", saved2)
+	}
+}
+
+func TestCompareDryRunWarning(t *testing.T) {
+	dir := t.TempDir()
+
+	b1 := writeTempFile(t, dir, "base-dry.json", `{
+		"config": {"workload": "custom", "dry_run": true},
+		"summary": {"success_rate": 0.98, "queue_delay_p50_ms": 5}
+	}`)
+	c1 := writeTempFile(t, dir, "cand-real.json", `{
+		"config": {"workload": "custom", "dry_run": false},
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 3}
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c1, "-o", out}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	report := string(saved)
+	if !strings.Contains(report, "> **Warning:** baseline is a dry-run export") {
+		t.Errorf("report missing the dry-run warning\n%s", report)
+	}
+	// dry_run must also surface in the config highlights.
+	if !strings.Contains(report, "dry_run=true") {
+		t.Errorf("dry_run missing from config highlights\n%s", report)
+	}
+}
+
+func TestCompareEscapesMetricKeys(t *testing.T) {
+	dir := t.TempDir()
+
+	b1 := writeTempFile(t, dir, "base.json", `{
+		"summary": {"success_rate": 0.9, "per_template.tpl|a.created": 4}
+	}`)
+	c1 := writeTempFile(t, dir, "cand.json", `{
+		"summary": {"success_rate": 0.9, "per_template.tpl|a.created": 6}
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c1, "-o", out}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(saved), "per_template.tpl\\|a.created") {
+		t.Errorf("pipe in metric key not escaped\n%s", saved)
+	}
+}
+
 func TestLoadSampleFileDropsDispatchKeysWhenFlagged(t *testing.T) {
 	dir := t.TempDir()
 

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -687,6 +687,46 @@ func TestComparePartialWarning(t *testing.T) {
 	}
 }
 
+func TestLoadSampleFileDropsDispatchKeysWhenFlagged(t *testing.T) {
+	dir := t.TempDir()
+
+	path := writeTempFile(t, dir, "flagged.json", `{
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 500, "dispatch_qps": 12.5, "dispatch_saturated": 1}
+	}`)
+	f, err := loadSampleFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !f.saturated {
+		t.Fatal("saturated flag not recorded")
+	}
+	// The flagged run's queue_delay_*/dispatch_* values describe the client
+	// semaphore, not the offered schedule: they must be dropped before the
+	// sample reaches the metric tables and verdict lists.
+	for _, k := range []string{"queue_delay_p50_ms", "dispatch_qps", "dispatch_saturated"} {
+		if _, ok := f.samples[0][k]; ok {
+			t.Errorf("key %q survived the flagged-sample drop", k)
+		}
+	}
+	if got := f.samples[0]["success_rate"]; got != 0.9 {
+		t.Errorf("success_rate = %v, want 0.9 (unrelated keys kept)", got)
+	}
+
+	path = writeTempFile(t, dir, "partial.json", `{
+		"summary": {"success_rate": 0.9, "queue_delay_p99_ms": 42, "partial": 1}
+	}`)
+	f, err = loadSampleFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !f.partial {
+		t.Fatal("partial flag not recorded")
+	}
+	if _, ok := f.samples[0]["queue_delay_p99_ms"]; ok {
+		t.Errorf("queue_delay_p99_ms survived the partial-sample drop")
+	}
+}
+
 func TestCompareNoDirSortedByImpact(t *testing.T) {
 	// Three directionless metrics: one small pct move, one large pct move, one
 	// zero-baseline row (no Δ%). Expect large pct first, then small pct, then

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -173,7 +173,9 @@ func TestCompareStatsAggregate(t *testing.T) {
 	if !a.hasCI {
 		t.Errorf("a.should have CI (n=3)")
 	}
-	if want := 1.96 * 2 / math.Sqrt(3); math.Abs(a.ci-want) > 1e-12 {
+	// n=3 -> df=2 -> t95 = 4.303; the small-sample interval is much wider
+	// than the normal 1.96·σ/√n.
+	if want := 4.303 * 2 / math.Sqrt(3); math.Abs(a.ci-want) > 1e-12 {
 		t.Errorf("a.ci = %v, want %v", a.ci, want)
 	}
 
@@ -187,9 +189,9 @@ func TestCompareStatsAggregate(t *testing.T) {
 	if math.Abs(b.stdDev-math.Sqrt(2)) > 1e-12 {
 		t.Errorf("b.stdDev = %v, want sqrt(2)", b.stdDev)
 	}
-	// 1.96 * sqrt(2) / sqrt(2) = 1.96 exactly
-	if math.Abs(b.ci-1.96) > 1e-12 {
-		t.Errorf("b.ci = %v, want 1.96", b.ci)
+	// n=2 -> df=1 -> t95 = 12.706; 12.706 * sqrt(2) / sqrt(2) = 12.706 exactly
+	if math.Abs(b.ci-12.706) > 1e-12 {
+		t.Errorf("b.ci = %v, want 12.706", b.ci)
 	}
 
 	single := aggregateSamples([]map[string]float64{{"x": 5}})["x"]
@@ -278,12 +280,17 @@ func TestMetricDirection(t *testing.T) {
 		{"fragment_ratio", dirLowerBetter},
 		{"herd_score", dirLowerBetter},
 		{"herding_index", dirLowerBetter},
+		// cube-bench stat blocks: any stat suffix under create/delete is
+		// lower-better, with or without a "_ms" suffix
+		{"create.p95", dirLowerBetter},
+		{"create.p95_ms", dirLowerBetter},
+		{"delete.avg", dirLowerBetter},
 		// no direction: unknown keys, and false-positive guards
 		{"strategy", dirNA},  // must not substring-match "rate"
 		{"discovery", dirNA}, // must not substring-match "cv"
 		{"total_time_s", dirNA},
 		{"queue_depth", dirNA},
-		{"create.p95_ms", dirNA},
+		{"create.count", dirNA}, // counts are not a quality signal
 	}
 	for _, tc := range cases {
 		if got := metricDirection(tc.key); got != tc.want {
@@ -393,30 +400,30 @@ func TestCompareEndToEnd(t *testing.T) {
 		"## Metric Comparison",
 		"### create",
 		"### sched",
-		"| success_rate | 0.92 ± 0.022632 | 0.98 ± 0.011316 | +0.06 | +6.5% | improved |",
-		"| error_rate | 0.1 ± 0.022632 | 0.05 ± 0 | -0.05 | -50.0% | improved |",
-		"| sched_latency_p95 | 120 ± 11.316 | 95 ± 5.658 | -25 | -20.8% | improved |",
-		"| throughput_qps | 100 ± 11.316 | 90 ± 5.658 | -10 | -10.0% | regressed |",
-		"| queue_depth | 5 ± 1.1316 | 7 ± 0 | +2 | +40.0% | n/a |",
-		// create.p95_ms carries no direction keyword -> n/a per the direction table
-		"| create.p95_ms | 60 ± 11.316 | 45 ± 5.658 | -15 | -25.0% | n/a |",
+		"| success_rate | 0.92 ± 0.049687 | 0.98 ± 0.024843 | +0.06 | +6.5% | improved |",
+		"| error_rate | 0.1 ± 0.049687 | 0.05 ± 0 | -0.05 | -50.0% | improved |",
+		"| sched_latency_p95 | 120 ± 24.843 | 95 ± 12.422 | -25 | -20.8% | improved |",
+		"| throughput_qps | 100 ± 24.843 | 90 ± 12.422 | -10 | -10.0% | regressed |",
+		"| queue_depth | 5 ± 2.4843 | 7 ± 0 | +2 | +40.0% | n/a |",
+		// cube-bench stat-block keys (create.p95_ms etc.) are lower-better
+		// per the direction table
+		"| create.p95_ms | 60 ± 24.843 | 45 ± 12.422 | -15 | -25.0% | improved |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Errorf("report missing table content %q", want)
 		}
 	}
 
-	// Conclusions.
+	// Conclusions: with n=3 per side the combined CI gate keeps only
+	// error_rate (|Δ| = 0.05 > 0.049687); the other directional deltas are
+	// within noise and stay out of the lists.
 	for _, want := range []string{
 		"## Conclusions",
-		"### Improved (|Δ%| ≥ 5%)",
+		"### Improved (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)",
 		"- **error_rate**: -50.0% (0.1 → 0.05)",
-		"- **sched_latency_p95**: -20.8% (120 → 95)",
-		"- **success_rate**: +6.5% (0.92 → 0.98)",
-		"### Regressed (|Δ%| ≥ 5%)",
-		"- **throughput_qps**: -10.0% (100 → 90)",
+		"### Regressed (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)",
+		"- (none)",
 		"### No direction (n/a)",
-		"- **create.p95_ms**: -25.0% (60 → 45)",
 		"- **queue_depth**: +40.0% (5 → 7)",
 	} {
 		if !strings.Contains(report, want) {
@@ -424,17 +431,23 @@ func TestCompareEndToEnd(t *testing.T) {
 		}
 	}
 
-	// Improved entries are ordered by |Δ%| descending.
-	iErr := strings.Index(report, "**error_rate**")
-	iSched := strings.Index(report, "**sched_latency_p95**")
-	iSuccess := strings.Index(report, "**success_rate**")
-	if !(iErr >= 0 && iErr < iSched && iSched < iSuccess) {
-		t.Errorf("improved list not ordered by |Δ%%| desc: error_rate@%d sched@%d success@%d", iErr, iSched, iSuccess)
+	// CI-gated deltas must not appear as conclusions.
+	for _, notWant := range []string{
+		"- **success_rate**:",
+		"- **sched_latency_p95**:",
+		"- **throughput_qps**:",
+		"- **create.p95_ms**:",
+	} {
+		if strings.Contains(report, notWant) {
+			t.Errorf("CI-gated metric %q must not appear in conclusions", notWant)
+		}
 	}
 
-	// regressed conclusion entry must appear after its heading, n/a entry after its own.
-	if strings.Index(report, "**throughput_qps**: -10.0%") < strings.Index(report, "### Regressed") {
-		t.Errorf("throughput_qps conclusion not under the Regressed heading")
+	// The single surviving improved entry must appear under its own heading,
+	// the n/a entry under its own.
+	iErr := strings.Index(report, "**error_rate**")
+	if iErr < strings.Index(report, "### Improved") {
+		t.Errorf("error_rate conclusion not under the Improved heading")
 	}
 	if strings.Index(report, "**queue_depth**") < strings.Index(report, "### No direction") {
 		t.Errorf("queue_depth conclusion not under the No direction heading")

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -755,6 +755,35 @@ func TestCompareConfigMismatchNote(t *testing.T) {
 	}
 }
 
+func TestCompareConfigMismatchNoteRequiresDispatchRows(t *testing.T) {
+	// Legacy-vs-legacy: the concurrency difference is real, but neither side
+	// has queue_delay_*/dispatch_* rows, so the note — which speaks only
+	// about those rows — must not fire.
+	dir := t.TempDir()
+
+	b1 := writeTempFile(t, dir, "base-legacy.json", `{
+		"config": {"concurrency": 5},
+		"summary": {"success_rate": 0.9, "create_p50_ms": 100}
+	}`)
+	c1 := writeTempFile(t, dir, "cand-legacy.json", `{
+		"config": {"concurrency": 10},
+		"summary": {"success_rate": 0.9, "create_p50_ms": 80}
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c1, "-o", out}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if strings.Contains(string(saved), "client-config artifacts") {
+		t.Errorf("legacy-vs-legacy pair without dispatch rows got the mismatch note\n%s", saved)
+	}
+}
+
 func TestCompareScheduledShapeUsesConfig(t *testing.T) {
 	// A partial scheduled export loses its queue_delay_*/per_template.* keys
 	// to the drop, so shape detection must come from the config block:

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -691,7 +691,7 @@ func TestLoadSampleFileDropsDispatchKeysWhenFlagged(t *testing.T) {
 	dir := t.TempDir()
 
 	path := writeTempFile(t, dir, "flagged.json", `{
-		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 500, "dispatch_qps": 12.5, "dispatch_saturated": 1}
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 500, "dispatch_qps": 12.5, "dispatch_saturated": 1, "per_template.tpl-a.created": 40}
 	}`)
 	f, err := loadSampleFile(path)
 	if err != nil {
@@ -702,7 +702,8 @@ func TestLoadSampleFileDropsDispatchKeysWhenFlagged(t *testing.T) {
 	}
 	// The flagged run's queue_delay_*/dispatch_* values describe the client
 	// semaphore, not the offered schedule: they must be dropped before the
-	// sample reaches the metric tables and verdict lists.
+	// sample reaches the metric tables and verdict lists. per_template.*
+	// blocks survive a saturated run — they reflect what actually ran.
 	for _, k := range []string{"queue_delay_p50_ms", "dispatch_qps", "dispatch_saturated"} {
 		if _, ok := f.samples[0][k]; ok {
 			t.Errorf("key %q survived the flagged-sample drop", k)
@@ -711,9 +712,12 @@ func TestLoadSampleFileDropsDispatchKeysWhenFlagged(t *testing.T) {
 	if got := f.samples[0]["success_rate"]; got != 0.9 {
 		t.Errorf("success_rate = %v, want 0.9 (unrelated keys kept)", got)
 	}
+	if got := f.samples[0]["per_template.tpl-a.created"]; got != 40 {
+		t.Errorf("per_template.tpl-a.created = %v, want 40 (kept for a saturated run)", got)
+	}
 
 	path = writeTempFile(t, dir, "partial.json", `{
-		"summary": {"success_rate": 0.9, "queue_delay_p99_ms": 42, "partial": 1}
+		"summary": {"success_rate": 0.9, "queue_delay_p99_ms": 42, "partial": 1, "per_template.tpl-a.created": 7}
 	}`)
 	f, err = loadSampleFile(path)
 	if err != nil {
@@ -724,6 +728,11 @@ func TestLoadSampleFileDropsDispatchKeysWhenFlagged(t *testing.T) {
 	}
 	if _, ok := f.samples[0]["queue_delay_p99_ms"]; ok {
 		t.Errorf("queue_delay_p99_ms survived the partial-sample drop")
+	}
+	// A partial run's per_template.* blocks aggregate only the results
+	// consumed before the quit, so they must be dropped too.
+	if _, ok := f.samples[0]["per_template.tpl-a.created"]; ok {
+		t.Errorf("per_template.tpl-a.created survived the partial-sample drop")
 	}
 }
 

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -100,6 +100,23 @@ func TestFlattenRoundsAndSingleSample(t *testing.T) {
 		t.Errorf("plain file samples = %v, want single {x:1}", f.samples)
 	}
 
+	// Real cube-bench exports keep the create/delete stat blocks at the top
+	// level, outside "summary"; they must fold into the sample so latency
+	// percentiles stay comparable.
+	withLat := writeTempFile(t, dir, "with_latency.json", `{
+		"summary": {"x": 1},
+		"create": {"count": 2, "p95": 120.5},
+		"delete": {"count": 2, "p95": 30}
+	}`)
+	f, err = loadSampleFile(withLat)
+	if err != nil {
+		t.Fatalf("loadSampleFile(withLat): %v", err)
+	}
+	wantLat := map[string]float64{"x": 1, "create.count": 2, "create.p95": 120.5, "delete.count": 2, "delete.p95": 30}
+	if len(f.samples) != 1 || !reflect.DeepEqual(f.samples[0], wantLat) {
+		t.Errorf("withLat samples = %v, want single %v", f.samples, wantLat)
+	}
+
 	// An empty rounds array falls back to the single-sample path.
 	emptyRounds := writeTempFile(t, dir, "empty_rounds.json", `{"summary": {"x": 2}, "rounds": []}`)
 	f, err = loadSampleFile(emptyRounds)

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -340,6 +340,12 @@ func TestMetricDirection(t *testing.T) {
 		{"create.count", dirNA}, // counts are not a quality signal
 		{"summary.errors", dirNA},
 		{"per_template.tpl-a.attempts", dirNA},
+		// Data-derived key segments must not flip classification: the
+		// template id in per_template.<id>.<stat> is user data.
+		{"per_template.sbx-errors.success_rate", dirHigherBetter},
+		{"per_template.herd-pool.success_rate", dirHigherBetter},
+		{"per_template.pool.with.dots.error_rate", dirLowerBetter},
+		{"per_template.tpl-a.created", dirNA},
 	}
 	for _, tc := range cases {
 		if got := metricDirection(tc.key); got != tc.want {
@@ -356,6 +362,10 @@ func TestCompareGroupPrefix(t *testing.T) {
 		"sched_latency_p99": "sched",
 		"load_balance_cv":   "load",
 		"jain":              "jain",
+		// per_template keys group by the embedded template id
+		"per_template.tpl-a.success_rate": "per_template.tpl-a",
+		"per_template.tpl-b.success_rate": "per_template.tpl-b",
+		"per_template.tpl-a":              "per_template.tpl-a",
 	}
 	for key, want := range cases {
 		if got := groupPrefix(key); got != want {

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -1,0 +1,442 @@
+package main
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeTempFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// Flattening / sample extraction
+// ---------------------------------------------------------------------------
+
+func TestFlattenSummaryNested(t *testing.T) {
+	obj := map[string]any{
+		"total_time_s": 12.5,
+		"success_rate": 0.9,
+		"create": map[string]any{
+			"p95_ms": 42.0,
+			"stats":  map[string]any{"count": 3.0},
+		},
+		// non-numeric leaves are skipped
+		"note":    "ignored",
+		"ok":      true,
+		"tags":    []any{1.0, 2.0},
+		"nothing": nil,
+	}
+	out := map[string]float64{}
+	flattenMetrics(obj, "", out)
+
+	want := map[string]float64{
+		"total_time_s":       12.5,
+		"success_rate":       0.9,
+		"create.p95_ms":      42,
+		"create.stats.count": 3,
+	}
+	if !reflect.DeepEqual(out, want) {
+		t.Errorf("flattened metrics mismatch\n got: %v\nwant: %v", out, want)
+	}
+}
+
+func TestFlattenRoundsAndSingleSample(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulator-style export: non-empty rounds array -> one sample per round.
+	sim := writeTempFile(t, dir, "sim.json", `{
+		"config": {"seed": 7, "workload": "mixed"},
+		"summary": {"ignored_when_rounds_present": 1},
+		"rounds": [
+			{"seed": 1, "summary": {"a": 1, "b": {"c": 2}}},
+			{"seed": 2, "summary": {"a": 3, "b": {"c": 4}}}
+		]
+	}`)
+	f, err := loadSampleFile(sim)
+	if err != nil {
+		t.Fatalf("loadSampleFile(sim): %v", err)
+	}
+	if !f.viaRounds {
+		t.Errorf("sim file should be marked viaRounds")
+	}
+	if len(f.samples) != 2 {
+		t.Fatalf("sim file contributed %d samples, want 2", len(f.samples))
+	}
+	if want := map[string]float64{"a": 1, "b.c": 2}; !reflect.DeepEqual(f.samples[0], want) {
+		t.Errorf("round 0 sample = %v, want %v", f.samples[0], want)
+	}
+	if want := map[string]float64{"a": 3, "b.c": 4}; !reflect.DeepEqual(f.samples[1], want) {
+		t.Errorf("round 1 sample = %v, want %v", f.samples[1], want)
+	}
+	if f.config["seed"] != 7.0 {
+		t.Errorf("config seed = %v, want 7", f.config["seed"])
+	}
+
+	// cube-bench-style export: no rounds -> the whole summary is one sample.
+	plain := writeTempFile(t, dir, "plain.json", `{
+		"config": {"template": "web"},
+		"summary": {"x": 1}
+	}`)
+	f, err = loadSampleFile(plain)
+	if err != nil {
+		t.Fatalf("loadSampleFile(plain): %v", err)
+	}
+	if f.viaRounds {
+		t.Errorf("plain file should not be marked viaRounds")
+	}
+	if len(f.samples) != 1 || !reflect.DeepEqual(f.samples[0], map[string]float64{"x": 1}) {
+		t.Errorf("plain file samples = %v, want single {x:1}", f.samples)
+	}
+
+	// An empty rounds array falls back to the single-sample path.
+	emptyRounds := writeTempFile(t, dir, "empty_rounds.json", `{"summary": {"x": 2}, "rounds": []}`)
+	f, err = loadSampleFile(emptyRounds)
+	if err != nil {
+		t.Fatalf("loadSampleFile(emptyRounds): %v", err)
+	}
+	if f.viaRounds || len(f.samples) != 1 {
+		t.Errorf("empty rounds should yield one sample, got viaRounds=%v n=%d", f.viaRounds, len(f.samples))
+	}
+
+	// Error paths.
+	badJSON := writeTempFile(t, dir, "bad.json", `{not json`)
+	if _, err := loadSampleFile(badJSON); err == nil {
+		t.Errorf("expected parse error for bad.json")
+	}
+	noSummary := writeTempFile(t, dir, "no_summary.json", `{"config": {}}`)
+	if _, err := loadSampleFile(noSummary); err == nil {
+		t.Errorf("expected error for missing summary")
+	}
+	badRound := writeTempFile(t, dir, "bad_round.json", `{"rounds": [{"seed": 1}]}`)
+	if _, err := loadSampleFile(badRound); err == nil {
+		t.Errorf("expected error for round without summary")
+	}
+	if _, err := loadSampleFile(filepath.Join(dir, "missing.json")); err == nil {
+		t.Errorf("expected error for missing file")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+func TestCompareStatsAggregate(t *testing.T) {
+	agg := aggregateSamples([]map[string]float64{
+		{"a": 10, "b": 1},
+		{"a": 12},
+		{"a": 14, "b": 3},
+	})
+
+	a, ok := agg["a"]
+	if !ok {
+		t.Fatalf("metric a missing")
+	}
+	if a.n != 3 {
+		t.Errorf("a.n = %d, want 3", a.n)
+	}
+	if a.mean != 12 {
+		t.Errorf("a.mean = %v, want 12", a.mean)
+	}
+	// sample stddev of {10,12,14}: sqrt((4+0+4)/2) = 2
+	if math.Abs(a.stdDev-2) > 1e-12 {
+		t.Errorf("a.stdDev = %v, want 2", a.stdDev)
+	}
+	if !a.hasCI {
+		t.Errorf("a.should have CI (n=3)")
+	}
+	if want := 1.96 * 2 / math.Sqrt(3); math.Abs(a.ci-want) > 1e-12 {
+		t.Errorf("a.ci = %v, want %v", a.ci, want)
+	}
+
+	b, ok := agg["b"]
+	if !ok {
+		t.Fatalf("metric b missing")
+	}
+	if b.n != 2 || b.mean != 2 {
+		t.Errorf("b = n:%d mean:%v, want n:2 mean:2 (samples without the key do not count)", b.n, b.mean)
+	}
+	if math.Abs(b.stdDev-math.Sqrt(2)) > 1e-12 {
+		t.Errorf("b.stdDev = %v, want sqrt(2)", b.stdDev)
+	}
+	// 1.96 * sqrt(2) / sqrt(2) = 1.96 exactly
+	if math.Abs(b.ci-1.96) > 1e-12 {
+		t.Errorf("b.ci = %v, want 1.96", b.ci)
+	}
+
+	single := aggregateSamples([]map[string]float64{{"x": 5}})["x"]
+	if single.n != 1 || single.mean != 5 {
+		t.Errorf("single = n:%d mean:%v, want n:1 mean:5", single.n, single.mean)
+	}
+	if single.hasCI {
+		t.Errorf("n=1 must not produce a CI")
+	}
+}
+
+func TestCompareZeroBaselinePct(t *testing.T) {
+	baseline := &sampleGroup{name: "b", samples: []map[string]float64{
+		{"restart_rate": 0, "sched_cv": 1, "only_base": 3},
+		{"restart_rate": 0, "sched_cv": 1, "only_base": 5},
+	}}
+	candidate := &sampleGroup{name: "c", samples: []map[string]float64{
+		{"restart_rate": 0.5, "sched_cv": 1},
+		{"restart_rate": 0.5, "sched_cv": 1},
+	}}
+	cmp := buildComparison(baseline, candidate, time.Now().UTC())
+
+	rows := map[string]*compareRow{}
+	for _, r := range cmp.rows {
+		rows[r.key] = r
+	}
+
+	rr := rows["restart_rate"]
+	if rr == nil {
+		t.Fatalf("restart_rate row missing")
+	}
+	if rr.hasPct {
+		t.Errorf("baseline mean is 0: Δ%% must be suppressed, got %v", rr.pct)
+	}
+	if got := pctCell(rr); got != "—" {
+		t.Errorf("pctCell = %q, want em dash", got)
+	}
+	if rr.verdict != verdictImproved {
+		t.Errorf("restart_rate verdict = %q, want improved (higher-better, delta>0)", rr.verdict)
+	}
+
+	cv := rows["sched_cv"]
+	if cv == nil || cv.verdict != verdictSame {
+		t.Errorf("sched_cv verdict = %v, want same (identical means)", cv)
+	}
+
+	ob := rows["only_base"]
+	if ob == nil || ob.verdict != verdictMissing {
+		t.Errorf("only_base verdict = %v, want missing (absent on candidate side)", ob)
+	}
+
+	// Rows without Δ% never enter the conclusions lists.
+	improved, _, _ := cmp.conclusions()
+	if len(improved) != 0 {
+		t.Errorf("conclusions improved = %v, want empty (restart_rate has no Δ%%)", improved)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Direction table
+// ---------------------------------------------------------------------------
+
+func TestMetricDirection(t *testing.T) {
+	cases := []struct {
+		key  string
+		want direction
+	}{
+		// higher-is-better
+		{"success_rate", dirHigherBetter},
+		{"hit_rate", dirHigherBetter},
+		{"alloc_rate", dirHigherBetter},
+		{"jain_fairness", dirHigherBetter},
+		{"jain", dirHigherBetter},
+		{"throughput_qps", dirHigherBetter},
+		{"qps", dirHigherBetter},
+		// lower-is-better
+		{"latency_p99", dirLowerBetter},
+		{"create.latency_p95", dirLowerBetter},
+		{"api_delay", dirLowerBetter},
+		{"job_duration", dirLowerBetter},
+		{"error_rate", dirLowerBetter}, // lower rules beat "rate"
+		{"failure_count", dirLowerBetter},
+		{"sched_cv", dirLowerBetter},
+		{"queue_cv_ratio", dirLowerBetter},
+		{"fragmentation", dirLowerBetter},
+		{"fragment_ratio", dirLowerBetter},
+		{"herd_score", dirLowerBetter},
+		{"herding_index", dirLowerBetter},
+		// no direction: unknown keys, and false-positive guards
+		{"strategy", dirNA},  // must not substring-match "rate"
+		{"discovery", dirNA}, // must not substring-match "cv"
+		{"total_time_s", dirNA},
+		{"queue_depth", dirNA},
+		{"create.p95_ms", dirNA},
+	}
+	for _, tc := range cases {
+		if got := metricDirection(tc.key); got != tc.want {
+			t.Errorf("metricDirection(%q) = %d, want %d", tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestCompareGroupPrefix(t *testing.T) {
+	cases := map[string]string{
+		"create.p95_ms":     "create",
+		"delete.p99_ms":     "delete",
+		"queue_depth":       "queue",
+		"sched_latency_p99": "sched",
+		"load_balance_cv":   "load",
+		"jain":              "jain",
+	}
+	for key, want := range cases {
+		if got := groupPrefix(key); got != want {
+			t.Errorf("groupPrefix(%q) = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End to end
+// ---------------------------------------------------------------------------
+
+func TestCompareEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+
+	// Baseline: one cube-bench-style export (single sample) + one
+	// simulator-style export (two samples via rounds).
+	b1 := writeTempFile(t, dir, "old1.json", `{
+		"config": {"seed": 1, "rounds": 3, "workload": "mixed", "version": "v1"},
+		"summary": {
+			"success_rate": 0.9, "throughput_qps": 100, "error_rate": 0.1,
+			"queue_depth": 4, "sched_latency_p95": 120, "create": {"p95_ms": 50}
+		}
+	}`)
+	b2 := writeTempFile(t, dir, "old2.json", `{
+		"config": {"workload": "mixed", "version": "v1"},
+		"rounds": [
+			{"seed": 11, "summary": {"success_rate": 0.92, "throughput_qps": 110, "error_rate": 0.08, "queue_depth": 5, "sched_latency_p95": 130, "create": {"p95_ms": 60}}},
+			{"seed": 12, "summary": {"success_rate": 0.94, "throughput_qps": 90, "error_rate": 0.12, "queue_depth": 6, "sched_latency_p95": 110, "create": {"p95_ms": 70}}}
+		]
+	}`)
+	c1 := writeTempFile(t, dir, "new1.json", `{
+		"config": {"workload": "mixed", "version": "v2"},
+		"summary": {
+			"success_rate": 0.99, "throughput_qps": 90, "error_rate": 0.05,
+			"queue_depth": 7, "sched_latency_p95": 100, "create": {"p95_ms": 45}
+		}
+	}`)
+	c2 := writeTempFile(t, dir, "new2.json", `{
+		"config": {"workload": "mixed", "version": "v2"},
+		"rounds": [
+			{"seed": 21, "summary": {"success_rate": 0.97, "throughput_qps": 95, "error_rate": 0.05, "queue_depth": 7, "sched_latency_p95": 90, "create": {"p95_ms": 40}}},
+			{"seed": 22, "summary": {"success_rate": 0.98, "throughput_qps": 85, "error_rate": 0.05, "queue_depth": 7, "sched_latency_p95": 95, "create": {"p95_ms": 50}}}
+		]
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	err := runCompare([]string{
+		"--baseline", b1 + "," + b2,
+		"--candidate", c1 + "," + c2,
+		"--baseline-name", "default",
+		"--candidate-name", "new-policy",
+		"-o", out,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+
+	printed := buf.String()
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(printed, string(saved)) {
+		t.Errorf("printed output does not contain the saved report")
+	}
+	t.Logf("generated report:\n%s", saved)
+
+	report := string(saved)
+
+	// Metadata.
+	for _, want := range []string{
+		"# A/B Comparison Report",
+		"Generated:",
+		"| baseline | default | 2 | 3 |",
+		"| candidate | new-policy | 2 | 3 |",
+		"(n=1)",
+		"(n=2 via rounds)",
+		"seed=1",
+		"workload=mixed",
+		"version=v2",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report missing metadata %q", want)
+		}
+	}
+
+	// Comparison table: metric rows, deltas, verdicts.
+	for _, want := range []string{
+		"## Metric Comparison",
+		"### create",
+		"### sched",
+		"| success_rate | 0.92 ± 0.022632 | 0.98 ± 0.011316 | +0.06 | +6.5% | improved |",
+		"| error_rate | 0.1 ± 0.022632 | 0.05 ± 0 | -0.05 | -50.0% | improved |",
+		"| sched_latency_p95 | 120 ± 11.316 | 95 ± 5.658 | -25 | -20.8% | improved |",
+		"| throughput_qps | 100 ± 11.316 | 90 ± 5.658 | -10 | -10.0% | regressed |",
+		"| queue_depth | 5 ± 1.1316 | 7 ± 0 | +2 | +40.0% | n/a |",
+		// create.p95_ms carries no direction keyword -> n/a per the direction table
+		"| create.p95_ms | 60 ± 11.316 | 45 ± 5.658 | -15 | -25.0% | n/a |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report missing table content %q", want)
+		}
+	}
+
+	// Conclusions.
+	for _, want := range []string{
+		"## Conclusions",
+		"### Improved (|Δ%| ≥ 5%)",
+		"- **error_rate**: -50.0% (0.1 → 0.05)",
+		"- **sched_latency_p95**: -20.8% (120 → 95)",
+		"- **success_rate**: +6.5% (0.92 → 0.98)",
+		"### Regressed (|Δ%| ≥ 5%)",
+		"- **throughput_qps**: -10.0% (100 → 90)",
+		"### No direction (n/a)",
+		"- **create.p95_ms**: -25.0% (60 → 45)",
+		"- **queue_depth**: +40.0% (5 → 7)",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report missing conclusion %q", want)
+		}
+	}
+
+	// Improved entries are ordered by |Δ%| descending.
+	iErr := strings.Index(report, "**error_rate**")
+	iSched := strings.Index(report, "**sched_latency_p95**")
+	iSuccess := strings.Index(report, "**success_rate**")
+	if !(iErr >= 0 && iErr < iSched && iSched < iSuccess) {
+		t.Errorf("improved list not ordered by |Δ%%| desc: error_rate@%d sched@%d success@%d", iErr, iSched, iSuccess)
+	}
+
+	// regressed conclusion entry must appear after its heading, n/a entry after its own.
+	if strings.Index(report, "**throughput_qps**: -10.0%") < strings.Index(report, "### Regressed") {
+		t.Errorf("throughput_qps conclusion not under the Regressed heading")
+	}
+	if strings.Index(report, "**queue_depth**") < strings.Index(report, "### No direction") {
+		t.Errorf("queue_depth conclusion not under the No direction heading")
+	}
+}
+
+func TestCompareFlagErrors(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runCompare(nil, &buf); err == nil {
+		t.Errorf("expected error when --baseline/--candidate are missing")
+	}
+	if err := runCompare([]string{"--bogus"}, &buf); err == nil {
+		t.Errorf("expected error for unknown flag")
+	}
+	buf.Reset()
+	if err := runCompare([]string{"--help"}, &buf); err != nil {
+		t.Errorf("--help should return nil, got %v", err)
+	}
+	if !strings.Contains(buf.String(), "--baseline") {
+		t.Errorf("usage text should mention --baseline")
+	}
+}

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -284,6 +284,12 @@ func TestCompareZeroBaselinePct(t *testing.T) {
 	if len(noDir) != 0 {
 		t.Errorf("conclusions noDir = %v, want empty (only_base misses the candidate side; sched_cv is unchanged)", noDir)
 	}
+
+	// The flagged zero-baseline row must carry the caveat marker in the
+	// rendered report so the report stands alone without the README.
+	if report := renderComparison(cmp); !strings.Contains(report, "zero baseline") {
+		t.Errorf("rendered report missing the zero-baseline marker:\n%s", report)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -606,5 +612,58 @@ func TestSampleCountNotes(t *testing.T) {
 	}
 	if got := buildComparison(same, same, time.Now()).sampleCountNotes(); len(got) != 0 {
 		t.Errorf("homogeneous comparison produced notes: %v", got)
+	}
+}
+
+func TestCompareDispatchSaturatedWarning(t *testing.T) {
+	dir := t.TempDir()
+
+	b1 := writeTempFile(t, dir, "base-saturated.json", `{
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 500, "dispatch_saturated": 1}
+	}`)
+	c1 := writeTempFile(t, dir, "cand-clean.json", `{
+		"summary": {"success_rate": 0.9, "queue_delay_p50_ms": 3}
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	if err := runCompare([]string{"--baseline", b1, "--candidate", c1, "-o", out}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	report := string(saved)
+
+	if !strings.Contains(report, "> **Warning:** baseline (") {
+		t.Errorf("report missing the saturation warning naming the baseline group\n%s", report)
+	}
+	// The marker is a run-quality flag, not a metric: it must not survive
+	// into the comparison table as a row.
+	if strings.Contains(report, "| dispatch_saturated |") {
+		t.Errorf("dispatch_saturated leaked into the metric table\n%s", report)
+	}
+}
+
+func TestCompareNoDirSortedByImpact(t *testing.T) {
+	// Three directionless metrics: one small pct move, one large pct move, one
+	// zero-baseline row (no Δ%). Expect large pct first, then small pct, then
+	// the zero-baseline row ranked by absolute delta rather than buried.
+	baseline := &sampleGroup{name: "b", samples: []map[string]float64{
+		{"aaa_small": 100, "zzz_big": 100, "mmm_zero": 0},
+	}}
+	candidate := &sampleGroup{name: "c", samples: []map[string]float64{
+		{"aaa_small": 106, "zzz_big": 160, "mmm_zero": 0.5},
+	}}
+	cmp := buildComparison(baseline, candidate, time.Now().UTC())
+
+	_, _, noDir := cmp.conclusions()
+	if len(noDir) != 3 {
+		t.Fatalf("noDir = %v, want 3 rows", noDir)
+	}
+	if noDir[0].key != "zzz_big" || noDir[1].key != "aaa_small" || noDir[2].key != "mmm_zero" {
+		t.Errorf("noDir order = [%s %s %s], want [zzz_big aaa_small mmm_zero]",
+			noDir[0].key, noDir[1].key, noDir[2].key)
 	}
 }

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -855,12 +855,31 @@ func TestCompareDryRunWarning(t *testing.T) {
 		t.Fatalf("read report: %v", err)
 	}
 	report := string(saved)
-	if !strings.Contains(report, "> **Warning:** baseline is a dry-run export") {
+	if !strings.Contains(report, "> **Warning:** baseline contains a dry-run export") {
 		t.Errorf("report missing the dry-run warning\n%s", report)
 	}
 	// dry_run must also surface in the config highlights.
 	if !strings.Contains(report, "dry_run=true") {
 		t.Errorf("dry_run missing from config highlights\n%s", report)
+	}
+
+	// A mixed dry-run/real group blends synthetic and measured latencies
+	// into the same rows; the warning must still fire even though dry_run
+	// takes two values inside the group.
+	b2 := writeTempFile(t, dir, "base-real.json", `{
+		"config": {"workload": "custom", "dry_run": false},
+		"summary": {"success_rate": 0.97, "queue_delay_p50_ms": 4}
+	}`)
+	out2 := filepath.Join(dir, "report2.md")
+	if err := runCompare([]string{"--baseline", b1 + "," + b2, "--candidate", c1, "-o", out2}, &buf); err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved2, err := os.ReadFile(out2)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(saved2), "> **Warning:** baseline contains a dry-run export") {
+		t.Errorf("mixed dry-run/real group missing the warning\n%s", saved2)
 	}
 }
 

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -271,10 +271,18 @@ func TestCompareZeroBaselinePct(t *testing.T) {
 		t.Errorf("only_base verdict = %v, want missing (absent on candidate side)", ob)
 	}
 
-	// Rows without Δ% never enter the conclusions lists.
-	improved, regressed, _ := cmp.conclusions()
-	if len(improved) != 0 || len(regressed) != 0 {
-		t.Errorf("conclusions improved=%v regressed=%v, want both empty (restart_rate has no Δ%%)", improved, regressed)
+	// Zero-baseline rows fall back to the absolute delta: 0 → 0.5 with tight
+	// CIs (both sides identical values ⇒ CI 0) is a flagged regression even
+	// though Δ% is suppressed in the table.
+	improved, regressed, noDir := cmp.conclusions()
+	if len(improved) != 0 {
+		t.Errorf("conclusions improved = %v, want empty", improved)
+	}
+	if len(regressed) != 1 || regressed[0].key != "restart_rate" {
+		t.Errorf("conclusions regressed = %v, want [restart_rate] (zero-baseline absolute-delta fallback)", regressed)
+	}
+	if len(noDir) != 0 {
+		t.Errorf("conclusions noDir = %v, want empty (only_base misses the candidate side; sched_cv is unchanged)", noDir)
 	}
 }
 
@@ -351,6 +359,50 @@ func TestCompareGroupPrefix(t *testing.T) {
 // ---------------------------------------------------------------------------
 // End to end
 // ---------------------------------------------------------------------------
+
+// TestCompareMixedShapesEndToEnd: a create-only export mixed into a
+// create-delete group must surface the per-metric sample-count note (and the
+// conclusion annotation) in the rendered report.
+func TestCompareMixedShapesEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+
+	b1 := writeTempFile(t, dir, "base-full.json", `{
+		"summary": {"success_rate": 0.9},
+		"create": {"p95_ms": 50}, "delete": {"p95_ms": 20}
+	}`)
+	b2 := writeTempFile(t, dir, "base-create-only.json", `{
+		"summary": {"success_rate": 0.92},
+		"create": {"p95_ms": 55}
+	}`)
+	c1 := writeTempFile(t, dir, "cand-full.json", `{
+		"summary": {"success_rate": 0.95},
+		"create": {"p95_ms": 40}, "delete": {"p95_ms": 30}
+	}`)
+
+	out := filepath.Join(dir, "report.md")
+	var buf bytes.Buffer
+	err := runCompare([]string{"--baseline", b1 + "," + b2, "--candidate", c1, "-o", out}, &buf)
+	if err != nil {
+		t.Fatalf("runCompare: %v", err)
+	}
+	saved, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	report := string(saved)
+
+	for _, want := range []string{
+		"Some metrics appear in fewer samples than the group header count",
+		"- `delete.p95_ms`: n=1 of 2 baseline samples",
+		// delete.p95_ms went 20 → 30 (+50%): flagged regressed (lower-better),
+		// annotated with the reduced baseline n.
+		"- **delete.p95_ms**: +50.0% (20 → 30) (baseline n=1/2)",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report missing %q\n%s", want, report)
+		}
+	}
+}
 
 func TestCompareEndToEnd(t *testing.T) {
 	dir := t.TempDir()
@@ -456,7 +508,7 @@ func TestCompareEndToEnd(t *testing.T) {
 		"- **error_rate**: -50.0% (0.1 → 0.05)",
 		"### Regressed (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)",
 		"- (none)",
-		"### No direction (n/a)",
+		"### No direction (n/a, only |Δ%| ≥ 5% or newly-nonzero shown)",
 		"- **queue_depth**: +40.0% (5 → 7)",
 	} {
 		if !strings.Contains(report, want) {

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -332,6 +332,8 @@ func TestMetricDirection(t *testing.T) {
 		{"total_time_s", dirNA},
 		{"queue_depth", dirNA},
 		{"create.count", dirNA}, // counts are not a quality signal
+		{"summary.errors", dirNA},
+		{"per_template.tpl-a.attempts", dirNA},
 	}
 	for _, tc := range cases {
 		if got := metricDirection(tc.key); got != tc.want {

--- a/examples/cube-bench/compare_test.go
+++ b/examples/cube-bench/compare_test.go
@@ -501,14 +501,16 @@ func TestCompareEndToEnd(t *testing.T) {
 		}
 	}
 
-	// Conclusions: with n=3 per side the combined CI gate keeps only
-	// error_rate (|Δ| = 0.05 > 0.049687); the other directional deltas are
+	// Conclusions: with n=3 per side the difference-CI gate keeps error_rate
+	// (|Δ| = 0.05 > √(0.049687² + 0²)) and success_rate (0.06 >
+	// √(0.049687² + 0.024843²) ≈ 0.0556); the other directional deltas are
 	// within noise and stay out of the lists.
 	for _, want := range []string{
 		"## Conclusions",
-		"### Improved (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)",
+		"### Improved (|Δ%| ≥ 5%, beyond 95% CI of the difference when n ≥ 2)",
 		"- **error_rate**: -50.0% (0.1 → 0.05)",
-		"### Regressed (|Δ%| ≥ 5%, beyond combined 95% CI when n ≥ 2)",
+		"- **success_rate**: +6.5% (0.92 → 0.98)",
+		"### Regressed (|Δ%| ≥ 5%, beyond 95% CI of the difference when n ≥ 2)",
 		"- (none)",
 		"### No direction (n/a, only |Δ%| ≥ 5% or newly-nonzero shown)",
 		"- **queue_depth**: +40.0% (5 → 7)",
@@ -520,7 +522,6 @@ func TestCompareEndToEnd(t *testing.T) {
 
 	// CI-gated deltas must not appear as conclusions.
 	for _, notWant := range []string{
-		"- **success_rate**:",
 		"- **sched_latency_p95**:",
 		"- **throughput_qps**:",
 		"- **create.p95_ms**:",

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -328,10 +328,15 @@ func parseConfig() *Config {
 				"semaphore, not the scheduler; the end-of-run saturation check will say if that happened.\n",
 				cfg.Rate, cfg.Concurrency)
 		case !cfg.DryRun && cfg.hasLifetime && cfg.Mode == "create-delete":
-			// ASAP dispatch with lifetimes: every worker slot is held for the
-			// full lifetime, so the run time is bounded below by
-			// total x mean lifetime / concurrency.
-			if est := float64(cfg.Total) * occS / float64(cfg.Concurrency); est > 300 {
+			// ASAP dispatch with lifetimes: every worker slot is held for at
+			// least the full lifetime, so the run time is bounded below by
+			// total x mean lifetime / concurrency. Use meanLife directly:
+			// occS deliberately stays 0 for sub-second lifetimes (a
+			// precise-looking rate x lifetime threshold would understate the
+			// slot requirement there), but this lower bound only needs the
+			// hold — the omitted create/delete tail makes the true run
+			// longer still.
+			if est := float64(cfg.Total) * meanLife / float64(cfg.Concurrency); est > 300 {
 				fmt.Fprintf(os.Stderr, "WARNING: %d requests with mean lifetime %gs at --concurrency %d will take at least ~%.0fs; "+
 					"raise --concurrency or add --rate to pace arrivals\n",
 					cfg.Total, meanLife, cfg.Concurrency, est)

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -311,7 +311,11 @@ func parseConfig() *Config {
 		}
 		switch {
 		case cfg.Rate > 0 && known:
-			if needed := cfg.Rate * occS; float64(cfg.Concurrency) < needed {
+			// Little's-law steady state assumes an unbounded stream; a finite
+			// run can never hold more than Total requests in flight, so cap
+			// the estimate (a 500-request burst at 50/s with a 65s mean
+			// lifetime needs ~500 slots, not 3250).
+			if needed := min(cfg.Rate*occS, float64(cfg.Total)); float64(cfg.Concurrency) < needed {
 				fmt.Fprintf(os.Stderr, "WARNING: --concurrency %d is below rate(%g/s) x mean occupancy(%gs) = %.0f; "+
 					"the dispatcher will stall on the semaphore and neither the arrival rate nor queue-delay metrics will be honored\n",
 					cfg.Concurrency, cfg.Rate, occS, needed)
@@ -568,7 +572,7 @@ func exportJSON(results []IterResult, cfg *Config) {
 		// dispatch_*/queue_delay_* aggregates are not misread as run
 		// characteristics (compare pops the marker and notes the group),
 		// and skip the saturation marker whose own sample is truncated.
-		partial := cfg.Total > 0 && len(results) < cfg.Total
+		partial := runTruncated(results, cfg)
 		if partial {
 			summaryBlock["partial"] = 1
 		}
@@ -767,7 +771,7 @@ func main() {
 
 	// An early TUI quit truncates the sample: say so next to the on-screen
 	// report so its numbers are not read as a finished run.
-	partial := cfg.Total > 0 && len(allResults) < cfg.Total
+	partial := runTruncated(allResults, cfg)
 	if partial {
 		fmt.Fprintf(os.Stderr, "NOTE: run quit early with %d of %d requests dispatched; "+
 			"the report above and any exported aggregates cover a truncated sample.\n",

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -145,7 +145,7 @@ func parseConfig() *Config {
 	flag.Float64Var(&cfg.Rate, "rate", 0, "Poisson arrival rate in requests/sec (<=0 = as fast as possible)")
 	lifetime := flag.String("lifetime", "", "Per-sandbox lifetime in seconds: min,max (uniform); client DELETEs at lifetime")
 	flag.StringVar(&cfg.TemplatesRaw, "templates", "", "Comma-separated templateID[:weight[:cpuMillis:memMiB]] pool")
-	flag.StringVar(&cfg.DumpTrace, "dump-trace", "", "Write the pre-generated request sequence to a JSON trace file")
+	flag.StringVar(&cfg.DumpTrace, "dump-trace", "", "Write the pre-generated request sequence to a JSON trace file (requires a scheduled workload)")
 
 	var noTUI bool
 	flag.BoolVar(&noTUI, "no-tui", false, "Disable interactive TUI (auto-detected in non-TTY)")
@@ -242,6 +242,11 @@ func parseConfig() *Config {
 	}
 
 	cfg.Scheduled = cfg.Workload != "" || cfg.Rate > 0 || cfg.hasLifetime || cfg.TemplatesRaw != ""
+
+	if cfg.DumpTrace != "" && !cfg.Scheduled {
+		fmt.Fprintln(os.Stderr, "ERROR: --dump-trace requires a scheduled workload (--workload, or --rate/--lifetime/--templates)")
+		os.Exit(1)
+	}
 
 	if cfg.Concurrency < 1 {
 		cfg.Concurrency = 1

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -63,9 +65,26 @@ type Config struct {
 	sequence     []ScheduledRequest
 
 	elapsed float64
-	// dispatchElapsed is the wall-clock span of the scheduled dispatch loop
-	// (first to last request release), excluding per-sandbox lifetime tails.
-	dispatchElapsed float64
+	// dispatchElapsedBits holds math.Float64bits of the wall-clock span of the
+	// scheduled dispatch loop (first to last request release), excluding
+	// per-sandbox lifetime tails. Stored atomically: on an early TUI quit the
+	// report path reads it while the dispatcher goroutine may still write it.
+	dispatchElapsedBits atomic.Uint64
+	// released counts scheduled requests actually admitted to a worker slot
+	// (semaphore acquired), so the TUI in-flight gauge reflects real releases
+	// instead of reconstructing them from the planned arrival schedule.
+	released atomic.Int64
+}
+
+// setDispatchElapsed publishes the dispatch window; getDispatchElapsed reads
+// it back. Both stay race-free against a dispatcher goroutine that is still
+// running because the TUI was quit early.
+func (c *Config) setDispatchElapsed(v float64) {
+	c.dispatchElapsedBits.Store(math.Float64bits(v))
+}
+
+func (c *Config) getDispatchElapsed() float64 {
+	return math.Float64frombits(c.dispatchElapsedBits.Load())
 }
 
 type createRequest struct {
@@ -494,9 +513,9 @@ func exportJSON(results []IterResult, cfg *Config) {
 		// reflects the arrival rate the scheduler actually saw. Only
 		// meaningful for rate-paced runs: without --rate the "window" is
 		// just the client's release burst, so the keys are omitted.
-		if cfg.Rate > 0 && cfg.dispatchElapsed > 0 {
-			summaryBlock["dispatch_window_s"] = cfg.dispatchElapsed
-			summaryBlock["dispatch_qps"] = float64(len(results)) / cfg.dispatchElapsed
+		if de := cfg.getDispatchElapsed(); cfg.Rate > 0 && de > 0 {
+			summaryBlock["dispatch_window_s"] = de
+			summaryBlock["dispatch_qps"] = float64(len(results)) / de
 		}
 		// Queue delay is measured per dispatched request, independent of
 		// create success, so it uses all results.

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -350,6 +350,16 @@ func parseConfig() *Config {
 		}
 	}
 
+	// A rate-paced create-delete run without --lifetime creates sandboxes
+	// with no server-side timeout, so an early quit (Ctrl-C, TUI quit)
+	// strands whatever was still in flight — permanently, since the
+	// lifetime-keyed TTL backstop below does not apply. Say so up front.
+	if cfg.Rate > 0 && !cfg.hasLifetime && !cfg.DryRun && cfg.Mode == "create-delete" {
+		fmt.Fprintf(os.Stderr, "NOTE: --rate without --lifetime creates sandboxes with no server-side TTL backstop; "+
+			"an early quit can strand up to --concurrency (%d) in-flight sandboxes. Set --lifetime to bound the leak.\n",
+			cfg.Concurrency)
+	}
+
 	// Validate host-mount early so the CLI fails fast on bad input while still
 	// preserving the original JSON for config display and exported reports.
 	// Cache the compacted JSON string once so benchmark throughput is not

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math/rand"
 	"os"
 	"runtime"
 	"strconv"
@@ -46,11 +47,27 @@ type Config struct {
 	DryErrorRate   float64
 	NoTUI          bool
 
+	// Scheduled workload generator. Scheduled is true when any of the
+	// scheduling flags (--workload/--rate/--lifetime/--templates) is in use;
+	// false keeps the exact legacy behavior.
+	Seed         int64
+	Workload     string
+	Rate         float64 // Poisson arrival rate in requests/sec (<=0 = asap)
+	LifetimeMin  float64 // seconds
+	LifetimeMax  float64 // seconds
+	hasLifetime  bool
+	TemplatesRaw string
+	Templates    []TemplateSpec
+	DumpTrace    string
+	Scheduled    bool
+	sequence     []ScheduledRequest
+
 	elapsed float64
 }
 
 type createRequest struct {
 	TemplateID          string                `json:"templateID"`
+	Timeout             *int64                `json:"timeout,omitempty"`
 	AllowInternetAccess *bool                 `json:"allow_internet_access,omitempty"`
 	Network             *sandboxNetworkConfig `json:"network,omitempty"`
 	Metadata            map[string]string     `json:"metadata,omitempty"`
@@ -77,7 +94,11 @@ func prepareHostMount(rawJSON string) (string, error) {
 }
 
 func buildCreateRequestBody(template string, hostMount string, networkPolicy string) ([]byte, error) {
-	reqBody := createRequest{TemplateID: template}
+	return buildCreateRequestBodyWithTimeout(template, hostMount, networkPolicy, nil)
+}
+
+func buildCreateRequestBodyWithTimeout(template string, hostMount string, networkPolicy string, timeoutS *int64) ([]byte, error) {
+	reqBody := createRequest{TemplateID: template, Timeout: timeoutS}
 	if hostMount != "" {
 		reqBody.Metadata = map[string]string{"host-mount": hostMount}
 	}
@@ -118,6 +139,14 @@ func parseConfig() *Config {
 	flag.StringVar(&cfg.ThemeName, "theme", "auto", "Color theme: dark | light | auto")
 	flag.BoolVar(&cfg.DryRun, "dry-run", false, "Simulate API calls with random latencies")
 
+	// Scheduled workload generator flags (empty/zero = legacy behavior)
+	flag.Int64Var(&cfg.Seed, "seed", 42, "Random seed for the pre-generated request sequence")
+	flag.StringVar(&cfg.Workload, "workload", "", "Workload preset: burst | template_storm | mixed_spec")
+	flag.Float64Var(&cfg.Rate, "rate", 0, "Poisson arrival rate in requests/sec (<=0 = as fast as possible)")
+	lifetime := flag.String("lifetime", "", "Per-sandbox lifetime in seconds: min,max (uniform); client DELETEs at lifetime")
+	flag.StringVar(&cfg.TemplatesRaw, "templates", "", "Comma-separated templateID[:weight[:cpuMillis:memMiB]] pool")
+	flag.StringVar(&cfg.DumpTrace, "dump-trace", "", "Write the pre-generated request sequence to a JSON trace file")
+
 	var noTUI bool
 	flag.BoolVar(&noTUI, "no-tui", false, "Disable interactive TUI (auto-detected in non-TTY)")
 
@@ -125,6 +154,11 @@ func parseConfig() *Config {
 	flag.Float64Var(&cfg.DryErrorRate, "dry-error-rate", 0.02, "Dry-run simulated error rate 0.0-1.0")
 
 	flag.Parse()
+
+	// Remember which flags were passed explicitly so workload presets only
+	// fill in defaults and never override user input.
+	explicit := map[string]bool{}
+	flag.Visit(func(f *flag.Flag) { explicit[f.Name] = true })
 
 	cfg.NoTUI = noTUI || !term.IsTerminal(int(os.Stdout.Fd()))
 
@@ -169,6 +203,46 @@ func parseConfig() *Config {
 		}
 	}
 
+	// Explicit --lifetime parses first; a workload preset only fills it in
+	// when the flag was not given.
+	if *lifetime != "" {
+		lo, hi, err := parseLifetime(*lifetime)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(1)
+		}
+		cfg.LifetimeMin, cfg.LifetimeMax, cfg.hasLifetime = lo, hi, true
+	}
+	if cfg.Workload != "" {
+		if err := applyWorkloadPreset(cfg, explicit); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	if cfg.Rate < 0 {
+		cfg.Rate = 0
+	}
+
+	// Template pool: --templates wins; otherwise the single -t/--template is
+	// equivalent to a one-element pool with weight 1.
+	if cfg.TemplatesRaw != "" {
+		templates, err := parseTemplates(cfg.TemplatesRaw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(1)
+		}
+		cfg.Templates = templates
+	} else if cfg.Template != "" {
+		cfg.Templates = []TemplateSpec{{TemplateID: cfg.Template, Weight: 1}}
+	}
+	if cfg.Workload == "mixed_spec" && len(cfg.Templates) < 2 {
+		fmt.Fprintln(os.Stderr, "ERROR: workload mixed_spec requires --templates with at least 2 templates, e.g.")
+		fmt.Fprintln(os.Stderr, "  --templates 'tpl-1c2g:6:1000:2048,tpl-2c4g:3:2000:4096,tpl-8c16g:1:8000:16384'  # 6:3:1 for 1C2G/2C4G/8C16G")
+		os.Exit(1)
+	}
+
+	cfg.Scheduled = cfg.Workload != "" || cfg.Rate > 0 || cfg.hasLifetime || cfg.TemplatesRaw != ""
+
 	if cfg.Concurrency < 1 {
 		cfg.Concurrency = 1
 	}
@@ -188,7 +262,13 @@ func parseConfig() *Config {
 	cfg.hostMountValue = hostMountValue
 	cfg.requestHeaders = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
 
-	requestBody, err := buildCreateRequestBody(cfg.Template, cfg.hostMountValue, cfg.NetworkPolicy)
+	// In scheduled mode without -t the pool drives per-request bodies; the
+	// cached body (warmup/fallback) then uses the first pool template.
+	bodyTemplate := cfg.Template
+	if bodyTemplate == "" && len(cfg.Templates) > 0 {
+		bodyTemplate = cfg.Templates[0].TemplateID
+	}
+	requestBody, err := buildCreateRequestBody(bodyTemplate, cfg.hostMountValue, cfg.NetworkPolicy)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: create request body build failed: %v\n", err)
 		os.Exit(1)
@@ -215,6 +295,21 @@ func renderConfig(cfg *Config) {
 		{"Warmup Rounds", fmt.Sprintf("%d", cfg.Warmup)},
 		{"Mode", cfg.Mode},
 		{"Network Policy", cfg.networkFP.summary()},
+	}
+	if cfg.Scheduled {
+		kvs = append(kvs,
+			kvPair{"Workload", workloadDisplayName(cfg)},
+			kvPair{"Seed", fmt.Sprintf("%d", cfg.Seed)},
+			kvPair{"Rate", fmt.Sprintf("%g req/s", cfg.Rate)},
+		)
+		if cfg.hasLifetime {
+			kvs = append(kvs, kvPair{"Lifetime", fmt.Sprintf("%g-%gs", cfg.LifetimeMin, cfg.LifetimeMax)})
+		}
+		var pool []string
+		for _, t := range cfg.Templates {
+			pool = append(pool, fmt.Sprintf("%s(w%d)", t.TemplateID, t.Weight))
+		}
+		kvs = append(kvs, kvPair{"Templates", strings.Join(pool, ", ")})
 	}
 	if cfg.HostMount != "" {
 		// Pretty-print the original host-mount JSON for readability.
@@ -302,6 +397,13 @@ func exportJSON(results []IterResult, cfg *Config) {
 			"create_ms": r.CreateMs,
 			"delete_ms": r.DeleteMs,
 		}
+		if cfg.Scheduled {
+			entry["template_id"] = r.TemplateID
+			entry["scheduled_arrival_ms"] = r.ScheduledArrivalMs
+			entry["actual_start_ms"] = r.ActualStartMs
+			entry["sched_delay_ms"] = r.SchedDelayMs
+			entry["lifetime_ms"] = r.LifetimeMs
+		}
 		if r.Err != "" {
 			entry["error"] = r.Err
 		}
@@ -317,30 +419,87 @@ func exportJSON(results []IterResult, cfg *Config) {
 		throughput = float64(len(okResults)) / cfg.elapsed
 	}
 
+	configBlock := map[string]interface{}{
+		"template":             cfg.Template,
+		"api_url":              cfg.APIURL,
+		"concurrency":          cfg.Concurrency,
+		"total":                cfg.Total,
+		"warmup":               cfg.Warmup,
+		"mode":                 cfg.Mode,
+		"host_mount":           cfg.HostMount,
+		"network_policy":       cfg.networkFP.Policy,
+		"network_allow_out":    cfg.networkFP.AllowOut,
+		"network_rules":        cfg.networkFP.Rules,
+		"network_inject_rules": cfg.networkFP.InjectRules,
+	}
+	if cfg.Scheduled {
+		configBlock["workload"] = workloadDisplayName(cfg)
+		configBlock["seed"] = cfg.Seed
+		configBlock["rate_per_sec"] = cfg.Rate
+		configBlock["lifetime_min_s"] = cfg.LifetimeMin
+		configBlock["lifetime_max_s"] = cfg.LifetimeMax
+		templates := make([]map[string]interface{}, len(cfg.Templates))
+		for i, t := range cfg.Templates {
+			templates[i] = map[string]interface{}{
+				"template_id": t.TemplateID,
+				"weight":      t.Weight,
+				"cpu_millis":  t.CpuMillis,
+				"mem_mib":     t.MemMiB,
+			}
+		}
+		configBlock["templates"] = templates
+	}
+
+	summaryBlock := map[string]interface{}{
+		"total_time_s":   cfg.elapsed,
+		"successful":     len(okResults),
+		"errors":         len(results) - len(okResults),
+		"success_rate":   successRate,
+		"throughput_qps": throughput,
+	}
+	if cfg.Scheduled {
+		// Queue delay is measured per dispatched request, independent of
+		// create success, so it uses all results.
+		delays := extractTimes(results, func(r IterResult) float64 { return r.SchedDelayMs })
+		if len(delays) > 0 {
+			summaryBlock["queue_delay_p50_ms"] = Percentile(delays, 50)
+			summaryBlock["queue_delay_p95_ms"] = Percentile(delays, 95)
+			summaryBlock["queue_delay_p99_ms"] = Percentile(delays, 99)
+		}
+		type tplAgg struct{ attempts, created int }
+		agg := map[string]*tplAgg{}
+		for _, r := range results {
+			a := agg[r.TemplateID]
+			if a == nil {
+				a = &tplAgg{}
+				agg[r.TemplateID] = a
+			}
+			a.attempts++
+			if r.Err == "" {
+				a.created++
+			}
+		}
+		perTemplate := map[string]interface{}{}
+		for id, a := range agg {
+			rate := 0.0
+			if a.attempts > 0 {
+				rate = float64(a.created) / float64(a.attempts)
+			}
+			perTemplate[id] = map[string]interface{}{
+				"attempts":     a.attempts,
+				"created":      a.created,
+				"success_rate": rate,
+			}
+		}
+		summaryBlock["per_template"] = perTemplate
+	}
+
 	report := map[string]interface{}{
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
-		"config": map[string]interface{}{
-			"template":             cfg.Template,
-			"api_url":              cfg.APIURL,
-			"concurrency":          cfg.Concurrency,
-			"total":                cfg.Total,
-			"warmup":               cfg.Warmup,
-			"mode":                 cfg.Mode,
-			"host_mount":           cfg.HostMount,
-			"network_policy":       cfg.networkFP.Policy,
-			"network_allow_out":    cfg.networkFP.AllowOut,
-			"network_rules":        cfg.networkFP.Rules,
-			"network_inject_rules": cfg.networkFP.InjectRules,
-		},
-		"summary": map[string]interface{}{
-			"total_time_s":   cfg.elapsed,
-			"successful":     len(okResults),
-			"errors":         len(results) - len(okResults),
-			"success_rate":   successRate,
-			"throughput_qps": throughput,
-		},
-		"create": statBlock(createTimes),
-		"raw":    raw,
+		"config":    configBlock,
+		"summary":   summaryBlock,
+		"create":    statBlock(createTimes),
+		"raw":       raw,
 	}
 	if cfg.Mode == "create-delete" {
 		report["delete"] = statBlock(deleteTimes)
@@ -384,6 +543,14 @@ func collectWithSimpleProgress(ch <-chan IterResult, total int) []IterResult {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "compare" {
+		if err := runCompare(os.Args[2:], os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, "ERROR:", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	cfg := parseConfig()
 
 	switch cfg.ThemeName {
@@ -396,8 +563,8 @@ func main() {
 	}
 
 	if !cfg.DryRun {
-		if cfg.Template == "" {
-			fmt.Fprintln(os.Stderr, T.Error.Render("ERROR:")+" template ID not set. Use -t or set CUBE_TEMPLATE_ID.")
+		if cfg.Template == "" && len(cfg.Templates) == 0 {
+			fmt.Fprintln(os.Stderr, T.Error.Render("ERROR:")+" template ID not set. Use -t/--templates or set CUBE_TEMPLATE_ID.")
 			os.Exit(1)
 		}
 		if cfg.APIURL == "" {
@@ -417,13 +584,32 @@ func main() {
 		renderDryRunBanner(cfg)
 	}
 
+	// Pre-generate the request sequence before any timing starts; dumping the
+	// trace must not delay the scheduled arrivals.
+	var sched []ScheduledRequest
+	if cfg.Scheduled {
+		sched = GenerateSequence(cfg, rand.New(rand.NewSource(cfg.Seed)))
+		cfg.sequence = sched
+		if cfg.DumpTrace != "" {
+			if err := DumpTrace(cfg.DumpTrace, cfg, sched); err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Printf("  %s %s\n\n", T.Muted.Render("Trace saved to"), lipgloss.NewStyle().Bold(true).Render(cfg.DumpTrace))
+		}
+	}
+
 	client := RunWarmup(cfg, os.Stdout)
 
 	resultCh := make(chan IterResult, cfg.Total)
 
 	startTime := time.Now()
 
-	go RunBenchmark(cfg, resultCh, client)
+	if cfg.Scheduled {
+		go RunScheduled(cfg, sched, resultCh, client)
+	} else {
+		go RunBenchmark(cfg, resultCh, client)
+	}
 
 	var allResults []IterResult
 

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -262,12 +262,21 @@ func parseConfig() *Config {
 	// can only honor the requested Poisson rate when concurrency >= rate x
 	// mean lifetime; otherwise queue delays measure the client's own
 	// concurrency limit, not the scheduler. Warn loudly (presets included).
-	if cfg.Scheduled && cfg.Rate > 0 && cfg.hasLifetime {
+	if cfg.Scheduled && cfg.hasLifetime {
 		meanLife := (cfg.LifetimeMin + cfg.LifetimeMax) / 2
-		if needed := cfg.Rate * meanLife; float64(cfg.Concurrency) < needed {
-			fmt.Fprintf(os.Stderr, "WARNING: --concurrency %d is below rate(%g/s) x mean lifetime(%gs) = %.0f; "+
-				"the dispatcher will stall on the semaphore and neither the arrival rate nor queue-delay metrics will be honored\n",
-				cfg.Concurrency, cfg.Rate, meanLife, needed)
+		if cfg.Rate > 0 {
+			if needed := cfg.Rate * meanLife; float64(cfg.Concurrency) < needed {
+				fmt.Fprintf(os.Stderr, "WARNING: --concurrency %d is below rate(%g/s) x mean lifetime(%gs) = %.0f; "+
+					"the dispatcher will stall on the semaphore and neither the arrival rate nor queue-delay metrics will be honored\n",
+					cfg.Concurrency, cfg.Rate, meanLife, needed)
+			}
+		} else if est := float64(cfg.Total) * meanLife / float64(cfg.Concurrency); est > 300 {
+			// ASAP dispatch with lifetimes: every worker slot is held for the
+			// full lifetime, so the run time is bounded below by
+			// total x mean lifetime / concurrency.
+			fmt.Fprintf(os.Stderr, "WARNING: %d requests with mean lifetime %gs at --concurrency %d will take at least ~%.0fs; "+
+				"raise --concurrency or add --rate to pace arrivals\n",
+				cfg.Total, meanLife, cfg.Concurrency, est)
 		}
 	}
 
@@ -482,8 +491,10 @@ func exportJSON(results []IterResult, cfg *Config) {
 		// Dispatch-side throughput: requests released per second of the
 		// dispatch window. Unlike throughput_qps (total requests over the
 		// whole run), this excludes per-sandbox lifetime tails, so it
-		// reflects the arrival rate the scheduler actually saw.
-		if cfg.dispatchElapsed > 0 {
+		// reflects the arrival rate the scheduler actually saw. Only
+		// meaningful for rate-paced runs: without --rate the "window" is
+		// just the client's release burst, so the keys are omitted.
+		if cfg.Rate > 0 && cfg.dispatchElapsed > 0 {
 			summaryBlock["dispatch_window_s"] = cfg.dispatchElapsed
 			summaryBlock["dispatch_qps"] = float64(len(results)) / cfg.dispatchElapsed
 		}

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -348,7 +348,16 @@ func parseConfig() *Config {
 	if bodyTemplate == "" && len(cfg.Templates) > 0 {
 		bodyTemplate = cfg.Templates[0].TemplateID
 	}
-	requestBody, err := buildCreateRequestBody(bodyTemplate, cfg.hostMountValue, cfg.NetworkPolicy)
+	// The cached body serves warmup requests, which otherwise get no TTL
+	// safety net: on a lifetime-bearing workload an interrupted run would leak
+	// them. Give warmup the same server-side fallback as measured requests,
+	// keyed to the top of the lifetime range.
+	var warmupTimeout *int64
+	if cfg.Scheduled && cfg.hasLifetime {
+		t := int64(cfg.LifetimeMax) + 60
+		warmupTimeout = &t
+	}
+	requestBody, err := buildCreateRequestBodyWithTimeout(bodyTemplate, cfg.hostMountValue, cfg.NetworkPolicy, warmupTimeout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: create request body build failed: %v\n", err)
 		os.Exit(1)
@@ -556,6 +565,14 @@ func exportJSON(results []IterResult, cfg *Config) {
 			summaryBlock["queue_delay_p95_ms"] = Percentile(delays, 95)
 			summaryBlock["queue_delay_p99_ms"] = Percentile(delays, 99)
 		}
+		// Machine-readable marker for the end-of-run saturation check: when
+		// set, the dispatcher fell permanently behind pace and the
+		// queue_delay_*/dispatch_* keys above describe the client's
+		// semaphore, not the offered schedule. compare surfaces this as a
+		// warning instead of a metric row.
+		if sat, _, _ := dispatchSaturated(results, cfg); sat {
+			summaryBlock["dispatch_saturated"] = 1
+		}
 		type tplAgg struct{ attempts, created int }
 		agg := map[string]*tplAgg{}
 		for _, r := range results {
@@ -725,16 +742,12 @@ func main() {
 	// fell permanently behind and the offered load degenerated to bursts; the
 	// queue_delay_* metrics then measure the client semaphore, not the
 	// scheduler. Surface that instead of letting the numbers read as a valid
-	// scheduled-mode run.
-	if cfg.Scheduled && cfg.Rate > 0 {
-		if delays := extractTimes(allResults, func(r IterResult) float64 { return r.SchedDelayMs }); len(delays) > 0 {
-			if p95, interArrival := Percentile(delays, 95), 1000/cfg.Rate; p95 > interArrival {
-				fmt.Fprintf(os.Stderr, "WARNING: queue-delay p95 (%.0fms) exceeded the mean inter-arrival time (%.0fms): "+
-					"the dispatcher fell permanently behind and the offered load degenerated to bursts — "+
-					"queue_delay_*/dispatch metrics measure the client's semaphore, not the scheduler. Raise --concurrency.\n",
-					p95, interArrival)
-			}
-		}
+	// scheduled-mode run; exportJSON marks the report machine-readably.
+	if sat, p95, interArrival := dispatchSaturated(allResults, cfg); sat {
+		fmt.Fprintf(os.Stderr, "WARNING: queue-delay p95 (%.0fms) exceeded the mean inter-arrival time (%.0fms): "+
+			"the dispatcher fell permanently behind and the offered load degenerated to bursts — "+
+			"queue_delay_*/dispatch metrics measure the client's semaphore, not the scheduler. Raise --concurrency.\n",
+			p95, interArrival)
 	}
 
 	if cfg.Output != "" {

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -277,36 +277,57 @@ func parseConfig() *Config {
 		cfg.Total = 1
 	}
 
-	// A worker slot is held for the full sandbox lifetime, so the dispatcher
-	// can only honor the requested Poisson rate when concurrency >= rate x
-	// mean lifetime; otherwise queue delays measure the client's own
-	// concurrency limit, not the scheduler. Warn loudly (presets included).
-	if cfg.Scheduled && cfg.hasLifetime {
+	// A worker slot is held for the request's whole occupancy, so the
+	// dispatcher can only honor the requested Poisson rate when
+	// concurrency >= rate x mean occupancy; otherwise queue delays measure
+	// the client's own concurrency limit, not the scheduler. Warn loudly.
+	if cfg.Scheduled {
 		meanLife := (cfg.LifetimeMin + cfg.LifetimeMax) / 2
-		if cfg.Rate > 0 {
-			if needed := cfg.Rate * meanLife; float64(cfg.Concurrency) < needed {
-				fmt.Fprintf(os.Stderr, "WARNING: --concurrency %d is below rate(%g/s) x mean lifetime(%gs) = %.0f; "+
-					"the dispatcher will stall on the semaphore and neither the arrival rate nor queue-delay metrics will be honored\n",
-					cfg.Concurrency, cfg.Rate, meanLife, needed)
+		// occS estimates how long a worker slot is held per request; known is
+		// false when no estimate exists (real run without a lifetime hold:
+		// only the unknown create/delete latency occupies the slot).
+		// Dry-run occupancy uses the synthetic latencies and the clamped
+		// lifetime sleep (dryRunMaxLifetimeSleep), never the configured
+		// lifetime range; create-only holds the slot for the create alone.
+		occS, known := 0.0, false
+		switch {
+		case cfg.DryRun:
+			occS, known = cfg.DryLatencyMean/1000, true
+			if cfg.Mode == "create-delete" {
+				occS += cfg.DryLatencyMean * 0.4 / 1000
+				if cfg.hasLifetime {
+					occS += min(meanLife, dryRunMaxLifetimeSleep.Seconds())
+				}
 			}
-		} else if est := float64(cfg.Total) * meanLife / float64(cfg.Concurrency); est > 300 {
+		case cfg.hasLifetime && cfg.Mode == "create-delete":
+			// Real create-delete run: create/delete latency is unknown ahead
+			// but the lifetime dominates for any realistic setting.
+			occS, known = meanLife, true
+		}
+		switch {
+		case cfg.Rate > 0 && known:
+			if needed := cfg.Rate * occS; float64(cfg.Concurrency) < needed {
+				fmt.Fprintf(os.Stderr, "WARNING: --concurrency %d is below rate(%g/s) x mean occupancy(%gs) = %.0f; "+
+					"the dispatcher will stall on the semaphore and neither the arrival rate nor queue-delay metrics will be honored\n",
+					cfg.Concurrency, cfg.Rate, occS, needed)
+			}
+		case cfg.Rate > 0:
+			// Real run with the slot held for create(+delete) only: no
+			// occupancy estimate to compute a numeric threshold from, so warn
+			// qualitatively.
+			fmt.Fprintf(os.Stderr, "WARNING: --rate without --lifetime: each worker slot is still occupied for "+
+				"create+delete, so at high rates a low --concurrency stalls the dispatcher and queue-delay "+
+				"metrics measure the client's own semaphore, not the scheduler\n")
+		case !cfg.DryRun && cfg.hasLifetime && cfg.Mode == "create-delete":
 			// ASAP dispatch with lifetimes: every worker slot is held for the
 			// full lifetime, so the run time is bounded below by
 			// total x mean lifetime / concurrency.
-			fmt.Fprintf(os.Stderr, "WARNING: %d requests with mean lifetime %gs at --concurrency %d will take at least ~%.0fs; "+
-				"raise --concurrency or add --rate to pace arrivals\n",
-				cfg.Total, meanLife, cfg.Concurrency, est)
+			if est := float64(cfg.Total) * occS / float64(cfg.Concurrency); est > 300 {
+				fmt.Fprintf(os.Stderr, "WARNING: %d requests with mean lifetime %gs at --concurrency %d will take at least ~%.0fs; "+
+					"raise --concurrency or add --rate to pace arrivals\n",
+					cfg.Total, meanLife, cfg.Concurrency, est)
+			}
 		}
-	}
-	if cfg.Scheduled && cfg.Rate > 0 && !cfg.hasLifetime {
-		// No --lifetime, but a worker slot is still held for create+delete:
-		// at high rates a small -c stalls the dispatcher just the same, and
-		// queue_delay_* then measures the client's own semaphore, not the
-		// scheduler. There is no residence estimate to compute a numeric
-		// threshold from, so warn qualitatively.
-		fmt.Fprintf(os.Stderr, "WARNING: --rate without --lifetime: each worker slot is still occupied for "+
-			"create+delete, so at high rates a low --concurrency stalls the dispatcher and queue-delay "+
-			"metrics measure the client's own semaphore, not the scheduler\n")
 	}
 
 	// Validate host-mount early so the CLI fails fast on bad input while still
@@ -699,6 +720,22 @@ func main() {
 	cfg.elapsed = time.Since(startTime).Seconds()
 
 	RenderReport(allResults, cfg)
+
+	// If queue-delay p95 exceeds the mean inter-arrival time, the dispatcher
+	// fell permanently behind and the offered load degenerated to bursts; the
+	// queue_delay_* metrics then measure the client semaphore, not the
+	// scheduler. Surface that instead of letting the numbers read as a valid
+	// scheduled-mode run.
+	if cfg.Scheduled && cfg.Rate > 0 {
+		if delays := extractTimes(allResults, func(r IterResult) float64 { return r.SchedDelayMs }); len(delays) > 0 {
+			if p95, interArrival := Percentile(delays, 95), 1000/cfg.Rate; p95 > interArrival {
+				fmt.Fprintf(os.Stderr, "WARNING: queue-delay p95 (%.0fms) exceeded the mean inter-arrival time (%.0fms): "+
+					"the dispatcher fell permanently behind and the offered load degenerated to bursts — "+
+					"queue_delay_*/dispatch metrics measure the client's semaphore, not the scheduler. Raise --concurrency.\n",
+					p95, interArrival)
+			}
+		}
+	}
 
 	if cfg.Output != "" {
 		exportJSON(allResults, cfg)

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -558,11 +558,6 @@ func exportJSON(results []IterResult, cfg *Config) {
 		configBlock["rate_per_sec"] = cfg.Rate
 		configBlock["lifetime_min_s"] = cfg.LifetimeMin
 		configBlock["lifetime_max_s"] = cfg.LifetimeMax
-		// Machine-readable dry-run marker: a scheduled dry-run shares rate/
-		// lifetime/concurrency/templates/seed with a real run of the same
-		// flags, so without this key compare cannot tell simulated latencies
-		// from measured ones.
-		configBlock["dry_run"] = cfg.DryRun
 		templates := make([]map[string]interface{}, len(cfg.Templates))
 		for i, t := range cfg.Templates {
 			templates[i] = map[string]interface{}{
@@ -573,6 +568,16 @@ func exportJSON(results []IterResult, cfg *Config) {
 			}
 		}
 		configBlock["templates"] = templates
+	}
+	if cfg.Scheduled || cfg.DryRun {
+		// Machine-readable dry-run marker: a dry-run shares rate/lifetime/
+		// concurrency/templates/seed (scheduled) or template/concurrency/
+		// total (legacy) with a real run of the same flags, so without this
+		// key compare cannot tell simulated latencies from measured ones.
+		// Legacy real runs keep the exact pre-scheduled export shape (no new
+		// key); legacy dry-runs opt into the marker so compare's warning
+		// fires for them too.
+		configBlock["dry_run"] = cfg.DryRun
 	}
 
 	summaryBlock := map[string]interface{}{

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -558,6 +558,11 @@ func exportJSON(results []IterResult, cfg *Config) {
 		configBlock["rate_per_sec"] = cfg.Rate
 		configBlock["lifetime_min_s"] = cfg.LifetimeMin
 		configBlock["lifetime_max_s"] = cfg.LifetimeMax
+		// Machine-readable dry-run marker: a scheduled dry-run shares rate/
+		// lifetime/concurrency/templates/seed with a real run of the same
+		// flags, so without this key compare cannot tell simulated latencies
+		// from measured ones.
+		configBlock["dry_run"] = cfg.DryRun
 		templates := make([]map[string]interface{}, len(cfg.Templates))
 		for i, t := range cfg.Templates {
 			templates[i] = map[string]interface{}{

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -299,10 +299,15 @@ func parseConfig() *Config {
 					occS += min(meanLife, dryRunMaxLifetimeSleep.Seconds())
 				}
 			}
-		case cfg.hasLifetime && cfg.Mode == "create-delete":
+		case cfg.hasLifetime && cfg.Mode == "create-delete" && meanLife >= 1:
 			// Real create-delete run: create/delete latency is unknown ahead
 			// but the lifetime dominates for any realistic setting.
 			occS, known = meanLife, true
+		case cfg.hasLifetime && cfg.Mode == "create-delete":
+			// Sub-second mean lifetime: the unknown create/delete tail is
+			// comparable to the hold (see README), so a precise-looking
+			// rate x lifetime threshold would understate the real slot
+			// requirement. Fall through to the qualitative warning.
 		}
 		switch {
 		case cfg.Rate > 0 && known:
@@ -312,12 +317,15 @@ func parseConfig() *Config {
 					cfg.Concurrency, cfg.Rate, occS, needed)
 			}
 		case cfg.Rate > 0:
-			// Real run with the slot held for create(+delete) only: no
-			// occupancy estimate to compute a numeric threshold from, so warn
-			// qualitatively.
-			fmt.Fprintf(os.Stderr, "WARNING: --rate without --lifetime: each worker slot is still occupied for "+
-				"create+delete, so at high rates a low --concurrency stalls the dispatcher and queue-delay "+
-				"metrics measure the client's own semaphore, not the scheduler\n")
+			// No reliable occupancy estimate (no lifetime hold, or a
+			// sub-second lifetime whose create/delete tail is comparable):
+			// warn qualitatively instead of printing a precise-looking
+			// threshold.
+			fmt.Fprintf(os.Stderr, "WARNING: at --rate %g/s each worker slot is held for a request's whole residency "+
+				"(create, any lifetime hold, delete), so a low --concurrency (%d) stalls the dispatcher and "+
+				"queue-delay metrics then measure the client's own semaphore, not the scheduler. "+
+				"Raise --concurrency towards rate x mean residency.\n",
+				cfg.Rate, cfg.Concurrency)
 		case !cfg.DryRun && cfg.hasLifetime && cfg.Mode == "create-delete":
 			// ASAP dispatch with lifetimes: every worker slot is held for the
 			// full lifetime, so the run time is bounded below by

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -63,6 +63,9 @@ type Config struct {
 	sequence     []ScheduledRequest
 
 	elapsed float64
+	// dispatchElapsed is the wall-clock span of the scheduled dispatch loop
+	// (first to last request release), excluding per-sandbox lifetime tails.
+	dispatchElapsed float64
 }
 
 type createRequest struct {
@@ -476,6 +479,14 @@ func exportJSON(results []IterResult, cfg *Config) {
 		"throughput_qps": throughput,
 	}
 	if cfg.Scheduled {
+		// Dispatch-side throughput: requests released per second of the
+		// dispatch window. Unlike throughput_qps (total requests over the
+		// whole run), this excludes per-sandbox lifetime tails, so it
+		// reflects the arrival rate the scheduler actually saw.
+		if cfg.dispatchElapsed > 0 {
+			summaryBlock["dispatch_window_s"] = cfg.dispatchElapsed
+			summaryBlock["dispatch_qps"] = float64(len(results)) / cfg.dispatchElapsed
+		}
 		// Queue delay is measured per dispatched request, independent of
 		// create success, so it uses all results.
 		delays := extractTimes(results, func(r IterResult) float64 { return r.SchedDelayMs })

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -743,8 +743,13 @@ func main() {
 
 	startTime := time.Now()
 
+	// stopAsked ends scheduled dispatch when the operator quits the TUI early,
+	// so the client stops releasing new sandboxes against a cluster whose run
+	// has been abandoned (released ones still finish their cycle; the
+	// per-request server-side timeout is the backstop).
+	stopAsked := make(chan struct{})
 	if cfg.Scheduled {
-		go RunScheduled(cfg, sched, resultCh, client)
+		go RunScheduled(cfg, sched, resultCh, client, stopAsked)
 	} else {
 		go RunBenchmark(cfg, resultCh, client)
 	}
@@ -763,6 +768,24 @@ func main() {
 		}
 		fm := finalModel.(model)
 		allResults = fm.results
+		if cfg.Scheduled {
+			close(stopAsked)
+			// Pull in results that completed but sat unread in the buffer when
+			// the TUI stopped consuming, so a truncated sample covers
+			// everything finished by quit time.
+		drain:
+			for {
+				select {
+				case r, ok := <-resultCh:
+					if !ok {
+						break drain
+					}
+					allResults = append(allResults, r)
+				default:
+					break drain
+				}
+			}
+		}
 	}
 
 	cfg.elapsed = time.Since(startTime).Seconds()
@@ -773,7 +796,7 @@ func main() {
 	// report so its numbers are not read as a finished run.
 	partial := runTruncated(allResults, cfg)
 	if partial {
-		fmt.Fprintf(os.Stderr, "NOTE: run quit early with %d of %d requests dispatched; "+
+		fmt.Fprintf(os.Stderr, "NOTE: run quit early with %d of %d requests completed; "+
 			"the report above and any exported aggregates cover a truncated sample.\n",
 			len(allResults), cfg.Total)
 	}

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -765,6 +765,15 @@ func main() {
 
 	RenderReport(allResults, cfg)
 
+	// An early TUI quit truncates the sample: say so next to the on-screen
+	// report so its numbers are not read as a finished run.
+	partial := cfg.Total > 0 && len(allResults) < cfg.Total
+	if partial {
+		fmt.Fprintf(os.Stderr, "NOTE: run quit early with %d of %d requests dispatched; "+
+			"the report above and any exported aggregates cover a truncated sample.\n",
+			len(allResults), cfg.Total)
+	}
+
 	// If queue-delay p95 exceeds the mean inter-arrival time, the dispatcher
 	// fell permanently behind and the offered load degenerated to bursts; the
 	// queue_delay_* metrics then measure the client semaphore, not the
@@ -772,7 +781,6 @@ func main() {
 	// scheduled-mode run; exportJSON marks the report machine-readably.
 	// Skipped on an early-quit truncated sample — the p95 would describe the
 	// partial run, and the export carries a "partial" marker instead.
-	partial := cfg.Total > 0 && len(allResults) < cfg.Total
 	if sat, p95, interArrival := dispatchSaturated(allResults, cfg); sat && !partial {
 		fmt.Fprintf(os.Stderr, "WARNING: queue-delay p95 (%.0fms) exceeded the mean inter-arrival time (%.0fms): "+
 			"the dispatcher fell permanently behind and the offered load degenerated to bursts — "+

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -255,6 +255,19 @@ func parseConfig() *Config {
 		cfg.Total = 1
 	}
 
+	// A worker slot is held for the full sandbox lifetime, so the dispatcher
+	// can only honor the requested Poisson rate when concurrency >= rate x
+	// mean lifetime; otherwise queue delays measure the client's own
+	// concurrency limit, not the scheduler. Warn loudly (presets included).
+	if cfg.Scheduled && cfg.Rate > 0 && cfg.hasLifetime {
+		meanLife := (cfg.LifetimeMin + cfg.LifetimeMax) / 2
+		if needed := cfg.Rate * meanLife; float64(cfg.Concurrency) < needed {
+			fmt.Fprintf(os.Stderr, "WARNING: --concurrency %d is below rate(%g/s) x mean lifetime(%gs) = %.0f; "+
+				"the dispatcher will stall on the semaphore and neither the arrival rate nor queue-delay metrics will be honored\n",
+				cfg.Concurrency, cfg.Rate, meanLife, needed)
+		}
+	}
+
 	// Validate host-mount early so the CLI fails fast on bad input while still
 	// preserving the original JSON for config display and exported reports.
 	// Cache the compacted JSON string once so benchmark throughput is not

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -320,11 +320,12 @@ func parseConfig() *Config {
 			// No reliable occupancy estimate (no lifetime hold, or a
 			// sub-second lifetime whose create/delete tail is comparable):
 			// warn qualitatively instead of printing a precise-looking
-			// threshold.
-			fmt.Fprintf(os.Stderr, "WARNING: at --rate %g/s each worker slot is held for a request's whole residency "+
-				"(create, any lifetime hold, delete), so a low --concurrency (%d) stalls the dispatcher and "+
-				"queue-delay metrics then measure the client's own semaphore, not the scheduler. "+
-				"Raise --concurrency towards rate x mean residency.\n",
+			// threshold. Worded as a caution: plenty of rate-paced runs
+			// without a lifetime hold are perfectly healthy.
+			fmt.Fprintf(os.Stderr, "NOTE: at --rate %g/s each worker slot is held for a request's whole residency "+
+				"(create, any lifetime hold, delete). If --concurrency (%d) is low relative to rate x mean "+
+				"residency, the dispatcher stalls and queue-delay metrics then measure the client's own "+
+				"semaphore, not the scheduler; the end-of-run saturation check will say if that happened.\n",
 				cfg.Rate, cfg.Concurrency)
 		case !cfg.DryRun && cfg.hasLifetime && cfg.Mode == "create-delete":
 			// ASAP dispatch with lifetimes: every worker slot is held for the
@@ -754,7 +755,9 @@ func main() {
 	if sat, p95, interArrival := dispatchSaturated(allResults, cfg); sat {
 		fmt.Fprintf(os.Stderr, "WARNING: queue-delay p95 (%.0fms) exceeded the mean inter-arrival time (%.0fms): "+
 			"the dispatcher fell permanently behind and the offered load degenerated to bursts — "+
-			"queue_delay_*/dispatch metrics measure the client's semaphore, not the scheduler. Raise --concurrency.\n",
+			"queue_delay_*/dispatch metrics no longer describe the offered schedule. Either --concurrency is too "+
+			"low for the offered rate (each slot is held for create+lifetime+delete) or create latency blew up "+
+			"server-side — check create.p95 before raising --concurrency.\n",
 			p95, interArrival)
 	}
 

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -316,12 +316,14 @@ func parseConfig() *Config {
 					"the dispatcher will stall on the semaphore and neither the arrival rate nor queue-delay metrics will be honored\n",
 					cfg.Concurrency, cfg.Rate, occS, needed)
 			}
-		case cfg.Rate > 0:
+		case cfg.Rate > 0 && cfg.Mode == "create-delete":
 			// No reliable occupancy estimate (no lifetime hold, or a
 			// sub-second lifetime whose create/delete tail is comparable):
 			// warn qualitatively instead of printing a precise-looking
 			// threshold. Worded as a caution: plenty of rate-paced runs
-			// without a lifetime hold are perfectly healthy.
+			// without a lifetime hold are perfectly healthy. Create-only
+			// runs hold a slot only for the create call and get no note;
+			// the end-of-run saturation check covers the stall case.
 			fmt.Fprintf(os.Stderr, "NOTE: at --rate %g/s each worker slot is held for a request's whole residency "+
 				"(create, any lifetime hold, delete). If --concurrency (%d) is low relative to rate x mean "+
 				"residency, the dispatcher stalls and queue-delay metrics then measure the client's own "+
@@ -356,8 +358,9 @@ func parseConfig() *Config {
 	cfg.hostMountValue = hostMountValue
 	cfg.requestHeaders = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
 
-	// In scheduled mode without -t the pool drives per-request bodies; the
-	// cached body (warmup/fallback) then uses the first pool template.
+	// In scheduled mode the pool drives per-request bodies; the cached body
+	// (warmup/fallback) uses -t / CUBE_TEMPLATE_ID when set and only falls
+	// back to the first pool template when neither is given.
 	bodyTemplate := cfg.Template
 	if bodyTemplate == "" && len(cfg.Templates) > 0 {
 		bodyTemplate = cfg.Templates[0].TemplateID
@@ -561,6 +564,14 @@ func exportJSON(results []IterResult, cfg *Config) {
 		"throughput_qps": throughput,
 	}
 	if cfg.Scheduled {
+		// An early TUI quit exports a truncated sample: mark it so partial
+		// dispatch_*/queue_delay_* aggregates are not misread as run
+		// characteristics (compare pops the marker and notes the group),
+		// and skip the saturation marker whose own sample is truncated.
+		partial := cfg.Total > 0 && len(results) < cfg.Total
+		if partial {
+			summaryBlock["partial"] = 1
+		}
 		// Dispatch-side throughput: requests released per second of the
 		// dispatch window. Unlike throughput_qps (total requests over the
 		// whole run), this excludes per-sandbox lifetime tails, so it
@@ -584,8 +595,10 @@ func exportJSON(results []IterResult, cfg *Config) {
 		// queue_delay_*/dispatch_* keys above describe the client's
 		// semaphore, not the offered schedule. compare surfaces this as a
 		// warning instead of a metric row.
-		if sat, _, _ := dispatchSaturated(results, cfg); sat {
-			summaryBlock["dispatch_saturated"] = 1
+		if !partial {
+			if sat, _, _ := dispatchSaturated(results, cfg); sat {
+				summaryBlock["dispatch_saturated"] = 1
+			}
 		}
 		type tplAgg struct{ attempts, created int }
 		agg := map[string]*tplAgg{}
@@ -757,7 +770,10 @@ func main() {
 	// queue_delay_* metrics then measure the client semaphore, not the
 	// scheduler. Surface that instead of letting the numbers read as a valid
 	// scheduled-mode run; exportJSON marks the report machine-readably.
-	if sat, p95, interArrival := dispatchSaturated(allResults, cfg); sat {
+	// Skipped on an early-quit truncated sample — the p95 would describe the
+	// partial run, and the export carries a "partial" marker instead.
+	partial := cfg.Total > 0 && len(allResults) < cfg.Total
+	if sat, p95, interArrival := dispatchSaturated(allResults, cfg); sat && !partial {
 		fmt.Fprintf(os.Stderr, "WARNING: queue-delay p95 (%.0fms) exceeded the mean inter-arrival time (%.0fms): "+
 			"the dispatcher fell permanently behind and the offered load degenerated to bursts — "+
 			"queue_delay_*/dispatch metrics no longer describe the offered schedule. Either --concurrency is too "+

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -298,6 +298,16 @@ func parseConfig() *Config {
 				cfg.Total, meanLife, cfg.Concurrency, est)
 		}
 	}
+	if cfg.Scheduled && cfg.Rate > 0 && !cfg.hasLifetime {
+		// No --lifetime, but a worker slot is still held for create+delete:
+		// at high rates a small -c stalls the dispatcher just the same, and
+		// queue_delay_* then measures the client's own semaphore, not the
+		// scheduler. There is no residence estimate to compute a numeric
+		// threshold from, so warn qualitatively.
+		fmt.Fprintf(os.Stderr, "WARNING: --rate without --lifetime: each worker slot is still occupied for "+
+			"create+delete, so at high rates a low --concurrency stalls the dispatcher and queue-delay "+
+			"metrics measure the client's own semaphore, not the scheduler\n")
+	}
 
 	// Validate host-mount early so the CLI fails fast on bad input while still
 	// preserving the original JSON for config display and exported reports.

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -582,8 +582,12 @@ func exportJSON(results []IterResult, cfg *Config) {
 		// whole run), this excludes per-sandbox lifetime tails, so it
 		// reflects the arrival rate the scheduler actually saw. Only
 		// meaningful for rate-paced runs: without --rate the "window" is
-		// just the client's release burst, so the keys are omitted.
-		if de := cfg.getDispatchElapsed(); cfg.Rate > 0 && de > 0 {
+		// just the client's release burst, so the keys are omitted. Skipped
+		// on partial runs too: the drained result count undercounts released
+		// requests and the dispatch-elapsed publish races the export, so the
+		// pair would be nondeterministic (compare strips dispatch_* for
+		// partial groups anyway).
+		if de := cfg.getDispatchElapsed(); cfg.Rate > 0 && de > 0 && !partial {
 			summaryBlock["dispatch_window_s"] = de
 			summaryBlock["dispatch_qps"] = float64(len(results)) / de
 		}

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -567,15 +567,16 @@ func exportJSON(results []IterResult, cfg *Config) {
 		"success_rate":   successRate,
 		"throughput_qps": throughput,
 	}
+	// An early TUI quit exports a truncated sample: mark it so partial
+	// aggregates are not misread as run characteristics (compare pops the
+	// marker and notes the group). This applies to legacy runs too — the
+	// console note prints for both modes, so the export must not disagree.
+	partial := runTruncated(results, cfg)
+	if partial {
+		summaryBlock["partial"] = 1
+	}
 	if cfg.Scheduled {
-		// An early TUI quit exports a truncated sample: mark it so partial
-		// dispatch_*/queue_delay_* aggregates are not misread as run
-		// characteristics (compare pops the marker and notes the group),
-		// and skip the saturation marker whose own sample is truncated.
-		partial := runTruncated(results, cfg)
-		if partial {
-			summaryBlock["partial"] = 1
-		}
+		// Skip the saturation marker whose own sample is truncated.
 		// Dispatch-side throughput: requests released per second of the
 		// dispatch window. Unlike throughput_qps (total requests over the
 		// whole run), this excludes per-sandbox lifetime tails, so it
@@ -745,8 +746,9 @@ func main() {
 
 	// stopAsked ends scheduled dispatch when the operator quits the TUI early,
 	// so the client stops releasing new sandboxes against a cluster whose run
-	// has been abandoned (released ones still finish their cycle; the
-	// per-request server-side timeout is the backstop).
+	// has been abandoned. Released requests are best-effort: the process does
+	// not wait for them after a quit, and the per-request server-side timeout
+	// (set only with --lifetime) is the backstop for anything abandoned.
 	stopAsked := make(chan struct{})
 	if cfg.Scheduled {
 		go RunScheduled(cfg, sched, resultCh, client, stopAsked)
@@ -771,8 +773,8 @@ func main() {
 		if cfg.Scheduled {
 			close(stopAsked)
 			// Pull in results that completed but sat unread in the buffer when
-			// the TUI stopped consuming, so a truncated sample covers
-			// everything finished by quit time.
+			// the TUI stopped consuming. Best effort: results still in flight
+			// at this instant are simply absent from the truncated sample.
 		drain:
 			for {
 				select {

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -452,6 +452,35 @@ func TestExportJSONPartialMarked(t *testing.T) {
 	}
 }
 
+func TestExportJSONLegacyPartialMarked(t *testing.T) {
+	// The truncation note prints for legacy runs too, so a truncated legacy
+	// export must carry the same marker instead of looking like a finished
+	// run to downstream consumers (compare pops it generically).
+	cfg := &Config{
+		Template:       "tpl-a",
+		Mode:           "create-delete",
+		Total:          5,
+		requestHeaders: map[string]string{},
+		elapsed:        5,
+	}
+	cfg.Output = t.TempDir() + "/report.json"
+
+	exportJSON([]IterResult{{Seq: 1, CreateMs: 100, DeleteMs: 40}}, cfg)
+
+	data, err := os.ReadFile(cfg.Output)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	summary := report["summary"].(map[string]any)
+	if got := summary["partial"]; got != float64(1) {
+		t.Fatalf("partial = %v, want 1", got)
+	}
+}
+
 func TestDispatchSaturated(t *testing.T) {
 	cfg, results := scheduledExportFixture()
 

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -436,3 +436,20 @@ func TestDispatchSaturated(t *testing.T) {
 		t.Errorf("saturated=%v p95=%v inter-arrival=%v, want saturated with p95 > inter-arrival", sat, p95, ia)
 	}
 }
+
+func TestDispatchSaturatedToleratesTransient(t *testing.T) {
+	cfg, _ := scheduledExportFixture() // rate 50/s -> 20ms inter-arrival
+	// 100 requests: 4 delayed far past the inter-arrival gap (a transient
+	// burst), the rest on time. p95 must stay under the gap, so the
+	// whole-run saturation marker stays off.
+	results := make([]IterResult, 100)
+	for i := range results {
+		results[i] = IterResult{Seq: i, SchedDelayMs: 1}
+	}
+	for _, i := range []int{10, 30, 60, 85} {
+		results[i].SchedDelayMs = 500
+	}
+	if sat, p95, ia := dispatchSaturated(results, cfg); sat {
+		t.Errorf("transient burst tripped the saturation marker (p95=%v, inter-arrival=%v)", p95, ia)
+	}
+}

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 )
 
@@ -177,5 +178,171 @@ func TestBuildCreateRequestBodyRulesKeepsHostMount(t *testing.T) {
 	}
 	if body.Network == nil {
 		t.Fatal("network missing when host-mount is set")
+	}
+}
+
+func TestBuildCreateRequestBodyWithTimeout(t *testing.T) {
+	timeout := int64(70)
+	raw, err := buildCreateRequestBodyWithTimeout("tpl-ttl", "", networkPolicyNone, &timeout)
+	if err != nil {
+		t.Fatalf("buildCreateRequestBodyWithTimeout: %v", err)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if string(body["timeout"]) != "70" {
+		t.Fatalf("timeout = %s, want 70", body["timeout"])
+	}
+	if string(body["templateID"]) != `"tpl-ttl"` {
+		t.Fatalf("templateID = %s, want tpl-ttl", body["templateID"])
+	}
+
+	// nil timeout must omit the field entirely (legacy behavior).
+	raw, err = buildCreateRequestBody("tpl-legacy", "", networkPolicyNone)
+	if err != nil {
+		t.Fatalf("buildCreateRequestBody: %v", err)
+	}
+	var legacy map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &legacy); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := legacy["timeout"]; ok {
+		t.Fatalf("legacy body must omit timeout, got %s", legacy["timeout"])
+	}
+}
+
+func scheduledExportFixture() (*Config, []IterResult) {
+	cfg := &Config{
+		Template:       "tpl-a",
+		Mode:           "create-delete",
+		Seed:           42,
+		Workload:       "burst",
+		Rate:           50,
+		hasLifetime:    true,
+		LifetimeMin:    10,
+		LifetimeMax:    120,
+		Scheduled:      true,
+		Templates:      []TemplateSpec{{TemplateID: "tpl-a", Weight: 1, CpuMillis: 1000, MemMiB: 2048}},
+		requestHeaders: map[string]string{},
+		elapsed:        12.5,
+	}
+	results := []IterResult{
+		{Seq: 0, CreateMs: 100, DeleteMs: 40, TemplateID: "tpl-a", ScheduledArrivalMs: 0, ActualStartMs: 1, SchedDelayMs: 1, LifetimeMs: 53210},
+		{Seq: 1, CreateMs: 120, DeleteMs: 41, TemplateID: "tpl-a", ScheduledArrivalMs: 20, ActualStartMs: 23, SchedDelayMs: 3, LifetimeMs: 61000},
+		{Seq: 2, CreateMs: 0, Err: "boom", TemplateID: "tpl-a", ScheduledArrivalMs: 40, ActualStartMs: 45, SchedDelayMs: 5, LifetimeMs: 70000},
+	}
+	return cfg, results
+}
+
+func TestExportJSONScheduledAddsKeys(t *testing.T) {
+	cfg, results := scheduledExportFixture()
+	cfg.Output = t.TempDir() + "/report.json"
+
+	exportJSON(results, cfg)
+
+	data, err := os.ReadFile(cfg.Output)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	config := report["config"].(map[string]any)
+	if config["workload"] != "burst" {
+		t.Fatalf("config.workload = %v", config["workload"])
+	}
+	if config["seed"].(float64) != 42 || config["rate_per_sec"].(float64) != 50 {
+		t.Fatalf("config seed/rate = %v/%v", config["seed"], config["rate_per_sec"])
+	}
+	if config["lifetime_min_s"].(float64) != 10 || config["lifetime_max_s"].(float64) != 120 {
+		t.Fatalf("config lifetime = %v/%v", config["lifetime_min_s"], config["lifetime_max_s"])
+	}
+	templates := config["templates"].([]any)
+	if len(templates) != 1 {
+		t.Fatalf("config.templates len = %d", len(templates))
+	}
+	tpl := templates[0].(map[string]any)
+	if tpl["template_id"] != "tpl-a" || tpl["weight"].(float64) != 1 || tpl["cpu_millis"].(float64) != 1000 || tpl["mem_mib"].(float64) != 2048 {
+		t.Fatalf("config.templates[0] = %v", tpl)
+	}
+
+	summary := report["summary"].(map[string]any)
+	// Legacy keys must remain.
+	for _, key := range []string{"total_time_s", "successful", "errors", "success_rate", "throughput_qps"} {
+		if _, ok := summary[key]; !ok {
+			t.Fatalf("summary missing legacy key %q", key)
+		}
+	}
+	for _, key := range []string{"queue_delay_p50_ms", "queue_delay_p95_ms", "queue_delay_p99_ms"} {
+		if _, ok := summary[key]; !ok {
+			t.Fatalf("summary missing key %q", key)
+		}
+	}
+	if summary["queue_delay_p50_ms"].(float64) != 3 {
+		t.Fatalf("queue_delay_p50_ms = %v, want 3", summary["queue_delay_p50_ms"])
+	}
+	perTemplate := summary["per_template"].(map[string]any)
+	agg := perTemplate["tpl-a"].(map[string]any)
+	if agg["attempts"].(float64) != 3 || agg["created"].(float64) != 2 {
+		t.Fatalf("per_template tpl-a = %v", agg)
+	}
+	if got := agg["success_rate"].(float64); got < 0.66 || got > 0.67 {
+		t.Fatalf("per_template success_rate = %v, want ~0.667", got)
+	}
+
+	raw := report["raw"].([]any)
+	first := raw[0].(map[string]any)
+	for _, key := range []string{"template_id", "scheduled_arrival_ms", "actual_start_ms", "sched_delay_ms", "lifetime_ms"} {
+		if _, ok := first[key]; !ok {
+			t.Fatalf("raw[0] missing key %q", key)
+		}
+	}
+	if first["template_id"] != "tpl-a" || first["lifetime_ms"].(float64) != 53210 {
+		t.Fatalf("raw[0] = %v", first)
+	}
+}
+
+func TestExportJSONLegacyOmitsScheduledKeys(t *testing.T) {
+	cfg := &Config{
+		Template:       "tpl-a",
+		Mode:           "create-delete",
+		requestHeaders: map[string]string{},
+		elapsed:        5,
+	}
+	cfg.Output = t.TempDir() + "/report.json"
+	results := []IterResult{{Seq: 1, CreateMs: 100, DeleteMs: 40}}
+
+	exportJSON(results, cfg)
+
+	data, err := os.ReadFile(cfg.Output)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	config := report["config"].(map[string]any)
+	for _, key := range []string{"workload", "seed", "rate_per_sec", "lifetime_min_s", "lifetime_max_s", "templates"} {
+		if _, ok := config[key]; ok {
+			t.Fatalf("legacy config must not contain %q", key)
+		}
+	}
+	summary := report["summary"].(map[string]any)
+	for _, key := range []string{"queue_delay_p50_ms", "queue_delay_p95_ms", "queue_delay_p99_ms", "per_template"} {
+		if _, ok := summary[key]; ok {
+			t.Fatalf("legacy summary must not contain %q", key)
+		}
+	}
+	raw := report["raw"].([]any)
+	first := raw[0].(map[string]any)
+	for _, key := range []string{"template_id", "scheduled_arrival_ms", "actual_start_ms", "sched_delay_ms", "lifetime_ms"} {
+		if _, ok := first[key]; ok {
+			t.Fatalf("legacy raw[0] must not contain %q", key)
+		}
 	}
 }

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -391,6 +391,12 @@ func TestExportJSONSaturatedMarked(t *testing.T) {
 	cfg.setDispatchElapsed(2.5)
 	// p95 100ms against a 20ms inter-arrival (50/s): the dispatcher fell
 	// permanently behind, so the export must carry the saturation marker.
+	// Pad to the marker's minimum sample size (below it p95 == max and the
+	// check stays silent by design).
+	for len(results) < 20 {
+		results = append(results, results[len(results)-1])
+	}
+	cfg.Total = len(results)
 	for i := range results {
 		results[i].SchedDelayMs = 100
 	}
@@ -410,6 +416,40 @@ func TestExportJSONSaturatedMarked(t *testing.T) {
 	if got := summary["dispatch_saturated"]; got != float64(1) {
 		t.Fatalf("dispatch_saturated = %v, want 1", got)
 	}
+	if _, ok := summary["partial"]; ok {
+		t.Fatalf("complete run must not set partial")
+	}
+}
+
+func TestExportJSONPartialMarked(t *testing.T) {
+	cfg, results := scheduledExportFixture()
+	cfg.setDispatchElapsed(2.5)
+	// Early TUI quit: fewer results than requested. Even with delays that
+	// would trip the saturation marker on a complete run, the export must
+	// carry "partial" and suppress the saturation marker.
+	cfg.Total = len(results) + 5
+	for i := range results {
+		results[i].SchedDelayMs = 100
+	}
+	cfg.Output = t.TempDir() + "/report.json"
+
+	exportJSON(results, cfg)
+
+	data, err := os.ReadFile(cfg.Output)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	summary := report["summary"].(map[string]any)
+	if got := summary["partial"]; got != float64(1) {
+		t.Fatalf("partial = %v, want 1", got)
+	}
+	if _, ok := summary["dispatch_saturated"]; ok {
+		t.Fatalf("partial run must not set dispatch_saturated")
+	}
 }
 
 func TestDispatchSaturated(t *testing.T) {
@@ -428,10 +468,21 @@ func TestDispatchSaturated(t *testing.T) {
 	if sat, p95, ia := dispatchSaturated(results, cfg); sat {
 		t.Errorf("fixture delays (p95 %v vs inter-arrival %v) reported saturated", p95, ia)
 	}
+	// Below the minimum sample size the check stays silent even when every
+	// request stalled: with n < 20 the p95 IS the maximum delay, so a single
+	// hiccup would otherwise trip the marker.
 	for i := range results {
 		results[i].SchedDelayMs = 100
 	}
-	sat, p95, ia := dispatchSaturated(results, cfg)
+	if sat, _, _ := dispatchSaturated(results, cfg); sat {
+		t.Errorf("small sample (n=%d) reported saturated", len(results))
+	}
+
+	big := make([]IterResult, 20)
+	for i := range big {
+		big[i] = IterResult{Seq: i, SchedDelayMs: 100}
+	}
+	sat, p95, ia := dispatchSaturated(big, cfg)
 	if !sat || p95 <= ia {
 		t.Errorf("saturated=%v p95=%v inter-arrival=%v, want saturated with p95 > inter-arrival", sat, p95, ia)
 	}

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -237,7 +237,7 @@ func scheduledExportFixture() (*Config, []IterResult) {
 
 func TestExportJSONScheduledAddsKeys(t *testing.T) {
 	cfg, results := scheduledExportFixture()
-	cfg.dispatchElapsed = 2.5
+	cfg.setDispatchElapsed(2.5)
 	cfg.Output = t.TempDir() + "/report.json"
 
 	exportJSON(results, cfg)
@@ -357,7 +357,7 @@ func TestExportJSONLegacyOmitsScheduledKeys(t *testing.T) {
 func TestExportJSONScheduledASAPOmitsDispatchKeys(t *testing.T) {
 	cfg, results := scheduledExportFixture()
 	cfg.Rate = 0 // ASAP dispatch: no arrival pacing, dispatch window is meaningless
-	cfg.dispatchElapsed = 0.01
+	cfg.setDispatchElapsed(0.01)
 	cfg.Output = t.TempDir() + "/report.json"
 
 	exportJSON(results, cfg)

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -237,6 +237,7 @@ func scheduledExportFixture() (*Config, []IterResult) {
 
 func TestExportJSONScheduledAddsKeys(t *testing.T) {
 	cfg, results := scheduledExportFixture()
+	cfg.dispatchElapsed = 2.5
 	cfg.Output = t.TempDir() + "/report.json"
 
 	exportJSON(results, cfg)
@@ -276,10 +277,16 @@ func TestExportJSONScheduledAddsKeys(t *testing.T) {
 			t.Fatalf("summary missing legacy key %q", key)
 		}
 	}
-	for _, key := range []string{"queue_delay_p50_ms", "queue_delay_p95_ms", "queue_delay_p99_ms"} {
+	for _, key := range []string{"queue_delay_p50_ms", "queue_delay_p95_ms", "queue_delay_p99_ms", "dispatch_window_s", "dispatch_qps"} {
 		if _, ok := summary[key]; !ok {
 			t.Fatalf("summary missing key %q", key)
 		}
+	}
+	if summary["dispatch_window_s"].(float64) != 2.5 {
+		t.Fatalf("dispatch_window_s = %v, want 2.5", summary["dispatch_window_s"])
+	}
+	if got := summary["dispatch_qps"].(float64); got != 1.2 {
+		t.Fatalf("dispatch_qps = %v, want 1.2 (3 requests / 2.5s)", got)
 	}
 	if summary["queue_delay_p50_ms"].(float64) != 3 {
 		t.Fatalf("queue_delay_p50_ms = %v, want 3", summary["queue_delay_p50_ms"])
@@ -333,7 +340,7 @@ func TestExportJSONLegacyOmitsScheduledKeys(t *testing.T) {
 		}
 	}
 	summary := report["summary"].(map[string]any)
-	for _, key := range []string{"queue_delay_p50_ms", "queue_delay_p95_ms", "queue_delay_p99_ms", "per_template"} {
+	for _, key := range []string{"queue_delay_p50_ms", "queue_delay_p95_ms", "queue_delay_p99_ms", "per_template", "dispatch_window_s", "dispatch_qps"} {
 		if _, ok := summary[key]; ok {
 			t.Fatalf("legacy summary must not contain %q", key)
 		}

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -356,6 +356,44 @@ func TestExportJSONLegacyOmitsScheduledKeys(t *testing.T) {
 			t.Fatalf("legacy raw[0] must not contain %q", key)
 		}
 	}
+	// A legacy real run keeps the exact pre-scheduled shape: no dry_run key.
+	if _, ok := config["dry_run"]; ok {
+		t.Fatalf("legacy non-dry-run config must not contain %q", "dry_run")
+	}
+}
+
+// TestExportJSONLegacyDryRunMarked: a legacy dry-run export opts into the
+// machine-readable dry_run marker so compare's synthesized-latency warning
+// fires for it too.
+func TestExportJSONLegacyDryRunMarked(t *testing.T) {
+	cfg := &Config{
+		Template:       "tpl-a",
+		Mode:           "create-delete",
+		DryRun:         true,
+		requestHeaders: map[string]string{},
+		elapsed:        5,
+	}
+	cfg.Output = t.TempDir() + "/report.json"
+	results := []IterResult{{Seq: 1, CreateMs: 100, DeleteMs: 40}}
+
+	exportJSON(results, cfg)
+
+	data, err := os.ReadFile(cfg.Output)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	config := report["config"].(map[string]any)
+	if config["dry_run"] != true {
+		t.Fatalf("legacy dry-run config dry_run = %v, want true", config["dry_run"])
+	}
+	// The rest of the legacy shape is untouched.
+	if _, ok := config["workload"]; ok {
+		t.Fatalf("legacy dry-run config must not contain %q", "workload")
+	}
 }
 
 func TestExportJSONScheduledASAPOmitsDispatchKeys(t *testing.T) {

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -353,3 +353,31 @@ func TestExportJSONLegacyOmitsScheduledKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestExportJSONScheduledASAPOmitsDispatchKeys(t *testing.T) {
+	cfg, results := scheduledExportFixture()
+	cfg.Rate = 0 // ASAP dispatch: no arrival pacing, dispatch window is meaningless
+	cfg.dispatchElapsed = 0.01
+	cfg.Output = t.TempDir() + "/report.json"
+
+	exportJSON(results, cfg)
+
+	data, err := os.ReadFile(cfg.Output)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	summary := report["summary"].(map[string]any)
+	for _, key := range []string{"dispatch_window_s", "dispatch_qps"} {
+		if _, ok := summary[key]; ok {
+			t.Fatalf("unpaced scheduled summary must not contain %q", key)
+		}
+	}
+	// Queue-delay keys are still meaningful without pacing.
+	if _, ok := summary["queue_delay_p50_ms"]; !ok {
+		t.Fatalf("summary missing key %q", "queue_delay_p50_ms")
+	}
+}

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -288,6 +288,10 @@ func TestExportJSONScheduledAddsKeys(t *testing.T) {
 	if got := summary["dispatch_qps"].(float64); got != 1.2 {
 		t.Fatalf("dispatch_qps = %v, want 1.2 (3 requests / 2.5s)", got)
 	}
+	// Delays of 1/3/5ms against a 20ms inter-arrival: not saturated, no marker.
+	if _, ok := summary["dispatch_saturated"]; ok {
+		t.Fatalf("unsaturated run must not set dispatch_saturated")
+	}
 	if summary["queue_delay_p50_ms"].(float64) != 3 {
 		t.Fatalf("queue_delay_p50_ms = %v, want 3", summary["queue_delay_p50_ms"])
 	}
@@ -379,5 +383,56 @@ func TestExportJSONScheduledASAPOmitsDispatchKeys(t *testing.T) {
 	// Queue-delay keys are still meaningful without pacing.
 	if _, ok := summary["queue_delay_p50_ms"]; !ok {
 		t.Fatalf("summary missing key %q", "queue_delay_p50_ms")
+	}
+}
+
+func TestExportJSONSaturatedMarked(t *testing.T) {
+	cfg, results := scheduledExportFixture()
+	cfg.setDispatchElapsed(2.5)
+	// p95 100ms against a 20ms inter-arrival (50/s): the dispatcher fell
+	// permanently behind, so the export must carry the saturation marker.
+	for i := range results {
+		results[i].SchedDelayMs = 100
+	}
+	cfg.Output = t.TempDir() + "/report.json"
+
+	exportJSON(results, cfg)
+
+	data, err := os.ReadFile(cfg.Output)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	summary := report["summary"].(map[string]any)
+	if got := summary["dispatch_saturated"]; got != float64(1) {
+		t.Fatalf("dispatch_saturated = %v, want 1", got)
+	}
+}
+
+func TestDispatchSaturated(t *testing.T) {
+	cfg, results := scheduledExportFixture()
+
+	// Legacy mode and unpaced runs never report saturation.
+	if sat, _, _ := dispatchSaturated([]IterResult{{SchedDelayMs: 1e6}}, &Config{}); sat {
+		t.Errorf("legacy config reported saturated")
+	}
+	asap, _ := scheduledExportFixture()
+	asap.Rate = 0
+	if sat, _, _ := dispatchSaturated(results, asap); sat {
+		t.Errorf("ASAP run reported saturated")
+	}
+
+	if sat, p95, ia := dispatchSaturated(results, cfg); sat {
+		t.Errorf("fixture delays (p95 %v vs inter-arrival %v) reported saturated", p95, ia)
+	}
+	for i := range results {
+		results[i].SchedDelayMs = 100
+	}
+	sat, p95, ia := dispatchSaturated(results, cfg)
+	if !sat || p95 <= ia {
+		t.Errorf("saturated=%v p95=%v inter-arrival=%v, want saturated with p95 > inter-arrival", sat, p95, ia)
 	}
 }

--- a/examples/cube-bench/report.go
+++ b/examples/cube-bench/report.go
@@ -269,3 +269,20 @@ func extractTimes(results []IterResult, fn func(IterResult) float64) []float64 {
 	}
 	return out
 }
+
+// dispatchSaturated reports whether the dispatcher fell permanently behind the
+// requested pace during a rate-paced scheduled run: queue-delay p95 beyond the
+// mean inter-arrival time means the offered load degenerated to bursts and the
+// queue_delay_*/dispatch_* metrics describe the client's semaphore, not the
+// scheduler. It returns the p95 and inter-arrival values for messaging.
+func dispatchSaturated(results []IterResult, cfg *Config) (saturated bool, p95, interArrival float64) {
+	if !cfg.Scheduled || cfg.Rate <= 0 {
+		return false, 0, 0
+	}
+	delays := extractTimes(results, func(r IterResult) float64 { return r.SchedDelayMs })
+	if len(delays) == 0 {
+		return false, 0, 0
+	}
+	p95, interArrival = Percentile(delays, 95), 1000/cfg.Rate
+	return p95 > interArrival, p95, interArrival
+}

--- a/examples/cube-bench/report.go
+++ b/examples/cube-bench/report.go
@@ -275,12 +275,19 @@ func extractTimes(results []IterResult, fn func(IterResult) float64) []float64 {
 // mean inter-arrival time means the offered load degenerated to bursts and the
 // queue_delay_*/dispatch_* metrics describe the client's semaphore, not the
 // scheduler. It returns the p95 and inter-arrival values for messaging.
+//
+// Percentile computes k = ceil(n*p/100)-1, so below 20 samples the p95 IS the
+// maximum delay and one stalled request (a GC pause, a server hiccup) would
+// trip the marker; stay silent there rather than cry wolf on short ad-hoc
+// runs. At very high rates the mean inter-arrival also shrinks toward the
+// time.Sleep granularity, where even healthy runs can trip it — see the
+// README before trusting the marker at several hundred req/s.
 func dispatchSaturated(results []IterResult, cfg *Config) (saturated bool, p95, interArrival float64) {
 	if !cfg.Scheduled || cfg.Rate <= 0 {
 		return false, 0, 0
 	}
 	delays := extractTimes(results, func(r IterResult) float64 { return r.SchedDelayMs })
-	if len(delays) == 0 {
+	if len(delays) < 20 {
 		return false, 0, 0
 	}
 	p95, interArrival = Percentile(delays, 95), 1000/cfg.Rate

--- a/examples/cube-bench/report.go
+++ b/examples/cube-bench/report.go
@@ -45,6 +45,12 @@ func RenderReport(results []IterResult, cfg *Config) {
 	fmt.Println()
 	fmt.Println(summaryBox)
 
+	// Queue delay intentionally covers failed creates too (it is recorded
+	// regardless of outcome), so render it before the early return below.
+	if cfg.Scheduled {
+		renderQueueDelaySection(results)
+	}
+
 	if len(okResults) == 0 {
 		fmt.Println(T.Error.Bold(true).Render("\n  No successful results to report."))
 		return
@@ -56,9 +62,6 @@ func RenderReport(results []IterResult, cfg *Config) {
 	renderLatencySection("CREATE", createTimes)
 	if cfg.Mode == "create-delete" {
 		renderLatencySection("DELETE", deleteTimes)
-	}
-	if cfg.Scheduled {
-		renderQueueDelaySection(results)
 	}
 
 	// ── Sparkline timeline ──

--- a/examples/cube-bench/report.go
+++ b/examples/cube-bench/report.go
@@ -270,6 +270,14 @@ func extractTimes(results []IterResult, fn func(IterResult) float64) []float64 {
 	return out
 }
 
+// runTruncated reports whether the run ended with fewer results than
+// requested (an early TUI quit), so partial aggregates must be marked rather
+// than read as run characteristics. Shared by the terminal report and the
+// JSON export so the two never disagree.
+func runTruncated(results []IterResult, cfg *Config) bool {
+	return cfg.Total > 0 && len(results) < cfg.Total
+}
+
 // dispatchSaturated reports whether the dispatcher fell permanently behind the
 // requested pace during a rate-paced scheduled run: queue-delay p95 beyond the
 // mean inter-arrival time means the offered load degenerated to bursts and the

--- a/examples/cube-bench/report.go
+++ b/examples/cube-bench/report.go
@@ -57,6 +57,9 @@ func RenderReport(results []IterResult, cfg *Config) {
 	if cfg.Mode == "create-delete" {
 		renderLatencySection("DELETE", deleteTimes)
 	}
+	if cfg.Scheduled {
+		renderQueueDelaySection(results)
+	}
 
 	// ── Sparkline timeline ──
 	sparkContent := renderSparklines(createTimes, deleteTimes, cfg.Mode)
@@ -159,6 +162,29 @@ func renderLatencySection(label string, times []float64) {
 		Width(78).
 		Render(T.Heading.Render(fmt.Sprintf("  %s Latency", label)) + "\n\n" + content)
 
+	fmt.Println()
+	fmt.Println(box)
+}
+
+// renderQueueDelaySection reports the gap between each request's scheduled
+// arrival and its actual start (dispatcher sleep overshoot + semaphore wait).
+func renderQueueDelaySection(results []IterResult) {
+	delays := extractTimes(results, func(r IterResult) float64 { return r.SchedDelayMs })
+	if len(delays) == 0 {
+		return
+	}
+	content := renderKV([]kvPair{
+		{"min / avg", fmt.Sprintf("%.2f / %.2f ms", Min(delays), Mean(delays))},
+		{"P50 / P95 / P99", fmt.Sprintf("%.2f / %.2f / %.2f ms",
+			Percentile(delays, 50), Percentile(delays, 95), Percentile(delays, 99))},
+		{"max", fmt.Sprintf("%.2f ms", Max(delays))},
+	})
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(T.Border).
+		Padding(1, 3).
+		Width(78).
+		Render(T.Heading.Render("  Queue Delay (scheduled → actual start)") + "\n\n" + content)
 	fmt.Println()
 	fmt.Println(box)
 }

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -270,6 +270,11 @@ func RunScheduled(cfg *Config, sched []ScheduledRequest, resultCh chan<- IterRes
 		}
 		wg.Add(1)
 		sem <- struct{}{}
+		// Count the release only after the semaphore admits the request, so
+		// the TUI in-flight gauge tracks live sandboxes instead of the
+		// planned schedule (which degenerates to "remaining" in ASAP mode
+		// and over-counts under back-pressure).
+		cfg.released.Add(1)
 		go func(sr ScheduledRequest, actualStart time.Duration) {
 			defer wg.Done()
 			defer func() { <-sem }()
@@ -291,7 +296,7 @@ func RunScheduled(cfg *Config, sched []ScheduledRequest, resultCh chan<- IterRes
 	// The dispatch window closes once the last request has been released;
 	// wg.Wait() below additionally waits out per-sandbox lifetime tails,
 	// which would otherwise dilute the arrival-side dispatch rate.
-	cfg.dispatchElapsed = time.Since(benchStart).Seconds()
+	cfg.setDispatchElapsed(time.Since(benchStart).Seconds())
 
 	wg.Wait()
 	close(resultCh)

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -107,8 +107,14 @@ func doBenchCycle(client *http.Client, cfg *Config, body []byte, seq int, delete
 }
 
 // benchOneScheduled runs one pre-generated request: per-request template,
-// server-side TTL hint (timeout = lifetime + 60s), and a client-side DELETE
-// once the lifetime elapses.
+// server-side TTL hint (timeout = trunc(lifetime) + 60s), and a client-side
+// DELETE once the lifetime elapses.
+//
+// Note: the create `timeout` is an *idle* timeout (see
+// docs/guide/lifecycle.md) — any sandbox activity refreshes the deadline.
+// cube-bench never touches a sandbox after create, so here it behaves like a
+// wall-clock fallback cap; the client-side DELETE remains the primary
+// lifetime enforcement.
 func benchOneScheduled(client *http.Client, cfg *Config, sr ScheduledRequest) IterResult {
 	var timeoutS *int64
 	if sr.Lifetime > 0 {

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -264,7 +264,10 @@ func RunBenchmark(cfg *Config, resultCh chan<- IterResult, client *http.Client) 
 // sleeps until each request's scheduled arrival offset, then blocks on the
 // concurrency semaphore before releasing the goroutine. The gap between
 // scheduled arrival and actual goroutine start is reported as SchedDelayMs.
-func RunScheduled(cfg *Config, sched []ScheduledRequest, resultCh chan<- IterResult, client *http.Client) {
+// Closing stop (e.g. an early TUI quit) ends dispatch: requests not yet
+// released are skipped, while released ones run their full create/lifetime/
+// delete cycle. A nil stop channel never fires.
+func RunScheduled(cfg *Config, sched []ScheduledRequest, resultCh chan<- IterResult, client *http.Client, stop <-chan struct{}) {
 	sem := make(chan struct{}, cfg.Concurrency)
 	var wg sync.WaitGroup
 
@@ -273,13 +276,27 @@ func RunScheduled(cfg *Config, sched []ScheduledRequest, resultCh chan<- IterRes
 	}
 
 	benchStart := time.Now()
+dispatch:
 	for i := range sched {
 		sr := sched[i]
 		if d := time.Until(benchStart.Add(sr.ArrivalOffset)); d > 0 {
-			time.Sleep(d)
+			timer := time.NewTimer(d)
+			select {
+			case <-timer.C:
+			case <-stop:
+				timer.Stop()
+				break dispatch
+			}
 		}
 		wg.Add(1)
-		sem <- struct{}{}
+		select {
+		case sem <- struct{}{}:
+		case <-stop:
+			// Stopped while back-pressured on the semaphore: undo the Add and
+			// end dispatch instead of releasing another sandbox after quit.
+			wg.Done()
+			break dispatch
+		}
 		// Count the release only after the semaphore admits the request, so
 		// the TUI in-flight gauge tracks live sandboxes instead of the
 		// planned schedule (which degenerates to "remaining" in ASAP mode

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -29,6 +29,12 @@ type createResp struct {
 	SandboxID string `json:"sandboxID"`
 }
 
+// dryRunMaxLifetimeSleep caps the per-sandbox occupancy sleep in dry-run
+// scheduled mode. Dry-run exists for fast determinism smoke tests, not
+// occupancy modeling, so lifetime-bearing presets must not stall for hours;
+// the planned lifetime is still recorded in IterResult.LifetimeMs.
+const dryRunMaxLifetimeSleep = 25 * time.Millisecond
+
 func benchOne(client *http.Client, cfg *Config, seq int) IterResult {
 	return doBenchCycle(client, cfg, cfg.requestBody, seq, 0)
 }
@@ -157,7 +163,11 @@ func benchOneDry(cfg *Config, seq int) IterResult {
 
 // benchOneDryScheduled simulates one scheduled request. Randomness comes from
 // a per-request rng derived from (seed, seq), so a fixed --seed reproduces the
-// exact same latencies/errors regardless of goroutine scheduling.
+// exact same latencies/errors regardless of goroutine scheduling. The
+// occupancy sleep is clamped to dryRunMaxLifetimeSleep: dry-run is the fast
+// smoke path, and with real lifetimes a lifetime-bearing preset (e.g. burst =
+// 500 × 10–120s) cannot finish in reasonable time at moderate concurrency.
+// The recorded LifetimeMs still carries the planned value.
 func benchOneDryScheduled(cfg *Config, sr ScheduledRequest) IterResult {
 	rng := rand.New(rand.NewSource(cfg.Seed*1000003 + int64(sr.Seq) + 1))
 	r := IterResult{Seq: sr.Seq}
@@ -175,8 +185,8 @@ func benchOneDryScheduled(cfg *Config, sr ScheduledRequest) IterResult {
 	}
 
 	if cfg.Mode == "create-delete" {
-		if sr.Lifetime > 0 {
-			time.Sleep(sr.Lifetime)
+		if lt := min(sr.Lifetime, dryRunMaxLifetimeSleep); lt > 0 {
+			time.Sleep(lt)
 		}
 		deleteLat := cfg.DryLatencyMean*0.4 + cfg.DryLatencyStd*0.5*rng.NormFloat64()
 		if deleteLat < 1 {

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -282,6 +282,11 @@ func RunScheduled(cfg *Config, sched []ScheduledRequest, resultCh chan<- IterRes
 		}(sr, time.Since(benchStart))
 	}
 
+	// The dispatch window closes once the last request has been released;
+	// wg.Wait() below additionally waits out per-sandbox lifetime tails,
+	// which would otherwise dilute the arrival-side dispatch rate.
+	cfg.dispatchElapsed = time.Since(benchStart).Seconds()
+
 	wg.Wait()
 	close(resultCh)
 }

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -16,6 +16,13 @@ type IterResult struct {
 	CreateMs float64
 	DeleteMs float64
 	Err      string
+
+	// Scheduled-workload diagnostics. All zero in legacy mode.
+	TemplateID         string
+	ScheduledArrivalMs float64 // planned arrival offset from bench start
+	ActualStartMs      float64 // actual goroutine start offset from bench start
+	SchedDelayMs       float64 // ActualStartMs - ScheduledArrivalMs (queueing delay)
+	LifetimeMs         float64
 }
 
 type createResp struct {
@@ -23,12 +30,19 @@ type createResp struct {
 }
 
 func benchOne(client *http.Client, cfg *Config, seq int) IterResult {
+	return doBenchCycle(client, cfg, cfg.requestBody, seq, 0)
+}
+
+// doBenchCycle runs one create(+delete) cycle with an explicit request body.
+// deleteDelay > 0 makes the client wait that long after a successful create
+// before issuing the DELETE (scheduled lifetime); 0 deletes immediately.
+func doBenchCycle(client *http.Client, cfg *Config, body []byte, seq int, deleteDelay time.Duration) IterResult {
 	r := IterResult{Seq: seq}
 	apiURL := cfg.APIURL
 
 	// CREATE
 	t0 := time.Now()
-	req, err := http.NewRequest("POST", apiURL+"/sandboxes", bytes.NewReader(cfg.requestBody))
+	req, err := http.NewRequest("POST", apiURL+"/sandboxes", bytes.NewReader(body))
 	if err != nil {
 		r.Err = fmt.Sprintf("create request build: %v", err)
 		return r
@@ -64,6 +78,9 @@ func benchOne(client *http.Client, cfg *Config, seq int) IterResult {
 
 	// DELETE
 	if cfg.Mode == "create-delete" && cr.SandboxID != "" {
+		if deleteDelay > 0 {
+			time.Sleep(deleteDelay)
+		}
 		t0 = time.Now()
 		dreq, err := http.NewRequest("DELETE", apiURL+"/sandboxes/"+cr.SandboxID, nil)
 		if err != nil {
@@ -89,6 +106,22 @@ func benchOne(client *http.Client, cfg *Config, seq int) IterResult {
 	return r
 }
 
+// benchOneScheduled runs one pre-generated request: per-request template,
+// server-side TTL hint (timeout = lifetime + 60s), and a client-side DELETE
+// once the lifetime elapses.
+func benchOneScheduled(client *http.Client, cfg *Config, sr ScheduledRequest) IterResult {
+	var timeoutS *int64
+	if sr.Lifetime > 0 {
+		t := int64(sr.Lifetime.Seconds()) + 60
+		timeoutS = &t
+	}
+	body, err := buildCreateRequestBodyWithTimeout(sr.TemplateID, cfg.hostMountValue, cfg.NetworkPolicy, timeoutS)
+	if err != nil {
+		return IterResult{Seq: sr.Seq, Err: fmt.Sprintf("create request body build: %v", err)}
+	}
+	return doBenchCycle(client, cfg, body, sr.Seq, sr.Lifetime)
+}
+
 func benchOneDry(cfg *Config, seq int) IterResult {
 	r := IterResult{Seq: seq}
 
@@ -106,6 +139,40 @@ func benchOneDry(cfg *Config, seq int) IterResult {
 
 	if cfg.Mode == "create-delete" {
 		deleteLat := cfg.DryLatencyMean*0.4 + cfg.DryLatencyStd*0.5*rand.NormFloat64()
+		if deleteLat < 1 {
+			deleteLat = 1
+		}
+		time.Sleep(time.Duration(deleteLat * float64(time.Millisecond)))
+		r.DeleteMs = deleteLat
+	}
+
+	return r
+}
+
+// benchOneDryScheduled simulates one scheduled request. Randomness comes from
+// a per-request rng derived from (seed, seq), so a fixed --seed reproduces the
+// exact same latencies/errors regardless of goroutine scheduling.
+func benchOneDryScheduled(cfg *Config, sr ScheduledRequest) IterResult {
+	rng := rand.New(rand.NewSource(cfg.Seed*1000003 + int64(sr.Seq) + 1))
+	r := IterResult{Seq: sr.Seq}
+
+	createLat := cfg.DryLatencyMean + cfg.DryLatencyStd*rng.NormFloat64()
+	if createLat < 1 {
+		createLat = 1
+	}
+	time.Sleep(time.Duration(createLat * float64(time.Millisecond)))
+	r.CreateMs = createLat
+
+	if rng.Float64() < cfg.DryErrorRate {
+		r.Err = fmt.Sprintf("simulated error (seq=%d)", sr.Seq)
+		return r
+	}
+
+	if cfg.Mode == "create-delete" {
+		if sr.Lifetime > 0 {
+			time.Sleep(sr.Lifetime)
+		}
+		deleteLat := cfg.DryLatencyMean*0.4 + cfg.DryLatencyStd*0.5*rng.NormFloat64()
 		if deleteLat < 1 {
 			deleteLat = 1
 		}
@@ -171,6 +238,48 @@ func RunBenchmark(cfg *Config, resultCh chan<- IterResult, client *http.Client) 
 			}
 			resultCh <- r
 		}(i + 1)
+	}
+
+	wg.Wait()
+	close(resultCh)
+}
+
+// RunScheduled dispatches a pre-generated request sequence: the dispatcher
+// sleeps until each request's scheduled arrival offset, then blocks on the
+// concurrency semaphore before releasing the goroutine. The gap between
+// scheduled arrival and actual goroutine start is reported as SchedDelayMs.
+func RunScheduled(cfg *Config, sched []ScheduledRequest, resultCh chan<- IterResult, client *http.Client) {
+	sem := make(chan struct{}, cfg.Concurrency)
+	var wg sync.WaitGroup
+
+	if !cfg.DryRun && client == nil {
+		client = newHTTPClient(cfg.Concurrency)
+	}
+
+	benchStart := time.Now()
+	for i := range sched {
+		sr := sched[i]
+		if d := time.Until(benchStart.Add(sr.ArrivalOffset)); d > 0 {
+			time.Sleep(d)
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(sr ScheduledRequest, actualStart time.Duration) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			var r IterResult
+			if cfg.DryRun {
+				r = benchOneDryScheduled(cfg, sr)
+			} else {
+				r = benchOneScheduled(client, cfg, sr)
+			}
+			r.TemplateID = sr.TemplateID
+			r.ScheduledArrivalMs = float64(sr.ArrivalOffset.Microseconds()) / 1000.0
+			r.ActualStartMs = float64(actualStart.Microseconds()) / 1000.0
+			r.SchedDelayMs = r.ActualStartMs - r.ScheduledArrivalMs
+			r.LifetimeMs = float64(sr.Lifetime.Microseconds()) / 1000.0
+			resultCh <- r
+		}(sr, time.Since(benchStart))
 	}
 
 	wg.Wait()

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -265,8 +265,10 @@ func RunBenchmark(cfg *Config, resultCh chan<- IterResult, client *http.Client) 
 // concurrency semaphore before releasing the goroutine. The gap between
 // scheduled arrival and actual goroutine start is reported as SchedDelayMs.
 // Closing stop (e.g. an early TUI quit) ends dispatch: requests not yet
-// released are skipped, while released ones run their full create/lifetime/
-// delete cycle. A nil stop channel never fires.
+// released are skipped. Released ones are NOT waited on at quit — main
+// returns and the process may exit mid create/lifetime/delete, so an
+// abandoned sandbox relies on the server-side timeout backstop (present
+// only in lifetime-bearing runs). A nil stop channel never fires.
 func RunScheduled(cfg *Config, sched []ScheduledRequest, resultCh chan<- IterResult, client *http.Client, stop <-chan struct{}) {
 	sem := make(chan struct{}, cfg.Concurrency)
 	var wg sync.WaitGroup

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -295,8 +295,8 @@ dispatch:
 		// in the past, e.g. saturation or ASAP mode) that branch is skipped,
 		// and in the two-case select below a ready semaphore slot would
 		// compete with the closed stop channel at random, releasing requests
-		// after quit. Re-check stop first so a quit under back-pressure stops
-		// dispatch deterministically.
+		// after quit. Re-check stop before AND after the admission so a quit
+		// under back-pressure stops dispatch deterministically.
 		select {
 		case <-stop:
 			break dispatch
@@ -310,6 +310,17 @@ dispatch:
 			// end dispatch instead of releasing another sandbox after quit.
 			wg.Done()
 			break dispatch
+		}
+		select {
+		case <-stop:
+			// stop closed while the semaphore admit raced it: hand the slot
+			// back and undo the Add rather than spawning work after quit.
+			// A stop landing after this check is not a leak — the admission
+			// decision legitimately predates it.
+			<-sem
+			wg.Done()
+			break dispatch
+		default:
 		}
 		// Count the release only after the semaphore admits the request, so
 		// the TUI in-flight gauge tracks live sandboxes instead of the

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -290,6 +290,18 @@ dispatch:
 				break dispatch
 			}
 		}
+		// The arrival-timer branch above is the only stop check while the
+		// dispatcher is on pace; once it falls behind (arrival offsets already
+		// in the past, e.g. saturation or ASAP mode) that branch is skipped,
+		// and in the two-case select below a ready semaphore slot would
+		// compete with the closed stop channel at random, releasing requests
+		// after quit. Re-check stop first so a quit under back-pressure stops
+		// dispatch deterministically.
+		select {
+		case <-stop:
+			break dispatch
+		default:
+		}
 		wg.Add(1)
 		select {
 		case sem <- struct{}{}:

--- a/examples/cube-bench/runner_test.go
+++ b/examples/cube-bench/runner_test.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestRunWarmupCompletesBeforeBenchmark(t *testing.T) {
@@ -172,5 +176,204 @@ func TestBenchOneDeletePath(t *testing.T) {
 	}
 	if !deleteCalled {
 		t.Fatal("benchOne did not issue the delete request")
+	}
+}
+
+// TestRunScheduledEndToEnd drives the scheduled path against a mock CubeAPI:
+// requests must arrive in sequence order (concurrency=1), each create body
+// must carry the scheduled templateID and timeout=lifetime+60, and each DELETE
+// must fire only after the sandbox's lifetime elapsed.
+func TestRunScheduledEndToEnd(t *testing.T) {
+	type createRec struct {
+		body map[string]any
+		at   time.Time
+	}
+	var mu sync.Mutex
+	var creates []createRec
+	deleteDelay := map[string]time.Duration{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, "decode body failed", http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			id := fmt.Sprintf("sb-%d", len(creates))
+			creates = append(creates, createRec{body: body, at: time.Now()})
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"sandboxID":%q}`, id)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/sandboxes/"):
+			id := strings.TrimPrefix(r.URL.Path, "/sandboxes/")
+			mu.Lock()
+			var n int
+			if _, err := fmt.Sscanf(id, "sb-%d", &n); err == nil && n < len(creates) {
+				deleteDelay[id] = time.Since(creates[n].at)
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		Concurrency:    1,
+		Total:          4,
+		Mode:           "create-delete",
+		APIURL:         server.URL,
+		Seed:           99,
+		Rate:           0, // asap; concurrency=1 keeps order deterministic
+		hasLifetime:    true,
+		LifetimeMin:    0.30,
+		LifetimeMax:    0.35,
+		Scheduled:      true,
+		Templates:      []TemplateSpec{{TemplateID: "tpl-a", Weight: 1}, {TemplateID: "tpl-b", Weight: 1}},
+		requestHeaders: map[string]string{},
+		NetworkPolicy:  networkPolicyNone,
+	}
+	sched := GenerateSequence(cfg, rand.New(rand.NewSource(cfg.Seed)))
+
+	resultCh := make(chan IterResult, cfg.Total)
+	go RunScheduled(cfg, sched, resultCh, server.Client())
+	var results []IterResult
+	for r := range resultCh {
+		results = append(results, r)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(creates) != cfg.Total {
+		t.Fatalf("creates = %d, want %d", len(creates), cfg.Total)
+	}
+	for i, rec := range creates {
+		wantTpl := sched[i].TemplateID
+		if got := rec.body["templateID"]; got != wantTpl {
+			t.Fatalf("create #%d templateID = %v, want %s (order broken?)", i, got, wantTpl)
+		}
+		wantTimeout := float64(int64(sched[i].Lifetime.Seconds()) + 60)
+		if got, ok := rec.body["timeout"]; !ok || got != wantTimeout {
+			t.Fatalf("create #%d timeout = %v (ok=%v), want %v", i, got, ok, wantTimeout)
+		}
+	}
+	if len(deleteDelay) != cfg.Total {
+		t.Fatalf("deletes = %d, want %d", len(deleteDelay), cfg.Total)
+	}
+	for i := range sched {
+		id := fmt.Sprintf("sb-%d", i)
+		if got := deleteDelay[id]; got < time.Duration(float64(sched[i].Lifetime)*0.9) {
+			t.Fatalf("delete %s fired after %v, want >= ~lifetime %v", id, got, sched[i].Lifetime)
+		}
+	}
+
+	if len(results) != cfg.Total {
+		t.Fatalf("results = %d, want %d", len(results), cfg.Total)
+	}
+	for _, r := range results {
+		if r.Err != "" {
+			t.Fatalf("result #%d error: %s", r.Seq, r.Err)
+		}
+		wantTpl := sched[r.Seq].TemplateID
+		if r.TemplateID != wantTpl {
+			t.Fatalf("result #%d TemplateID = %q, want %q", r.Seq, r.TemplateID, wantTpl)
+		}
+		wantLifeMs := float64(sched[r.Seq].Lifetime.Microseconds()) / 1000.0
+		if r.LifetimeMs != wantLifeMs {
+			t.Fatalf("result #%d LifetimeMs = %v, want %v", r.Seq, r.LifetimeMs, wantLifeMs)
+		}
+		if r.SchedDelayMs < -1 {
+			t.Fatalf("result #%d SchedDelayMs = %v, want >= ~0", r.Seq, r.SchedDelayMs)
+		}
+	}
+}
+
+// TestRunScheduledDryRunReproducible verifies the dry-run scheduled path uses
+// a derived rng: same seed -> identical results, and lifetimes are honored.
+func TestRunScheduledDryRunReproducible(t *testing.T) {
+	newCfg := func() *Config {
+		return &Config{
+			Concurrency:    3,
+			Total:          12,
+			Mode:           "create-delete",
+			DryRun:         true,
+			DryLatencyMean: 2,
+			DryLatencyStd:  1,
+			DryErrorRate:   0,
+			Seed:           5,
+			Rate:           0,
+			hasLifetime:    true,
+			LifetimeMin:    0.01,
+			LifetimeMax:    0.02,
+			Scheduled:      true,
+			Templates:      []TemplateSpec{{TemplateID: "tpl-dry", Weight: 1}},
+		}
+	}
+	run := func() map[int]IterResult {
+		cfg := newCfg()
+		sched := GenerateSequence(cfg, rand.New(rand.NewSource(cfg.Seed)))
+		resultCh := make(chan IterResult, cfg.Total)
+		go RunScheduled(cfg, sched, resultCh, nil)
+		results := map[int]IterResult{}
+		for r := range resultCh {
+			results[r.Seq] = r
+		}
+		return results
+	}
+
+	a := run()
+	b := run()
+	if len(a) != 12 {
+		t.Fatalf("results = %d, want 12", len(a))
+	}
+	for seq := 0; seq < 12; seq++ {
+		ra, okA := a[seq]
+		rb, okB := b[seq]
+		if !okA || !okB {
+			t.Fatalf("seq %d missing (a=%v b=%v)", seq, okA, okB)
+		}
+		if ra.Err != "" {
+			t.Fatalf("unexpected error: %s", ra.Err)
+		}
+		if ra.CreateMs != rb.CreateMs || ra.DeleteMs != rb.DeleteMs {
+			t.Fatalf("seq %d not reproducible: %v/%v vs %v/%v",
+				seq, ra.CreateMs, ra.DeleteMs, rb.CreateMs, rb.DeleteMs)
+		}
+		if ra.TemplateID != "tpl-dry" {
+			t.Fatalf("seq %d TemplateID = %q", seq, ra.TemplateID)
+		}
+		if ra.LifetimeMs < 10 || ra.LifetimeMs > 20 {
+			t.Fatalf("seq %d LifetimeMs = %v, want within [10, 20]", seq, ra.LifetimeMs)
+		}
+	}
+}
+
+// TestBenchOneLegacyLeavesScheduledFieldsZero pins legacy behavior: without
+// scheduling flags the new IterResult diagnostics stay zero.
+func TestBenchOneLegacyLeavesScheduledFieldsZero(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"sandboxID":"sb-legacy"}`)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		Mode:           "create-only",
+		APIURL:         server.URL,
+		requestBody:    []byte(`{"templateID":"tpl-legacy"}`),
+		requestHeaders: map[string]string{},
+	}
+	r := benchOne(server.Client(), cfg, 1)
+	if r.Err != "" {
+		t.Fatalf("benchOne error: %s", r.Err)
+	}
+	if r.TemplateID != "" || r.ScheduledArrivalMs != 0 || r.ActualStartMs != 0 || r.SchedDelayMs != 0 || r.LifetimeMs != 0 {
+		t.Fatalf("legacy result has scheduled fields set: %+v", r)
 	}
 }

--- a/examples/cube-bench/runner_test.go
+++ b/examples/cube-bench/runner_test.go
@@ -240,7 +240,7 @@ func TestRunScheduledEndToEnd(t *testing.T) {
 	sched := GenerateSequence(cfg, rand.New(rand.NewSource(cfg.Seed)))
 
 	resultCh := make(chan IterResult, cfg.Total)
-	go RunScheduled(cfg, sched, resultCh, server.Client())
+	go RunScheduled(cfg, sched, resultCh, server.Client(), nil)
 	var results []IterResult
 	for r := range resultCh {
 		results = append(results, r)
@@ -327,7 +327,7 @@ func TestRunScheduledDryRunReproducible(t *testing.T) {
 		cfg := newCfg()
 		sched := GenerateSequence(cfg, rand.New(rand.NewSource(cfg.Seed)))
 		resultCh := make(chan IterResult, cfg.Total)
-		go RunScheduled(cfg, sched, resultCh, nil)
+		go RunScheduled(cfg, sched, resultCh, nil, nil)
 		results := map[int]IterResult{}
 		for r := range resultCh {
 			results[r.Seq] = r
@@ -359,6 +359,58 @@ func TestRunScheduledDryRunReproducible(t *testing.T) {
 		if ra.LifetimeMs < 10 || ra.LifetimeMs > 20 {
 			t.Fatalf("seq %d LifetimeMs = %v, want within [10, 20]", seq, ra.LifetimeMs)
 		}
+	}
+}
+
+// TestRunScheduledStopsDispatchOnStop: closing the stop channel (an early TUI
+// quit) must end dispatch — with a 1 req/s pace a 12-request run would take
+// ~11 s, so a run finishing right after the first result with far fewer
+// results proves the remaining schedule was abandoned, while the released
+// request still completed its cycle.
+func TestRunScheduledStopsDispatchOnStop(t *testing.T) {
+	cfg := &Config{
+		Concurrency:    1,
+		Total:          12,
+		Mode:           "create-delete",
+		DryRun:         true,
+		DryLatencyMean: 2,
+		DryLatencyStd:  1,
+		DryErrorRate:   0,
+		Seed:           5,
+		Rate:           1,
+		hasLifetime:    true,
+		LifetimeMin:    0.01,
+		LifetimeMax:    0.02,
+		Scheduled:      true,
+		Templates:      []TemplateSpec{{TemplateID: "tpl-stop", Weight: 1}},
+	}
+	sched := GenerateSequence(cfg, rand.New(rand.NewSource(cfg.Seed)))
+	resultCh := make(chan IterResult, cfg.Total)
+	stop := make(chan struct{})
+	go RunScheduled(cfg, sched, resultCh, nil, stop)
+
+	first, ok := <-resultCh
+	if !ok || first.Err != "" {
+		t.Fatalf("first result = %+v, ok=%v", first, ok)
+	}
+	close(stop)
+
+	done := time.After(5 * time.Second)
+	count := 1
+	for {
+		select {
+		case _, ok := <-resultCh:
+			if !ok {
+				goto closed
+			}
+			count++
+		case <-done:
+			t.Fatal("dispatcher did not close resultCh after stop")
+		}
+	}
+closed:
+	if count >= cfg.Total {
+		t.Fatalf("results = %d, want the remaining schedule abandoned (< %d)", count, cfg.Total)
 	}
 }
 

--- a/examples/cube-bench/runner_test.go
+++ b/examples/cube-bench/runner_test.go
@@ -414,6 +414,44 @@ closed:
 	}
 }
 
+// TestRunScheduledStopBeforeDispatch: with stop already closed and every
+// arrival offset in the past (ASAP pace, or a dispatcher that fell behind
+// schedule), the dispatcher must release nothing — without the
+// pre-admission stop check the two-case semaphore select admits requests at
+// random against the closed stop channel.
+func TestRunScheduledStopBeforeDispatch(t *testing.T) {
+	cfg := &Config{
+		Concurrency:    4,
+		Total:          12,
+		Mode:           "create-delete",
+		DryRun:         true,
+		DryLatencyMean: 2,
+		DryLatencyStd:  1,
+		DryErrorRate:   0,
+		Seed:           5,
+		Scheduled:      true,
+		Templates:      []TemplateSpec{{TemplateID: "tpl-stop", Weight: 1}},
+	}
+	sched := make([]ScheduledRequest, cfg.Total)
+	for i := range sched {
+		sched[i] = ScheduledRequest{
+			Seq:           i + 1,
+			ArrivalOffset: 0, // already due at dispatch start
+			TemplateID:    "tpl-stop",
+			CpuMillis:     1000,
+			MemMiB:        2048,
+			Lifetime:      10 * time.Millisecond,
+		}
+	}
+	resultCh := make(chan IterResult, cfg.Total)
+	stop := make(chan struct{})
+	close(stop) // the quit lands before dispatch begins
+	RunScheduled(cfg, sched, resultCh, nil, stop)
+	for r := range resultCh {
+		t.Fatalf("request released despite the closed stop channel: %+v", r)
+	}
+}
+
 // TestBenchOneLegacyLeavesScheduledFieldsZero pins legacy behavior: without
 // scheduling flags the new IterResult diagnostics stay zero.
 func TestBenchOneLegacyLeavesScheduledFieldsZero(t *testing.T) {

--- a/examples/cube-bench/runner_test.go
+++ b/examples/cube-bench/runner_test.go
@@ -291,6 +291,15 @@ func TestRunScheduledEndToEnd(t *testing.T) {
 			t.Fatalf("result #%d SchedDelayMs = %v, want >= ~0", r.Seq, r.SchedDelayMs)
 		}
 	}
+
+	// Every request was admitted to the single worker slot exactly once, and
+	// the dispatch window was published through the atomic accessor.
+	if got := cfg.released.Load(); got != int64(cfg.Total) {
+		t.Fatalf("released = %d, want %d", got, cfg.Total)
+	}
+	if got := cfg.getDispatchElapsed(); got <= 0 {
+		t.Fatalf("dispatchElapsed = %v, want > 0", got)
+	}
 }
 
 // TestRunScheduledDryRunReproducible verifies the dry-run scheduled path uses

--- a/examples/cube-bench/sequence.go
+++ b/examples/cube-bench/sequence.go
@@ -221,7 +221,11 @@ type traceFile struct {
 }
 
 // DumpTrace writes the pre-generated sequence as a JSON trace file that other
-// tooling (e.g. a scheduling simulator) can replay.
+// tooling (e.g. a scheduling simulator) can replay. arrival_ms/lifetime_ms
+// are integer milliseconds (Duration.Milliseconds(), truncated toward zero),
+// while the JSON export's raw entries keep float-millisecond precision for
+// the same seq — cross-checking the two files can show sub-millisecond
+// differences, which is expected.
 func DumpTrace(path string, cfg *Config, seq []ScheduledRequest) error {
 	tf := traceFile{
 		Workload:    workloadDisplayName(cfg),

--- a/examples/cube-bench/sequence.go
+++ b/examples/cube-bench/sequence.go
@@ -174,6 +174,9 @@ func pickTemplate(templates []TemplateSpec, totalWeight int, rng *rand.Rand) Tem
 		}
 		draw -= t.Weight
 	}
+	// Unreachable while totalWeight > 0 and every weight is >= 1 (both enforced
+	// by parseTemplates); kept as a defensive fallback so a future relaxation
+	// of those invariants degrades to a biased pick instead of an index panic.
 	return templates[len(templates)-1]
 }
 

--- a/examples/cube-bench/sequence.go
+++ b/examples/cube-bench/sequence.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// TemplateSpec describes one template pool entry for scheduled workloads.
+// CpuMillis/MemMiB are spec annotations carried into the trace file; they are
+// not sent to the API (resource sizing is a template-side concern).
+type TemplateSpec struct {
+	TemplateID string
+	Weight     int
+	CpuMillis  int64
+	MemMiB     int64
+}
+
+// ScheduledRequest is one pre-generated request in a workload sequence.
+type ScheduledRequest struct {
+	Seq           int
+	ArrivalOffset time.Duration // offset from benchmark start
+	TemplateID    string
+	CpuMillis     int64
+	MemMiB        int64
+	Lifetime      time.Duration // 0 = delete immediately after create
+}
+
+// workloadPreset holds flag defaults for a named workload. Explicitly passed
+// flags always win over preset values (see applyWorkloadPreset).
+type workloadPreset struct {
+	total   int
+	rate    float64
+	lifeMin float64 // seconds
+	lifeMax float64 // seconds
+}
+
+var workloadPresets = map[string]workloadPreset{
+	"burst":          {total: 500, rate: 50, lifeMin: 10, lifeMax: 120},
+	"template_storm": {total: 300, rate: 30, lifeMin: 30, lifeMax: 90},
+	"mixed_spec":     {total: 400, rate: 10, lifeMin: 30, lifeMax: 300},
+}
+
+// applyWorkloadPreset fills cfg with preset defaults for flags the user did
+// not pass explicitly. explicit holds flag names seen by flag.Visit.
+func applyWorkloadPreset(cfg *Config, explicit map[string]bool) error {
+	p, ok := workloadPresets[cfg.Workload]
+	if !ok {
+		return fmt.Errorf("unknown workload %q (valid: burst, template_storm, mixed_spec)", cfg.Workload)
+	}
+	if !explicit["n"] && !explicit["total"] {
+		cfg.Total = p.total
+	}
+	if !explicit["rate"] {
+		cfg.Rate = p.rate
+	}
+	if !explicit["lifetime"] {
+		cfg.LifetimeMin, cfg.LifetimeMax, cfg.hasLifetime = p.lifeMin, p.lifeMax, true
+	}
+	return nil
+}
+
+// parseTemplates parses "id[:weight[:cpuMillis:memMiB]],..." entries.
+// Weight defaults to 1, cpu/mem default to 0 (unknown spec).
+func parseTemplates(spec string) ([]TemplateSpec, error) {
+	var out []TemplateSpec
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("--templates contains an empty entry")
+		}
+		fields := strings.Split(part, ":")
+		if len(fields) > 4 {
+			return nil, fmt.Errorf("--templates entry %q: want templateID[:weight[:cpuMillis:memMiB]]", part)
+		}
+		ts := TemplateSpec{TemplateID: strings.TrimSpace(fields[0]), Weight: 1}
+		if ts.TemplateID == "" {
+			return nil, fmt.Errorf("--templates entry %q: template ID must not be empty", part)
+		}
+		if len(fields) >= 2 {
+			w, err := strconv.Atoi(strings.TrimSpace(fields[1]))
+			if err != nil || w < 1 {
+				return nil, fmt.Errorf("--templates entry %q: weight must be a positive integer", part)
+			}
+			ts.Weight = w
+		}
+		if len(fields) >= 3 {
+			cpu, err := strconv.ParseInt(strings.TrimSpace(fields[2]), 10, 64)
+			if err != nil || cpu < 0 {
+				return nil, fmt.Errorf("--templates entry %q: cpuMillis must be a non-negative integer", part)
+			}
+			ts.CpuMillis = cpu
+		}
+		if len(fields) >= 4 {
+			mem, err := strconv.ParseInt(strings.TrimSpace(fields[3]), 10, 64)
+			if err != nil || mem < 0 {
+				return nil, fmt.Errorf("--templates entry %q: memMiB must be a non-negative integer", part)
+			}
+			ts.MemMiB = mem
+		}
+		out = append(out, ts)
+	}
+	return out, nil
+}
+
+// parseLifetime parses "min,max" (seconds). A single value means a constant
+// lifetime (min == max).
+func parseLifetime(spec string) (float64, float64, error) {
+	parts := strings.Split(spec, ",")
+	if len(parts) > 2 {
+		return 0, 0, fmt.Errorf("--lifetime must be min,max in seconds (got %q)", spec)
+	}
+	lo, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil || lo < 0 {
+		return 0, 0, fmt.Errorf("--lifetime min must be a non-negative number (got %q)", spec)
+	}
+	hi := lo
+	if len(parts) == 2 {
+		hi, err = strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil || hi < 0 {
+			return 0, 0, fmt.Errorf("--lifetime max must be a non-negative number (got %q)", spec)
+		}
+	}
+	if hi < lo {
+		return 0, 0, fmt.Errorf("--lifetime max (%.3g) must be >= min (%.3g)", hi, lo)
+	}
+	return lo, hi, nil
+}
+
+// GenerateSequence pre-generates the full request schedule with a dedicated
+// rng so identical seeds reproduce identical sequences. Draw order per request
+// is fixed: arrival interval, lifetime, template pick.
+func GenerateSequence(cfg *Config, rng *rand.Rand) []ScheduledRequest {
+	seq := make([]ScheduledRequest, cfg.Total)
+
+	totalWeight := 0
+	for _, t := range cfg.Templates {
+		totalWeight += t.Weight
+	}
+
+	var offset time.Duration
+	for i := range seq {
+		sr := ScheduledRequest{Seq: i, ArrivalOffset: offset}
+		// Poisson process: inter-arrival times are Exp(λ). The first request
+		// goes out immediately (offset 0). rate <= 0 means "as fast as
+		// possible", i.e. every offset stays 0 like the legacy flood.
+		if cfg.Rate > 0 {
+			offset += time.Duration(rng.ExpFloat64() / cfg.Rate * float64(time.Second))
+		}
+		if cfg.hasLifetime {
+			lt := cfg.LifetimeMin + rng.Float64()*(cfg.LifetimeMax-cfg.LifetimeMin)
+			sr.Lifetime = time.Duration(lt * float64(time.Second))
+		}
+		if totalWeight > 0 {
+			t := pickTemplate(cfg.Templates, totalWeight, rng)
+			sr.TemplateID = t.TemplateID
+			sr.CpuMillis = t.CpuMillis
+			sr.MemMiB = t.MemMiB
+		}
+		seq[i] = sr
+	}
+	return seq
+}
+
+func pickTemplate(templates []TemplateSpec, totalWeight int, rng *rand.Rand) TemplateSpec {
+	draw := rng.Intn(totalWeight)
+	for _, t := range templates {
+		if draw < t.Weight {
+			return t
+		}
+		draw -= t.Weight
+	}
+	return templates[len(templates)-1]
+}
+
+// workloadDisplayName is the label used in traces/reports; ad-hoc scheduled
+// runs (new flags without --workload) are reported as "custom".
+func workloadDisplayName(cfg *Config) string {
+	if cfg.Workload != "" {
+		return cfg.Workload
+	}
+	return "custom"
+}
+
+// ── Trace file (cross-tool contract; field names must stay stable) ──
+
+type traceParams struct {
+	RatePerSec   float64 `json:"rate_per_sec"`
+	LifetimeMinS float64 `json:"lifetime_min_s"`
+	LifetimeMaxS float64 `json:"lifetime_max_s"`
+	Total        int     `json:"total"`
+}
+
+type traceTemplate struct {
+	TemplateID string `json:"template_id"`
+	Weight     int    `json:"weight"`
+	CpuMillis  int64  `json:"cpu_millis"`
+	MemMiB     int64  `json:"mem_mib"`
+}
+
+type traceRequest struct {
+	Seq        int    `json:"seq"`
+	ArrivalMs  int64  `json:"arrival_ms"`
+	TemplateID string `json:"template_id"`
+	CpuMillis  int64  `json:"cpu_millis"`
+	MemMiB     int64  `json:"mem_mib"`
+	LifetimeMs int64  `json:"lifetime_ms"`
+}
+
+type traceFile struct {
+	Workload    string          `json:"workload"`
+	Seed        int64           `json:"seed"`
+	GeneratedAt string          `json:"generated_at"`
+	Params      traceParams     `json:"params"`
+	Templates   []traceTemplate `json:"templates"`
+	Requests    []traceRequest  `json:"requests"`
+}
+
+// DumpTrace writes the pre-generated sequence as a JSON trace file that other
+// tooling (e.g. a scheduling simulator) can replay.
+func DumpTrace(path string, cfg *Config, seq []ScheduledRequest) error {
+	tf := traceFile{
+		Workload:    workloadDisplayName(cfg),
+		Seed:        cfg.Seed,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Params: traceParams{
+			RatePerSec:   cfg.Rate,
+			LifetimeMinS: cfg.LifetimeMin,
+			LifetimeMaxS: cfg.LifetimeMax,
+			Total:        cfg.Total,
+		},
+	}
+	tf.Templates = make([]traceTemplate, len(cfg.Templates))
+	for i, t := range cfg.Templates {
+		tf.Templates[i] = traceTemplate{
+			TemplateID: t.TemplateID,
+			Weight:     t.Weight,
+			CpuMillis:  t.CpuMillis,
+			MemMiB:     t.MemMiB,
+		}
+	}
+	tf.Requests = make([]traceRequest, len(seq))
+	for i, sr := range seq {
+		tf.Requests[i] = traceRequest{
+			Seq:        sr.Seq,
+			ArrivalMs:  sr.ArrivalOffset.Milliseconds(),
+			TemplateID: sr.TemplateID,
+			CpuMillis:  sr.CpuMillis,
+			MemMiB:     sr.MemMiB,
+			LifetimeMs: sr.Lifetime.Milliseconds(),
+		}
+	}
+	data, err := json.MarshalIndent(tf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("trace marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("trace write: %w", err)
+	}
+	return nil
+}

--- a/examples/cube-bench/sequence.go
+++ b/examples/cube-bench/sequence.go
@@ -65,9 +65,13 @@ func applyWorkloadPreset(cfg *Config, explicit map[string]bool) error {
 }
 
 // parseTemplates parses "id[:weight[:cpuMillis:memMiB]],..." entries.
-// Weight defaults to 1, cpu/mem default to 0 (unknown spec).
+// Weight defaults to 1, cpu/mem default to 0 (unknown spec). Duplicate IDs
+// are rejected: two entries sharing an ID would draw the same template_id
+// with different specs, making the trace ambiguous and silently merging the
+// per_template export bucket — combine their weights into one entry instead.
 func parseTemplates(spec string) ([]TemplateSpec, error) {
 	var out []TemplateSpec
+	seen := make(map[string]struct{})
 	for _, part := range strings.Split(spec, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
@@ -81,6 +85,10 @@ func parseTemplates(spec string) ([]TemplateSpec, error) {
 		if ts.TemplateID == "" {
 			return nil, fmt.Errorf("--templates entry %q: template ID must not be empty", part)
 		}
+		if _, dup := seen[ts.TemplateID]; dup {
+			return nil, fmt.Errorf("--templates entry %q: duplicate template ID %q; combine the weights into one entry", part, ts.TemplateID)
+		}
+		seen[ts.TemplateID] = struct{}{}
 		if len(fields) >= 2 {
 			w, err := strconv.Atoi(strings.TrimSpace(fields[1]))
 			if err != nil || w < 1 {

--- a/examples/cube-bench/sequence_test.go
+++ b/examples/cube-bench/sequence_test.go
@@ -165,6 +165,8 @@ func TestParseTemplatesRejectsBadSpecs(t *testing.T) {
 		"tpl-a:1:-5",
 		"tpl-a:1:1000:-1",
 		"tpl-a:1:1000:2048:extra",
+		"tpl-a,tpl-a",
+		"tpl-a:1:1000:2048,tpl-a:2:2000:4096",
 	} {
 		if _, err := parseTemplates(spec); err == nil {
 			t.Fatalf("parseTemplates(%q) returned nil error, want rejection", spec)

--- a/examples/cube-bench/sequence_test.go
+++ b/examples/cube-bench/sequence_test.go
@@ -1,0 +1,374 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func schedTestConfig() *Config {
+	return &Config{
+		Total:       100,
+		Rate:        50,
+		hasLifetime: true,
+		LifetimeMin: 10,
+		LifetimeMax: 120,
+		Templates:   []TemplateSpec{{TemplateID: "tpl-a", Weight: 1}},
+	}
+}
+
+func TestGenerateSequenceDeterministic(t *testing.T) {
+	cfg := schedTestConfig()
+	cfg.Templates = []TemplateSpec{
+		{TemplateID: "tpl-a", Weight: 6, CpuMillis: 1000, MemMiB: 2048},
+		{TemplateID: "tpl-b", Weight: 3, CpuMillis: 2000, MemMiB: 4096},
+		{TemplateID: "tpl-c", Weight: 1, CpuMillis: 8000, MemMiB: 16384},
+	}
+
+	a := GenerateSequence(cfg, rand.New(rand.NewSource(42)))
+	b := GenerateSequence(cfg, rand.New(rand.NewSource(42)))
+	if !reflect.DeepEqual(a, b) {
+		t.Fatal("same seed produced different sequences")
+	}
+
+	c := GenerateSequence(cfg, rand.New(rand.NewSource(43)))
+	if reflect.DeepEqual(a, c) {
+		t.Fatal("different seeds produced identical sequences")
+	}
+}
+
+func TestGenerateSequenceInterArrivalMean(t *testing.T) {
+	cfg := schedTestConfig()
+	cfg.Total = 1500
+	cfg.Rate = 50 // expected mean inter-arrival = 20ms
+
+	seq := GenerateSequence(cfg, rand.New(rand.NewSource(7)))
+	if seq[0].ArrivalOffset != 0 {
+		t.Fatalf("first arrival offset = %v, want 0", seq[0].ArrivalOffset)
+	}
+
+	var sum time.Duration
+	for i := 1; i < len(seq); i++ {
+		d := seq[i].ArrivalOffset - seq[i-1].ArrivalOffset
+		if d < 0 {
+			t.Fatalf("arrival offsets not ascending at %d", i)
+		}
+		sum += d
+	}
+	mean := float64(sum) / float64(len(seq)-1) / float64(time.Millisecond)
+	want := 1000.0 / cfg.Rate // 20ms
+	if math.Abs(mean-want) > want*0.2 {
+		t.Fatalf("mean inter-arrival = %.2fms, want %.2fms ±20%%", mean, want)
+	}
+}
+
+func TestGenerateSequenceZeroRateFloods(t *testing.T) {
+	cfg := schedTestConfig()
+	cfg.Rate = 0
+	seq := GenerateSequence(cfg, rand.New(rand.NewSource(1)))
+	for i, sr := range seq {
+		if sr.ArrivalOffset != 0 {
+			t.Fatalf("seq[%d].ArrivalOffset = %v, want 0 for rate=0", i, sr.ArrivalOffset)
+		}
+	}
+}
+
+func TestGenerateSequenceLifetimeBounds(t *testing.T) {
+	cfg := schedTestConfig()
+	seq := GenerateSequence(cfg, rand.New(rand.NewSource(9)))
+	lo := time.Duration(cfg.LifetimeMin * float64(time.Second))
+	hi := time.Duration(cfg.LifetimeMax * float64(time.Second))
+	for i, sr := range seq {
+		if sr.Lifetime < lo || sr.Lifetime > hi {
+			t.Fatalf("seq[%d].Lifetime = %v, want within [%v, %v]", i, sr.Lifetime, lo, hi)
+		}
+	}
+}
+
+func TestGenerateSequenceNoLifetime(t *testing.T) {
+	cfg := schedTestConfig()
+	cfg.hasLifetime = false
+	seq := GenerateSequence(cfg, rand.New(rand.NewSource(9)))
+	for i, sr := range seq {
+		if sr.Lifetime != 0 {
+			t.Fatalf("seq[%d].Lifetime = %v, want 0 without --lifetime", i, sr.Lifetime)
+		}
+	}
+}
+
+func TestGenerateSequenceTemplateWeights(t *testing.T) {
+	cfg := schedTestConfig()
+	cfg.Total = 6000
+	cfg.Templates = []TemplateSpec{
+		{TemplateID: "small", Weight: 6},
+		{TemplateID: "medium", Weight: 3},
+		{TemplateID: "large", Weight: 1},
+	}
+	seq := GenerateSequence(cfg, rand.New(rand.NewSource(11)))
+
+	counts := map[string]int{}
+	for _, sr := range seq {
+		counts[sr.TemplateID]++
+		if sr.TemplateID == "" {
+			t.Fatalf("seq[%d] has empty template", sr.Seq)
+		}
+	}
+	want := map[string]float64{"small": 0.6, "medium": 0.3, "large": 0.1}
+	for id, p := range want {
+		got := float64(counts[id]) / float64(cfg.Total)
+		if math.Abs(got-p) > p*0.35 {
+			t.Fatalf("template %s share = %.3f, want %.3f (loose)", id, got, p)
+		}
+	}
+}
+
+func TestGenerateSequenceCarriesSpecAnnotations(t *testing.T) {
+	cfg := schedTestConfig()
+	cfg.Total = 10
+	cfg.Templates = []TemplateSpec{{TemplateID: "tpl-a", Weight: 1, CpuMillis: 2000, MemMiB: 4096}}
+	seq := GenerateSequence(cfg, rand.New(rand.NewSource(3)))
+	for i, sr := range seq {
+		if sr.CpuMillis != 2000 || sr.MemMiB != 4096 {
+			t.Fatalf("seq[%d] spec = %d/%d, want 2000/4096", i, sr.CpuMillis, sr.MemMiB)
+		}
+	}
+}
+
+func TestParseTemplates(t *testing.T) {
+	got, err := parseTemplates("tpl-a, tpl-b:2, tpl-c:3:1000:2048")
+	if err != nil {
+		t.Fatalf("parseTemplates: %v", err)
+	}
+	want := []TemplateSpec{
+		{TemplateID: "tpl-a", Weight: 1},
+		{TemplateID: "tpl-b", Weight: 2},
+		{TemplateID: "tpl-c", Weight: 3, CpuMillis: 1000, MemMiB: 2048},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestParseTemplatesRejectsBadSpecs(t *testing.T) {
+	for _, spec := range []string{
+		"",
+		"tpl-a,,tpl-b",
+		":2",
+		"tpl-a:0",
+		"tpl-a:-1",
+		"tpl-a:x",
+		"tpl-a:1:-5",
+		"tpl-a:1:1000:-1",
+		"tpl-a:1:1000:2048:extra",
+	} {
+		if _, err := parseTemplates(spec); err == nil {
+			t.Fatalf("parseTemplates(%q) returned nil error, want rejection", spec)
+		}
+	}
+}
+
+func TestParseLifetime(t *testing.T) {
+	lo, hi, err := parseLifetime("10,120")
+	if err != nil || lo != 10 || hi != 120 {
+		t.Fatalf("parseLifetime(10,120) = %v,%v,%v", lo, hi, err)
+	}
+	lo, hi, err = parseLifetime("30")
+	if err != nil || lo != 30 || hi != 30 {
+		t.Fatalf("parseLifetime(30) = %v,%v,%v", lo, hi, err)
+	}
+	for _, spec := range []string{"", "abc", "120,10", "-5,10", "1,2,3"} {
+		if _, _, err := parseLifetime(spec); err == nil {
+			t.Fatalf("parseLifetime(%q) returned nil error, want rejection", spec)
+		}
+	}
+}
+
+func TestApplyWorkloadPreset(t *testing.T) {
+	cfg := &Config{Workload: "burst", Total: 20}
+	if err := applyWorkloadPreset(cfg, map[string]bool{}); err != nil {
+		t.Fatalf("applyWorkloadPreset: %v", err)
+	}
+	if cfg.Total != 500 || cfg.Rate != 50 || cfg.LifetimeMin != 10 || cfg.LifetimeMax != 120 || !cfg.hasLifetime {
+		t.Fatalf("burst preset not applied: %+v", cfg)
+	}
+
+	// Explicit flags win over preset defaults.
+	cfg = &Config{Workload: "burst", Total: 20, Rate: 5}
+	explicit := map[string]bool{"n": true, "rate": true}
+	if err := applyWorkloadPreset(cfg, explicit); err != nil {
+		t.Fatalf("applyWorkloadPreset: %v", err)
+	}
+	if cfg.Total != 20 || cfg.Rate != 5 {
+		t.Fatalf("explicit flags overridden: total=%d rate=%v", cfg.Total, cfg.Rate)
+	}
+	if !cfg.hasLifetime || cfg.LifetimeMin != 10 || cfg.LifetimeMax != 120 {
+		t.Fatalf("lifetime preset not applied: %+v", cfg)
+	}
+
+	cfg = &Config{Workload: "mixed_spec", Total: 20}
+	if err := applyWorkloadPreset(cfg, map[string]bool{}); err != nil {
+		t.Fatalf("applyWorkloadPreset: %v", err)
+	}
+	if cfg.Total != 400 || cfg.Rate != 10 || cfg.LifetimeMin != 30 || cfg.LifetimeMax != 300 {
+		t.Fatalf("mixed_spec preset not applied: %+v", cfg)
+	}
+
+	if err := applyWorkloadPreset(&Config{Workload: "nope"}, map[string]bool{}); err == nil {
+		t.Fatal("unknown workload returned nil error")
+	}
+}
+
+func TestDumpTraceSchema(t *testing.T) {
+	cfg := &Config{
+		Workload:    "burst",
+		Seed:        7,
+		Total:       50,
+		Rate:        50,
+		hasLifetime: true,
+		LifetimeMin: 10,
+		LifetimeMax: 120,
+		Templates: []TemplateSpec{
+			{TemplateID: "tpl-small", Weight: 1, CpuMillis: 1000, MemMiB: 2048},
+		},
+	}
+	seq := GenerateSequence(cfg, rand.New(rand.NewSource(cfg.Seed)))
+
+	path := filepath.Join(t.TempDir(), "trace.json")
+	if err := DumpTrace(path, cfg, seq); err != nil {
+		t.Fatalf("DumpTrace: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read trace: %v", err)
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("trace unmarshal: %v", err)
+	}
+	for _, key := range []string{"workload", "seed", "generated_at", "params", "templates", "requests"} {
+		if _, ok := top[key]; !ok {
+			t.Fatalf("trace missing top-level key %q", key)
+		}
+	}
+	if string(top["workload"]) != `"burst"` {
+		t.Fatalf("workload = %s, want \"burst\"", top["workload"])
+	}
+	if string(top["seed"]) != "7" {
+		t.Fatalf("seed = %s, want 7", top["seed"])
+	}
+	var genAt string
+	if err := json.Unmarshal(top["generated_at"], &genAt); err != nil {
+		t.Fatalf("generated_at unmarshal: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, genAt); err != nil {
+		t.Fatalf("generated_at %q not RFC3339: %v", genAt, err)
+	}
+
+	var params map[string]json.RawMessage
+	if err := json.Unmarshal(top["params"], &params); err != nil {
+		t.Fatalf("params unmarshal: %v", err)
+	}
+	for _, key := range []string{"rate_per_sec", "lifetime_min_s", "lifetime_max_s", "total"} {
+		if _, ok := params[key]; !ok {
+			t.Fatalf("params missing key %q", key)
+		}
+	}
+	if string(params["rate_per_sec"]) != "50" || string(params["total"]) != "50" {
+		t.Fatalf("params = %v", params)
+	}
+	if string(params["lifetime_min_s"]) != "10" || string(params["lifetime_max_s"]) != "120" {
+		t.Fatalf("lifetime params = %v", params)
+	}
+
+	var templates []map[string]json.RawMessage
+	if err := json.Unmarshal(top["templates"], &templates); err != nil {
+		t.Fatalf("templates unmarshal: %v", err)
+	}
+	if len(templates) != 1 {
+		t.Fatalf("templates len = %d, want 1", len(templates))
+	}
+	for _, key := range []string{"template_id", "weight", "cpu_millis", "mem_mib"} {
+		if _, ok := templates[0][key]; !ok {
+			t.Fatalf("templates[0] missing key %q", key)
+		}
+	}
+	if string(templates[0]["template_id"]) != `"tpl-small"` ||
+		string(templates[0]["weight"]) != "1" ||
+		string(templates[0]["cpu_millis"]) != "1000" ||
+		string(templates[0]["mem_mib"]) != "2048" {
+		t.Fatalf("templates[0] = %v", templates[0])
+	}
+
+	var requests []map[string]json.RawMessage
+	if err := json.Unmarshal(top["requests"], &requests); err != nil {
+		t.Fatalf("requests unmarshal: %v", err)
+	}
+	if len(requests) != cfg.Total {
+		t.Fatalf("requests len = %d, want %d", len(requests), cfg.Total)
+	}
+	var prev int64 = -1
+	for i, req := range requests {
+		for _, key := range []string{"seq", "arrival_ms", "template_id", "cpu_millis", "mem_mib", "lifetime_ms"} {
+			if _, ok := req[key]; !ok {
+				t.Fatalf("requests[%d] missing key %q", i, key)
+			}
+		}
+		var seqNo, arrival, life int64
+		if err := json.Unmarshal(req["seq"], &seqNo); err != nil {
+			t.Fatalf("requests[%d].seq: %v", i, err)
+		}
+		if err := json.Unmarshal(req["arrival_ms"], &arrival); err != nil {
+			t.Fatalf("requests[%d].arrival_ms: %v", i, err)
+		}
+		if err := json.Unmarshal(req["lifetime_ms"], &life); err != nil {
+			t.Fatalf("requests[%d].lifetime_ms: %v", i, err)
+		}
+		if int(seqNo) != i {
+			t.Fatalf("requests[%d].seq = %d", i, seqNo)
+		}
+		if arrival < prev {
+			t.Fatalf("requests not sorted by arrival_ms at %d: %d < %d", i, arrival, prev)
+		}
+		prev = arrival
+		if life < 10000 || life > 120000 {
+			t.Fatalf("requests[%d].lifetime_ms = %d, want within [10000, 120000]", i, life)
+		}
+	}
+	if string(requests[0]["arrival_ms"]) != "0" {
+		t.Fatalf("first arrival_ms = %s, want 0", requests[0]["arrival_ms"])
+	}
+}
+
+func TestDumpTraceUnannotatedTemplateZeroSpec(t *testing.T) {
+	cfg := &Config{
+		Seed:      1,
+		Total:     5,
+		Templates: []TemplateSpec{{TemplateID: "tpl-x", Weight: 1}},
+	}
+	seq := GenerateSequence(cfg, rand.New(rand.NewSource(cfg.Seed)))
+	path := filepath.Join(t.TempDir(), "trace.json")
+	if err := DumpTrace(path, cfg, seq); err != nil {
+		t.Fatalf("DumpTrace: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	var tf struct {
+		Requests []struct {
+			CpuMillis int64 `json:"cpu_millis"`
+			MemMiB    int64 `json:"mem_mib"`
+		} `json:"requests"`
+	}
+	if err := json.Unmarshal(data, &tf); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for i, r := range tf.Requests {
+		if r.CpuMillis != 0 || r.MemMiB != 0 {
+			t.Fatalf("requests[%d] spec = %d/%d, want 0/0 for unannotated template", i, r.CpuMillis, r.MemMiB)
+		}
+	}
+}

--- a/examples/cube-bench/ui.go
+++ b/examples/cube-bench/ui.go
@@ -42,8 +42,13 @@ func newModel(cfg *Config, resultCh <-chan IterResult) model {
 		resultCh: resultCh,
 		total:    cfg.Total,
 		progress: p,
-		qpsStart: time.Now(),
-		width:    80,
+		// The model is created as the dispatcher starts, so key elapsed/
+		// in-flight off creation time, not the first completion — for
+		// lifetime-bearing runs the first result only arrives after a full
+		// create → lifetime-sleep → delete cycle.
+		startTime: time.Now(),
+		qpsStart:  time.Now(),
+		width:     80,
 	}
 }
 

--- a/examples/cube-bench/ui.go
+++ b/examples/cube-bench/ui.go
@@ -37,19 +37,23 @@ func newModel(cfg *Config, resultCh <-chan IterResult) model {
 		progress.WithDefaultGradient(),
 		progress.WithWidth(50),
 	)
-	return model{
+	m := model{
 		cfg:      cfg,
 		resultCh: resultCh,
 		total:    cfg.Total,
 		progress: p,
+		qpsStart: time.Now(),
+		width:    80,
+	}
+	if cfg.Scheduled {
 		// The model is created as the dispatcher starts, so key elapsed/
 		// in-flight off creation time, not the first completion — for
 		// lifetime-bearing runs the first result only arrives after a full
-		// create → lifetime-sleep → delete cycle.
-		startTime: time.Now(),
-		qpsStart:  time.Now(),
-		width:     80,
+		// create → lifetime-sleep → delete cycle. Legacy mode keeps its
+		// historical first-completion baseline via the lazy init in Update.
+		m.startTime = time.Now()
 	}
+	return m
 }
 
 func (m model) Init() tea.Cmd {

--- a/examples/cube-bench/ui.go
+++ b/examples/cube-bench/ui.go
@@ -225,6 +225,20 @@ func (m model) renderStats(elapsed time.Duration) string {
 	kv("QPS", T.Accent.Render(fmt.Sprintf("%.1f", qps))+" req/s")
 	kv("Avg Create", LatencyStyle(createAvg).Render(fmt.Sprintf("%.0f ms", createAvg)))
 	kv("Avg Delete", LatencyStyle(deleteAvg).Render(fmt.Sprintf("%.0f ms", deleteAvg)))
+	if m.cfg.Scheduled && len(m.cfg.sequence) > 0 {
+		// Approximate in-flight: released per schedule minus completed.
+		started := 0
+		for _, sr := range m.cfg.sequence {
+			if sr.ArrivalOffset <= elapsed {
+				started++
+			}
+		}
+		inFlight := started - m.completed
+		if inFlight < 0 {
+			inFlight = 0
+		}
+		kv("In-Flight", T.Accent.Render(fmt.Sprintf("~%d", inFlight)))
+	}
 	kv("Elapsed", fmt.Sprintf("%.1fs", elapsed.Seconds()))
 
 	return b.String()

--- a/examples/cube-bench/ui.go
+++ b/examples/cube-bench/ui.go
@@ -231,14 +231,11 @@ func (m model) renderStats(elapsed time.Duration) string {
 	kv("Avg Create", LatencyStyle(createAvg).Render(fmt.Sprintf("%.0f ms", createAvg)))
 	kv("Avg Delete", LatencyStyle(deleteAvg).Render(fmt.Sprintf("%.0f ms", deleteAvg)))
 	if m.cfg.Scheduled && len(m.cfg.sequence) > 0 {
-		// Approximate in-flight: released per schedule minus completed.
-		started := 0
-		for _, sr := range m.cfg.sequence {
-			if sr.ArrivalOffset <= elapsed {
-				started++
-			}
-		}
-		inFlight := started - m.completed
+		// In-flight from actual dispatcher releases minus completions. The
+		// planned arrival schedule is not usable here: in ASAP mode every
+		// offset is 0 (gauge would read "remaining"), and under semaphore
+		// back-pressure scheduled arrivals outpace real releases.
+		inFlight := int(m.cfg.released.Load()) - m.completed
 		if inFlight < 0 {
 			inFlight = 0
 		}


### PR DESCRIPTION
## Summary

Split out from #1619 to fit the auto-review time budget; #1619 remains as the overall design overview.

Extend `examples/cube-bench` from a single fixed benchmark into a repeatable scheduler workload harness:

- **Pre-generated request sequences from a fixed `--seed`**: Poisson arrivals (`--rate`), uniform per-sandbox lifetimes (`--lifetime`, client-scheduled delete plus server-side timeout as a safety net), and weighted multi-template mixes (`--templates id[:weight[:cpuMillis:memMiB]]`).
- **Workload presets** matching the scheduler benchmark plan: `burst`, `template_storm`, `mixed_spec`; `--dump-trace` writes the exact sequence as a JSON trace for replay by the scheduling simulator.
- **New per-request fields** (template, scheduled/actual start, queue delay) exported in JSON; queue-delay percentiles added to the report.
- **New `compare` subcommand**: multi-seed A/B report with mean ± 95% CI, absolute/relative deltas and direction-aware improved/regressed verdicts; accepts both cube-bench exports and schedsim reports.
- Legacy mode is unchanged when no scheduling flags are given (regression-tested).

## Test plan

- `cd examples/cube-bench && go test ./...` — passing (sequence determinism, distribution bounds, scheduled end-to-end via httptest, compare stats/direction/e2e).

Assisted-by: Kimi Code CLI:kimi-k2
