### PR TITLE
fix(one-click): honor ONE_CLICK_ENABLE_S3LVOL enable/disable on upgrade

### DIFF
--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -64,7 +64,7 @@ Kernel multi-version inventory (content-addressed):
 - `KERNEL_TAG` / `PVM_KERNEL_TAG` are **not** inventory directory names; `release-manifest` `kernel.version` / `pvm_version` also record content short hashes
 - Ensure maps the digest from Master identity onto that short key
 
-The installed runtime still uses `cube-kernel-scf/vmlinux` as the active guest kernel path. The package stores `vmlinux-bm` and keeps `vmlinux` as a symlink: by default it points to `vmlinux-bm`; if the target machine sets `CUBE_PVM_ENABLE=1` during installation, the installer points it to `vmlinux-pvm`.
+The installed runtime still uses `cube-kernel-scf/vmlinux` as the active guest kernel path. The package stores `vmlinux-bm` and keeps `vmlinux` as a symlink: by default it points to `vmlinux-bm`; if the target machine sets `CUBE_PVM_ENABLE=1` during installation, the installer points it to `vmlinux-pvm`. `CUBE_PVM_ENABLE` is an installer toggle: on upgrades, `CUBE_PVM_ENABLE=0|1 ./install.sh` or the key appearing in the bundle `.env` always wins (even for `0`, the default), while a full `cp env.example .env` resets it to `0`.
 
 The guest image no longer depends on a local zip file. By default it is generated locally from `deploy/guest-image/Dockerfile` during the one-click release package build. Common override parameters:
 
@@ -238,9 +238,15 @@ role target:
   role target. `wal_bdev.img` is **never overwritten** (created only on first
   install; its size fixes the journal/WAL layout), and the `RCOW_*` settings in
   `.one-click.env` are merged and kept across the upgrade.
