### PR TITLE
feat(cubemaster): add scheduler Prometheus metrics

### DIFF
--- a/CubeMaster/go.mod
+++ b/CubeMaster/go.mod
@@ -109,9 +109,9 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect

--- a/CubeMaster/go.mod
+++ b/CubeMaster/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/CubeMaster/pkg/scheduler/init.go
+++ b/CubeMaster/pkg/scheduler/init.go
@@ -39,4 +39,6 @@ func InitScheduler(ctx context.Context) {
 	scheduler.postScore = postscore.NewSelector()
 
 	initTask(ctx)
+
+	startClusterGaugeCollector(ctx)
 }

--- a/CubeMaster/pkg/scheduler/metrics.go
+++ b/CubeMaster/pkg/scheduler/metrics.go
@@ -57,7 +57,6 @@ const (
 const (
 	rescheduleReasonRPCError     = "rpc_error"
 	rescheduleReasonCircuitBreak = "circuit_break"
-	rescheduleReasonReuse        = "reuse"
 	rescheduleReasonLoopRetry    = "loop_retry"
 	rescheduleReasonBackoff      = "backoff"
 	rescheduleReasonAdmission    = "admission"
@@ -102,7 +101,7 @@ var (
 
 	schedulerReschedules = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "scheduler_reschedules_total",
-		Help: "Total handleCubelet retry/reschedule events during sandbox create, by profile and error-code category.",
+		Help: "Total node reselection events during sandbox create (handleCubelet retries that pick a new host), by profile and error-code category.",
 	}, []string{profileLabel, reasonLabel})
 
 	sandboxCreateAttempts = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -127,7 +126,7 @@ var (
 
 	nodeLoadCVGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "scheduler_node_load_cv",
-		Help: "Coefficient of variation (population stddev / mean) of per-node load ratio (usage / raw quota) across healthy nodes.",
+		Help: "Coefficient of variation (population stddev / mean) of per-node load ratio (accounted allocation / overcommitted capacity) across healthy nodes.",
 	}, []string{resourceLabel})
 
 	activeNodesGauge = promauto.NewGauge(prometheus.GaugeOpts{
@@ -180,8 +179,11 @@ func RecordDecision(profile string, templateHit bool) {
 	schedulerDecisions.WithLabelValues(profile, strconv.FormatBool(templateHit)).Inc()
 }
 
-// RecordReschedule counts one handleCubelet retry/reschedule event,
-// categorized from the cubelet/master error code that triggered it.
+// RecordReschedule counts one node reselection during sandbox create,
+// categorized from the cubelet/master error code that triggered it. Callers
+// must only record retries that actually re-run Select: reuse-code retries
+// keep the same host (errorCodeRetry clears c.reschedule) and are not
+// reselections, so the "reuse" category never appears on this metric.
 func RecordReschedule(profile string, code errorcode.ErrorCode) {
 	schedulerReschedules.WithLabelValues(profile, rescheduleReason(code)).Inc()
 }
@@ -197,8 +199,6 @@ func rescheduleReason(code errorcode.ErrorCode) string {
 		return rescheduleReasonRPCError
 	case errorcode.IsCircutBreakCode(code):
 		return rescheduleReasonCircuitBreak
-	case errorcode.IsReuseCode(code):
-		return rescheduleReasonReuse
 	case errorcode.IsLoopRetryCode(code):
 		return rescheduleReasonLoopRetry
 	case errorcode.IsBackoffRetryCode(code):
@@ -290,18 +290,23 @@ func sumClusterQuota(nodes []nodeResourceStat, fn nodeCapacityFunc) clusterQuota
 	return q
 }
 
-// nodeLoadCV returns the coefficient of variation of per-node load ratios
-// (usage / raw quota), computed over nodes with a positive quota. An empty
-// set or zero mean yields 0.
-func nodeLoadCV(nodes []nodeResourceStat) (cpuCV, memCV float64) {
+// nodeLoadCV returns the coefficient of variation of per-node load ratios,
+// computed over nodes with a positive capacity. Ratios use the same
+// scheduler-accounted quantities as the sibling cluster gauges: accounted
+// allocation (EffectiveAllocated) over overcommitted capacity
+// (EffectiveQuota*) — raw usage/quota would diverge under heterogeneous
+// overcommit ratios or ignore_redis_allocation. An empty set or zero mean
+// yields 0.
+func nodeLoadCV(nodes []nodeResourceStat, fn nodeCapacityFunc) (cpuCV, memCV float64) {
 	cpuRatios := make([]float64, 0, len(nodes))
 	memRatios := make([]float64, 0, len(nodes))
 	for _, n := range nodes {
-		if n.quotaCpuMilli > 0 {
-			cpuRatios = append(cpuRatios, float64(n.cpuUsageMilli)/float64(n.quotaCpuMilli))
+		cpuCap, memCap, cpuAlloc, memAlloc := fn(n)
+		if cpuCap > 0 {
+			cpuRatios = append(cpuRatios, float64(cpuAlloc)/float64(cpuCap))
 		}
-		if n.quotaMemMB > 0 {
-			memRatios = append(memRatios, float64(n.memUsageMB)/float64(n.quotaMemMB))
+		if memCap > 0 {
+			memRatios = append(memRatios, float64(memAlloc)/float64(memCap))
 		}
 	}
 	return cvOfRatios(cpuRatios), cvOfRatios(memRatios)
@@ -330,10 +335,12 @@ func cvOfRatios(ratios []float64) float64 {
 }
 
 // countActiveEmptyNodes splits nodes into active (running microVMs or any
-// accounted usage) and empty.
-func countActiveEmptyNodes(nodes []nodeResourceStat) (active, empty int) {
+// accounted allocation) and empty, using the same accounted-allocation view
+// as the other cluster gauges.
+func countActiveEmptyNodes(nodes []nodeResourceStat, fn nodeCapacityFunc) (active, empty int) {
 	for _, n := range nodes {
-		if n.mvmNum > 0 || n.cpuUsageMilli > 0 || n.memUsageMB > 0 {
+		_, _, cpuAlloc, memAlloc := fn(n)
+		if n.mvmNum > 0 || cpuAlloc > 0 || memAlloc > 0 {
 			active++
 		} else {
 			empty++
@@ -378,7 +385,11 @@ func fragmentedCapacityRatio(nodes []nodeResourceStat, fn nodeCapacityFunc, shap
 var clusterGaugeOnce sync.Once
 
 // startClusterGaugeCollector launches the periodic gauge collection exactly
-// once, even if InitScheduler is called repeatedly (e.g. in-process restarts).
+// once per process. The loop is bound to the ctx of the FIRST call:
+// InitScheduler is invoked exactly once in cmd/cubemaster/app/main.go with a
+// process-lifetime context, which is the contract this relies on — a later
+// call with a different ctx would NOT restart the loop after the original
+// ctx is cancelled, so callers must not cancel the original ctx early.
 func startClusterGaugeCollector(ctx context.Context) {
 	clusterGaugeOnce.Do(func() {
 		recov.GoWithRecover(func() {
@@ -439,11 +450,11 @@ func collectClusterGauges() {
 	clusterQuotaGauge.WithLabelValues(resourceLabelMem, quotaTypeAllocated).Set(quota.memAllocated)
 	clusterQuotaGauge.WithLabelValues(resourceLabelMem, quotaTypeCapacity).Set(quota.memCapacity)
 
-	cpuCV, memCV := nodeLoadCV(stats)
+	cpuCV, memCV := nodeLoadCV(stats, capFn)
 	nodeLoadCVGauge.WithLabelValues(resourceLabelCPU).Set(cpuCV)
 	nodeLoadCVGauge.WithLabelValues(resourceLabelMem).Set(memCV)
 
-	active, empty := countActiveEmptyNodes(stats)
+	active, empty := countActiveEmptyNodes(stats, capFn)
 	activeNodesGauge.Set(float64(active))
 	emptyNodesGauge.Set(float64(empty))
 

--- a/CubeMaster/pkg/scheduler/metrics.go
+++ b/CubeMaster/pkg/scheduler/metrics.go
@@ -1,0 +1,454 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package scheduler
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/ret"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx"
+)
+
+// DefaultProfile is the scheduling profile label attached to every metric in
+// this file.
+// TODO(profile-router): pass the real profile name once the module-1 Profile
+// Router lands; until then all series carry profile="default".
+const DefaultProfile = "default"
+
+// Label value enums. Cardinality is intentionally kept small and closed.
+const (
+	metricResultSuccess = "success"
+	metricResultError   = "error"
+
+	// attemptReasonNone marks successful attempts; the reason label is always
+	// present so series stay queryable with a fixed label set.
+	attemptReasonNone = "none"
+	// attemptReasonNoNode maps ErrorCode_SelectNodesNoRes: a stage ended with
+	// an empty candidate set (preFilter/filter/score/backoff all converge on
+	// this code).
+	attemptReasonNoNode = "no_node"
+	// attemptReasonPreFilter maps ErrorCode_SelectNodesFailed: the
+	// pre-selector (or backoff selector) call itself failed.
+	attemptReasonPreFilter = "prefilter"
+	// attemptReasonError covers everything else (panic recovery, internal
+	// errors, ...).
+	attemptReasonError = "error"
+)
+
+// Reschedule reason categories for handleCubelet retries, derived from the
+// cubelet/master error code. The classification order in rescheduleReason is
+// significant because a code can sit in several retry maps at once:
+// rpc_error > circuit_break > reuse > loop_retry > backoff > admission > other.
+const (
+	rescheduleReasonRPCError     = "rpc_error"
+	rescheduleReasonCircuitBreak = "circuit_break"
+	rescheduleReasonReuse        = "reuse"
+	rescheduleReasonLoopRetry    = "loop_retry"
+	rescheduleReasonBackoff      = "backoff"
+	rescheduleReasonAdmission    = "admission"
+	rescheduleReasonOther        = "other"
+)
+
+const (
+	resourceLabelCPU    = "cpu"
+	resourceLabelMem    = "mem"
+	quotaTypeAllocated  = "allocated"
+	quotaTypeCapacity   = "capacity"
+	templateHitLabel    = "template_hit"
+	profileLabel        = "profile"
+	resultLabel         = "result"
+	reasonLabel         = "reason"
+	resourceLabel       = "resource"
+	quotaTypeLabel      = "type"
+	shapeLabel          = "shape"
+	fragmentShapeMaxMVM = "max_mvm"
+)
+
+// clusterGaugeCollectInterval is how often the cluster-level gauges are
+// re-computed from localcache.
+const clusterGaugeCollectInterval = 15 * time.Second
+
+var (
+	schedulerAttempts = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "scheduler_attempts_total",
+		Help: "Total scheduler Select attempts, by profile, result and failure reason.",
+	}, []string{profileLabel, resultLabel, reasonLabel})
+
+	schedulerDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "scheduler_duration_seconds",
+		Help:    "Latency of a single scheduler Select call, by profile.",
+		Buckets: prometheus.ExponentialBuckets(0.0005, 2, 13), // 0.5ms .. ~2s
+	}, []string{profileLabel})
+
+	schedulerDecisions = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "scheduler_decisions_total",
+		Help: "Total successful scheduling decisions, by profile and whether the selected node already holds a local replica of the requested template.",
+	}, []string{profileLabel, templateHitLabel})
+
+	schedulerReschedules = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "scheduler_reschedules_total",
+		Help: "Total handleCubelet retry/reschedule events during sandbox create, by profile and error-code category.",
+	}, []string{profileLabel, reasonLabel})
+
+	sandboxCreateAttempts = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "sandbox_create_attempts_total",
+		Help: "Total sandbox create requests, by profile and result.",
+	}, []string{profileLabel, resultLabel})
+
+	sandboxCreateDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "sandbox_create_duration_seconds",
+		Help:    "End-to-end latency from sandbox create acceptance to completion, by profile and result.",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 13), // 100ms .. ~7min
+	}, []string{profileLabel, resultLabel})
+
+	// clusterQuotaGauge exposes summed cluster resources: allocated is the
+	// usage the scheduler accounts for (EffectiveAllocated), capacity is the
+	// overcommitted quota (quota * overcommit_ratio). cpu in millicores,
+	// mem in MB.
+	clusterQuotaGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "scheduler_cluster_quota",
+		Help: "Summed cluster quota seen by the scheduler (cpu in millicores, mem in MB), by resource and type (allocated/capacity).",
+	}, []string{resourceLabel, quotaTypeLabel})
+
+	nodeLoadCVGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "scheduler_node_load_cv",
+		Help: "Coefficient of variation (population stddev / mean) of per-node load ratio (usage / raw quota) across healthy nodes.",
+	}, []string{resourceLabel})
+
+	activeNodesGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "scheduler_active_nodes",
+		Help: "Number of healthy nodes with MvmNum > 0 or non-zero accounted usage.",
+	})
+
+	emptyNodesGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "scheduler_empty_nodes",
+		Help: "Number of healthy nodes with MvmNum == 0 and zero accounted usage.",
+	})
+
+	fragmentedCapacityGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "scheduler_fragmented_capacity_ratio",
+		Help: "Ratio of free capacity stranded on nodes that cannot fit the reference shape (see fragmentedCapacityRatio), by shape.",
+	}, []string{shapeLabel})
+)
+
+// ObserveScheduleAttempt records one Select call: the attempts counter with a
+// classified result/reason, and the duration histogram (observed for both
+// success and failure).
+func ObserveScheduleAttempt(profile string, err error, d time.Duration) {
+	result, reason := metricResultSuccess, attemptReasonNone
+	if err != nil {
+		result, reason = metricResultError, classifyAttemptError(err)
+	}
+	schedulerAttempts.WithLabelValues(profile, result, reason).Inc()
+	schedulerDuration.WithLabelValues(profile).Observe(d.Seconds())
+}
+
+// classifyAttemptError maps the Select failure error code to a small reason
+// enum. ret.FromError normalizes non-ret errors to ErrorCode_Unknown, which
+// lands in the generic "error" bucket.
+func classifyAttemptError(err error) string {
+	st, _ := ret.FromError(err)
+	switch st.Code() {
+	case errorcode.ErrorCode_SelectNodesNoRes:
+		return attemptReasonNoNode
+	case errorcode.ErrorCode_SelectNodesFailed:
+		return attemptReasonPreFilter
+	default:
+		return attemptReasonError
+	}
+}
+
+// RecordDecision counts one successful scheduling decision. templateHit marks
+// that the selected node already has a local replica of the requested
+// template; requests without a template always record false.
+func RecordDecision(profile string, templateHit bool) {
+	schedulerDecisions.WithLabelValues(profile, strconv.FormatBool(templateHit)).Inc()
+}
+
+// RecordReschedule counts one handleCubelet retry/reschedule event,
+// categorized from the cubelet/master error code that triggered it.
+func RecordReschedule(profile string, code errorcode.ErrorCode) {
+	schedulerReschedules.WithLabelValues(profile, rescheduleReason(code)).Inc()
+}
+
+// rescheduleReason classifies the error code into a low-cardinality category.
+// Precedence matters for codes present in several retry maps (e.g.
+// HostDiskNotEnough is both circuit-breaking and loop-retryable): the first
+// matching category wins, mirroring how handleCubelet treats the code.
+func rescheduleReason(code errorcode.ErrorCode) string {
+	switch {
+	case code == errorcode.ErrorCode_ReqCubeAPIFailed:
+		// errRetry (cubelet RPC failure) always synthesizes this code.
+		return rescheduleReasonRPCError
+	case errorcode.IsCircutBreakCode(code):
+		return rescheduleReasonCircuitBreak
+	case errorcode.IsReuseCode(code):
+		return rescheduleReasonReuse
+	case errorcode.IsLoopRetryCode(code):
+		return rescheduleReasonLoopRetry
+	case errorcode.IsBackoffRetryCode(code):
+		return rescheduleReasonBackoff
+	case code == errorcode.ErrorCode_SelectNodesFailed:
+		// The scheduling-admission gate rejected the selected node.
+		return rescheduleReasonAdmission
+	default:
+		return rescheduleReasonOther
+	}
+}
+
+// ObserveSandboxCreate records one finished sandbox create request.
+// start/end reuse the createSandboxContext timestamps; an unset or inverted
+// end falls back to now so early-return paths still get a sane duration.
+func ObserveSandboxCreate(profile string, success bool, start, end time.Time) {
+	if start.IsZero() {
+		start = time.Now()
+	}
+	if end.IsZero() || end.Before(start) {
+		end = time.Now()
+	}
+	result := metricResultSuccess
+	if !success {
+		result = metricResultError
+	}
+	sandboxCreateAttempts.WithLabelValues(profile, result).Inc()
+	sandboxCreateDuration.WithLabelValues(profile, result).Observe(end.Sub(start).Seconds())
+}
+
+// observeSelect is the deferred metrics hook of Select. It runs after the
+// panic-recovery defer, so it observes the final (nodes, err) pair. A nil
+// node with nil error is normalized to a no_node failure: the caller treats
+// it as an error anyway.
+func observeSelect(selCtx *selctx.SelectorCtx, selected *node.Node, err error, start time.Time) {
+	if err == nil && selected == nil {
+		err = ret.Err(errorcode.ErrorCode_SelectNodesNoRes, ErrNoRes.Error())
+	}
+	ObserveScheduleAttempt(DefaultProfile, err, time.Since(start))
+	if err != nil {
+		return
+	}
+	RecordDecision(DefaultProfile, templateLocalHit(selCtx, selected))
+}
+
+// templateLocalHit reports whether the selected node holds a local replica of
+// the requested template. Only checked when the request carries a TemplateID;
+// the lookup is an in-memory image-cache read.
+func templateLocalHit(selCtx *selctx.SelectorCtx, selected *node.Node) bool {
+	if selCtx == nil || selCtx.ReqRes == nil || selCtx.ReqRes.TemplateID == "" || selected == nil {
+		return false
+	}
+	return localcache.GetImageStateByNode(selCtx.ReqRes.TemplateID, selected.ID()) != nil
+}
+
+// nodeResourceStat is the projection of node.Node needed by the cluster-level
+// gauges. cpu values are in millicores, mem values in MB.
+type nodeResourceStat struct {
+	instanceType  string
+	quotaCpuMilli int64
+	quotaMemMB    int64
+	cpuUsageMilli int64
+	memUsageMB    int64
+	mvmNum        int64
+}
+
+// nodeCapacityFunc resolves one node's overcommitted schedulable capacity and
+// the allocated usage the scheduler accounts for (EffectiveAllocated), in cpu
+// millicores / mem MB.
+type nodeCapacityFunc func(n nodeResourceStat) (cpuCapMilli, memCapMB, cpuAllocMilli, memAllocMB int64)
+
+// clusterQuota holds summed cluster resources for the quota gauge.
+type clusterQuota struct {
+	cpuAllocated float64
+	cpuCapacity  float64
+	memAllocated float64
+	memCapacity  float64
+}
+
+func sumClusterQuota(nodes []nodeResourceStat, fn nodeCapacityFunc) clusterQuota {
+	var q clusterQuota
+	for _, n := range nodes {
+		cpuCap, memCap, cpuAlloc, memAlloc := fn(n)
+		q.cpuCapacity += float64(cpuCap)
+		q.memCapacity += float64(memCap)
+		q.cpuAllocated += float64(cpuAlloc)
+		q.memAllocated += float64(memAlloc)
+	}
+	return q
+}
+
+// nodeLoadCV returns the coefficient of variation of per-node load ratios
+// (usage / raw quota), computed over nodes with a positive quota. An empty
+// set or zero mean yields 0.
+func nodeLoadCV(nodes []nodeResourceStat) (cpuCV, memCV float64) {
+	cpuRatios := make([]float64, 0, len(nodes))
+	memRatios := make([]float64, 0, len(nodes))
+	for _, n := range nodes {
+		if n.quotaCpuMilli > 0 {
+			cpuRatios = append(cpuRatios, float64(n.cpuUsageMilli)/float64(n.quotaCpuMilli))
+		}
+		if n.quotaMemMB > 0 {
+			memRatios = append(memRatios, float64(n.memUsageMB)/float64(n.quotaMemMB))
+		}
+	}
+	return cvOfRatios(cpuRatios), cvOfRatios(memRatios)
+}
+
+// cvOfRatios computes population stddev / mean; the full node set is
+// enumerated, so no sample correction is applied.
+func cvOfRatios(ratios []float64) float64 {
+	if len(ratios) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, r := range ratios {
+		sum += r
+	}
+	mean := sum / float64(len(ratios))
+	if mean == 0 {
+		return 0
+	}
+	var sq float64
+	for _, r := range ratios {
+		d := r - mean
+		sq += d * d
+	}
+	return math.Sqrt(sq/float64(len(ratios))) / mean
+}
+
+// countActiveEmptyNodes splits nodes into active (running microVMs or any
+// accounted usage) and empty.
+func countActiveEmptyNodes(nodes []nodeResourceStat) (active, empty int) {
+	for _, n := range nodes {
+		if n.mvmNum > 0 || n.cpuUsageMilli > 0 || n.memUsageMB > 0 {
+			active++
+		} else {
+			empty++
+		}
+	}
+	return active, empty
+}
+
+// fragmentedCapacityRatio measures how much free capacity is stranded on
+// nodes that cannot fit the reference shape: per node, free = max(0,
+// overcommitted capacity - accounted allocation); a node whose free cpu OR
+// free mem is below the shape counts as unfit, and its free resources count
+// as fragmented. The result is the mean of the cpu and mem fragmented ratios,
+// in [0,1]; a resource whose cluster-wide free total is 0 contributes 0.
+//
+// The reference shape is MaxMvmCPU x MaxMvmMemory (label shape="max_mvm"),
+// i.e. "cannot host even one largest schedulable microVM" — the only shape
+// configured cluster-wide, which keeps the label cardinality at 1.
+func fragmentedCapacityRatio(nodes []nodeResourceStat, fn nodeCapacityFunc, shapeCpuMilli, shapeMemMB int64) float64 {
+	var totalFreeCpu, totalFreeMem, fragFreeCpu, fragFreeMem float64
+	for _, n := range nodes {
+		cpuCap, memCap, cpuAlloc, memAlloc := fn(n)
+		freeCpu := math.Max(0, float64(cpuCap-cpuAlloc))
+		freeMem := math.Max(0, float64(memCap-memAlloc))
+		totalFreeCpu += freeCpu
+		totalFreeMem += freeMem
+		if freeCpu < float64(shapeCpuMilli) || freeMem < float64(shapeMemMB) {
+			fragFreeCpu += freeCpu
+			fragFreeMem += freeMem
+		}
+	}
+	fragCpu, fragMem := 0.0, 0.0
+	if totalFreeCpu > 0 {
+		fragCpu = fragFreeCpu / totalFreeCpu
+	}
+	if totalFreeMem > 0 {
+		fragMem = fragFreeMem / totalFreeMem
+	}
+	return (fragCpu + fragMem) / 2
+}
+
+var clusterGaugeOnce sync.Once
+
+// startClusterGaugeCollector launches the periodic gauge collection exactly
+// once, even if InitScheduler is called repeatedly (e.g. in-process restarts).
+func startClusterGaugeCollector(ctx context.Context) {
+	clusterGaugeOnce.Do(func() {
+		recov.GoWithRecover(func() {
+			collectClusterGaugesLoop(ctx)
+		})
+	})
+}
+
+func collectClusterGaugesLoop(ctx context.Context) {
+	ticker := time.NewTicker(clusterGaugeCollectInterval)
+	defer ticker.Stop()
+	for {
+		recov.WithRecover(collectClusterGauges, func(panicError interface{}) {
+			log.G(ctx).Errorf("collectClusterGauges panic:%v", panicError)
+		})
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// collectClusterGauges recomputes all cluster-level gauges from the healthy
+// node set in localcache. Unhealthy nodes are excluded (consistent with the
+// existing stdev/limit loops); cordoned-but-healthy nodes stay included since
+// they still hold capacity and load.
+func collectClusterGauges() {
+	cfg := config.GetConfig()
+	if cfg == nil || cfg.Scheduler == nil {
+		return
+	}
+	nodes := localcache.GetHealthyNodes(-1)
+	stats := make([]nodeResourceStat, 0, nodes.Len())
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		stats = append(stats, nodeResourceStat{
+			instanceType:  n.InstanceType,
+			quotaCpuMilli: n.QuotaCpu,
+			quotaMemMB:    n.QuotaMem,
+			cpuUsageMilli: n.QuotaCpuUsage,
+			memUsageMB:    n.QuotaMemUsage,
+			mvmNum:        n.MvmNum,
+		})
+	}
+	capFn := func(n nodeResourceStat) (int64, int64, int64, int64) {
+		return cfg.Scheduler.EffectiveQuotaCpu(n.instanceType, n.quotaCpuMilli),
+			cfg.Scheduler.EffectiveQuotaMem(n.instanceType, n.quotaMemMB),
+			cfg.Scheduler.EffectiveAllocated(n.cpuUsageMilli),
+			cfg.Scheduler.EffectiveAllocated(n.memUsageMB)
+	}
+
+	quota := sumClusterQuota(stats, capFn)
+	clusterQuotaGauge.WithLabelValues(resourceLabelCPU, quotaTypeAllocated).Set(quota.cpuAllocated)
+	clusterQuotaGauge.WithLabelValues(resourceLabelCPU, quotaTypeCapacity).Set(quota.cpuCapacity)
+	clusterQuotaGauge.WithLabelValues(resourceLabelMem, quotaTypeAllocated).Set(quota.memAllocated)
+	clusterQuotaGauge.WithLabelValues(resourceLabelMem, quotaTypeCapacity).Set(quota.memCapacity)
+
+	cpuCV, memCV := nodeLoadCV(stats)
+	nodeLoadCVGauge.WithLabelValues(resourceLabelCPU).Set(cpuCV)
+	nodeLoadCVGauge.WithLabelValues(resourceLabelMem).Set(memCV)
+
+	active, empty := countActiveEmptyNodes(stats)
+	activeNodesGauge.Set(float64(active))
+	emptyNodesGauge.Set(float64(empty))
+
+	shapeCPU := cfg.Scheduler.MaxMvmCPURes()
+	shapeMem := cfg.Scheduler.MaxMvmMemoryRes()
+	fragmentedCapacityGauge.WithLabelValues(fragmentShapeMaxMVM).
+		Set(fragmentedCapacityRatio(stats, capFn, shapeCPU.MilliValue(), shapeMem.Value()/(1024*1024)))
+}

--- a/CubeMaster/pkg/scheduler/metrics.go
+++ b/CubeMaster/pkg/scheduler/metrics.go
@@ -53,7 +53,13 @@ const (
 // Reschedule reason categories for handleCubelet retries, derived from the
 // cubelet/master error code. The classification order in rescheduleReason is
 // significant because a code can sit in several retry maps at once:
-// rpc_error > circuit_break > reuse > loop_retry > backoff > admission > other.
+// rpc_error > circuit_break > loop_retry > backoff > admission > other.
+// Note on reachability: with RecordReschedule gated on actual reselections,
+// the current call sites only emit rpc_error / circuit_break / loop_retry
+// (cubelet retry codes) and admission (scheduling-gate rejections);
+// backoff-only codes never trigger a retry (the loop-map check precedes the
+// backoff delay in errorCodeRetry), so backoff and other are kept for
+// future-proofing but are not emitted today.
 const (
 	rescheduleReasonRPCError     = "rpc_error"
 	rescheduleReasonCircuitBreak = "circuit_break"
@@ -90,18 +96,18 @@ var (
 
 	schedulerDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "scheduler_duration_seconds",
-		Help:    "Latency of a single scheduler Select call, by profile.",
+		Help:    "Latency of a single scheduler Select call, by profile and result (the split keeps failure modes like no_node out of the success SLO).",
 		Buckets: prometheus.ExponentialBuckets(0.0005, 2, 13), // 0.5ms .. ~2s
-	}, []string{profileLabel})
+	}, []string{profileLabel, resultLabel})
 
 	schedulerDecisions = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "scheduler_decisions_total",
-		Help: "Total successful scheduling decisions, by profile and whether the selected node already holds a local replica of the requested template.",
+		Help: "Total successful scheduler Select calls, by profile and whether the selected node already holds a local replica of the requested template. One create can re-run Select (admission rejection, reschedule) and migrate/restore flows also call it, so this exceeds actual sandbox placements under churn.",
 	}, []string{profileLabel, templateHitLabel})
 
 	schedulerReschedules = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "scheduler_reschedules_total",
-		Help: "Total node reselection events during sandbox create (handleCubelet retries that pick a new host), by profile and error-code category.",
+		Help: "Total scheduler reselection attempts during sandbox create (handleCubelet retries that re-run Select; the same host may still be re-picked), by profile and error-code category.",
 	}, []string{profileLabel, reasonLabel})
 
 	sandboxCreateAttempts = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -154,7 +160,7 @@ func ObserveScheduleAttempt(profile string, err error, d time.Duration) {
 		result, reason = metricResultError, classifyAttemptError(err)
 	}
 	schedulerAttempts.WithLabelValues(profile, result, reason).Inc()
-	schedulerDuration.WithLabelValues(profile).Observe(d.Seconds())
+	schedulerDuration.WithLabelValues(profile, result).Observe(d.Seconds())
 }
 
 // classifyAttemptError maps the Select failure error code to a small reason