-- **Enable/disable**: flip `ONE_CLICK_ENABLE_S3LVOL` to 1/0 in `.env` and
-  re-run `install.sh` (or `systemctl enable/disable
-  cube-sandbox-s3lvol.service` directly).
+- **Enable/disable**: preferred `ONE_CLICK_ENABLE_S3LVOL=0|1 ./install.sh`
+  (honored on upgrade as well). Or put only that key in the bundle `.env`
+  and re-run `install.sh`. Do not `cp env.example .env` as a full copy
+  before upgrade — that resets this switch to `0`. Hand-editing
+  `.one-click.env` is no longer required. `systemctl enable/disable
+  cube-sandbox-s3lvol.service` still works as a direct systemd toggle.
+  `CUBE_PVM_ENABLE` follows the same rule: appearing in `.env` or the
+  process environment always counts as an explicit choice (so a full
+  `cp env.example .env` before an upgrade also resets it to `0`).
 - **S3 backend**: when enabled, `install.sh` writes `/data/cubelet/s3.cfg`
   from `CUBE_S3_*` (bundled MinIO fill, or the operator's external store).
   s3lvol uses its own bucket (`CUBE_S3LVOL_BUCKET`, default `cube-s3lvol`)

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -64,7 +64,7 @@ export ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX=/abs/path/to/vmlinux-pvm
 - `KERNEL_TAG` / `PVM_KERNEL_TAG` **不作为**库存目录名；`release-manifest` 的 `kernel.version` / `pvm_version` 同样记录内容短哈希
 - Ensure 从 Master identity 中的 digest 映射到上述短 key
 
-运行时仍然使用 `cube-kernel-scf/vmlinux`。包内保留 `vmlinux-bm`，`vmlinux` 为软链：默认指向 `vmlinux-bm`；目标机安装时设 `CUBE_PVM_ENABLE=1` 则指向 `vmlinux-pvm`。
+运行时仍然使用 `cube-kernel-scf/vmlinux`。包内保留 `vmlinux-bm`，`vmlinux` 为软链：默认指向 `vmlinux-bm`；目标机安装时设 `CUBE_PVM_ENABLE=1` 则指向 `vmlinux-pvm`。`CUBE_PVM_ENABLE` 是安装器开关：升级时 `CUBE_PVM_ENABLE=0|1 ./install.sh` 或包内 `.env` 出现该 key 即为显式设置（`0` 默认值同样生效），整份 `cp env.example .env` 会把它重置为 `0`。
 
 guest image 不再依赖本地 zip。默认在构建 one-click 发布包时基于 `deploy/guest-image/Dockerfile` 本地生成。常用覆盖参数如下：
 
@@ -201,7 +201,7 @@ CubeS3lvol（s3lvol）作为 `cube-sandbox-*` 角色 target 的 `Wants=` 成员�
 
 - **停止（`down.sh` / `systemctl stop cube-sandbox-{control,compute}.target`）**：s3lvol 单元会走 `cube-s3lvol-stop.sh` 的**条件卸载**——target 进程存活时完整执行 `rcow_stop.sh`（断开 initiator → 卸载 lvstore/回刷 → 终止 target），target 已崩溃时只清理 target 侧残留、绝不断开 NVMf initiator。`down.sh` 只停止服务，**不删除任何数据**（`/data/cubelet/rcow/wal_bdev.img` 与 bstore 元数据保留），再次启动走 attach/replay 恢复。
 - **升级（`install.sh` 升级模式）**：旧 `CubeS3lvol/` 目录被替换（新二进制自动生效），随后 target 随角色 target 重启。`wal_bdev.img` **永不覆盖**（仅首次安装创建，其尺寸固定 journal/WAL 布局），`.one-click.env` 中 `RCOW_*` 配置经升级合并保留。
-- **启停开关**：`.env` 里 `ONE_CLICK_ENABLE_S3LVOL` 翻转为 1/0 后重跑 `install.sh`（或直接 `systemctl enable/disable cube-sandbox-s3lvol.service`）即可。
+- **启停开关**：推荐 `ONE_CLICK_ENABLE_S3LVOL=0|1 ./install.sh`（upgrade 同样生效）。或在包内 `.env` **只写这一项** 再重跑 `install.sh`。不要整份 `cp env.example .env` 再 upgrade，否则这个开关会被重置成 `0`。不必再手改 `.one-click.env`。也可以直接 `systemctl enable/disable cube-sandbox-s3lvol.service`。`CUBE_PVM_ENABLE` 遵循同样规则：出现在 `.env` 或进程环境中即视为显式设置（整份 `cp` 同样会把它重置为 `0`）。
 - **S3 后端**：启用后 `install.sh` 用 `CUBE_S3_*` 自动写出 `/data/cubelet/s3.cfg`（默认对接内置 MinIO；配了外部 S3 就跟外部走）。s3lvol 使用独立桶 `CUBE_S3LVOL_BUCKET`（默认 `cube-s3lvol`），与 volume 插件的 `cube-volumes` 分开。supervisor 启动前会用 stdlib SigV4 工具幂等建桶，不依赖 awscli。手写且不含 one-click sentinel 的 `s3.cfg` 不会被覆盖。开发机上旧的 `/data/cubelet/cos.cfg` **不会回落**，请改名为 `s3.cfg` 并换成新字段名。
 
 控制节点安装完成后，可以打开 Dashboard：

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -43,6 +43,10 @@ esac
 require_root
 
 ENV_FILE="${ONE_CLICK_ENV_FILE:-${SCRIPT_DIR}/.env}"
+# Snapshot this-run toggle intent (ONE_CLICK_TOGGLE_KEYS) before any file is
+# sourced: the upgrade merge later loads the old .one-click.env, which would
+# otherwise clobber both `VAR=x ./install.sh` and toggle keys carried in .env.
+snapshot_one_click_toggles "${ENV_FILE}"
 if [[ -f "${ENV_FILE}" ]]; then
   load_env_file "${ENV_FILE}"
   # CLI flags must win over .env values: load_env_file uses `set -a; source`,
@@ -249,6 +253,10 @@ if [[ "${INSTALL_MODE}" == "upgrade" ]]; then
   apply_cli_overrides
   DEPLOY_ROLE="$(one_click_deploy_role)"
 fi
+# Re-apply this-run toggle intent (harmless on fresh install): the merged env
+# above preserves the old runtime values for keys whose .env value equals the
+# env.example default, which would otherwise ignore an explicit flip back.
+apply_one_click_toggles
 
 init_external_dep_defaults
 if [[ "${DEPLOY_ROLE}" == "compute" ]]; then
@@ -1344,6 +1352,11 @@ stop_existing_systemd_deployment() {
   # service afterwards, which both forces failed units back to inactive
   # and guarantees the next `enable --now <target>` actually re-runs
   # ExecStart instead of returning a "no-op, already active" exit 0.
+  #
+  # Stop s3lvol before the target/glob stop so it can flush to MinIO
+  # while the S3 endpoint is still up. A glob `cube-sandbox-*.service`
+  # stop has undefined order and otherwise races MinIO down first.
+  systemctl stop cube-sandbox-s3lvol.service >/dev/null 2>&1 || true
   systemctl disable --now \
     cube-sandbox-control.target \
     cube-sandbox-compute.target >/dev/null 2>&1 || true
@@ -1407,6 +1420,7 @@ start_systemd_target() {
       || log "WARN: could not enable cube-sandbox-s3lvol.service"
   else
     systemctl disable cube-sandbox-s3lvol.service >/dev/null 2>&1 || true
+    systemctl reset-failed cube-sandbox-s3lvol.service >/dev/null 2>&1 || true
   fi
 
   systemctl enable --now "${target}"

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -499,6 +499,73 @@ load_env_file() {
   fi
 }
 
+# Installer toggle keys: on/off switches whose this-run value must survive the
+# upgrade env merge. The merge treats a bundle-.env value as an explicit
+# operator override only when it differs from the new env.example default
+# (the `cp env.example .env` safeguard), so flipping one of these keys BACK to
+# the template default via .env would otherwise be inexpressible on upgrade.
+# For the keys listed here, presence in the bundle .env or in install.sh's
+# process environment counts as explicit operator intent and is re-applied
+# after the merge (snapshot_one_click_toggles / apply_one_click_toggles).
+#
+# Opting a key in gives it presence-implies-explicit semantics: a wholesale
+# `cp env.example .env` carried into an upgrade resets the key to the template
+# default (documented caveat in the one-click README).
+ONE_CLICK_TOGGLE_KEYS=(
+  ONE_CLICK_ENABLE_S3LVOL
+  CUBE_PVM_ENABLE
+)
+
+# snapshot_one_click_toggles: capture this-run operator intent for
+# ONE_CLICK_TOGGLE_KEYS from the process environment and the bundle .env.
+# Must run BEFORE any env file is sourced: the upgrade merge later sources the
+# merged old-runtime env, which would otherwise clobber both channels.
+#   ONE_CLICK_TOGGLE_ENV_SNAPSHOT     key -> value from the process environment
+#   ONE_CLICK_TOGGLE_DOTENV_SNAPSHOT  key -> value from the bundle .env
+# (presence in .env is enough — a value equal to the env.example default still
+# counts, which is exactly what makes "flip back to default" expressible)
+snapshot_one_click_toggles() {
+  local env_file="$1"
+  local key
+  # -g: these are process-wide state read later by apply_one_click_toggles;
+  # -A: keys are env-var names, not numeric indexes. NOTE: the declaration and
+  # the empty-assignment must be separate statements — bash 4.2 (CentOS 7)
+  # mishandles `declare -gA VAR=()` by creating a function-local array.
+  declare -gA ONE_CLICK_TOGGLE_ENV_SNAPSHOT
+  declare -gA ONE_CLICK_TOGGLE_DOTENV_SNAPSHOT
+  ONE_CLICK_TOGGLE_ENV_SNAPSHOT=()
+  ONE_CLICK_TOGGLE_DOTENV_SNAPSHOT=()
+  for key in "${ONE_CLICK_TOGGLE_KEYS[@]}"; do
+    if [[ -n "${!key+x}" ]]; then
+      ONE_CLICK_TOGGLE_ENV_SNAPSHOT["${key}"]="${!key}"
+    fi
+    if [[ -f "${env_file}" ]] && grep -q "^${key}=" "${env_file}"; then
+      ONE_CLICK_TOGGLE_DOTENV_SNAPSHOT["${key}"]="$(read_env_key "${env_file}" "${key}")"
+    fi
+  done
+  return 0
+}
+
+# apply_one_click_toggles: re-apply the snapshotted operator intent after the
+# env files (including the upgrade merge output) have been sourced. Precedence
+# mirrors install.sh's documented channel order (CLI flags > .env > process
+# environment > defaults): .env key > process environment > merged/loaded
+# value. The final value is persisted by install.sh's upsert_env_kv, so this
+# is the single place toggle intent is resolved.
+apply_one_click_toggles() {
+  local key
+  for key in "${ONE_CLICK_TOGGLE_KEYS[@]}"; do
+    if [[ -n "${ONE_CLICK_TOGGLE_DOTENV_SNAPSHOT[${key}]+x}" ]]; then
+      printf -v "${key}" '%s' "${ONE_CLICK_TOGGLE_DOTENV_SNAPSHOT[${key}]}"
+      log "toggle ${key}=${!key} (explicit in .env)"
+    elif [[ -n "${ONE_CLICK_TOGGLE_ENV_SNAPSHOT[${key}]+x}" ]]; then
+      printf -v "${key}" '%s' "${ONE_CLICK_TOGGLE_ENV_SNAPSHOT[${key}]}"
+      log "toggle ${key}=${!key} (explicit in process environment)"
+    fi
+  done
+  return 0
+}
+
 # Load build-machine overrides for release-bundle scripts.
 # Precedence: ONE_CLICK_BUILD_ENV_FILE > ${ONE_CLICK_DIR}/build.env >
 # legacy ONE_CLICK_ENV_FILE / .env (with a migration hint).
@@ -1474,6 +1541,10 @@ for line in template:
     # differs from the new env.example default. This is intentional: the common
     # way to create a .env is `cp env.example .env`, which would otherwise make
     # every key an "override" and clobber the user's existing customizations.
+    # (Installer toggle keys such as ONE_CLICK_ENABLE_S3LVOL are NOT special-
+    # cased here: their this-run intent is captured and re-applied around this
+    # merge by snapshot_one_click_toggles / apply_one_click_toggles in
+    # install.sh, and persisted via upsert_env_kv afterwards.)
     if key in new_overrides and new_overrides[key] != new_defaults.get(key):
         chosen = new_overrides[key]
         explicit.append(key)

--- a/deploy/one-click/systemd/cube-sandbox-s3lvol.service
+++ b/deploy/one-click/systemd/cube-sandbox-s3lvol.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cube Sandbox S3lvol (RCOW data plane)
-After=network-online.target
+After=network-online.target cube-sandbox-minio.service
 Wants=network-online.target
 ConditionPathExists=/usr/local/services/cubetoolbox/.one-click.env
 RequiresMountsFor=/data/cubelet /data/log

--- a/deploy/one-click/tests/test_env_merge.sh
+++ b/deploy/one-click/tests/test_env_merge.sh
@@ -362,6 +362,56 @@ EOF
   assert_contains "${diff}" "[explicit]"
 }
 
+# Contract boundary: the merge stays generic — a .env value that EQUALS the
+# env.example default is never an explicit override, for toggle keys too.
+# Toggle intent (flipping ONE_CLICK_ENABLE_S3LVOL back to 0 on upgrade) is
+# handled outside the merge by snapshot_one_click_toggles /
+# apply_one_click_toggles (see tests/test_toggle_inputs.sh), and the final
+# value is persisted by install.sh's upsert_env_kv.
+test_dotenv_default_valued_key_not_explicit() {
+  local new="${TMP_DIR}/new_s3lvol.example" old="${TMP_DIR}/old_s3lvol.env"
+  local dotenv="${TMP_DIR}/new_s3lvol.env"
+  local out="${TMP_DIR}/out_s3lvol.env" diff="${TMP_DIR}/diff_s3lvol.txt"
+  cat > "${new}" <<'EOF'
+ONE_CLICK_ENABLE_S3LVOL=0
+CUBE_SANDBOX_MYSQL_PORT=3306
+EOF
+  cat > "${old}" <<'EOF'
+ONE_CLICK_ENABLE_S3LVOL=1
+CUBE_SANDBOX_MYSQL_PORT=3307
+EOF
+  cat > "${dotenv}" <<'EOF'
+ONE_CLICK_ENABLE_S3LVOL=0
+CUBE_SANDBOX_MYSQL_PORT=3306
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "${dotenv}" "${out}" "${diff}" 2>/dev/null
+
+  # Both keys equal the new defaults, so the old runtime values are preserved
+  # (cp env.example .env regression guard).
+  assert_value "${out}" ONE_CLICK_ENABLE_S3LVOL 1
+  assert_value "${out}" CUBE_SANDBOX_MYSQL_PORT 3307
+  assert_contains "${diff}" "[preserved]"
+  assert_contains "${diff}" "= ONE_CLICK_ENABLE_S3LVOL=1"
+}
+
+test_absent_dotenv_preserves_s3lvol() {
+  local new="${TMP_DIR}/new_s3lvol2.example" old="${TMP_DIR}/old_s3lvol2.env"
+  local out="${TMP_DIR}/out_s3lvol2.env" diff="${TMP_DIR}/diff_s3lvol2.txt"
+  cat > "${new}" <<'EOF'
+ONE_CLICK_ENABLE_S3LVOL=0
+EOF
+  cat > "${old}" <<'EOF'
+ONE_CLICK_ENABLE_S3LVOL=1
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  assert_value "${out}" ONE_CLICK_ENABLE_S3LVOL 1
+  assert_contains "${diff}" "[preserved]"
+  assert_contains "${diff}" "= ONE_CLICK_ENABLE_S3LVOL=1"
+}
+
 test_version_lt() {
   version_lt 1.0.0 2.0.0 || fail "1.0.0 < 2.0.0 should be true"
   version_lt v0.2.2 v0.2.3 || fail "v0.2.2 < v0.2.3 should be true"
@@ -656,6 +706,8 @@ test_two_way_migrates_legacy_cube_proxy_cert_dir_default
 test_two_way_migrates_single_quoted_legacy_cube_proxy_cert_dir_default
 test_two_way_preserves_custom_cube_proxy_cert_dir
 test_new_dotenv_overrides_take_priority
+test_dotenv_default_valued_key_not_explicit
+test_absent_dotenv_preserves_s3lvol
 test_version_lt
 test_diff_report_redacts_secrets
 test_drops_obsolete_agenthub_keys

--- a/deploy/one-click/tests/test_install_mode.sh
+++ b/deploy/one-click/tests/test_install_mode.sh
@@ -574,6 +574,15 @@ test_install_sh_wires_upgrade_flow() {
   # on upgrade, CIDR host-conflict detection is skipped (M2)
   assert_contains "${f}" 'check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}" "${cidr_skip_conflict}" "CUBE_SANDBOX_NETWORK_CIDR" 24 16'
   assert_contains "${f}" 'check_cidr_preflight "192.168.0.0/18" "${cidr_skip_conflict}" "default CubeSandbox network CIDR" 24 16'
+  # This-run toggle intent (ONE_CLICK_TOGGLE_KEYS) must be captured before any
+  # env sourcing and re-applied after the upgrade merge.
+  assert_contains "${f}" "snapshot_one_click_toggles"
+  assert_contains "${f}" "apply_one_click_toggles"
+  assert_contains "${f}" "ONE_CLICK_TOGGLE_KEYS"
+  # Stop s3lvol before the target/glob stop so it can flush while MinIO is up.
+  assert_contains "${f}" "systemctl stop cube-sandbox-s3lvol.service"
+  # Disable must clear leftover failed state.
+  assert_contains "${f}" "systemctl reset-failed cube-sandbox-s3lvol.service"
 }
 
 test_explicit_install_mode

--- a/deploy/one-click/tests/test_runtime_file_safety.sh
+++ b/deploy/one-click/tests/test_runtime_file_safety.sh
@@ -175,6 +175,12 @@ test_unit_dependency_order() {
   assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-cubemaster.service" "After=network-online.target cube-sandbox-mysql.service cube-sandbox-redis.service"
   assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-cube-api.service" "After=network-online.target cube-sandbox-cubemaster.service"
   assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-webui.service" "After=docker.service network-online.target cube-sandbox-cubemaster.service cube-sandbox-cubeops.service"
+  # s3lvol must start after MinIO and therefore stop before it (no Requires=:
+  # compute nodes do not ship MinIO).
+  assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-s3lvol.service" "After=network-online.target cube-sandbox-minio.service"
+  if grep -Fq 'Requires=cube-sandbox-minio.service' "${ONE_CLICK_DIR}/systemd/cube-sandbox-s3lvol.service"; then
+    fail "s3lvol must not Require minio (compute nodes have no MinIO unit)"
+  fi
 }
 
 test_detect_glibc_version_consumes_full_ldd_output() {

--- a/deploy/one-click/tests/test_toggle_inputs.sh
+++ b/deploy/one-click/tests/test_toggle_inputs.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Unit tests for the installer toggle mechanism (ONE_CLICK_TOGGLE_KEYS,
+# snapshot_one_click_toggles, apply_one_click_toggles) in lib/common.sh.
+# Toggle keys are on/off switches whose this-run value (process environment
+# or bundle .env, presence implying explicit intent even for the default
+# value) must survive the upgrade env merge, which otherwise preserves the
+# old runtime value for keys whose .env value equals the env.example default.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ONE_CLICK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+# shellcheck source=../lib/common.sh
+source "${ONE_CLICK_DIR}/lib/common.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# Assert that every entry in "$@" is present in ONE_CLICK_TOGGLE_KEYS, in
+# order, with no extras — removing a key here silently resurrects the
+# "cannot flip back to default on upgrade" bug for that key.
+assert_toggle_keys() {
+  local expected="${*}"
+  local actual
+  actual="${ONE_CLICK_TOGGLE_KEYS[*]}"
+  [[ "${actual}" == "${expected}" ]] \
+    || fail "expected ONE_CLICK_TOGGLE_KEYS='${expected}', got '${actual}'"
+}
+
+# Reset the toggle variables so leftovers from a previous scenario cannot
+# leak into the next snapshot as process-env intent.
+reset_toggle_vars() {
+  unset ONE_CLICK_ENABLE_S3LVOL CUBE_PVM_ENABLE
+}
+
+# Simulate what install.sh does around the upgrade merge for the toggle keys:
+# snapshot the intent, let the merged old-runtime value clobber the variable
+# (as `load_env_file "${MERGED_ENV}"` would), then re-apply.
+run_toggle_roundtrip() {
+  local dotenv="$1"
+  snapshot_one_click_toggles "${dotenv}"
+  ONE_CLICK_ENABLE_S3LVOL="${MERGED_S3LVOL:-}"
+  CUBE_PVM_ENABLE="${MERGED_PVM:-}"
+  apply_one_click_toggles 2>/dev/null
+}
+
+test_toggle_keys_registry() {
+  assert_toggle_keys ONE_CLICK_ENABLE_S3LVOL CUBE_PVM_ENABLE
+}
+
+# Core regression: a .env value that equals the env.example default (0) must
+# still count as explicit — this is what makes "disable on upgrade" work.
+test_dotenv_default_value_is_explicit() {
+  local dotenv="${TMP_DIR}/dotenv1.env"
+  cat > "${dotenv}" <<'EOF'
+ONE_CLICK_ENABLE_S3LVOL=0
+CUBE_PVM_ENABLE=1
+EOF
+  reset_toggle_vars
+  MERGED_S3LVOL=1
+  MERGED_PVM=0
+  run_toggle_roundtrip "${dotenv}"
+  [[ "${ONE_CLICK_ENABLE_S3LVOL}" == "0" ]] \
+    || fail "expected .env ONE_CLICK_ENABLE_S3LVOL=0 to disable the runtime 1"
+  [[ "${CUBE_PVM_ENABLE}" == "1" ]] \
+    || fail "expected .env CUBE_PVM_ENABLE=1 to win over the runtime 0"
+}
+
+# `VAR=x ./install.sh`: process-environment intent survives the merge even
+# without any .env.
+test_process_env_is_explicit() {
+  local dotenv="${TMP_DIR}/absent.env"
+  reset_toggle_vars
+  ONE_CLICK_ENABLE_S3LVOL=0
+  MERGED_S3LVOL=1
+  MERGED_PVM=1
+  run_toggle_roundtrip "${dotenv}"
+  [[ "${ONE_CLICK_ENABLE_S3LVOL}" == "0" ]] \
+    || fail "expected process-env ONE_CLICK_ENABLE_S3LVOL=0 to disable the runtime 1"
+  [[ "${CUBE_PVM_ENABLE}" == "1" ]] \
+    || fail "expected untouched CUBE_PVM_ENABLE to keep the merged value 1"
+}
+
+# Both channels set: .env wins, mirroring install.sh's documented channel
+# order (CLI flags > .env file > process environment > defaults).
+test_dotenv_beats_process_env() {
+  local dotenv="${TMP_DIR}/dotenv2.env"
+  cat > "${dotenv}" <<'EOF'
+ONE_CLICK_ENABLE_S3LVOL=1
+EOF
+  reset_toggle_vars
+  ONE_CLICK_ENABLE_S3LVOL=0
+  MERGED_S3LVOL=0
+  run_toggle_roundtrip "${dotenv}"
+  [[ "${ONE_CLICK_ENABLE_S3LVOL}" == "1" ]] \
+    || fail "expected .env ONE_CLICK_ENABLE_S3LVOL=1 to beat the process-env 0"
+}
+
+# No intent anywhere: the merged (old runtime) value is left untouched.
+test_no_intent_keeps_merged_value() {
+  local dotenv="${TMP_DIR}/dotenv3.env"
+  echo "CUBE_SANDBOX_MYSQL_PORT=3307" > "${dotenv}"
+  reset_toggle_vars
+  MERGED_S3LVOL=1
+  MERGED_PVM=1
+  run_toggle_roundtrip "${dotenv}"
+  [[ "${ONE_CLICK_ENABLE_S3LVOL}" == "1" ]] \
+    || fail "expected no-intent run to keep the merged ONE_CLICK_ENABLE_S3LVOL=1"
+  [[ "${CUBE_PVM_ENABLE}" == "1" ]] \
+    || fail "expected no-intent run to keep the merged CUBE_PVM_ENABLE=1"
+}
+
+# A commented-out or absent key in .env is not intent: the snapshot must key
+# off an active KEY= line, not a template comment.
+test_commented_dotenv_line_is_not_intent() {
+  local dotenv="${TMP_DIR}/dotenv4.env"
+  cat > "${dotenv}" <<'EOF'
+# ONE_CLICK_ENABLE_S3LVOL=0
+CUBE_PVM_ENABLE=0
+EOF
+  reset_toggle_vars
+  MERGED_S3LVOL=1
+  MERGED_PVM=1
+  run_toggle_roundtrip "${dotenv}"
+  [[ "${ONE_CLICK_ENABLE_S3LVOL}" == "1" ]] \
+    || fail "commented .env line must not count as intent"
+  [[ "${CUBE_PVM_ENABLE}" == "0" ]] \
+    || fail "active .env CUBE_PVM_ENABLE=0 must count as intent"
+}
+
+test_toggle_keys_registry
+test_dotenv_default_value_is_explicit
+test_process_env_is_explicit
+test_dotenv_beats_process_env
+test_no_intent_keeps_merged_value
+test_commented_dotenv_line_is_not_intent
+
+echo "test_toggle_inputs: all tests passed"


### PR DESCRIPTION
## Summary

Follow-up to #1622: the s3lvol on/off switch set through the one-click installer was unreliable during an `install.sh` upgrade. Two causes: the three-way `.env` merge only treats a value as an explicit override when it differs from the `env.example` default (the `cp env.example .env` safeguard), so flipping the switch back to its default `0` could never be expressed; and on upgrade the merged old-runtime env is sourced after `.env`, clobbering both `VAR=x ./install.sh` and `.env`-provided values. Stopping also raced the bundled MinIO.

## Changes

- **`lib/common.sh`** — new generic installer-toggle mechanism: `ONE_CLICK_TOGGLE_KEYS` (currently `ONE_CLICK_ENABLE_S3LVOL`, `CUBE_PVM_ENABLE`), `snapshot_one_click_toggles` (captures this-run intent from the process environment and the bundle `.env` before any file is sourced — presence counts as explicit, even when the value equals the `env.example` default) and `apply_one_click_toggles` (re-applies it after the upgrade merge, alongside the existing `apply_cli_overrides` pattern). The final value is persisted by the existing `upsert_env_kv`; the env merge itself stays fully generic — the per-key special case from the first revision is gone.
- **`install.sh`** — wires the two mechanism calls; stops the s3lvol unit before the role-target/glob stop so it can flush to MinIO while the S3 endpoint is still up; clears a leftover failed state via `reset-failed` on disable.
- **`CUBE_PVM_ENABLE`** had the same bug and now rides the same mechanism: a `.env` carrying `CUBE_PVM_ENABLE=0` actually disables it on upgrade (previously the old runtime `1` was silently kept).
- **`systemd/cube-sandbox-s3lvol.service`** — declare `After=network-online.target cube-sandbox-minio.service` so it starts after and stops before the bundled MinIO. No `Requires=`: compute nodes do not ship MinIO.
- **Tests** — merge contract coverage in `tests/test_env_merge.sh` (a default-valued `.env` key is not explicit in the merge), a new `tests/test_toggle_inputs.sh` for the snapshot/apply matrix, and install-mode / unit-dependency assertions.
- **Docs** — one-click README (EN/ZH) enable/disable guidance updated: no more hand-editing `.one-click.env`; avoid a full `cp env.example .env` before upgrade, which resets the toggles to their defaults; `CUBE_PVM_ENABLE` follows the same rule.

## Upgrade note

After this change, disabling s3lvol on an upgrade is done with `ONE_CLICK_ENABLE_S3LVOL=0 ./install.sh` (or by putting only that key in the bundle `.env` and re-running `install.sh`). The same applies to `CUBE_PVM_ENABLE`.