@@ -458,6 +464,10 @@ func collectClusterGauges() {
 	activeNodesGauge.Set(float64(active))
 	emptyNodesGauge.Set(float64(empty))
 
+	// The reference shape defaults to 100 cores / 300Gi when MaxMvmCPU /
+	// MaxMvmMemory are unset (config preHandle*), under which essentially no
+	// node is "fit" and this gauge sits near 1 — only informative when the
+	// deployment configures real shape values.
 	shapeCPU := cfg.Scheduler.MaxMvmCPURes()
 	shapeMem := cfg.Scheduler.MaxMvmMemoryRes()
 	fragmentedCapacityGauge.WithLabelValues(fragmentShapeMaxMVM).

--- a/CubeMaster/pkg/scheduler/metrics.go
+++ b/CubeMaster/pkg/scheduler/metrics.go
@@ -147,7 +147,8 @@ var (
 
 	fragmentedCapacityGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "scheduler_fragmented_capacity_ratio",
-		Help: "Ratio of free capacity stranded on nodes that cannot fit the reference shape (see fragmentedCapacityRatio), by shape.",
+		Help: "Ratio of free capacity stranded on nodes that cannot fit the reference shape (see fragmentedCapacityRatio), by shape. " +
+			"With default (unset) shape config the reference shape is 100C/300Gi and this gauge sits near 1 — only informative with real shape values configured.",
 	}, []string{shapeLabel})
 )
 
@@ -195,19 +196,27 @@ func RecordReschedule(profile string, code errorcode.ErrorCode) {
 }
 
 // rescheduleReason classifies the error code into a low-cardinality category.
-// Precedence matters for codes present in several retry maps (e.g.
-// HostDiskNotEnough is both circuit-breaking and loop-retryable): the first
-// matching category wins, mirroring how handleCubelet treats the code.
 func rescheduleReason(code errorcode.ErrorCode) string {
+	return classifyRescheduleReason(code,
+		errorcode.IsCircutBreakCode, errorcode.IsLoopRetryCode, errorcode.IsBackoffRetryCode)
+}
+
+// classifyRescheduleReason is the pure core of rescheduleReason with the
+// retry-map predicates injected, so tests can exercise the classification
+// without touching the process-global errorcode maps. Precedence matters for
+// codes present in several retry maps (e.g. HostDiskNotEnough is both
+// circuit-breaking and loop-retryable): the first matching category wins,
+// mirroring how handleCubelet treats the code.
+func classifyRescheduleReason(code errorcode.ErrorCode, isCircuitBreak, isLoopRetry, isBackoffRetry func(errorcode.ErrorCode) bool) string {
 	switch {
 	case code == errorcode.ErrorCode_ReqCubeAPIFailed:
 		// errRetry (cubelet RPC failure) always synthesizes this code.
 		return rescheduleReasonRPCError
-	case errorcode.IsCircutBreakCode(code):
+	case isCircuitBreak(code):
 		return rescheduleReasonCircuitBreak
-	case errorcode.IsLoopRetryCode(code):
+	case isLoopRetry(code):
 		return rescheduleReasonLoopRetry
-	case errorcode.IsBackoffRetryCode(code):
+	case isBackoffRetry(code):
 		return rescheduleReasonBackoff
 	case code == errorcode.ErrorCode_SelectNodesFailed:
 		// The scheduling-admission gate rejected the selected node.

--- a/CubeMaster/pkg/scheduler/metrics.go
+++ b/CubeMaster/pkg/scheduler/metrics.go
@@ -91,18 +91,20 @@ const clusterGaugeCollectInterval = 15 * time.Second
 var (
 	schedulerAttempts = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "scheduler_attempts_total",
-		Help: "Total scheduler Select attempts, by profile, result and failure reason.",
+		Help: "Total scheduler Select attempts, by profile, result and failure reason. " +
+			"Select is shared by create (including reschedule re-selects), migrate and restore flows, so this is not a create-only series.",
 	}, []string{profileLabel, resultLabel, reasonLabel})
 
 	schedulerDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "scheduler_duration_seconds",
-		Help:    "Latency of a single scheduler Select call, by profile and result (the split keeps failure modes like no_node out of the success SLO).",
+		Help:    "Latency of a single scheduler Select call, by profile and result (the split keeps failure modes like no_node out of the success SLO). Covers create, migrate and restore flows.",
 		Buckets: prometheus.ExponentialBuckets(0.0005, 2, 13), // 0.5ms .. ~2s
 	}, []string{profileLabel, resultLabel})
 
 	schedulerDecisions = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "scheduler_decisions_total",
-		Help: "Total successful scheduler Select calls, by profile and whether the selected node already holds a local replica of the requested template. One create can re-run Select (admission rejection, reschedule) and migrate/restore flows also call it, so this exceeds actual sandbox placements under churn.",
+		Help: "Total successful scheduler Select calls, by profile and whether the selected node already holds a local replica of the requested template. One create can re-run Select (admission rejection, reschedule) and migrate/restore flows also call it, so this exceeds actual sandbox placements under churn. " +
+			"template_hit=true only means the chosen node happens to hold a local replica; it is not proof the locality filter drove the choice (the filter may be off or AllowNonLocalTemplate set).",
 	}, []string{profileLabel, templateHitLabel})
 
 	schedulerReschedules = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -148,7 +150,7 @@ var (
 	fragmentedCapacityGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "scheduler_fragmented_capacity_ratio",
 		Help: "Ratio of free capacity stranded on nodes that cannot fit the reference shape (see fragmentedCapacityRatio), by shape. " +
-			"With default (unset) shape config the reference shape is 100C/300Gi and this gauge sits near 1 — only informative with real shape values configured.",
+			"Only exported when the shape is explicitly configured via max_mvm_cpu/max_mvm_memory; with defaults (100C/300Gi) it would sit near 1 and carry no signal.",
 	}, []string{shapeLabel})
 )
 
@@ -226,9 +228,11 @@ func classifyRescheduleReason(code errorcode.ErrorCode, isCircuitBreak, isLoopRe
 	}
 }
 
-// ObserveSandboxCreate records one finished sandbox create request.
-// start/end reuse the createSandboxContext timestamps; an unset or inverted
-// end falls back to now so early-return paths still get a sane duration.
+// ObserveSandboxCreate records one finished sandbox create request that
+// entered the scheduling path (admission-rejected and mock-short-circuited
+// requests never reach the call site — see CreateSandbox). start/end reuse
+// the createSandboxContext timestamps; an unset or inverted end falls back to
+// now so early-return paths still get a sane duration.
 func ObserveSandboxCreate(profile string, success bool, start, end time.Time) {
 	if start.IsZero() {
 		start = time.Now()
@@ -473,12 +477,14 @@ func collectClusterGauges() {
 	activeNodesGauge.Set(float64(active))
 	emptyNodesGauge.Set(float64(empty))
 
-	// The reference shape defaults to 100 cores / 300Gi when MaxMvmCPU /
-	// MaxMvmMemory are unset (config preHandle*), under which essentially no
-	// node is "fit" and this gauge sits near 1 — only informative when the
-	// deployment configures real shape values.
-	shapeCPU := cfg.Scheduler.MaxMvmCPURes()
-	shapeMem := cfg.Scheduler.MaxMvmMemoryRes()
-	fragmentedCapacityGauge.WithLabelValues(fragmentShapeMaxMVM).
-		Set(fragmentedCapacityRatio(stats, capFn, shapeCPU.MilliValue(), shapeMem.Value()/(1024*1024)))
+	// Only export when the reference shape was explicitly configured: unset
+	// MaxMvmCPU/MaxMvmMemory fall back to 100C/300Gi (the string fields stay
+	// empty after preHandle fills the parsed defaults), under which the gauge
+	// is pinned near 1 and carries no signal.
+	if cfg.Scheduler.MaxMvmCPU != "" && cfg.Scheduler.MaxMvmMemory != "" {
+		shapeCPU := cfg.Scheduler.MaxMvmCPURes()
+		shapeMem := cfg.Scheduler.MaxMvmMemoryRes()
+		fragmentedCapacityGauge.WithLabelValues(fragmentShapeMaxMVM).
+			Set(fragmentedCapacityRatio(stats, capFn, shapeCPU.MilliValue(), shapeMem.Value()/(1024*1024)))
+	}
 }

--- a/CubeMaster/pkg/scheduler/metrics_test.go
+++ b/CubeMaster/pkg/scheduler/metrics_test.go
@@ -90,7 +90,10 @@ func TestRecordDecision(t *testing.T) {
 
 func TestRecordReschedule(t *testing.T) {
 	// rescheduleReason consults the errorcode retry maps; initialize them
-	// with an empty config the same way main does.
+	// with an empty config the same way main does. Caveat: this replaces
+	// process-global retry maps that cannot be restored (they are private),
+	// so any future test in this package that depends on real retry-map
+	// contents becomes order-dependent with this one.
 	errorcode.InitCubeCodeRetryMap(&config.Config{CubeletConf: &config.CubeletConf{}})
 
 	rpcBefore := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonRPCError)
@@ -178,7 +181,7 @@ func TestNodeLoadCV(t *testing.T) {
 		{quotaCpuMilli: 1000, quotaMemMB: 0, cpuUsageMilli: 750, memUsageMB: 4096},
 	}
 
-	cpuCV, memCV := nodeLoadCV(nodes)
+	cpuCV, memCV := nodeLoadCV(nodes, identityCapFn)
 	// cpu ratios 0.5 / 0.25 / 0.75: mean 0.5, population stddev sqrt(1/24).
 	wantCPU := math.Sqrt(1.0/24.0) / 0.5
 	if math.Abs(cpuCV-wantCPU) > 1e-9 {
@@ -190,12 +193,12 @@ func TestNodeLoadCV(t *testing.T) {
 		t.Fatalf("mem CV = %v, want %v", memCV, wantMem)
 	}
 
-	if cpuCV, memCV := nodeLoadCV(nil); cpuCV != 0 || memCV != 0 {
+	if cpuCV, memCV := nodeLoadCV(nil, identityCapFn); cpuCV != 0 || memCV != 0 {
 		t.Fatalf("empty nodes CV = (%v, %v), want (0, 0)", cpuCV, memCV)
 	}
 	// All-idle nodes: zero mean must not divide by zero.
 	idle := []nodeResourceStat{{quotaCpuMilli: 1000, quotaMemMB: 2048}}
-	if cpuCV, memCV := nodeLoadCV(idle); cpuCV != 0 || memCV != 0 {
+	if cpuCV, memCV := nodeLoadCV(idle, identityCapFn); cpuCV != 0 || memCV != 0 {
 		t.Fatalf("idle nodes CV = (%v, %v), want (0, 0)", cpuCV, memCV)
 	}
 }
@@ -207,11 +210,11 @@ func TestCountActiveEmptyNodes(t *testing.T) {
 		{memUsageMB: 1},
 		{},
 	}
-	active, empty := countActiveEmptyNodes(nodes)
+	active, empty := countActiveEmptyNodes(nodes, identityCapFn)
 	if active != 3 || empty != 1 {
 		t.Fatalf("active/empty = (%d, %d), want (3, 1)", active, empty)
 	}
-	if active, empty := countActiveEmptyNodes(nil); active != 0 || empty != 0 {
+	if active, empty := countActiveEmptyNodes(nil, identityCapFn); active != 0 || empty != 0 {
 		t.Fatalf("nil nodes active/empty = (%d, %d), want (0, 0)", active, empty)
 	}
 }

--- a/CubeMaster/pkg/scheduler/metrics_test.go
+++ b/CubeMaster/pkg/scheduler/metrics_test.go
@@ -46,7 +46,8 @@ func TestObserveScheduleAttempt(t *testing.T) {
 	noNodeBefore := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonNoNode)
 	prefilterBefore := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonPreFilter)
 	errorBefore := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonError)
-	histBefore := histogramCount(t, schedulerDuration, DefaultProfile)
+	histSuccBefore := histogramCount(t, schedulerDuration, DefaultProfile, metricResultSuccess)
+	histErrBefore := histogramCount(t, schedulerDuration, DefaultProfile, metricResultError)
 
 	ObserveScheduleAttempt(DefaultProfile, nil, time.Millisecond)
 	ObserveScheduleAttempt(DefaultProfile, ret.Err(errorcode.ErrorCode_SelectNodesNoRes, "no res"), 2*time.Millisecond)
@@ -67,8 +68,11 @@ func TestObserveScheduleAttempt(t *testing.T) {
 	if got := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonError); got != errorBefore+2 {
 		t.Fatalf("error attempts delta = %v, want 2", got-errorBefore)
 	}
-	if got := histogramCount(t, schedulerDuration, DefaultProfile); got != histBefore+5 {
-		t.Fatalf("duration histogram count delta = %v, want 5", got-histBefore)
+	if got := histogramCount(t, schedulerDuration, DefaultProfile, metricResultSuccess); got != histSuccBefore+1 {
+		t.Fatalf("success duration histogram count delta = %v, want 1", got-histSuccBefore)
+	}
+	if got := histogramCount(t, schedulerDuration, DefaultProfile, metricResultError); got != histErrBefore+4 {
+		t.Fatalf("error duration histogram count delta = %v, want 4", got-histErrBefore)
 	}
 }
 

--- a/CubeMaster/pkg/scheduler/metrics_test.go
+++ b/CubeMaster/pkg/scheduler/metrics_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/ret"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 )
@@ -92,35 +91,45 @@ func TestRecordDecision(t *testing.T) {
 	}
 }
 
-func TestRecordReschedule(t *testing.T) {
-	// rescheduleReason consults the errorcode retry maps; initialize them
-	// with an empty config the same way main does. Caveat: this replaces
-	// process-global retry maps that cannot be restored (they are private),
-	// so any future test in this package that depends on real retry-map
-	// contents becomes order-dependent with this one.
-	errorcode.InitCubeCodeRetryMap(&config.Config{CubeletConf: &config.CubeletConf{}})
+func TestClassifyRescheduleReason(t *testing.T) {
+	no := func(errorcode.ErrorCode) bool { return false }
+	yes := func(errorcode.ErrorCode) bool { return true }
+	isConnHost := func(code errorcode.ErrorCode) bool { return code == errorcode.ErrorCode_ConnHostFailed }
 
+	cases := []struct {
+		name                         string
+		code                         errorcode.ErrorCode
+		isCircuit, isLoop, isBackoff func(errorcode.ErrorCode) bool
+		want                         string
+	}{
+		{"rpc error", errorcode.ErrorCode_ReqCubeAPIFailed, no, no, no, rescheduleReasonRPCError},
+		{"circuit break", errorcode.ErrorCode_ConnHostFailed, isConnHost, no, no, rescheduleReasonCircuitBreak},
+		// ConnHostFailed in several maps: circuit_break wins (handleCubelet precedence).
+		{"circuit beats loop", errorcode.ErrorCode_ConnHostFailed, yes, yes, no, rescheduleReasonCircuitBreak},
+		{"loop retry", errorcode.ErrorCode_ConnHostFailed, no, yes, no, rescheduleReasonLoopRetry},
+		{"backoff", errorcode.ErrorCode_ConnHostFailed, no, no, yes, rescheduleReasonBackoff},
+		{"admission", errorcode.ErrorCode_SelectNodesFailed, no, no, no, rescheduleReasonAdmission},
+		{"other", errorcode.ErrorCode_DBError, no, no, no, rescheduleReasonOther},
+	}
+	for _, tc := range cases {
+		if got := classifyRescheduleReason(tc.code, tc.isCircuit, tc.isLoop, tc.isBackoff); got != tc.want {
+			t.Errorf("%s: classifyRescheduleReason = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestRecordReschedule(t *testing.T) {
+	// Only the fixed-code path is exercised end to end: ReqCubeAPIFailed
+	// short-circuits before any retry-map predicate, so this test needs no
+	// errorcode map init and never mutates that process-global state (the
+	// maps are private and cannot be restored). Category classification is
+	// covered by TestClassifyRescheduleReason with injected predicates.
 	rpcBefore := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonRPCError)
-	circuitBefore := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonCircuitBreak)
-	admissionBefore := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonAdmission)
-	otherBefore := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonOther)
 
 	RecordReschedule(DefaultProfile, errorcode.ErrorCode_ReqCubeAPIFailed)
-	RecordReschedule(DefaultProfile, errorcode.ErrorCode_ConnHostFailed)
-	RecordReschedule(DefaultProfile, errorcode.ErrorCode_SelectNodesFailed)
-	RecordReschedule(DefaultProfile, errorcode.ErrorCode_DBError)
 
 	if got := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonRPCError); got != rpcBefore+1 {
 		t.Fatalf("rpc_error delta = %v, want 1", got-rpcBefore)
-	}
-	if got := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonCircuitBreak); got != circuitBefore+1 {
-		t.Fatalf("circuit_break delta = %v, want 1", got-circuitBefore)
-	}
-	if got := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonAdmission); got != admissionBefore+1 {
-		t.Fatalf("admission delta = %v, want 1", got-admissionBefore)
-	}
-	if got := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonOther); got != otherBefore+1 {
-		t.Fatalf("other delta = %v, want 1", got-otherBefore)
 	}
 }
 

--- a/CubeMaster/pkg/scheduler/metrics_test.go
+++ b/CubeMaster/pkg/scheduler/metrics_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package scheduler
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/ret"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+)
+
+func counterValue(t *testing.T, vec *prometheus.CounterVec, labels ...string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(vec.WithLabelValues(labels...))
+}
+
+func histogramCount(t *testing.T, vec *prometheus.HistogramVec, labels ...string) uint64 {
+	t.Helper()
+	obs, err := vec.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues(%v): %v", labels, err)
+	}
+	h, ok := obs.(prometheus.Histogram)
+	if !ok {
+		t.Fatalf("metric %v is not a histogram", labels)
+	}
+	m := &dto.Metric{}
+	if err := h.Write(m); err != nil {
+		t.Fatalf("histogram Write: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
+func TestObserveScheduleAttempt(t *testing.T) {
+	successBefore := counterValue(t, schedulerAttempts, DefaultProfile, metricResultSuccess, attemptReasonNone)
+	noNodeBefore := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonNoNode)
+	prefilterBefore := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonPreFilter)
+	errorBefore := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonError)
+	histBefore := histogramCount(t, schedulerDuration, DefaultProfile)
+
+	ObserveScheduleAttempt(DefaultProfile, nil, time.Millisecond)
+	ObserveScheduleAttempt(DefaultProfile, ret.Err(errorcode.ErrorCode_SelectNodesNoRes, "no res"), 2*time.Millisecond)
+	ObserveScheduleAttempt(DefaultProfile, ret.Err(errorcode.ErrorCode_SelectNodesFailed, "prefilter"), 3*time.Millisecond)
+	ObserveScheduleAttempt(DefaultProfile, ret.Err(errorcode.ErrorCode_MasterInternalError, "boom"), 4*time.Millisecond)
+	ObserveScheduleAttempt(DefaultProfile, errors.New("plain"), 5*time.Millisecond)
+
+	if got := counterValue(t, schedulerAttempts, DefaultProfile, metricResultSuccess, attemptReasonNone); got != successBefore+1 {
+		t.Fatalf("success attempts delta = %v, want 1", got-successBefore)
+	}
+	if got := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonNoNode); got != noNodeBefore+1 {
+		t.Fatalf("no_node attempts delta = %v, want 1", got-noNodeBefore)
+	}
+	if got := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonPreFilter); got != prefilterBefore+1 {
+		t.Fatalf("prefilter attempts delta = %v, want 1", got-prefilterBefore)
+	}
+	// MasterInternalError and a plain error both land in the generic bucket.
+	if got := counterValue(t, schedulerAttempts, DefaultProfile, metricResultError, attemptReasonError); got != errorBefore+2 {
+		t.Fatalf("error attempts delta = %v, want 2", got-errorBefore)
+	}
+	if got := histogramCount(t, schedulerDuration, DefaultProfile); got != histBefore+5 {
+		t.Fatalf("duration histogram count delta = %v, want 5", got-histBefore)
+	}
+}
+
+func TestRecordDecision(t *testing.T) {
+	hitBefore := counterValue(t, schedulerDecisions, DefaultProfile, "true")
+	missBefore := counterValue(t, schedulerDecisions, DefaultProfile, "false")
+
+	RecordDecision(DefaultProfile, true)
+	RecordDecision(DefaultProfile, false)
+	RecordDecision(DefaultProfile, false)
+
+	if got := counterValue(t, schedulerDecisions, DefaultProfile, "true"); got != hitBefore+1 {
+		t.Fatalf("template_hit=true delta = %v, want 1", got-hitBefore)
+	}
+	if got := counterValue(t, schedulerDecisions, DefaultProfile, "false"); got != missBefore+2 {
+		t.Fatalf("template_hit=false delta = %v, want 2", got-missBefore)
+	}
+}
+
+func TestRecordReschedule(t *testing.T) {
+	// rescheduleReason consults the errorcode retry maps; initialize them
+	// with an empty config the same way main does.
+	errorcode.InitCubeCodeRetryMap(&config.Config{CubeletConf: &config.CubeletConf{}})
+
+	rpcBefore := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonRPCError)
+	circuitBefore := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonCircuitBreak)
+	admissionBefore := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonAdmission)
+	otherBefore := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonOther)
+
+	RecordReschedule(DefaultProfile, errorcode.ErrorCode_ReqCubeAPIFailed)
+	RecordReschedule(DefaultProfile, errorcode.ErrorCode_ConnHostFailed)
+	RecordReschedule(DefaultProfile, errorcode.ErrorCode_SelectNodesFailed)
+	RecordReschedule(DefaultProfile, errorcode.ErrorCode_DBError)
+
+	if got := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonRPCError); got != rpcBefore+1 {
+		t.Fatalf("rpc_error delta = %v, want 1", got-rpcBefore)
+	}
+	if got := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonCircuitBreak); got != circuitBefore+1 {
+		t.Fatalf("circuit_break delta = %v, want 1", got-circuitBefore)
+	}
+	if got := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonAdmission); got != admissionBefore+1 {
+		t.Fatalf("admission delta = %v, want 1", got-admissionBefore)
+	}
+	if got := counterValue(t, schedulerReschedules, DefaultProfile, rescheduleReasonOther); got != otherBefore+1 {
+		t.Fatalf("other delta = %v, want 1", got-otherBefore)
+	}
+}
+
+func TestObserveSandboxCreate(t *testing.T) {
+	successBefore := counterValue(t, sandboxCreateAttempts, DefaultProfile, metricResultSuccess)
+	errorBefore := counterValue(t, sandboxCreateAttempts, DefaultProfile, metricResultError)
+	successHistBefore := histogramCount(t, sandboxCreateDuration, DefaultProfile, metricResultSuccess)
+	errorHistBefore := histogramCount(t, sandboxCreateDuration, DefaultProfile, metricResultError)
+
+	start := time.Now()
+	ObserveSandboxCreate(DefaultProfile, true, start, start.Add(1500*time.Millisecond))
+	// Early-return path: endTime never set.
+	ObserveSandboxCreate(DefaultProfile, false, start, time.Time{})
+
+	if got := counterValue(t, sandboxCreateAttempts, DefaultProfile, metricResultSuccess); got != successBefore+1 {
+		t.Fatalf("create success delta = %v, want 1", got-successBefore)
+	}
+	if got := counterValue(t, sandboxCreateAttempts, DefaultProfile, metricResultError); got != errorBefore+1 {
+		t.Fatalf("create error delta = %v, want 1", got-errorBefore)
+	}
+	if got := histogramCount(t, sandboxCreateDuration, DefaultProfile, metricResultSuccess); got != successHistBefore+1 {
+		t.Fatalf("create success duration count delta = %v, want 1", got-successHistBefore)
+	}
+	if got := histogramCount(t, sandboxCreateDuration, DefaultProfile, metricResultError); got != errorHistBefore+1 {
+		t.Fatalf("create error duration count delta = %v, want 1", got-errorHistBefore)
+	}
+}
+
+// identityCapFn resolves capacity as raw quota (no overcommit) and accounted
+// allocation as raw usage.
+func identityCapFn(n nodeResourceStat) (int64, int64, int64, int64) {
+	return n.quotaCpuMilli, n.quotaMemMB, n.cpuUsageMilli, n.memUsageMB
+}
+
+func TestSumClusterQuota(t *testing.T) {
+	nodes := []nodeResourceStat{
+		{quotaCpuMilli: 1000, quotaMemMB: 2048, cpuUsageMilli: 100, memUsageMB: 512},
+		{quotaCpuMilli: 2000, quotaMemMB: 1024},
+	}
+	overcommitFn := func(n nodeResourceStat) (int64, int64, int64, int64) {
+		return n.quotaCpuMilli * 3, n.quotaMemMB * 2, n.cpuUsageMilli, n.memUsageMB
+	}
+
+	q := sumClusterQuota(nodes, overcommitFn)
+	if q.cpuAllocated != 100 || q.cpuCapacity != 9000 {
+		t.Fatalf("cpu quota = (%v, %v), want (100, 9000)", q.cpuAllocated, q.cpuCapacity)
+	}
+	if q.memAllocated != 512 || q.memCapacity != 6144 {
+		t.Fatalf("mem quota = (%v, %v), want (512, 6144)", q.memAllocated, q.memCapacity)
+	}
+
+	if got := sumClusterQuota(nil, identityCapFn); got != (clusterQuota{}) {
+		t.Fatalf("empty nodes quota = %+v, want zero", got)
+	}
+}
+
+func TestNodeLoadCV(t *testing.T) {
+	nodes := []nodeResourceStat{
+		{quotaCpuMilli: 1000, quotaMemMB: 2048, cpuUsageMilli: 500, memUsageMB: 512},
+		{quotaCpuMilli: 1000, quotaMemMB: 2048, cpuUsageMilli: 250, memUsageMB: 1024},
+		// Zero mem quota must be skipped, not skew the CV towards 0.
+		{quotaCpuMilli: 1000, quotaMemMB: 0, cpuUsageMilli: 750, memUsageMB: 4096},
+	}
+
+	cpuCV, memCV := nodeLoadCV(nodes)
+	// cpu ratios 0.5 / 0.25 / 0.75: mean 0.5, population stddev sqrt(1/24).
+	wantCPU := math.Sqrt(1.0/24.0) / 0.5
+	if math.Abs(cpuCV-wantCPU) > 1e-9 {
+		t.Fatalf("cpu CV = %v, want %v", cpuCV, wantCPU)
+	}
+	// mem ratios 0.25 / 0.5: mean 0.375, population stddev 0.125.
+	wantMem := 0.125 / 0.375
+	if math.Abs(memCV-wantMem) > 1e-9 {
+		t.Fatalf("mem CV = %v, want %v", memCV, wantMem)
+	}
+
+	if cpuCV, memCV := nodeLoadCV(nil); cpuCV != 0 || memCV != 0 {
+		t.Fatalf("empty nodes CV = (%v, %v), want (0, 0)", cpuCV, memCV)
+	}
+	// All-idle nodes: zero mean must not divide by zero.
+	idle := []nodeResourceStat{{quotaCpuMilli: 1000, quotaMemMB: 2048}}
+	if cpuCV, memCV := nodeLoadCV(idle); cpuCV != 0 || memCV != 0 {
+		t.Fatalf("idle nodes CV = (%v, %v), want (0, 0)", cpuCV, memCV)
+	}
+}
+
+func TestCountActiveEmptyNodes(t *testing.T) {
+	nodes := []nodeResourceStat{
+		{mvmNum: 2},
+		{cpuUsageMilli: 1},
+		{memUsageMB: 1},
+		{},
+	}
+	active, empty := countActiveEmptyNodes(nodes)
+	if active != 3 || empty != 1 {
+		t.Fatalf("active/empty = (%d, %d), want (3, 1)", active, empty)
+	}
+	if active, empty := countActiveEmptyNodes(nil); active != 0 || empty != 0 {
+		t.Fatalf("nil nodes active/empty = (%d, %d), want (0, 0)", active, empty)
+	}
+}
+
+func TestFragmentedCapacityRatio(t *testing.T) {
+	// Shape 2000m / 2048MB against identity capacity.
+	// A fits; B is short on cpu; C is short on mem.
+	nodes := []nodeResourceStat{
+		{quotaCpuMilli: 4000, quotaMemMB: 4096, cpuUsageMilli: 1000, memUsageMB: 1024}, // free 3000m/3072MB
+		{quotaCpuMilli: 4000, quotaMemMB: 4096, cpuUsageMilli: 3500, memUsageMB: 1024}, // free 500m/3072MB
+		{quotaCpuMilli: 4000, quotaMemMB: 4096, cpuUsageMilli: 0, memUsageMB: 4000},    // free 4000m/96MB
+	}
+
+	got := fragmentedCapacityRatio(nodes, identityCapFn, 2000, 2048)
+	// fragCpu = (500+4000)/7500 = 0.6; fragMem = (3072+96)/6240.
+	want := (0.6 + 3168.0/6240.0) / 2
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("fragmented ratio = %v, want %v", got, want)
+	}
+
+	// Every node fits the shape -> no fragmentation.
+	roomy := []nodeResourceStat{{quotaCpuMilli: 8000, quotaMemMB: 8192, cpuUsageMilli: 1000}}
+	if got := fragmentedCapacityRatio(roomy, identityCapFn, 2000, 2048); got != 0 {
+		t.Fatalf("all-fit fragmented ratio = %v, want 0", got)
+	}
+
+	// No nodes (or no free capacity) -> 0, never NaN.
+	if got := fragmentedCapacityRatio(nil, identityCapFn, 2000, 2048); got != 0 {
+		t.Fatalf("empty fragmented ratio = %v, want 0", got)
+	}
+	full := []nodeResourceStat{{quotaCpuMilli: 4000, quotaMemMB: 4096, cpuUsageMilli: 4000, memUsageMB: 4096}}
+	if got := fragmentedCapacityRatio(full, identityCapFn, 2000, 2048); got != 0 {
+		t.Fatalf("fully-allocated fragmented ratio = %v, want 0", got)
+	}
+}

--- a/CubeMaster/pkg/scheduler/schedule.go
+++ b/CubeMaster/pkg/scheduler/schedule.go
@@ -7,6 +7,7 @@ package scheduler
 import (
 	"math/rand"
 	"runtime/debug"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -23,6 +24,12 @@ import (
 )
 
 func Select(selCtx *selctx.SelectorCtx) (nodes *node.Node, err error) {
+	startTime := time.Now()
+	// Registered first so it runs after the panic-recovery defer below and
+	// observes the final (nodes, err) pair, including the BackoffSelect
+	// fallback and recovered panics.
+	defer func() { observeSelect(selCtx, nodes, err, startTime) }()
+
 	defer func() {
 		if r := recover(); r != nil {
 			log.G(selCtx.Ctx).Fatalf("Select panic:%+v", string(debug.Stack()))

--- a/CubeMaster/pkg/service/sandbox/sandbox_run.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_run.go
@@ -121,16 +121,6 @@ func CreateSandbox(ctx context.Context, req *types.CreateCubeSandboxReq) (rsp *t
 		reschedule: true,
 		retryCost:  time.Duration(0),
 	}
-	// Record the create attempt on every return path (mock / param failure
-	// included); endTime stays zero on early returns and the helper falls
-	// back to now. Mock creates (MockCreateDirect) share the sandbox_create_*
-	// series deliberately — mock mode is a dev/debug facility, and anyone
-	// reading create success-rate SLOs from these metrics must not run with
-	// mock config enabled.
-	defer func() {
-		scheduler.ObserveSandboxCreate(scheduler.DefaultProfile,
-			rsp.Ret.RetCode == int(errorcode.ErrorCode_Success), startTime, createCtx.endTime)
-	}()
 	if log.IsDebug() {
 		log.G(ctx).Debugf("CreateSandbox:%s", safePrintCreateCubeSandboxReq(req))
 	} else {
@@ -163,6 +153,18 @@ func CreateSandbox(ctx context.Context, req *types.CreateCubeSandboxReq) (rsp *t
 		createCtx.setMasterRsp(int(err.Code()), err.Message())
 		return
 	}
+
+	// Record the create attempt once the request has entered the scheduling
+	// path. API-admission failures (param validation, unknown debug target)
+	// and the MockCreateDirect short-circuit above return before this point
+	// and are excluded by design: they never reached the scheduler, so
+	// counting them would inflate create-infra error-rate SLOs with
+	// client-input errors. endTime stays zero on later early returns and the
+	// helper falls back to now.
+	defer func() {
+		scheduler.ObserveSandboxCreate(scheduler.DefaultProfile,
+			rsp.Ret.RetCode == int(errorcode.ErrorCode_Success), startTime, createCtx.endTime)
+	}()
 
 	if config.GetConfig().Common.MockCreateDirectHandle {
 		createCtx.Handle()

--- a/CubeMaster/pkg/service/sandbox/sandbox_run.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_run.go
@@ -121,6 +121,13 @@ func CreateSandbox(ctx context.Context, req *types.CreateCubeSandboxReq) (rsp *t
 		reschedule: true,
 		retryCost:  time.Duration(0),
 	}
+	// Record the create attempt on every return path (mock / param failure
+	// included); endTime stays zero on early returns and the helper falls
+	// back to now.
+	defer func() {
+		scheduler.ObserveSandboxCreate(scheduler.DefaultProfile,
+			rsp.Ret.RetCode == int(errorcode.ErrorCode_Success), startTime, createCtx.endTime)
+	}()
 	if log.IsDebug() {
 		log.G(ctx).Debugf("CreateSandbox:%s", safePrintCreateCubeSandboxReq(req))
 	} else {
@@ -227,6 +234,8 @@ func (c *createSandboxContext) handleCubelet() {
 			}
 			c.selctx.AddLastBadNode(c.selectHost)
 			c.reschedule = true
+			status, _ := ret.FromError(err)
+			scheduler.RecordReschedule(scheduler.DefaultProfile, status.Code())
 			log.G(c.ctx).Warnf("selected host blocked by scheduling admission, reschedule host=%s err=%v",
 				c.selectHost.ID(), err)
 			continue
@@ -235,6 +244,8 @@ func (c *createSandboxContext) handleCubelet() {
 		if c.callCubelet() {
 			c.retryCost += c.cubeletEndTime.Sub(c.cubeletStartTime)
 			c.retryTimes++
+			scheduler.RecordReschedule(scheduler.DefaultProfile,
+				errorcode.MasterCode(c.cubeletRsp.GetRet().GetRetCode()))
 
 			if c.cubeletRsp != nil && c.cubeletRsp.GetRet() != nil &&
 				errorcode.IsCircutBreakCode(errorcode.MasterCode(c.cubeletRsp.GetRet().GetRetCode())) {

--- a/CubeMaster/pkg/service/sandbox/sandbox_run.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_run.go
@@ -244,8 +244,12 @@ func (c *createSandboxContext) handleCubelet() {
 		if c.callCubelet() {
 			c.retryCost += c.cubeletEndTime.Sub(c.cubeletStartTime)
 			c.retryTimes++
-			scheduler.RecordReschedule(scheduler.DefaultProfile,
-				errorcode.MasterCode(c.cubeletRsp.GetRet().GetRetCode()))
+			// Count only actual reselections: reuse-code retries keep the same
+			// host (errorCodeRetry cleared c.reschedule) and never re-Select.
+			if c.reschedule {
+				scheduler.RecordReschedule(scheduler.DefaultProfile,
+					errorcode.MasterCode(c.cubeletRsp.GetRet().GetRetCode()))
+			}
 
 			if c.cubeletRsp != nil && c.cubeletRsp.GetRet() != nil &&
 				errorcode.IsCircutBreakCode(errorcode.MasterCode(c.cubeletRsp.GetRet().GetRetCode())) {

--- a/CubeMaster/pkg/service/sandbox/sandbox_run.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_run.go
@@ -246,7 +246,9 @@ func (c *createSandboxContext) handleCubelet() {
 			c.retryTimes++
 			// Count only actual reselections: reuse-code retries keep the same
 			// host (errorCodeRetry cleared c.reschedule) and never re-Select.
-			if c.reschedule {
+			// Direct-host (debug InsId/InsIp) creates pin the host and never
+			// re-Select either, so they must not count as reschedules.
+			if c.reschedule && !c.directHost {
 				scheduler.RecordReschedule(scheduler.DefaultProfile,
 					errorcode.MasterCode(c.cubeletRsp.GetRet().GetRetCode()))
 			}

--- a/CubeMaster/pkg/service/sandbox/sandbox_run.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_run.go
@@ -123,7 +123,10 @@ func CreateSandbox(ctx context.Context, req *types.CreateCubeSandboxReq) (rsp *t
 	}
 	// Record the create attempt on every return path (mock / param failure
 	// included); endTime stays zero on early returns and the helper falls
-	// back to now.
+	// back to now. Mock creates (MockCreateDirect) share the sandbox_create_*
+	// series deliberately — mock mode is a dev/debug facility, and anyone
+	// reading create success-rate SLOs from these metrics must not run with
+	// mock config enabled.
 	defer func() {
 		scheduler.ObserveSandboxCreate(scheduler.DefaultProfile,
 			rsp.Ret.RetCode == int(errorcode.ErrorCode_Success), startTime, createCtx.endTime)


### PR DESCRIPTION
## Summary

Split out from #1619 to fit the auto-review time budget; #1619 remains as the overall design overview.

Add a Prometheus metric set for the scheduler:

- `pkg/scheduler/metrics.go` defines the scheduler metric set via promauto: `scheduler_attempts_total` / `scheduler_duration_seconds` / `scheduler_decisions_total` / `scheduler_reschedules_total` / `sandbox_create_attempts_total` / `sandbox_create_duration_seconds`, plus cluster gauges (`scheduler_cluster_quota`, `scheduler_node_load_cv`, `scheduler_active_nodes`, `scheduler_empty_nodes`, `scheduler_fragmented_capacity_ratio`) refreshed by a 15s collector.
- Instrument `Select` (attempts/duration/decisions with `template_hit`) and `CreateSandbox`/`handleCubelet` (create attempts/duration, reschedule reasons), reusing the existing startTime/endTime timing points.
- The `profile` label is pinned to `"default"` until the profile router lands (TODO(profile-router)).

## Test plan

- `go test ./pkg/scheduler/...` — passing (8 new cases).
- `go build ./...` — passing.

Assisted-by: Kimi Code CLI:kimi-k2
