### PR TITLE
feat(s3lvol,k8s): optional s3lvol sidecar in the cube-node Big Pod

### DIFF
--- a/.github/workflows/kubernetes-chart-check.yml
+++ b/.github/workflows/kubernetes-chart-check.yml
@@ -54,6 +54,7 @@ jobs:
           sh -n deploy/kubernetes/images/scripts/pvm-host-bootstrap.sh
           sh -n deploy/kubernetes/images/scripts/wait-node-prep.sh
           sh -n deploy/kubernetes/chart/files/cube-proxy/cube-proxy-entrypoint.sh
+          bash -n deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh
       # Cloud-free chart/image guard suite (deploy/kubernetes/*/scripts/
       # test-*.sh). Helm is installed above; every script is self-contained.
       # Loop so new test-*.sh are picked up automatically instead of drifting

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -18,7 +18,7 @@ on:
         type: string
         default: ''
       components:
-        description: 'Comma-separated components to build, or "all" (cube-egress, cube-egress-net, cube-master, cubemastercli, cubelet, cube-shim, cube-kernel, cube-guest, cube-agent, cube-pvm-host-bootstrap, cube-node-init, cube-wait-node-prep, cube-api, cube-ops, cube-proxy, webui, cube-lifecycle-manager)'
+        description: 'Comma-separated components to build, or "all" (cube-egress, cube-egress-net, cube-s3lvol, cube-master, cubemastercli, cubelet, cube-shim, cube-kernel, cube-guest, cube-agent, cube-pvm-host-bootstrap, cube-node-init, cube-wait-node-prep, cube-api, cube-ops, cube-proxy, webui, cube-lifecycle-manager)'
         required: false
         type: string
         default: all
@@ -204,6 +204,7 @@ jobs:
           known = {
               "cube-egress",
               "cube-egress-net",
+              "cube-s3lvol",
               "cube-master",
               "cubemastercli",
               "cubelet",
@@ -244,6 +245,14 @@ jobs:
                   "context": "cube-egress-net-ctx",
                   "dockerfile": "deploy/kubernetes/images/cube-egress-net/Dockerfile",
                   "cache_scope": "cube-egress-net",
+              },
+              {
+                  "component": "cube-s3lvol",
+                  "image": "cube-s3lvol",
+                  "context": ".",
+                  "dockerfile": "deploy/kubernetes/images/cube-s3lvol/Dockerfile",
+                  "cache_scope": "cube-s3lvol",
+                  "arches": ["amd64"],
               },
               {
                   "component": "cube-master",
@@ -731,6 +740,7 @@ jobs:
             CUBE_VERSION=${{ inputs.image_tag }}
             CUBE_COMMIT=${{ steps.meta.outputs.commit }}
             CUBE_BUILD_TIME=${{ steps.meta.outputs.build_time }}
+            CUBE_BUILDER_IMAGE=ghcr.io/tencentcloud/cubesandbox-builder:ubuntu2004
             CUBE_PROXY_BASE_IMAGE=${{ env.OPENRESTY_BASE_IMAGE }}
             OPENRESTY_BASE_IMAGE=${{ env.OPENRESTY_BASE_IMAGE }}
             CUBE_KERNEL_BM_VERSION=${{ steps.stage_kernel.outputs.asset_tag_bm || inputs.image_tag }}

--- a/CubeS3lvol/README.md
+++ b/CubeS3lvol/README.md
@@ -146,7 +146,7 @@ used ones:
 |---|---|---|
 | `RCOW_S3_CFG` | `/data/cubelet/s3.cfg` | |
 | `RCOW_WAL_IMG` | `/data/cubelet/rcow/wal_bdev.img` | |
-| `RCOW_LVS_NAME` | derived `rcow-<hostname-hash>`; a pre-existing `rcow` entry is honoured | lvstore name, also the prefix in S3 |
+| `RCOW_LVS_NAME` | derived `rcow-<identity-hash>`; a pre-existing `rcow` entry is honoured | lvstore name, also the prefix in S3 |
 | `RCOW_CAPACITY_GB` | `16384` | used only at first create; thin, unused space costs nothing |
 | `RCOW_CACHE_MB` | `490496` | chunk cache on the WAL image; only matters before the first start |
 | `RCOW_LISTEN_ADDR` / `RCOW_LISTEN_PORT` | `127.0.0.1` / `4420` | |
@@ -164,11 +164,24 @@ hostname: two machines with the same hostname (containers, cloned disks)
 each consider the other's marker stale and force-take a volume the other is
 still serving, which can corrupt data.
 
-The lvstore name is derived from the same hostname (`rcow-<hostname-hash>`),
-so duplicate hostnames also collide on the S3 prefix itself. When nodes have
-a real unique id (an inventory id, a Kubernetes node name, an instance id),
-pin `RCOW_LVS_NAME` to it instead of relying on the hostname-derived
-default, and never let two nodes share a hostname.
+The lvstore name is derived from the same hostname (`rcow-<identity-hash>`),
+so duplicate hostnames also collide on the S3 prefix itself. The identity
+string is `hostname -s` for a DNS name (`worker1.example.com` → `worker1`),
+so an existing prefix survives a domain-suffix change. An address is not an
+FQDN: `hostname -s` of `192.0.2.48` is `192`, which would give every node
+in a /8 the same prefix. IPv4, IPv6, and a purely numeric short name of a
+dotted hostname (`192.0.2.48.internal`) are hashed in full.
+
+Changing the identity string changes the prefix. A node whose hostname is
+already an IP, and that already created a store under the old `hostname -s`
+hash, looks like a new machine on upgrade (create formats the WAL; the old
+S3 prefix is orphaned unless you pin `RCOW_LVS_NAME` to the old name).
+
+When nodes have a real unique id (an inventory id, a Kubernetes node name,
+an instance id), pin `RCOW_LVS_NAME` to `rcow-<hash of that full id>`
+instead of relying on `hostname -s`, and never let two nodes share a
+hostname. The Helm sidecar does this automatically from the full
+`spec.nodeName`.
 
 `RCOW_NO_HUGE=1` is a **choice, not a concession**: nothing on this data path
 needs DMA (the local disk goes through `bdev_aio` read/write syscalls, the

--- a/CubeS3lvol/scripts/rcow_common.sh
+++ b/CubeS3lvol/scripts/rcow_common.sh
@@ -1396,8 +1396,12 @@ sequential reads on those will issue one S3 request per 128 KiB"
 # the design doc, single-writer is an upper-layer guarantee. This is that layer
 # doing its part.
 #
-# A truncated digest of the short hostname is what makes it per-node: stable across
-# reboots, needs no coordination, and does not leak the hostname into bucket keys.
+# A truncated digest of the identity hostname is what makes it per-node: stable
+# across reboots, needs no coordination, and does not leak the hostname into
+# bucket keys. DNS names still use hostname -s (the label before the first
+# dot) so an existing one-click prefix survives a domain-suffix change.
+# Addresses and dotted hostnames with a numeric short name (192.0.2.48,
+# 192.0.2.48.internal -> short name "192", one prefix per /8) hash in full.
 #
 # On collisions, honestly: 4 bytes is 32 bits, so for N nodes in one bucket the
 # birthday probability is roughly N^2 / 2^33 -- about 1 in 8600 at a thousand
@@ -1425,6 +1429,81 @@ RCOW_LVS_NAME_LEGACY="${RCOW_LVS_NAME_LEGACY:-rcow}"
 #
 # printf, not echo: the digest must be of the hostname alone, with no trailing
 # newline, or it changes depending on who recomputes it.
+#
+# rcow_node_hash [id]: hash an explicit identity, or this machine's
+# rcow_identity_host when no argument is given.
+
+# IPv4 (four decimal fields) or IPv6 (hostnames cannot contain ':').
+# Deliberately loose: octets are not range-checked.
+rcow_is_ip_hostname()
+{
+	local s="${1:-}"
+	local oct
+
+	[ -n "${s}" ] || return 1
+	case "${s}" in
+	*:*)
+		return 0
+		;;
+	esac
+
+	local IFS='.'
+	# shellcheck disable=SC2086
+	set -- ${s}
+	[ "$#" -eq 4 ] || return 1
+	for oct; do
+		case "${oct}" in
+		''|*[!0-9]*)
+			return 1
+			;;
+		esac
+	done
+	return 0
+}
+
+# Identity string to hash, given the full hostname and hostname -s.
+rcow_identity_host_from()
+{
+	local full="${1:-}"
+	local short="${2:-}"
+
+	if [ -z "${full}" ] && [ -z "${short}" ]; then
+		return 1
+	fi
+	if rcow_is_ip_hostname "${full}"; then
+		printf '%s' "${full}"
+		return 0
+	fi
+	# hostname -s of 192.0.2.48.internal is "192" -- the same collision as a
+	# bare IPv4, with a search domain appended.
+	case "${short}" in
+	''|*[!0-9]*)
+		;;
+	*)
+		case "${full}" in
+		*.*)
+			printf '%s' "${full}"
+			return 0
+			;;
+		esac
+		;;
+	esac
+	if [ -n "${short}" ]; then
+		printf '%s' "${short}"
+		return 0
+	fi
+	printf '%s' "${full}"
+}
+
+rcow_identity_host()
+{
+	local full short
+
+	full="$(hostname 2>/dev/null || true)"
+	short="$(hostname -s 2>/dev/null || true)"
+	rcow_identity_host_from "${full}" "${short}"
+}
+
 rcow_node_hash()
 {
 	local host
@@ -1435,13 +1514,17 @@ rcow_node_hash()
 		return 1
 	}
 
-	host="$(hostname -s 2>/dev/null || true)"
+	if [ "$#" -ge 1 ]; then
+		host="${1}"
+	else
+		host="$(rcow_identity_host)" || true
+	fi
 	if [ -z "${host}" ]; then
 		# Refusing rather than falling back to a constant: a fallback would give
 		# every affected node the same prefix, which is the failure this whole
 		# mechanism exists to prevent.
-		rcow_err "'hostname -s' is empty, so a per-node lvstore name cannot be"
-		rcow_err "derived; set RCOW_LVS_NAME explicitly"
+		rcow_err "identity hostname is empty, so a per-node lvstore name cannot"
+		rcow_err "be derived; set RCOW_LVS_NAME explicitly"
 		return 1
 	fi
 

--- a/CubeS3lvol/scripts/rcow_start.sh
+++ b/CubeS3lvol/scripts/rcow_start.sh
@@ -226,9 +226,12 @@ printf '\n==== %s: starting %s\n' "$(date -Is)" "${RCOW_TGT_BIN}" >>"${RCOW_LOG}
 # options, and the pools are allocated during subsystem init. Passed separately
 # from TGT_ARGS so that overriding those cannot drop it.
 #
+# -r must match RCOW_RPC_SOCK: s3lvol_tgt defaults to /var/run/s3lvol.sock,
+# and rcow_wait_rpc below probes RCOW_RPC_SOCK -- a mismatch just times out.
+#
 # shellcheck disable=SC2086
 TGT_PID="$(rcow_start_target_detached "${RCOW_TGT_BIN}" -m "${RCOW_TGT_CPUMASK}" \
-	--wait-for-rpc ${TGT_ARGS})" ||
+	-r "${RCOW_RPC_SOCK}" --wait-for-rpc ${TGT_ARGS})" ||
 	bail "the target did not come up far enough to record its pid"
 
 rcow_wait_rpc 60 "${TGT_PID}" ||

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -312,6 +312,7 @@ echo "--- offline tools"
 run_suite s3_bucket_selftest python3 ./test/tools/s3_bucket.py --self-test
 run_suite isa_baseline ./test/tools/test_isa_baseline.sh
 run_suite rpc_py38_compat ./test/tools/test_rpc_py38_compat.sh
+run_suite lvs_identity ./test/tools/test_lvs_identity.sh
 echo ""
 
 echo "--- integration (no S3, no root)"

--- a/CubeS3lvol/test/tools/test_lvs_identity.sh
+++ b/CubeS3lvol/test/tools/test_lvs_identity.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Offline tests for rcow lvstore identity: IPv4/IPv6 and numeric short names
+# hash the full hostname; DNS FQDNs still use hostname -s.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMMON="${ROOT}/scripts/rcow_common.sh"
+
+fail() {
+	echo "FAIL: $*" >&2
+	echo "result: 0 passed, 1 failed"
+	exit 1
+}
+
+[[ -f "${COMMON}" ]] || fail "missing ${COMMON}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+# Pin so sourcing does not depend on this machine's hostname, and so mkdir
+# does not touch /data/cubelet.
+# shellcheck source=../../scripts/rcow_common.sh
+RCOW_LVS_NAME=lvs-identity-test
+RCOW_ACTIVE_FILE="${tmp}/active_lvols"
+RCOW_BSTORE_FILE="${tmp}/bstore.json"
+# shellcheck disable=SC1090
+source "${COMMON}"
+
+want_ip() {
+	rcow_is_ip_hostname "$1" || fail "expected IP hostname: $1"
+}
+
+refuse_ip() {
+	if rcow_is_ip_hostname "$1"; then
+		fail "did not expect IP hostname: $1"
+	fi
+}
+
+want_id() {
+	local full="$1" short="$2" expect="$3" got
+	got="$(rcow_identity_host_from "${full}" "${short}")" \
+		|| fail "identity_host_from ${full} / ${short} failed"
+	[[ "${got}" == "${expect}" ]] \
+		|| fail "identity_host_from ${full} / ${short}: got ${got}, want ${expect}"
+}
+
+want_ip "192.0.2.48"
+want_ip "192.0.2.44"
+want_ip "2001:db8::1"
+want_ip "fe80::1"
+want_ip "::ffff:192.0.2.1"
+refuse_ip "worker-1"
+refuse_ip "n1.zone-a"
+refuse_ip "192.0.2.48.internal"
+refuse_ip ""
+
+want_id "worker-1" "worker-1" "worker-1"
+want_id "n1.zone-a" "n1" "n1"
+want_id "worker1.example.com" "worker1" "worker1"
+want_id "192.0.2.48" "192" "192.0.2.48"
+want_id "192.0.2.44" "192" "192.0.2.44"
+want_id "2001:db8::1" "2001:db8::1" "2001:db8::1"
+want_id "192.0.2.48.internal" "192" "192.0.2.48.internal"
+want_id "123" "123" "123"
+
+h48="$(rcow_node_hash 192.0.2.48)" || fail "rcow_node_hash 192.0.2.48"
+h44="$(rcow_node_hash 192.0.2.44)" || fail "rcow_node_hash 192.0.2.44"
+h192="$(rcow_node_hash 192)" || fail "rcow_node_hash 192"
+[[ "${h48}" != "${h44}" ]] || fail "IPv4 nodes must not share a hash"
+[[ "${h48}" != "${h192}" ]] || fail "full IPv4 must not hash like hostname -s"
+[[ "${h48}" == "$(rcow_node_hash 192.0.2.48)" ]] \
+	|| fail "rcow_node_hash must be stable for the same input"
+
+h_short="$(rcow_node_hash worker-1)" || fail "rcow_node_hash worker-1"
+expect_short="$(printf '%s' worker-1 | sha256sum | cut -c1-8)"
+[[ "${h_short}" == "${expect_short}" ]] \
+	|| fail "hash(worker-1) must match sha256 8hex (got ${h_short})"
+
+echo "lvs identity tests OK"
+echo "result: 21 passed, 0 failed"

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -638,6 +638,32 @@ cubeEgress:
 
 Do not rotate the CubeEgress CA casually: templates baked with the old CA and sandboxes trusting the old CA must be considered during rotation.
 
+## CubeS3lvol
+
+`cubeS3lvol.enabled=false` by default, same as one-click. Enabling it injects a `cube-s3lvol` sidecar into the Cube Node Big Pod and **recreates that Pod, interrupting sandboxes on the node** — budget about 2 CPU, 18 GiB RAM, and a 512 GiB sparse WAL per compute node (x86_64 needs AVX2).
+
+When enabled, the sidecar:
+
+- runs in its own `cube-s3lvol` image next to cubelet;
+- shares a Unix socket (`/var/run/s3lvol/s3lvol.sock`) with cubelet over an in-memory emptyDir, and writes cubelet's `[cow.s3] enable = true` + `socket_path` (a socket path alone does not opt in);
+- keeps WAL and logs on the existing `data-cubelet` / `data-log` hostPaths, so a Pod recreate loses nothing;
+- reads S3 config from a chart Secret mounted at `/etc/s3lvol/s3.cfg`; an `existingSecret` must contain that key in s3lvol format (not `volume-s3.conf`);
+- reuses chart MinIO or `volumeS3` endpoint and credentials by default. The bucket is `cube-s3lvol` and must not be the volume plugin's `cube-volumes` (Helm fails on a shared bucket);
+- identifies the node by hashing the full Kubernetes node name (`spec.nodeName`) to `rcow-<8hex>`, so a Pod recreate is not a new machine and IP / dotted node names stay unique. `cubeS3lvol.lvsName` pins the same name on every node — do not set it when more than one node runs the sidecar;
+- uses rcow's default CPU mask (`0x3`); set `cubeS3lvol.cpuMask` when cores are isolated.
+
+```yaml
+cubeS3lvol:
+  enabled: true
+  # Optional: explicit S3 (otherwise chart MinIO or volumeS3 is reused).
+  # s3:
+  #   existingSecret: my-s3lvol-cfg   # key must be s3.cfg
+  #   endpoint: https://s3.example.com
+  #   accessKeyId: ...
+  #   secretAccessKey: ...
+  #   bucket: cube-s3lvol
+```
+
 ## Render and lint
 
 ```bash

--- a/deploy/kubernetes/chart/scripts/test-big-pod-inplace-guard.sh
+++ b/deploy/kubernetes/chart/scripts/test-big-pod-inplace-guard.sh
@@ -110,4 +110,6 @@ assert_recreate_change_detected network \
   --set-string cubeNode.network.ethName=eth9
 assert_recreate_change_detected egress \
   --set cubeEgress.enabled=false
+assert_recreate_change_detected s3lvol \
+  --set cubeS3lvol.enabled=true
 echo "Big Pod template stability guard passed"

--- a/deploy/kubernetes/chart/scripts/test-s3lvol-sidecar-guard.sh
+++ b/deploy/kubernetes/chart/scripts/test-s3lvol-sidecar-guard.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+# Guard: cube-s3lvol is off by default; enabling it injects the sidecar,
+# shared RPC socket, s3.cfg Secret, and NODE_NAME from spec.nodeName.
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+CHART_DIR="$(dirname "$SCRIPT_DIR")"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+COMMON_SETS="--set-string mysql.password=test --set-string mysql.rootPassword=test --set-string redis.password=test"
+
+expect_fail() {
+  name="$1"
+  err_file="$2"
+  needle="$3"
+  shift 3
+  if helm template "$name" "$CHART_DIR" $COMMON_SETS "$@" >/dev/null 2>"$err_file"; then
+    echo "expected fail: $name" >&2
+    exit 1
+  fi
+  grep -qi "$needle" "$err_file" || {
+    echo "unexpected error for $name (wanted /$needle/):" >&2
+    cat "$err_file" >&2
+    exit 1
+  }
+}
+
+extract_big_pod() {
+  input="$1"
+  output="$2"
+  python3 - "$input" "$output" <<'PY'
+import pathlib
+import re
+import sys
+
+documents = pathlib.Path(sys.argv[1]).read_text().split("\n---\n")
+matches = [
+    doc for doc in documents
+    if "\nkind: DaemonSet\n" in f"\n{doc}\n"
+    and "\n    app.kubernetes.io/component: cube-node\n" in f"\n{doc}\n"
+    and re.search(r"(?m)^apiVersion:\s*apps/v1\s*$", doc)
+]
+if len(matches) != 1:
+    raise SystemExit(f"expected one cube-node DaemonSet, found {len(matches)}")
+pathlib.Path(sys.argv[2]).write_text(matches[0].strip() + "\n")
+PY
+}
+
+helm template s3lvol-default "$CHART_DIR" $COMMON_SETS > "$TMP_DIR/default.yaml"
+extract_big_pod "$TMP_DIR/default.yaml" "$TMP_DIR/default-node.yaml"
+if grep -q 'name: cube-s3lvol' "$TMP_DIR/default-node.yaml"; then
+  echo "default render must not include the cube-s3lvol container" >&2
+  exit 1
+fi
+if grep -q 'name: s3lvol-rpc' "$TMP_DIR/default-node.yaml"; then
+  echo "default render must not include the s3lvol-rpc volume" >&2
+  exit 1
+fi
+if grep -q 'CUBE_S3LVOL_SOCKET' "$TMP_DIR/default-node.yaml"; then
+  echo "default render must not set CUBE_S3LVOL_SOCKET on cubelet" >&2
+  exit 1
+fi
+if grep -q 'app.kubernetes.io/component: cube-s3lvol' "$TMP_DIR/default.yaml"; then
+  echo "default render must not create the cube-s3lvol Secret" >&2
+  exit 1
+fi
+echo "ok: default render has no cube-s3lvol sidecar"
+
+helm template s3lvol-on "$CHART_DIR" $COMMON_SETS \
+  --set cubeS3lvol.enabled=true \
+  > "$TMP_DIR/on.yaml"
+extract_big_pod "$TMP_DIR/on.yaml" "$TMP_DIR/on-node.yaml"
+
+grep -q 'name: cube-s3lvol' "$TMP_DIR/on-node.yaml" \
+  || { echo "cubeS3lvol.enabled=true must add container cube-s3lvol" >&2; exit 1; }
+grep -q 'name: s3lvol-rpc' "$TMP_DIR/on-node.yaml" \
+  || { echo "enabled sidecar must mount s3lvol-rpc emptyDir" >&2; exit 1; }
+grep -q 'name: s3lvol-cfg' "$TMP_DIR/on-node.yaml" \
+  || { echo "enabled sidecar must mount s3lvol-cfg Secret" >&2; exit 1; }
+grep -q 'CUBE_S3LVOL_SOCKET' "$TMP_DIR/on-node.yaml" \
+  || { echo "enabled sidecar must set CUBE_S3LVOL_SOCKET on cubelet" >&2; exit 1; }
+grep -q '/var/run/s3lvol/s3lvol.sock' "$TMP_DIR/on-node.yaml" \
+  || { echo "enabled sidecar must use /var/run/s3lvol/s3lvol.sock" >&2; exit 1; }
+grep -q 'app.kubernetes.io/component: cube-s3lvol' "$TMP_DIR/on.yaml" \
+  || { echo "enabled sidecar must create the cube-s3lvol Secret" >&2; exit 1; }
+grep -q 'buckets=\["cube-s3lvol"\]' "$TMP_DIR/on.yaml" \
+  || { echo "s3.cfg must use the cube-s3lvol bucket, not cube-volumes" >&2; exit 1; }
+
+python3 - "$TMP_DIR/on-node.yaml" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+# NODE_NAME in the cube-s3lvol container must be spec.nodeName (not the Pod name).
+block = re.search(r"- name: cube-s3lvol\n(.*?)(?:\n      volumes:|\Z)", text, re.S)
+if not block:
+    raise SystemExit("cube-s3lvol container block not found")
+body = block.group(1)
+if "name: NODE_NAME" not in body:
+    raise SystemExit("cube-s3lvol must set NODE_NAME")
+if "fieldPath: spec.nodeName" not in body:
+    raise SystemExit("cube-s3lvol NODE_NAME must use spec.nodeName")
+if "RCOW_LVS_NAME" in body:
+    raise SystemExit("default RCOW_LVS_NAME must be derived at runtime by rcow_common, not rendered")
+if "livenessProbe:" in body:
+    raise SystemExit("cube-s3lvol must not have a livenessProbe")
+if "timeoutSeconds: 8" not in body:
+    raise SystemExit("s3lvol probes must allow the 5s RPC timeout (timeoutSeconds >= 8)")
+if "terminationGracePeriodSeconds: 180" not in text:
+    raise SystemExit("enabling cube-s3lvol must raise terminationGracePeriodSeconds to at least 180")
+print("ok: NODE_NAME is spec.nodeName; LVS name is derived at runtime; no liveness")
+PY
+
+echo "ok: cubeS3lvol.enabled=true injects sidecar + socket + s3.cfg"
+
+expect_fail s3lvol-no-s3 "$TMP_DIR/no-s3.err" "S3" \
+  --set cubeS3lvol.enabled=true \
+  --set minio.enabled=false
+
+expect_fail s3lvol-shared-bucket "$TMP_DIR/shared-bucket.err" "cube-volumes" \
+  --set cubeS3lvol.enabled=true \
+  --set-string cubeS3lvol.s3.bucket=cube-volumes
+
+expect_fail s3lvol-same-vol-bucket "$TMP_DIR/same-vol-bucket.err" "volumeS3.bucket" \
+  --set cubeS3lvol.enabled=true \
+  --set minio.enabled=false \
+  --set-string volumeS3.endpoint=https://s3.example.com \
+  --set-string volumeS3.accessKeyId=ak \
+  --set-string volumeS3.secretAccessKey=sk \
+  --set-string volumeS3.bucket=shared-bucket \
+  --set-string cubeS3lvol.s3.bucket=shared-bucket
+
+helm template s3lvol-external "$CHART_DIR" $COMMON_SETS \
+  --set cubeS3lvol.enabled=true \
+  --set minio.enabled=false \
+  --set-string volumeS3.endpoint=https://s3.example.com \
+  --set-string volumeS3.accessKeyId=ak \
+  --set-string volumeS3.secretAccessKey=sk \
+  --set-string volumeS3.bucket=cube-volumes \
+  > "$TMP_DIR/external.yaml"
+grep -q 'buckets=\["cube-s3lvol"\]' "$TMP_DIR/external.yaml" \
+  || { echo "external volumeS3 must still use cube-s3lvol bucket" >&2; exit 1; }
+grep -q 'endpoint="s3.example.com"' "$TMP_DIR/external.yaml" \
+  || { echo "s3.cfg endpoint must strip https://" >&2; exit 1; }
+if grep -q 'no_tls="true"' "$TMP_DIR/external.yaml"; then
+  echo "https endpoint must not set no_tls" >&2
+  exit 1
+fi
+echo "ok: external S3 fill keeps cube-s3lvol bucket and strips scheme"
+
+helm template s3lvol-lvs "$CHART_DIR" $COMMON_SETS \
+  --set cubeS3lvol.enabled=true \
+  --set-string cubeS3lvol.lvsName=rcow-explicit \
+  > "$TMP_DIR/lvs.yaml"
+grep -q 'name: RCOW_LVS_NAME' "$TMP_DIR/lvs.yaml" \
+  || { echo "cubeS3lvol.lvsName must render RCOW_LVS_NAME" >&2; exit 1; }
+grep -q 'rcow-explicit' "$TMP_DIR/lvs.yaml" \
+  || { echo "explicit lvsName must appear in the sidecar env" >&2; exit 1; }
+echo "ok: cubeS3lvol.lvsName override is rendered"
+
+echo "cube-s3lvol sidecar guard passed"

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -1204,3 +1204,116 @@ set -euo pipefail
 echo "cube.stageToolboxScript is superseded by per-component install containers" >&2
 exit 1
 {{- end -}}
+
+{{- define "cube.s3lvolEnabled" -}}
+{{- if ((.Values.cubeS3lvol).enabled) -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "cube.s3lvolSocketPath" -}}
+{{- ((.Values.cubeS3lvol).socketPath) | default "/var/run/s3lvol/s3lvol.sock" -}}
+{{- end -}}
+
+{{- define "cube.s3lvolSecretName" -}}
+{{- $s3 := default dict ((.Values.cubeS3lvol).s3) -}}
+{{- if ne (($s3.existingSecret) | default "") "" -}}
+{{- $s3.existingSecret -}}
+{{- else if ne (($s3.secretName) | default "") "" -}}
+{{- $s3.secretName -}}
+{{- else -}}
+{{- printf "%s-s3lvol" (include "cube.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* True when the chart must generate the Secret from chart MinIO root credentials. */}}
+{{- define "cube.s3lvolFillsFromMinio" -}}
+{{- $s3 := default dict ((.Values.cubeS3lvol).s3) -}}
+{{- $userCreds := and (ne (($s3.accessKeyId) | default "") "") (ne (($s3.secretAccessKey) | default "") "") -}}
+{{- if and (eq (include "cube.s3lvolEnabled" .) "true") (eq (($s3.existingSecret) | default "") "") (not $userCreds) (eq (include "cube.minioBuiltinEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "cube.s3lvolEffectiveEndpoint" -}}
+{{- $s3 := default dict ((.Values.cubeS3lvol).s3) -}}
+{{- if ne (($s3.endpoint) | default "") "" -}}
+{{- $s3.endpoint -}}
+{{- else if ne (include "cube.volumeS3EffectiveEndpoint" .) "" -}}
+{{- include "cube.volumeS3EffectiveEndpoint" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cube.s3lvolEffectiveBucket" -}}
+{{- $s3 := default dict ((.Values.cubeS3lvol).s3) -}}
+{{- $s3.bucket | default "cube-s3lvol" -}}
+{{- end -}}
+
+{{- define "cube.s3lvolEffectiveRegion" -}}
+{{- $s3 := default dict ((.Values.cubeS3lvol).s3) -}}
+{{- if ne (($s3.region) | default "") "" -}}
+{{- $s3.region -}}
+{{- else if ne (((.Values.volumeS3).region) | default "") "" -}}
+{{- .Values.volumeS3.region -}}
+{{- else -}}
+us-east-1
+{{- end -}}
+{{- end -}}
+
+{{- define "cube.s3lvolPathStyle" -}}
+{{- $s3 := default dict ((.Values.cubeS3lvol).s3) -}}
+{{- if hasKey $s3 "pathStyle" -}}
+{{- if $s3.pathStyle -}}true{{- else -}}false{{- end -}}
+{{- else if eq (include "cube.s3lvolFillsFromMinio" .) "true" -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/* s3.cfg body. Caller passes dict: accessKeyId, secretAccessKey, endpoint, region, bucket, pathStyle. */}}
+{{- define "cube.s3lvolCfgBody" -}}
+{{- $e := .endpoint | toString -}}
+{{- $host := first (splitList "/" (trimPrefix "https://" (trimPrefix "http://" $e))) -}}
+access_key_id="{{ .accessKeyId }}"
+secret_access_key="{{ .secretAccessKey }}"
+endpoint="{{ $host }}"
+region="{{ .region }}"
+buckets=["{{ .bucket }}"]
+{{- if .pathStyle }}
+path_style="true"
+{{- end }}
+{{- if hasPrefix "http://" $e }}
+no_tls="true"
+{{- end }}
+{{- end -}}
+
+{{- define "cube.s3lvolHasResolvedCreds" -}}
+{{- $s3 := default dict ((.Values.cubeS3lvol).s3) -}}
+{{- if ne (($s3.existingSecret) | default "") "" -}}
+true
+{{- else if and (ne (($s3.accessKeyId) | default "") "") (ne (($s3.secretAccessKey) | default "") "") -}}
+true
+{{- else if and (ne (((.Values.volumeS3).accessKeyId) | default "") "") (ne (((.Values.volumeS3).secretAccessKey) | default "") "") -}}
+true
+{{- else if eq (include "cube.minioBuiltinEnabled" .) "true" -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "cube.s3lvolProbeCommand" -}}
+sock={{ include "cube.s3lvolSocketPath" . }}; test -S "${sock}" && python3 /opt/s3lvol/scripts/s3lvol_rpc.py --sock "${sock}" --timeout 5 rcow_get_lvstores >/dev/null
+{{- end -}}
+
+{{/* Big Pod grace = max(cubeNode, cubeS3lvol) terminationGracePeriodSeconds. */}}
+{{- define "cube.nodeTerminationGracePeriodSeconds" -}}
+{{- $grace := int (.Values.cubeNode.terminationGracePeriodSeconds | default 30) -}}
+{{- if eq (include "cube.s3lvolEnabled" .) "true" -}}
+{{- $s3lvolGrace := int (((.Values.cubeS3lvol).terminationGracePeriodSeconds) | default 180) -}}
+{{- if gt $s3lvolGrace $grace -}}
+{{- $s3lvolGrace -}}
+{{- else -}}
+{{- $grace -}}
+{{- end -}}
+{{- else -}}
+{{- $grace -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/kubernetes/chart/templates/node-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       automountServiceAccountToken: true
       hostPID: {{ .Values.security.hostPID }}
       hostNetwork: {{ .Values.cubeNode.hostNetwork }}
-      terminationGracePeriodSeconds: {{ .Values.cubeNode.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ include "cube.nodeTerminationGracePeriodSeconds" . }}
       # With hostNetwork the Pod shares the host netns; ClusterFirstWithHostNet
       # keeps in-cluster DNS working from the host network namespace.
       dnsPolicy: {{ if .Values.cubeNode.hostNetwork }}ClusterFirstWithHostNet{{ else }}ClusterFirst{{ end }}
@@ -67,6 +67,10 @@ spec:
               value: run
             {{- with .Values.cubeNode.env }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.cubeS3lvol.enabled }}
+            - name: CUBE_S3LVOL_SOCKET
+              value: {{ include "cube.s3lvolSocketPath" . | quote }}
             {{- end }}
           ports:
             - name: cubelet-grpc
@@ -145,6 +149,10 @@ spec:
               mountPath: /usr/local/services/cubetoolbox/Cubelet/plugin/volume-s3.conf
               subPath: volume-s3.conf
               readOnly: true
+          {{- end }}
+          {{- if .Values.cubeS3lvol.enabled }}
+            - name: s3lvol-rpc
+              mountPath: /var/run/s3lvol
           {{- end }}
           resources:
             {{- toYaml .Values.cubeNode.resources | nindent 12 }}
@@ -269,6 +277,95 @@ spec:
           {{- end }}
         {{- end }}
         {{- end }}
+        {{- if .Values.cubeS3lvol.enabled }}
+        - name: cube-s3lvol
+          image: {{ include "cube.cubeImage" (dict "image" .Values.images.cubeS3lvol "context" $) | quote }}
+          imagePullPolicy: {{ .Values.images.cubeS3lvol.pullPolicy }}
+          securityContext:
+            {{- include "cube.nodeDataplaneSecurityContext" . | nindent 12 }}
+          env:
+            {{- include "cube.timezoneEnv" . | nindent 12 }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: S3LVOL_ROOT
+              value: /opt/s3lvol
+            - name: RCOW_RPC_SOCK
+              value: {{ include "cube.s3lvolSocketPath" . | quote }}
+            - name: RCOW_S3_CFG
+              value: /etc/s3lvol/s3.cfg
+            - name: RCOW_WAL_IMG
+              value: /data/cubelet/rcow/wal_bdev.img
+            - name: RCOW_RUN_DIR
+              value: /var/run/s3lvol
+            - name: RCOW_LOG_DIR
+              value: /data/log/rcow
+            - name: RCOW_LISTEN_ADDR
+              value: {{ .Values.cubeS3lvol.listenAddr | quote }}
+            - name: RCOW_LISTEN_PORT
+              value: {{ .Values.cubeS3lvol.listenPort | quote }}
+            - name: RCOW_TGT_MEM_MB
+              value: {{ .Values.cubeS3lvol.tgtMemMB | quote }}
+            - name: RCOW_JOURNAL_MB
+              value: {{ .Values.cubeS3lvol.journalMB | quote }}
+            - name: RCOW_WAL_MB
+              value: {{ .Values.cubeS3lvol.walMB | quote }}
+            - name: RCOW_CACHE_MB
+              value: {{ .Values.cubeS3lvol.cacheMB | quote }}
+            {{- if .Values.cubeS3lvol.lvsName }}
+            - name: RCOW_LVS_NAME
+              value: {{ .Values.cubeS3lvol.lvsName | quote }}
+            {{- end }}
+            {{- if .Values.cubeS3lvol.cpuMask }}
+            - name: RCOW_TGT_CPUMASK
+              value: {{ .Values.cubeS3lvol.cpuMask | quote }}
+            {{- end }}
+          {{- if .Values.cubeS3lvol.probes.startup.enabled }}
+          startupProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - {{ include "cube.s3lvolProbeCommand" . | replace "\r" "" | quote }}
+            timeoutSeconds: {{ .Values.cubeS3lvol.probes.startup.timeoutSeconds }}
+            periodSeconds: {{ .Values.cubeS3lvol.probes.startup.periodSeconds }}
+            failureThreshold: {{ .Values.cubeS3lvol.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.cubeS3lvol.probes.readiness.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - {{ include "cube.s3lvolProbeCommand" . | replace "\r" "" | quote }}
+            timeoutSeconds: {{ .Values.cubeS3lvol.probes.readiness.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.cubeS3lvol.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.cubeS3lvol.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.cubeS3lvol.probes.readiness.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            - name: data-cubelet
+              mountPath: {{ .Values.hostPaths.dataCubelet }}
+            - name: data-log
+              mountPath: {{ .Values.hostPaths.dataLog }}
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: s3lvol-rpc
+              mountPath: /var/run/s3lvol
+            - name: s3lvol-cfg
+              mountPath: /etc/s3lvol
+              readOnly: true
+          {{- with .Values.cubeS3lvol.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       volumes:
         - name: host-root
           hostPath:
@@ -354,5 +451,15 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 64Mi
+      {{- end }}
+      {{- if .Values.cubeS3lvol.enabled }}
+        - name: s3lvol-rpc
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+        - name: s3lvol-cfg
+          secret:
+            secretName: {{ include "cube.s3lvolSecretName" . }}
+            defaultMode: 0400
       {{- end }}
 {{- end }}

--- a/deploy/kubernetes/chart/templates/s3lvol-secret.yaml
+++ b/deploy/kubernetes/chart/templates/s3lvol-secret.yaml
@@ -1,0 +1,35 @@
+{{/* s3.cfg Secret from explicit cubeS3lvol.s3.* or volumeS3 credentials;
+     the chart-MinIO variant renders in secret.yaml. */}}
+{{- if and (eq (include "cube.s3lvolEnabled" .) "true") (ne (include "cube.s3lvolFillsFromMinio" .) "true") (eq (include "cube.s3lvolHasResolvedCreds" .) "true") }}
+{{- $s3 := default dict ((.Values.cubeS3lvol).s3) }}
+{{- if eq (($s3.existingSecret) | default "") "" }}
+{{- $ak := $s3.accessKeyId | default "" }}
+{{- $sk := $s3.secretAccessKey | default "" }}
+{{- if not $ak }}
+{{- $ak = (.Values.volumeS3).accessKeyId | default "" }}
+{{- end }}
+{{- if not $sk }}
+{{- $sk = (.Values.volumeS3).secretAccessKey | default "" }}
+{{- end }}
+{{- $endpoint := include "cube.s3lvolEffectiveEndpoint" . }}
+{{- $cfg := dict
+  "accessKeyId" $ak
+  "secretAccessKey" $sk
+  "endpoint" $endpoint
+  "region" (include "cube.s3lvolEffectiveRegion" .)
+  "bucket" (include "cube.s3lvolEffectiveBucket" .)
+  "pathStyle" (eq (include "cube.s3lvolPathStyle" .) "true")
+}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cube.s3lvolSecretName" . }}
+  labels:
+    {{- include "cube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cube-s3lvol
+type: Opaque
+stringData:
+  s3.cfg: |
+    {{- include "cube.s3lvolCfgBody" $cfg | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/deploy/kubernetes/chart/templates/secret.yaml
+++ b/deploy/kubernetes/chart/templates/secret.yaml
@@ -82,4 +82,29 @@ stringData:
   volume-s3.conf: |
     {{- include "cube.volumeS3ConfBody" $s3 | nindent 4 }}
 {{- end }}
+{{/* cube-s3lvol s3.cfg filled from chart MinIO root; the explicit/volumeS3
+     variant renders in s3lvol-secret.yaml. */}}
+{{- if eq (include "cube.s3lvolFillsFromMinio" .) "true" }}
+{{- $s3lvolEndpoint := include "cube.s3lvolEffectiveEndpoint" . }}
+{{- $s3lvol := dict
+  "accessKeyId" $minioUser
+  "secretAccessKey" $minioPassword
+  "endpoint" $s3lvolEndpoint
+  "region" (include "cube.s3lvolEffectiveRegion" .)
+  "bucket" (include "cube.s3lvolEffectiveBucket" .)
+  "pathStyle" (eq (include "cube.s3lvolPathStyle" .) "true")
+}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cube.s3lvolSecretName" . }}
+  labels:
+    {{- include "cube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cube-s3lvol
+type: Opaque
+stringData:
+  s3.cfg: |
+    {{- include "cube.s3lvolCfgBody" $s3lvol | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -124,6 +124,16 @@ spec:
           echo "${container_names}" | grep -qxF 'cube-egress'
           echo "${container_names}" | grep -qxF 'cube-egress-net'
           {{- end }}
+
+          {{- if .Values.cubeS3lvol.enabled }}
+          echo '[health-test] check CubeS3lvol container by name in CubeNode pods'
+          pods_json="$(kget "/api/v1/namespaces/${ns}/pods?labelSelector=app.kubernetes.io/component%3Dcube-node")"
+          container_names="$(printf '%s\n' "${pods_json}" \
+            | tr ',' '\n' \
+            | grep -oE '"name"[[:space:]]*:[[:space:]]*"[^"]+"' \
+            | awk -F'"' '{print $4}')"
+          echo "${container_names}" | grep -qxF 'cube-s3lvol'
+          {{- end }}
 {{ if eq (include "cube.cubemastercliEnabled" .) "true" }}
 ---
 apiVersion: v1

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -249,6 +249,34 @@
 {{- if and (eq (include "cube.minioBuiltinEnabled" .) "true") .Values.minio.rootPassword (lt (len (printf "%s" .Values.minio.rootPassword)) 8) }}
 {{- fail "minio.rootPassword must be at least 8 characters when set (leave empty to generate one)" }}
 {{- end }}
+{{- if eq (include "cube.s3lvolEnabled" .) "true" }}
+{{- if not ((.Values.images.cubeS3lvol).repository) }}
+{{- fail "cubeS3lvol.enabled=true requires images.cubeS3lvol.repository" }}
+{{- end }}
+{{- $s3lvolBucket := include "cube.s3lvolEffectiveBucket" . }}
+{{- if eq $s3lvolBucket "cube-volumes" }}
+{{- fail "cubeS3lvol must not share the S3 volume plugin bucket (cube-volumes); set cubeS3lvol.s3.bucket" }}
+{{- end }}
+{{- $volBucket := ((.Values.volumeS3).bucket) | default "" }}
+{{- if and (ne $volBucket "") (eq $s3lvolBucket $volBucket) }}
+{{- fail "cubeS3lvol.s3.bucket must not equal volumeS3.bucket; cube-s3lvol must use its own bucket" }}
+{{- end }}
+{{- $s3lvolS3 := default dict ((.Values.cubeS3lvol).s3) }}
+{{- if eq (($s3lvolS3.existingSecret) | default "") "" }}
+{{- if eq (include "cube.s3lvolEffectiveEndpoint" .) "" }}
+{{- fail "cubeS3lvol.enabled=true requires cubeS3lvol.s3.endpoint, volumeS3.endpoint, cubeS3lvol.s3.existingSecret, or chart MinIO" }}
+{{- end }}
+{{- if ne (include "cube.s3lvolHasResolvedCreds" .) "true" }}
+{{- fail "cubeS3lvol.enabled=true requires S3 credentials: cubeS3lvol.s3.existingSecret, cubeS3lvol.s3.accessKeyId+secretAccessKey, volumeS3.accessKeyId+secretAccessKey, or chart MinIO" }}
+{{- end }}
+{{- $s3lvolQuoteCheck := list ($s3lvolS3.accessKeyId | default "") ($s3lvolS3.secretAccessKey | default "") ($s3lvolS3.bucket | default "cube-s3lvol") }}
+{{- range $s3lvolQuoteCheck }}
+{{- if contains "\"" (. | toString) }}
+{{- fail "cubeS3lvol.s3 values must not contain double quotes (s3.cfg is double-quoted TOML)" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- if eq (include "cube.opsEnabled" .) "true" }}
 {{- if hasKey (.Values.cubeOps | default dict) "persistence" }}
 {{- fail "cubeOps.persistence was removed; warehouse blobs are stored in S3. Remove cubeOps.persistence from your values (including values-tke.yaml)." }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -100,6 +100,11 @@ images:
     tag: v0.7.0
     pullPolicy: IfNotPresent
 
+  cubeS3lvol:
+    repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-s3lvol
+    tag: v0.7.0
+    pullPolicy: IfNotPresent
+
   webui:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-webui
     tag: v0.7.0
@@ -958,6 +963,61 @@ cubeEgress:
       memory: "64Mi"
     limits:
       memory: "128Mi"
+
+# Optional CubeS3lvol NVMe/TCP target sidecar (S3-backed cross-node snapshots)
+# in the cube-node Big Pod. Off by default, same as one-click. Enabling it
+# recreates the Big Pod (interrupting sandboxes on the node) and adds ~2 CPU
+# + 18 GiB RAM plus a ~512 GiB sparse WAL per compute node; x86_64 needs AVX2.
+cubeS3lvol:
+  enabled: false
+  # Optional cluster-wide pin. Empty: the sidecar hashes the full Kubernetes
+  # node name (spec.nodeName) to rcow-<8hex>. Do not set this on a multi-node
+  # cluster — every node would share one S3 prefix.
+  lvsName: ""
+  socketPath: /var/run/s3lvol/s3lvol.sock
+  # Empty: rcow default 0x3 (CPU0+1). Set when the container is pinned to
+  # isolated cores.
+  cpuMask: ""
+  tgtMemMB: 16384
+  journalMB: 1024
+  walMB: 32768
+  cacheMB: 490496
+  listenAddr: "127.0.0.1"
+  listenPort: 4420
+  # rcow_stop needs disconnect + unload; Big Pod default 30s is too short.
+  terminationGracePeriodSeconds: 180
+  s3:
+    # Existing Secret must contain key s3.cfg (s3lvol format, not volume-s3.conf).
+    existingSecret: ""
+    secretName: ""
+    # Explicit override; otherwise chart MinIO or volumeS3 is reused.
+    endpoint: ""
+    accessKeyId: ""
+    secretAccessKey: ""
+    bucket: cube-s3lvol
+    region: ""
+    # Default: true only when filling from chart MinIO; external path-style
+    # endpoints must set pathStyle: true.
+    # pathStyle: true
+  probes:
+    startup:
+      enabled: true
+      # Probe RPC uses --timeout 5; kubelet default timeoutSeconds is 1.
+      timeoutSeconds: 8
+      periodSeconds: 10
+      failureThreshold: 30
+    readiness:
+      enabled: true
+      timeoutSeconds: 8
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      failureThreshold: 12
+  resources:
+    requests:
+      cpu: "2"
+      memory: "18Gi"
+    limits:
+      memory: "20Gi"
 
 bootstrap:
   pvmHostKernel:

--- a/deploy/kubernetes/images/README.md
+++ b/deploy/kubernetes/images/README.md
@@ -99,7 +99,7 @@ IMAGE_TAG=v0.7.0 ./deploy/kubernetes/images/build-cube-images.sh cube-guest cube
 ## Pinning source to a release tag
 
 `cube-master`, `cubemastercli`, `cubelet`, `cube-shim`, `cube-api`, `cube-ops`,
-`cube-proxy`, `cube-egress`, `cube-lifecycle-manager`, and `cube-webui` are
+`cube-proxy`, `cube-egress`, `cube-s3lvol`, `cube-lifecycle-manager`, and `cube-webui` are
 compiled from repository source (rather than binaries in the release tarball).
 By default the script pins those source trees to `${SOURCE_REF}` (defaulting to
 `${VERSION}`, so `v0.7.0` for the default build). It exports `CubeMaster/`,
@@ -119,6 +119,8 @@ When building `cubelet`, it also exports `Cubelet/`, `CubeNet/`, `pkgs/CubeLog/`
 When building `cube-ops`, it also exports `CubeOps/`, the cubelog module, and `CubeDB/` (required by
 `CubeOps/Dockerfile`; not present on older release tags such as `v0.5.1` — use
 `SOURCE_REF=""` for worktree builds).
+When building `cube-s3lvol`, it also exports `CubeS3lvol/` and
+`deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh`.
 The cubelog module path is probed on `${SOURCE_REF}`: tags at or after this
 move export `pkgs/CubeLog/`; older tags including the default `${VERSION}`
 (`v0.7.0`) still have `cubelog/` and matching `COPY cubelog/` Dockerfiles.
@@ -241,6 +243,12 @@ behavior.
   `CubeEgress/scripts/cube-proxy-iptables-init.sh` plus a small idempotent
   entrypoint that waits for `cube-dev`, applies rules, and removes them on
   termination.
+- `cube-s3lvol` is the optional cube-node sidecar that runs the CubeS3lvol
+  NVMe/TCP target (`s3lvol_tgt`). Context is the repository root; file is
+  `deploy/kubernetes/images/cube-s3lvol/Dockerfile` (builder stage
+  `CUBE_BUILDER_IMAGE`, Ubuntu 20.04 runtime). Enable it with chart
+  `cubeS3lvol.enabled`. Release binaries need Haswell/AVX2 on x86_64; the
+  publish workflow is amd64-only.
 - `cube-webui` is built exactly like CI (`.github/workflows/release-docker-images.yml`):
   context = repository root, file = `deploy/one-click/webui/Dockerfile`, with
   `OPENRESTY_BASE_IMAGE` / `CUBE_VERSION` / `CUBE_COMMIT` / `CUBE_BUILD_TIME`.

--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -99,6 +99,7 @@ ALL_IMAGES=(
   cube-lifecycle-manager
   cube-egress
   cube-egress-net
+  cube-s3lvol
   cube-webui
   cubelet
   cube-shim
@@ -126,6 +127,7 @@ SOURCE_IMAGES=(
   cube-lifecycle-manager
   cube-egress
   cube-egress-net
+  cube-s3lvol
   cube-webui
 )
 
@@ -401,7 +403,7 @@ ensure_source_tree() {
   SOURCE_REF_SHA="$(git -C "${WORKTREE_ROOT}" rev-parse "${SOURCE_REF}^{commit}")"
   SOURCE_TREE_STAMP="${SOURCE_TREE_DIR}/.exported-sha"
   # Probe cubelog only when a consumer image is selected. cube-api / cube-proxy /
-  # cube-webui / cube-egress / cube-lifecycle-manager never export it, so a
+  # cube-webui / cube-egress / cube-s3lvol / cube-lifecycle-manager never export it, so a
   # SOURCE_REF that predates both pkgs/CubeLog and cubelog must still be able to
   # build those images (same reason CubeOps is gated below).
   CUBELOG_SRC=""
@@ -419,6 +421,9 @@ ensure_source_tree() {
   # cubecow / deploy scripts + volume plugin examples.
   # cube-shim needs CubeShim / hypervisor / config-cube.toml + entrypoint.
   SOURCE_EXPORT_SET="CubeMaster CubeAPI CubeProxy CubeEgress cube-lifecycle-manager web deploy/one-click/webui"
+  if should_build cube-s3lvol; then
+    SOURCE_EXPORT_SET="${SOURCE_EXPORT_SET} CubeS3lvol deploy/kubernetes/images/scripts deploy/kubernetes/images/cube-s3lvol"
+  fi
   if should_build cube-master || should_build cubemastercli; then
     SOURCE_EXPORT_SET="${SOURCE_EXPORT_SET} ${CUBELOG_SRC} CubeDB Cubelet"
   fi
@@ -816,6 +821,22 @@ EOF
   build_image cube-node "${ctx}" "${dockerfile}"
 }
 
+# Same as .github/workflows/release-docker-images.yml for component "cube-s3lvol":
+# context=., file=deploy/kubernetes/images/cube-s3lvol/Dockerfile, CUBE_BUILDER_IMAGE.
+build_cube_s3lvol_image() {
+  [[ -f "${SCRIPT_DIR}/cube-s3lvol/Dockerfile" ]] \
+    || fail "missing deploy/kubernetes/images/cube-s3lvol/Dockerfile"
+  [[ -d "${REPO_ROOT}/CubeS3lvol" ]] || fail "missing CubeS3lvol tree in ${REPO_ROOT}"
+  [[ -f "${REPO_ROOT}/CubeS3lvol/make_release.sh" ]] \
+    || fail "missing CubeS3lvol/make_release.sh in ${REPO_ROOT}"
+  [[ -f "${REPO_ROOT}/deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh" ]] \
+    || fail "missing cube-s3lvol-entrypoint.sh in ${REPO_ROOT}"
+  build_image cube-s3lvol "${REPO_ROOT}" \
+    --build-arg "CUBE_BUILDER_IMAGE=${CUBE_BUILDER_IMAGE}" \
+    --build-arg "CUBE_VERSION=${IMAGE_TAG}"
+  record_built cube-s3lvol
+}
+
 copy_cube_egress_net_context() {
   local ctx="$1"
   local init_script="${REPO_ROOT}/CubeEgress/scripts/cube-proxy-iptables-init.sh"
@@ -1115,6 +1136,11 @@ run_selected_builds() {
     copy_cube_egress_net_context "${ctx}"
     build_image cube-egress-net "${ctx}"
     record_built cube-egress-net
+  fi
+
+  if should_build cube-s3lvol; then
+    ensure_source_tree
+    build_cube_s3lvol_image
   fi
 
   if should_build cube-webui; then

--- a/deploy/kubernetes/images/cube-s3lvol/Dockerfile
+++ b/deploy/kubernetes/images/cube-s3lvol/Dockerfile
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Multi-stage build for the cube-s3lvol sidecar (s3lvol_tgt + rcow scripts).
+# Build context must be the repository root; BuildKit is required so the
+# adjacent Dockerfile.dockerignore applies. The builder stage defaults to
+# cubesandbox-builder (ships /opt/s3lvol-spdk and the AWS CRT); override with
+# --build-arg CUBE_BUILDER_IMAGE=... The runtime stays on Ubuntu 20.04 so the
+# shared libs (libaio / libnuma / libuuid) match the linked glibc; OpenSSL
+# is static.
+
+ARG CUBE_BUILDER_IMAGE=ghcr.io/tencentcloud/cubesandbox-builder:ubuntu2004
+FROM ${CUBE_BUILDER_IMAGE} AS builder
+
+ARG CUBE_VERSION=0.0.0-dev
+
+WORKDIR /workspace
+COPY CubeS3lvol/ /workspace/CubeS3lvol/
+
+RUN set -eux; \
+    cd /workspace/CubeS3lvol; \
+    AWS_BUILD_TYPE=RelWithDebInfo ./setup_dep.sh --jobs "$(nproc)"; \
+    AWS_BUILD_TYPE=RelWithDebInfo make S3LVOL_BUILD_TYPE=release -j"$(nproc)"; \
+    AWS_BUILD_TYPE=RelWithDebInfo ./make_release.sh --no-tar --skip-smoke \
+      --version "${CUBE_VERSION}" --outdir /out/CubeS3lvol; \
+    pkg="$(find /out/CubeS3lvol -mindepth 1 -maxdepth 1 -type d -name 's3lvol-*' | head -1)"; \
+    test -n "${pkg}"; \
+    test -x "${pkg}/bin/s3lvol_tgt"; \
+    mv "${pkg}" /out/s3lvol
+
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG CUBE_VERSION=0.0.0-dev
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      coreutils \
+      hostname \
+      kmod \
+      libaio1 \
+      libnuma1 \
+      libuuid1 \
+      nvme-cli \
+      procps \
+      python3 \
+      tini \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /out/s3lvol /opt/s3lvol
+COPY deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh \
+     /usr/local/bin/cube-s3lvol-entrypoint.sh
+
+RUN chmod +x /usr/local/bin/cube-s3lvol-entrypoint.sh \
+      /opt/s3lvol/bin/s3lvol_tgt \
+      /opt/s3lvol/scripts/*.sh \
+      /opt/s3lvol/scripts/*.py \
+    && test -x /opt/s3lvol/bin/s3lvol_tgt \
+    && test -f /opt/s3lvol/scripts/rcow_start.sh \
+    && test -f /opt/s3lvol/scripts/s3lvol_rpc.py \
+    && test -f /opt/s3lvol/scripts/s3_bucket.py
+
+ENV S3LVOL_ROOT=/opt/s3lvol \
+    RCOW_REPO_ROOT=/opt/s3lvol \
+    RCOW_RPC_SOCK=/var/run/s3lvol/s3lvol.sock \
+    RCOW_S3_CFG=/etc/s3lvol/s3.cfg \
+    RCOW_WAL_IMG=/data/cubelet/rcow/wal_bdev.img \
+    RCOW_RUN_DIR=/var/run/s3lvol \
+    RCOW_LOG_DIR=/data/log/rcow \
+    CUBE_VERSION=${CUBE_VERSION}
+
+ENTRYPOINT ["/usr/bin/tini", "-s", "--", "/usr/local/bin/cube-s3lvol-entrypoint.sh"]

--- a/deploy/kubernetes/images/cube-s3lvol/Dockerfile.dockerignore
+++ b/deploy/kubernetes/images/cube-s3lvol/Dockerfile.dockerignore
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Build-context filter for cube-s3lvol/Dockerfile (context = repository root).
+# Keep CubeS3lvol sources and the k8s entrypoint; drop local deps/release
+# artifacts so the builder image's /opt/s3lvol-* trees are used instead.
+**
+!CubeS3lvol
+!CubeS3lvol/**
+CubeS3lvol/deps/**
+!CubeS3lvol/deps/.gitkeep
+!CubeS3lvol/deps/README.md
+CubeS3lvol/release/**
+CubeS3lvol/app/s3lvol_tgt/s3lvol_tgt
+CubeS3lvol/test/unit/**/*
+CubeS3lvol/test/integration/**/*
+!CubeS3lvol/test/tools
+!CubeS3lvol/test/tools/**
+!deploy
+!deploy/kubernetes
+!deploy/kubernetes/images
+!deploy/kubernetes/images/scripts
+!deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh

--- a/deploy/kubernetes/images/scripts/component-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/component-entrypoint.sh
@@ -583,6 +583,100 @@ sed_escape_replacement() {
   printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g' -e 's/[/]/\\\//g'
 }
 
+# Opt cubelet into CubeS3lvol: [cow.s3] enable = true (the image default is
+# false -- a socket path alone does not opt in) and socket_path pointing at
+# the sidecar socket. No undo path is needed: stage_component resets
+# config.toml from the image on every start.
+patch_cow_s3_opt_in() {
+  local cfg="$1"
+  local sock="$2"
+  local header='[plugins."io.cubelet.internal.v1.storage".cow.s3]'
+  local header_re='^[[:space:]]*\[plugins\."io\.cubelet\.internal\.v1\.storage"\.cow\.s3\]'
+  local tmp
+  local header_count
+  local enable_ok=0
+  local socket_ok=0
+
+  [[ -n "${sock}" ]] || fail "CUBE_S3LVOL_SOCKET is empty"
+  tmp="$(mktemp "${cfg}.XXXXXX")"
+  if grep -Eq "${header_re}" "${cfg}"; then
+    awk -v sock="${sock}" -v header="${header}" '
+      function is_table(line, name,    t) {
+        t = line
+        sub(/^[[:space:]]+/, "", t)
+        return index(t, name) == 1
+      }
+      function flush_s3() {
+        if (in_s3) {
+          if (!found_enable) {
+            print "    enable = true"
+          }
+          if (!found_socket) {
+            print "    socket_path = \"" sock "\""
+          }
+          in_s3 = 0
+        }
+      }
+      is_table($0, header) {
+        in_s3 = 1
+        print
+        next
+      }
+      in_s3 && /^[[:space:]]*\[/ {
+        flush_s3()
+      }
+      in_s3 && /^[[:space:]]*enable[[:space:]]*=/ {
+        print "    enable = true"
+        found_enable = 1
+        next
+      }
+      in_s3 && /^[[:space:]]*socket_path[[:space:]]*=/ {
+        print "    socket_path = \"" sock "\""
+        found_socket = 1
+        next
+      }
+      { print }
+      END { flush_s3() }
+    ' "${cfg}" > "${tmp}"
+  else
+    cat "${cfg}" > "${tmp}"
+    printf '\n    %s\n    enable = true\n    socket_path = "%s"\n' "${header}" "${sock}" >> "${tmp}"
+  fi
+  header_count="$(grep -Ec "${header_re}" "${tmp}" || true)"
+  if [[ "${header_count}" -ne 1 ]]; then
+    rm -f "${tmp}"
+    fail "expected exactly one live ${header} (got ${header_count})"
+  fi
+  enable_ok="$(awk -v header="${header}" '
+    function is_table(line, name,    t) {
+      t = line
+      sub(/^[[:space:]]+/, "", t)
+      return index(t, name) == 1
+    }
+    is_table($0, header) { in_s3 = 1; next }
+    in_s3 && /^[[:space:]]*\[/ { in_s3 = 0 }
+    in_s3 && /^[[:space:]]*enable[[:space:]]*=[[:space:]]*true[[:space:]]*$/ { found = 1 }
+    END { print found + 0 }
+  ' "${tmp}")"
+  socket_ok="$(awk -v header="${header}" -v sock="${sock}" '
+    function is_table(line, name,    t) {
+      t = line
+      sub(/^[[:space:]]+/, "", t)
+      return index(t, name) == 1
+    }
+    is_table($0, header) { in_s3 = 1; next }
+    in_s3 && /^[[:space:]]*\[/ { in_s3 = 0 }
+    in_s3 && $0 ~ ("^[[:space:]]*socket_path[[:space:]]*=[[:space:]]*\"" sock "\"[[:space:]]*$") { found = 1 }
+    END { print found + 0 }
+  ' "${tmp}")"
+  if [[ "${enable_ok}" -ne 1 || "${socket_ok}" -ne 1 ]]; then
+    rm -f "${tmp}"
+    fail "failed to set ${header} enable = true and socket_path = ${sock}"
+  fi
+  mv -f "${tmp}" "${cfg}"
+  log "cow.s3 enable=true socket_path=${sock}"
+}
+
 detect_primary_interface() {
   ip route get 1.1.1.1 2>/dev/null | awk '
     {
@@ -814,6 +908,9 @@ run_cubelet() {
     local egress_admin_url_esc
     egress_admin_url_esc="$(sed_escape_replacement "${egress_admin_url}")"
     sed -i "s|cube_egress_admin_url = \"[^\"]*\"|cube_egress_admin_url = \"${egress_admin_url_esc}\"|" "${cfg}"
+  fi
+  if [[ -n "${CUBE_S3LVOL_SOCKET:-}" ]]; then
+    patch_cow_s3_opt_in "${cfg}" "${CUBE_S3LVOL_SOCKET}"
   fi
   if [[ -n "${CUBE_TAP_INIT_NUM:-}" ]]; then
     [[ "${CUBE_TAP_INIT_NUM}" =~ ^[0-9]+$ ]] || fail "CUBE_TAP_INIT_NUM must be a non-negative integer"

--- a/deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Foreground supervisor for the s3lvol NVMe/TCP target in the cube-node Big Pod:
+# rcow_start.sh detaches the target (setsid) and returns, so this script stays
+# in the foreground, polls the pidfile, and on SIGTERM runs rcow_stop.sh.
+#
+# The Pod hostname changes on recreate, so pin the UTS hostname to
+# spec.nodeName before sourcing rcow_common.sh (owner recovery matches on
+# hostname), and derive the lvstore name from the full node name rather than
+# hostname -s, which truncates an address to its first octet.
+set -euo pipefail
+
+S3LVOL_ROOT="${S3LVOL_ROOT:-/opt/s3lvol}"
+RCOW_COMMON="${S3LVOL_ROOT}/scripts/rcow_common.sh"
+RCOW_START="${S3LVOL_ROOT}/scripts/rcow_start.sh"
+RCOW_STOP="${S3LVOL_ROOT}/scripts/rcow_stop.sh"
+
+log() { printf '[cube-s3lvol] %s\n' "$*"; }
+fail() { printf '[cube-s3lvol] ERROR: %s\n' "$*" >&2; exit 1; }
+
+s3lvol_ensure_wal() {
+  local img="${RCOW_WAL_IMG}"
+  local total_mb bytes
+
+  [[ -n "${img}" ]] || fail "RCOW_WAL_IMG is empty"
+  if [[ -e "${img}" ]]; then
+    bytes="$(stat -c %s "${img}" 2>/dev/null || echo unknown)"
+    log "WAL image already exists: ${img} (${bytes} bytes); layout is frozen, not resized"
+    return 0
+  fi
+  [[ "${RCOW_JOURNAL_MB}" =~ ^[0-9]+$ && "${RCOW_WAL_MB}" =~ ^[0-9]+$ && "${RCOW_CACHE_MB}" =~ ^[0-9]+$ ]] \
+    || fail "RCOW_JOURNAL_MB / RCOW_WAL_MB / RCOW_CACHE_MB must be integers"
+  total_mb=$((RCOW_JOURNAL_MB + RCOW_WAL_MB + RCOW_CACHE_MB))
+  mkdir -p "$(dirname "${img}")"
+  log "creating sparse WAL image ${img} (${total_mb} MiB = journal+wal+cache)"
+  truncate -s "${total_mb}M" "${img}"
+}
+
+s3lvol_ensure_bucket() {
+  local s3_bucket_py s3_host s3_region s3_bucket
+  local -a s3_flags=()
+
+  s3_bucket_py="${S3LVOL_ROOT}/scripts/s3_bucket.py"
+  if [[ ! -f "${s3_bucket_py}" ]]; then
+    log "WARN: s3_bucket.py not found; skipping bucket ensure"
+    return 0
+  fi
+  if ! rcow_load_credentials; then
+    log "WARN: could not read credentials from ${RCOW_S3_CFG}; skipping bucket ensure"
+    return 0
+  fi
+  s3_host="$(rcow_cfg_get endpoint)"
+  s3_region="$(rcow_cfg_get region)"
+  s3_bucket="$(rcow_s3_buckets | head -1)"
+  [[ -n "${s3_region}" ]] || s3_region="us-east-1"
+  rcow_s3_addr_flags s3_flags
+  if [[ -z "${s3_host}" || -z "${s3_bucket}" ]]; then
+    log "WARN: ${RCOW_S3_CFG} has no endpoint/buckets; skipping bucket ensure"
+    return 0
+  fi
+  if python3 "${s3_bucket_py}" ensure \
+      -e "${s3_host}" -b "${s3_bucket}" -r "${s3_region}" \
+      "${s3_flags[@]+"${s3_flags[@]}"}"; then
+    log "bucket ${s3_bucket} is ready"
+  else
+    log "WARN: could not ensure bucket ${s3_bucket} at ${s3_host}; rcow_start.sh will fail with the precise error if it is missing"
+  fi
+}
+
+s3lvol_shutdown() {
+  if type rcow_target_alive >/dev/null 2>&1 && rcow_target_alive; then
+    log "SIGTERM: target alive, full teardown via rcow_stop.sh"
+    "${RCOW_STOP}" || true
+  else
+    log "SIGTERM: target not running; cleaning target-side state"
+    rm -f \
+      "${RCOW_PIDFILE:-}" \
+      "${RCOW_RPC_SOCK:-}" \
+      "${RCOW_RPC_SOCK:-}.lock" \
+      /var/tmp/spdk_cpu_lock_* 2>/dev/null || true
+  fi
+}
+
+# Standalone copy of rcow_node_hash's digest (sha256, first 8 hex): this runs
+# before rcow_common.sh is sourced.
+s3lvol_derived_lvs_name() {
+  local id="${1:-}"
+  [[ -n "${id}" ]] || return 1
+  command -v sha256sum >/dev/null 2>&1 || return 1
+  printf 'rcow-%s' "$(printf '%s' "${id}" | sha256sum | cut -c1-8)"
+}
+
+# An explicit RCOW_LVS_NAME (cubeS3lvol.lvsName) wins; otherwise derive
+# rcow-<hash of NODE_NAME> now, before rcow_common.sh resolves the name at
+# source time. RCOW_TGT_CPUMASK is exported only when set (rcow default 0x3).
+s3lvol_export_optional_knobs() {
+  if [[ -n "${RCOW_LVS_NAME:-}" ]]; then
+    export RCOW_LVS_NAME
+    log "RCOW_LVS_NAME=${RCOW_LVS_NAME} (explicit)"
+  else
+    local node="${NODE_NAME:-}"
+    [[ -n "${node}" ]] || fail "NODE_NAME is required to derive RCOW_LVS_NAME"
+    RCOW_LVS_NAME="$(s3lvol_derived_lvs_name "${node}")" \
+      || fail "could not derive RCOW_LVS_NAME from NODE_NAME=${node}"
+    export RCOW_LVS_NAME
+    log "RCOW_LVS_NAME=${RCOW_LVS_NAME} (from NODE_NAME=${node})"
+  fi
+  if [[ -n "${RCOW_TGT_CPUMASK:-}" ]]; then
+    export RCOW_TGT_CPUMASK
+    log "RCOW_TGT_CPUMASK=${RCOW_TGT_CPUMASK} (explicit)"
+  else
+    log "RCOW_TGT_CPUMASK unset; rcow_common default is 0x3"
+  fi
+}
+
+s3lvol_prepare_identity() {
+  local node="${NODE_NAME:-}"
+  [[ -n "${node}" ]] || fail "NODE_NAME is required (spec.nodeName)"
+  if ! hostname "${node}"; then
+    fail "failed to set UTS hostname to ${node}; cube-s3lvol must run privileged"
+  fi
+  log "hostname pinned to ${node}"
+  s3lvol_export_optional_knobs
+}
+
+s3lvol_main() {
+  [[ -f "${RCOW_COMMON}" ]] || fail "missing ${RCOW_COMMON}"
+  [[ -x "${RCOW_START}" ]] || fail "missing ${RCOW_START}"
+  [[ -x "${RCOW_STOP}" ]] || fail "missing ${RCOW_STOP}"
+
+  export RCOW_REPO_ROOT="${S3LVOL_ROOT}"
+  export RCOW_RPC_SOCK="${RCOW_RPC_SOCK:-/var/run/s3lvol/s3lvol.sock}"
+  export RCOW_S3_CFG="${RCOW_S3_CFG:-/etc/s3lvol/s3.cfg}"
+  export RCOW_WAL_IMG="${RCOW_WAL_IMG:-/data/cubelet/rcow/wal_bdev.img}"
+  export RCOW_RUN_DIR="${RCOW_RUN_DIR:-/var/run/s3lvol}"
+  export RCOW_PIDFILE="${RCOW_PIDFILE:-${RCOW_RUN_DIR}/s3lvol_tgt.pid}"
+  export RCOW_LOG_DIR="${RCOW_LOG_DIR:-/data/log/rcow}"
+  export RCOW_JOURNAL_MB="${RCOW_JOURNAL_MB:-1024}"
+  export RCOW_WAL_MB="${RCOW_WAL_MB:-32768}"
+  export RCOW_CACHE_MB="${RCOW_CACHE_MB:-490496}"
+
+  mkdir -p "${RCOW_RUN_DIR}" "${RCOW_LOG_DIR}" "$(dirname "${RCOW_WAL_IMG}")"
+
+  s3lvol_prepare_identity
+  s3lvol_ensure_wal
+
+  # shellcheck source=/dev/null
+  source "${RCOW_COMMON}"
+
+  trap 's3lvol_shutdown; exit 0' TERM INT
+
+  s3lvol_ensure_bucket
+
+  log "running rcow_start.sh"
+  local rc=0
+  "${RCOW_START}" || rc=$?
+  if [[ "${rc}" -ne 0 ]]; then
+    fail "rcow_start.sh failed (rc=${rc})"
+  fi
+
+  log "target up, monitoring pidfile ${RCOW_PIDFILE}"
+  while :; do
+    sleep 3
+    if ! rcow_target_alive; then
+      log "target exited; exiting so kubelet restarts the container"
+      exit 1
+    fi
+  done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  s3lvol_main "$@"
+fi

--- a/deploy/kubernetes/images/scripts/test-cube-s3lvol-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/test-cube-s3lvol-entrypoint.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Unit tests for cube-s3lvol-entrypoint helpers and cubelet [cow.s3] opt-in patch.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="${SCRIPT_DIR}/cube-s3lvol-entrypoint.sh"
+COMPONENT="${SCRIPT_DIR}/component-entrypoint.sh"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+# shellcheck source=./cube-s3lvol-entrypoint.sh
+source "${ENTRYPOINT}"
+
+RCOW_COMMON="$(cd "${SCRIPT_DIR}/../../../.." && pwd)/CubeS3lvol/scripts/rcow_common.sh"
+[[ -f "${RCOW_COMMON}" ]] || fail "missing ${RCOW_COMMON}"
+
+cross_hash() {
+  local id="$1"
+  local tmp
+  tmp="$(mktemp -d)"
+  RCOW_LVS_NAME=entrypoint-cross-hash \
+    RCOW_ACTIVE_FILE="${tmp}/active_lvols" \
+    RCOW_BSTORE_FILE="${tmp}/bstore.json" \
+    bash -c '
+      set -euo pipefail
+      # shellcheck disable=SC1090
+      source "$1"
+      rcow_node_hash "$2"
+    ' _ "${RCOW_COMMON}" "${id}"
+  rm -rf "${tmp}"
+}
+
+unset RCOW_LVS_NAME RCOW_TGT_CPUMASK
+NODE_NAME=worker-1
+s3lvol_export_optional_knobs
+[[ "${RCOW_LVS_NAME}" == "$(s3lvol_derived_lvs_name worker-1)" ]] \
+  || fail "worker-1 must derive rcow-<hash of full node name>"
+[[ "${RCOW_LVS_NAME}" == "rcow-$(cross_hash worker-1)" ]] \
+  || fail "entrypoint hash of worker-1 must match rcow_node_hash"
+[[ -z "${RCOW_TGT_CPUMASK:-}" ]] || fail "must not invent RCOW_TGT_CPUMASK when unset"
+
+unset RCOW_LVS_NAME
+NODE_NAME=192.0.2.48
+s3lvol_export_optional_knobs
+from48="${RCOW_LVS_NAME}"
+[[ "${from48}" == "$(s3lvol_derived_lvs_name 192.0.2.48)" ]] \
+  || fail "192.0.2.48 must derive from the full node name"
+[[ "${from48}" == "rcow-$(cross_hash 192.0.2.48)" ]] \
+  || fail "entrypoint hash of 192.0.2.48 must match rcow_node_hash"
+[[ "${from48}" != "rcow-$(cross_hash 192)" ]] \
+  || fail "192.0.2.48 must not hash like hostname -s"
+
+unset RCOW_LVS_NAME
+NODE_NAME=192.0.2.44
+s3lvol_export_optional_knobs
+from44="${RCOW_LVS_NAME}"
+[[ "${from44}" != "${from48}" ]] \
+  || fail "192.0.2.48 and 192.0.2.44 must get different LVS names"
+[[ "${from44}" == "rcow-$(cross_hash 192.0.2.44)" ]] \
+  || fail "entrypoint hash of 192.0.2.44 must match rcow_node_hash"
+
+unset RCOW_LVS_NAME
+NODE_NAME=n1.zone-a
+s3lvol_export_optional_knobs
+from_zone_a="${RCOW_LVS_NAME}"
+unset RCOW_LVS_NAME
+NODE_NAME=n1.zone-b
+s3lvol_export_optional_knobs
+from_zone_b="${RCOW_LVS_NAME}"
+[[ "${from_zone_a}" != "${from_zone_b}" ]] \
+  || fail "n1.zone-a and n1.zone-b must get different LVS names"
+
+RCOW_LVS_NAME=rcow-explicit
+RCOW_TGT_CPUMASK=0x30
+NODE_NAME=192.0.2.48
+s3lvol_export_optional_knobs
+[[ "${RCOW_LVS_NAME}" == "rcow-explicit" ]] || fail "must keep explicit RCOW_LVS_NAME"
+[[ "${RCOW_TGT_CPUMASK}" == "0x30" ]] || fail "must keep explicit RCOW_TGT_CPUMASK"
+
+tmp="$(mktemp)"
+fn="$(mktemp)"
+trap 'rm -f "${tmp}" "${fn}"' EXIT
+
+# component-entrypoint.sh always runs main; extract the patch helper only.
+python3 - "${COMPONENT}" "${fn}" <<'PY'
+from pathlib import Path
+import sys
+text = Path(sys.argv[1]).read_text()
+start = text.index("patch_cow_s3_opt_in()")
+end = text.index("\ndetect_primary_interface()")
+Path(sys.argv[2]).write_text(text[start:end])
+PY
+grep -q 'patch_cow_s3_opt_in' "${fn}" || fail "failed to extract patch_cow_s3_opt_in"
+
+run_patch() {
+  local sock="$1"
+  bash -c '
+    set -euo pipefail
+    fail() { printf "%s\n" "$*" >&2; exit 1; }
+    log() { :; }
+    source "$1"
+    patch_cow_s3_opt_in "$2" "$3"
+  ' _ "${fn}" "${tmp}" "${sock}"
+}
+
+count_key() {
+  local key="$1"
+  grep -c "^[[:space:]]*${key}[[:space:]]*=" "${tmp}"
+}
+
+# Config with the section present, enable = false, image-default socket.
+cat > "${tmp}" <<'EOF'
+    [plugins."io.cubelet.internal.v1.storage"]
+    storage_backend = "cubecow"
+    [plugins."io.cubelet.internal.v1.storage".cow.log]
+    level = "info"
+    [plugins."io.cubelet.internal.v1.storage".cow.s3]
+    enable = false
+    socket_path = "/var/run/s3lvol.sock"
+    [plugins."io.cubelet.internal.v1.images"]
+    foo = "bar"
+EOF
+
+run_patch "/var/run/s3lvol/s3lvol.sock"
+grep -Fq '[plugins."io.cubelet.internal.v1.storage".cow.s3]' "${tmp}" \
+  || fail "patch must keep cow.s3 section"
+grep -Fq 'enable = true' "${tmp}" \
+  || fail "patch must set enable = true"
+grep -Fq 'enable = false' "${tmp}" \
+  && fail "patch must replace enable = false"
+grep -Fq 'socket_path = "/var/run/s3lvol/s3lvol.sock"' "${tmp}" \
+  || fail "patch must override socket_path to the sidecar socket"
+grep -Fq 'socket_path = "/var/run/s3lvol.sock"' "${tmp}" \
+  && fail "patch must not keep the default socket_path"
+[[ "$(count_key enable)" -eq 1 ]] || fail "must keep a single enable (got $(count_key enable))"
+[[ "$(count_key socket_path)" -eq 1 ]] || fail "must keep a single socket_path (got $(count_key socket_path))"
+[[ "$(grep -c '\[plugins\."io.cubelet.internal.v1.storage"\.cow\.s3\]' "${tmp}")" -eq 1 ]] \
+  || fail "must not insert a second cow.s3 table"
+
+run_patch "/tmp/other.sock"
+[[ "$(count_key enable)" -eq 1 ]] || fail "re-patch must keep a single enable"
+[[ "$(count_key socket_path)" -eq 1 ]] || fail "re-patch must keep a single socket_path"
+grep -Fq 'enable = true' "${tmp}" || fail "re-patch must keep enable = true"
+grep -Fq 'socket_path = "/tmp/other.sock"' "${tmp}" \
+  || fail "re-patch must replace socket_path"
+
+# No [cow.s3] section: append enable + socket.
+cat > "${tmp}" <<'EOF'
+    [plugins."io.cubelet.internal.v1.storage"]
+    storage_backend = "cubecow"
+    [plugins."io.cubelet.internal.v1.storage".cow.log]
+    level = "info"
+EOF
+
+run_patch "/var/run/s3lvol/s3lvol.sock"
+grep -Fq '[plugins."io.cubelet.internal.v1.storage".cow.s3]' "${tmp}" \
+  || fail "patch must add cow.s3 section when missing"
+grep -Fq 'enable = true' "${tmp}" \
+  || fail "append path must write enable = true"
+grep -Fq 'socket_path = "/var/run/s3lvol/s3lvol.sock"' "${tmp}" \
+  || fail "append path must write socket_path"
+
+RCOW_START="$(cd "${SCRIPT_DIR}/../../../.." && pwd)/CubeS3lvol/scripts/rcow_start.sh"
+[[ -f "${RCOW_START}" ]] || fail "missing ${RCOW_START}"
+# Literal -r "${RCOW_RPC_SOCK}" so a non-default emptyDir socket is honored.
+grep -Fq -- '-r "${RCOW_RPC_SOCK}"' "${RCOW_START}" \
+  || fail "rcow_start.sh must pass -r \"\${RCOW_RPC_SOCK}\" to s3lvol_tgt"
+
+echo "cube-s3lvol entrypoint helper tests passed"

--- a/docs/guide/cross-node-snapshot.md
+++ b/docs/guide/cross-node-snapshot.md
@@ -1,7 +1,7 @@
 # Cross-Node Snapshots (Pause / Resume / Snapshot)
 
-::: tip Deployment scope (v0.7.0)
-In this release, CubeS3lvol can only be enabled on compute nodes installed via **one-click (bare-metal) deployment**; Kubernetes (Helm) deployments do not include the s3lvol target, so the cross-node S3 snapshot path is unavailable there.
+::: tip Deployment scope
+CubeS3lvol is **off by default** on both one-click and Kubernetes deployments. To enable it see [§2 Configuring the S3 backend](#2-configuring-the-s3-backend); for resource and storage planning see [§3 Storage requirements on every node](#3-storage-requirements-on-every-node).
 :::
 
 CubeSandbox persists a sandbox as a **package** of three objects (rootfs / memory / metadata) so you can **Pause**, **Resume**, and take a **Snapshot**:
@@ -122,16 +122,42 @@ Cubelet reads `/proc/cpuinfo` on the node and hashes CPU identity plus the featu
 Cube install ships MinIO as the default S3 service so you can try the feature out of the box.
 To point at your own S3 store, follow the [CubeS3lvol README](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeS3lvol/README.md).
 
+### 2.1 Kubernetes (Helm)
+
+Set `cubeS3lvol.enabled=true` on the chart. Nothing else is required: the sidecar reuses the chart MinIO or `volumeS3` endpoint and credentials, and writes to its own `cube-s3lvol` bucket — always separate from the S3 volume plugin's `cube-volumes` bucket. The cubelet entrypoint then sets `[cow.s3] enable = true` and points `socket_path` at the shared emptyDir socket; writing a socket path without `enable` does not opt in. Enabling it **recreates the Big Pod and interrupts sandboxes on that node**; do this in a maintenance window.
+
+Identity comes from the full Kubernetes node name, hashed to `rcow-<8hex>`. A Pod recreate keeps the same name. `cubeS3lvol.lvsName` pins the same name on every node — do not set it on a multi-node cluster.
+
+Extra settings are only needed when:
+
+- the S3 endpoint is external and path-style — set `cubeS3lvol.s3.pathStyle: true`;
+- cores are isolated — set `cubeS3lvol.cpuMask` (default is rcow's `0x3`).
+
+```yaml
+cubeS3lvol:
+  enabled: true
+  # Optional: override endpoint / keys. Bucket must stay separate from cube-volumes.
+  # s3:
+  #   endpoint: https://s3.example.com
+  #   accessKeyId: ...
+  #   secretAccessKey: ...
+  #   bucket: cube-s3lvol
+```
+
+The first start creates the sparse WAL if it is missing; `journalMB` / `walMB` / `cacheMB` only apply before that file exists. Enabling the sidecar also raises the Big Pod's `terminationGracePeriodSeconds` to at least 180s so `rcow_stop` can disconnect and unload.
+
 ---
 
 ## 3. Storage requirements on every node
+
+Every node that runs the s3lvol target needs about **2 CPU + 18 GiB RAM**; x86_64 hosts need AVX2 (Haswell).
 
 Snapshot objects live in shared S3, but **every node that runs the s3lvol target also needs a local WAL image**. Cross-node restore depends on it: writes to the snapshot are staged on local disk first and flushed to S3 asynchronously, and a node without the image can neither take snapshots nor restore them.
 
 ### 3.1 The WAL image
 
 - Path: `/data/cubelet/rcow/wal_bdev.img`
-- Logical size: **512 GiB** by default, created as a **sparse** file by `install.sh`
+- Logical size: **512 GiB** by default, created as a **sparse** file by one-click `install.sh` or the Helm sidecar entrypoint on first start
 - Created once; the journal / WAL / cache split is fixed at creation and cannot be resized afterwards (only by re-creating the image)
 
 The default 512 GiB is three regions:
@@ -147,7 +173,7 @@ The default 512 GiB is three regions:
 ### 3.2 Cluster planning
 
 - **Every node that may restore cross-node needs its own WAL image on local disk** — compute nodes running sandboxes, and control nodes that run the s3lvol target, included.
-- The region sizes are set at install time via `RCOW_JOURNAL_MB` / `RCOW_WAL_MB` / `RCOW_CACHE_MB` (one-click install), or the equivalent runtime env in the CubeS3lvol config. Tuning them only matters **before the first start** — the layout is frozen once the image exists.
+- The region sizes are set at install time via `RCOW_JOURNAL_MB` / `RCOW_WAL_MB` / `RCOW_CACHE_MB` (one-click), chart `cubeS3lvol.journalMB` / `walMB` / `cacheMB` (Helm), or the equivalent runtime env. Tuning them only matters **before the first start** — the layout is frozen once the image exists.
 - The image does not hold snapshot data permanently: it is a write buffer plus a cache. The durable copy is in S3.
 
 ---

--- a/docs/guide/kubernetes/architecture.md
+++ b/docs/guide/kubernetes/architecture.md
@@ -18,7 +18,7 @@ For install steps, see [Helm Install](./install.md). For compute image upgrades,
 | Admin entry | WebUI | Deployment + Service + ConfigMap | Static console; reverse-proxies `/opsapi/` and `/cubeapi/v1/` to CubeOps (depends on `cubeOps.enabled`) |
 | Ops entry | cubemastercli | Deployment | CLI for `kubectl exec`; injects this Release’s CubeMaster endpoint |
 | Dependent storage | MySQL / Redis / MinIO | Built-in StatefulSet or third-party | Business data / Proxy and lifecycle state / S3 volume backend |
-| Compute · runtime | `cube-node` (Big Pod) | Native `apps/v1` DaemonSet | `wait-node-prep` init + cubelet with embedded network runtime + optional egress |
+| Compute · runtime | `cube-node` (Big Pod) | Native `apps/v1` DaemonSet | `wait-node-prep` init + cubelet with embedded network runtime + optional egress / s3lvol |
 | Compute · artifacts | `cube-node-installer` | Native `apps/v1` DaemonSet | Installs shim / kernel / guest into the host toolbox |
 | Compute · node bootstrap | `cube-node-bootstrap` | Native `apps/v1` DaemonSet | `wait-pvm-host`, `cube-node-init`, writes `node-prep-ready` |
 | Compute · PVM host | `cube-node-pvm` | Native `apps/v1` DaemonSet (`placement.pvm` only) | PVM host kernel install (may reboot); manages L0 taints and writes fingerprints |
@@ -63,6 +63,7 @@ flowchart TB
       WAIT["init: wait-node-prep (exits when ready)"]
       RUN["cubelet + embedded network runtime"]
       EG["cube-egress + cube-egress-net"]
+      S3L["optional cube-s3lvol"]
     end
   end
 
@@ -138,6 +139,7 @@ All four compute lines (Big Pod / installer / bootstrap / PVM) are native `apps/
 | `wait-node-prep` (init) | `images.waitNodePrep` | Read-only hostPath `node-prep-ready` self-describing fingerprint; exits when matched so run containers can start |
 | `cubelet` | `images.cubelet` | Starts after self-stage; includes embedded network runtime and CubeVS tools |
 | `cube-egress` / `cube-egress-net` | matching images | Optional; transparent egress / TPROXY |
+| `cube-s3lvol` | `images.cubeS3lvol` | Optional; SPDK NVMe/TCP target for S3 CoW / cross-node snapshots |
 
 **Container names / volumeMount / securityContext / imagePullPolicy changes also recreate**.
 
@@ -303,6 +305,7 @@ Probe conventions:
 - After network-agent was embedded into Cubelet, node readiness / `NotReady` no longer probes a standalone network daemon. Runtime network degradation (for example TAP pool exhaustion or sustained CubeEgress push failures) is surfaced on create/release paths and local diagnostics instead of flipping the node to NotReady. Monitor create failure rates, TAP pool state (`cubecli container taps` / loopback `GET /v1/network/taps`), and CubeEgress health rather than relying on node Ready alone.
 - `cube-egress`: `127.0.0.1:9091/admin/v1/health` (default; `cubeEgress.adminPort`).
 - `cube-egress-net`: `cube-dev`, ip rule, table 100, mangle `TRANSPROXY`.
+- `cube-s3lvol` (when enabled): startup and readiness probe the Unix socket `/var/run/s3lvol/s3lvol.sock` plus a light `s3lvol_rpc.py` RPC. There is no liveness probe — the entrypoint exits when the target dies so kubelet restarts the container.
 
 ### 4.4 Registration and acceptance checkpoints
 
@@ -412,6 +415,7 @@ Does not install built-in Master / API / MySQL / Redis / MinIO / WebUI; by defau
 | `cubeProxy.enabled` / `ingress.enabled` | `true` | Proxy / Ingress |
 | `lifecycleManager.enabled` | `true` | Required when Proxy is enabled |
 | `cubeEgress.enabled` | `true` | Big Pod egress sidecar |
+| `cubeS3lvol.enabled` | `false` | Big Pod s3lvol sidecar (recreates the Pod; ~2 CPU / 18 GiB / 512 GiB sparse WAL) |
 | `cubeOps.enabled` | `true` | CubeOps (JWT ops API; WebUI upstream) |
 | `webui.enabled` | `true` | WebUI (requires `cubeOps.enabled=true`) |
 
@@ -419,7 +423,7 @@ Does not install built-in Master / API / MySQL / Redis / MinIO / WebUI; by defau
 
 | Test Pod | Coverage |
 | --- | --- |
-| `<release>-health-test` | Master / Ops / API / node registration / WebUI / Proxy / workload Ready / Egress presence |
+| `<release>-health-test` | Master / Ops / API / node registration / WebUI / Proxy / workload Ready / Egress presence / s3lvol presence when enabled |
 | `<release>-mysql-test` / `redis-test` | Built-in dependency connectivity |
 | `<release>-dns-test` | `cube.app` / wildcard → Proxy Service |
 | `<release>-node-image-test` | Runtime tools and assets inside the image |

--- a/docs/zh/guide/cross-node-snapshot.md
+++ b/docs/zh/guide/cross-node-snapshot.md
@@ -1,7 +1,7 @@
 # 跨机快照（Pause / Resume / Snapshot）
 
-::: tip 部署范围（v0.7.0）
-本版本暂时只支持在 **one-click 部署**的计算节点上启用 CubeS3lvol；Kubernetes（Helm）部署暂未包含 s3lvol 组件，无法启用跨机 S3 快照。
+::: tip 部署范围
+CubeS3lvol 在 one-click 和 Kubernetes 上都**默认关闭**。开启方式见 [§2 配置后端 S3 服务](#2-如何配置后端-s3-服务)；资源与存储规划见 [§3 每台节点的存储需求](#3-每台节点的存储需求重点是-wal)。
 :::
 
 CubeSandbox 通过一份可持久化的「包对象」（rootfs / memory / metadata）实现沙箱的
@@ -148,9 +148,35 @@ cubemastercli tpl create-from-image \
 Cube 安装时默认安装 MinIO 作为 S3 服务，方便开箱体验。
 若要接入自己的 S3，按 [CubeS3lvol 文档](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeS3lvol/README.md) 配置即可。
 
+### 2.1 Kubernetes（Helm）
+
+设置 `cubeS3lvol.enabled=true` 即可，无需其他配置：sidecar 复用 chart MinIO 或 `volumeS3` 的 endpoint 与凭证，写入自己的 `cube-s3lvol` 桶——始终与 S3 volume 插件的 `cube-volumes` 桶分开。cubelet 的 entrypoint 会把 `[cow.s3] enable` 写成 `true`，并把 `socket_path` 指到共享 emptyDir socket；只写 socket、不写 `enable` 不会开启。开启会**重建该节点的 Big Pod 并中断其上正在运行的沙箱**，请在维护窗口操作。
+
+身份来自完整的 Kubernetes 节点名，哈希成 `rcow-<8hex>`。Pod 重建仍是同一台机器。`cubeS3lvol.lvsName` 会给集群里每个节点钉同一个名字——多节点不要设。
+
+只有以下情况需要额外设置：
+
+- 外部 S3 端点为 path-style——显式设 `cubeS3lvol.s3.pathStyle: true`；
+- CPU 核做了隔离——设置 `cubeS3lvol.cpuMask`（默认 rcow 的 `0x3`）。
+
+```yaml
+cubeS3lvol:
+  enabled: true
+  # 可选：覆盖 endpoint / 密钥。桶必须与 cube-volumes 分开。
+  # s3:
+  #   endpoint: https://s3.example.com
+  #   accessKeyId: ...
+  #   secretAccessKey: ...
+  #   bucket: cube-s3lvol
+```
+
+首次启动时若 WAL 文件不存在会创建稀疏文件；`journalMB` / `walMB` / `cacheMB` 只在该文件出现之前生效。开启 sidecar 后，Big Pod 的 `terminationGracePeriodSeconds` 会提高到至少 180s，以便 `rcow_stop` 完成 disconnect 与 unload。
+
 ---
 
 ## 3. 每台节点的存储需求（重点是 WAL）
+
+每台运行 s3lvol 的节点需预留约 **2 核 CPU + 18 GiB 内存**；x86_64 节点需要 AVX2（Haswell）。
 
 快照对象存放在共享 S3 上，但**每台运行 s3lvol 的节点还需要一块本地 WAL 镜像盘**。
 跨机恢复依赖它：对快照的写入会先落到本地盘，再异步刷写回 S3；没有这块盘的节点既无法制作快照，
@@ -159,7 +185,7 @@ Cube 安装时默认安装 MinIO 作为 S3 服务，方便开箱体验。
 ### 3.1 WAL 镜像盘
 
 - 路径：`/data/cubelet/rcow/wal_bdev.img`
-- 逻辑大小：默认 **512 GiB**，由 `install.sh` 以**稀疏文件**方式创建
+- 逻辑大小：默认 **512 GiB**，由 one-click `install.sh` 或 Helm sidecar 入口在首次启动时以**稀疏文件**方式创建
 - 只创建一次：journal / WAL / cache 三段的划分在创建时就固定，之后无法调整（只能重新创建镜像）
 
 默认 512 GiB 由三段组成：
@@ -178,7 +204,8 @@ Cube 安装时默认安装 MinIO 作为 S3 服务，方便开箱体验。
 - **每台可能参与跨机恢复的节点都要在本地磁盘上准备自己的 WAL 镜像**——包括运行沙箱的计算节点，
   以及运行 s3lvol 的控制节点。
 - 三段大小在安装时通过 `RCOW_JOURNAL_MB` / `RCOW_WAL_MB` / `RCOW_CACHE_MB`
-  （一键安装）或 CubeS3lvol 运行时环境配置设置。调整只在**首次启动前**有意义——镜像一旦创建，布局即固定。
+  （一键安装）、chart 的 `cubeS3lvol.journalMB` / `walMB` / `cacheMB`（Helm）
+  或 CubeS3lvol 运行时环境配置设置。调整只在**首次启动前**有意义——镜像一旦创建，布局即固定。
 - 镜像不长期保存快照数据：它只是写缓冲加缓存，持久副本在 S3。
 
 ---

--- a/docs/zh/guide/kubernetes/architecture.md
+++ b/docs/zh/guide/kubernetes/architecture.md
@@ -18,7 +18,7 @@
 | 管理入口 | WebUI | Deployment + Service + ConfigMap | 静态控制台；`/opsapi/`、`/cubeapi/v1/` 反代到 CubeOps（依赖 `cubeOps.enabled`） |
 | 运维入口 | cubemastercli | Deployment | `kubectl exec` 用 CLI；注入本 Release 的 CubeMaster endpoint |
 | 依赖存储 | MySQL / Redis / MinIO | 内置 StatefulSet 或第三方 | 业务数据 / Proxy 与 lifecycle 状态 / S3 Volume 后端 |
-| 计算面 · 运行时 | `cube-node`（Big Pod） | 原生 `apps/v1` DaemonSet | `wait-node-prep` init + 内嵌 network runtime 的 cubelet + 可选 egress |
+| 计算面 · 运行时 | `cube-node`（Big Pod） | 原生 `apps/v1` DaemonSet | `wait-node-prep` init + 内嵌 network runtime 的 cubelet + 可选 egress / s3lvol |
 | 计算面 · 产物 | `cube-node-installer` | 原生 `apps/v1` DaemonSet | 将 shim / kernel / guest 安装到宿主机 toolbox |
 | 计算面 · 节点引导 | `cube-node-bootstrap` | 原生 `apps/v1` DaemonSet | `wait-pvm-host`、`cube-node-init`、写 `node-prep-ready` |
 | 计算面 · PVM 宿主机 | `cube-node-pvm` | 原生 `apps/v1` DaemonSet（仅 `placement.pvm`） | PVM host kernel 安装（可 reboot）；管理 L0 污点并写指纹 |
@@ -63,6 +63,7 @@ flowchart TB
       WAIT["init: wait-node-prep（就绪后退出）"]
       RUN["cubelet + embedded network runtime"]
       EG["cube-egress + cube-egress-net"]
+      S3L["optional cube-s3lvol"]
     end
   end
 
@@ -138,6 +139,7 @@ flowchart TB
 | `wait-node-prep`（init） | `images.waitNodePrep` | 只读 hostPath `node-prep-ready` 自描述指纹；匹配后退出，主容器才启动 |
 | `cubelet` | `images.cubelet` | self-stage 后启动；包含内嵌 network runtime 和 CubeVS 工具 |
 | `cube-egress` / `cube-egress-net` | 对应镜像 | 可选；透明出站 / TPROXY |
+| `cube-s3lvol` | `images.cubeS3lvol` | 可选；SPDK NVMe/TCP target，用于 S3 CoW / 跨机快照 |
 
 **容器名 / volumeMount / securityContext / imagePullPolicy 变更同样 recreate**。
 
@@ -303,6 +305,7 @@ sequenceDiagram
 - network-agent 合入 Cubelet 后，节点就绪 / `NotReady` 不再探测独立网络进程。运行期网络退化（例如 TAP 池耗尽、CubeEgress 持续推送失败）会体现在 create/release 失败与本地诊断上，而不会把节点打成 NotReady。请改看创建失败率、TAP 池状态（`cubecli container taps` / loopback `GET /v1/network/taps`）以及 CubeEgress 健康，而不是只依赖节点 Ready。
 - `cube-egress`：`127.0.0.1:9091/admin/v1/health`（默认；`cubeEgress.adminPort`）。
 - `cube-egress-net`：`cube-dev`、ip rule、table 100、mangle `TRANSPROXY`。
+- `cube-s3lvol`（启用时）：startup / readiness 探测 Unix socket `/var/run/s3lvol/s3lvol.sock` 与一次轻量 `s3lvol_rpc.py` RPC。没有 liveness：target 退出时 entrypoint 以非 0 退出，由 kubelet 重启容器。
 
 ### 4.4 注册与验收关注点
 
@@ -411,6 +414,7 @@ externalControlPlane:
 | `cubeProxy.enabled` / `ingress.enabled` | `true` | Proxy / Ingress |
 | `lifecycleManager.enabled` | `true` | Proxy 启用时必开 |
 | `cubeEgress.enabled` | `true` | Big Pod egress sidecar |
+| `cubeS3lvol.enabled` | `false` | Big Pod s3lvol sidecar（会重建 Pod；约 2 核 / 18 GiB / 512 GiB 稀疏 WAL） |
 | `cubeOps.enabled` | `true` | CubeOps（JWT 运维 API；WebUI 上游） |
 | `webui.enabled` | `true` | WebUI（要求 `cubeOps.enabled=true`） |
 
@@ -418,7 +422,7 @@ externalControlPlane:
 
 | Test Pod | 覆盖 |
 | --- | --- |
-| `<release>-health-test` | Master / Ops / API / 节点注册 / WebUI / Proxy / 工作负载 Ready / Egress 存在性 |
+| `<release>-health-test` | Master / Ops / API / 节点注册 / WebUI / Proxy / 工作负载 Ready / Egress 存在性 / 启用时的 s3lvol 存在性 |
 | `<release>-mysql-test` / `redis-test` | 内置依赖连通性 |
 | `<release>-dns-test` | `cube.app` / wildcard → Proxy Service |
 | `<release>-node-image-test` | 镜像内 runtime 工具与 asset |

--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -35,7 +35,7 @@ PERL_IMAGE_ASSIGN="s{((?:IMAGE_TAG|CUBE_VERSION)=)${PERL_SEMVER}}{\$1\$ENV{VER}}
 # Component images that follow the release version (chart + one-click / CI).
 # openresty-tproxy is deliberately excluded: its tag tracks the OpenResty
 # version, not the release.
-COMPONENTS='cube-egress|cube-egress-net|cube-master|cubemastercli|cube-api|cube-ops|cube-proxy|cube-webui|cube-lifecycle-manager|cubelet|cube-shim|cube-kernel|cube-guest|cube-agent|cube-node-init|cube-wait-node-prep|cube-pvm-host-bootstrap'
+COMPONENTS='cube-egress|cube-egress-net|cube-s3lvol|cube-master|cubemastercli|cube-api|cube-ops|cube-proxy|cube-webui|cube-lifecycle-manager|cubelet|cube-shim|cube-kernel|cube-guest|cube-agent|cube-node-init|cube-wait-node-prep|cube-pvm-host-bootstrap'
 
 usage() {
 	sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'


### PR DESCRIPTION
## Summary

Bring CubeS3lvol to Kubernetes (Helm): a new `cube-s3lvol` sidecar in the
cube-node Big Pod runs the s3lvol NVMe/TCP target for S3-backed cross-node
snapshots. Off by default, mirroring one-click; enabling it recreates the Big
Pod. Also fixes the lvstore identity derivation so hostnames that are IP
addresses no longer collide on one S3 prefix.

Close: #1615 

## Chart

- `values.yaml` / `node-daemonset.yaml` — new `cubeS3lvol` block (default
  `enabled: false`). When enabled, injects the sidecar with env knobs, a
  shared RPC socket (`/var/run/s3lvol/s3lvol.sock`) on an in-memory
  emptyDir, the s3.cfg Secret, startup/readiness probes (no liveness: the
  entrypoint exits when the target dies so kubelet restarts it), and raises
  `terminationGracePeriodSeconds` to at least 180 for rcow_stop teardown.
  cubelet gets `CUBE_S3LVOL_SOCKET`.
- `s3lvol-secret.yaml` / `secret.yaml` / `_helpers.tpl` — s3.cfg is
  generated from explicit `cubeS3lvol.s3.*`, `volumeS3`, or chart MinIO
  root credentials; `existingSecret` is supported.
- `validate.yaml` — requires an image repository, endpoint, and
  credentials; forbids sharing the `cube-volumes` bucket or
  `volumeS3.bucket`.
- `tests/node-health.yaml` — checks the sidecar container by name when
  enabled.

## Images

- `images/cube-s3lvol/Dockerfile` (+ `.dockerignore`) — multi-stage build
  from repository source (builder ships SPDK + AWS CRT; Ubuntu 20.04
  runtime keeps glibc matching the linked shared libs).
- `images/scripts/cube-s3lvol-entrypoint.sh` — foreground supervisor: pins
  the UTS hostname to `spec.nodeName` (the Pod name changes on recreate),
  derives `RCOW_LVS_NAME` from the full node name, creates the sparse WAL
  on first start, ensures the bucket, and tears down via `rcow_stop.sh` on
  SIGTERM.
- `images/scripts/component-entrypoint.sh` — with `CUBE_S3LVOL_SOCKET` set,
  patches cubelet's `[cow.s3]` to `enable = true` plus the sidecar socket
  (a socket path alone does not opt in). No undo path is needed:
  stage_component resets config.toml from the image on every start.
- `build-cube-images.sh` / `release-docker-images.yml` / `bump-image.sh` /
  `kubernetes-chart-check.yml` — wire the component in (publish workflow is
  amd64-only; release binaries need AVX2).

## Identity fix

- `CubeS3lvol/scripts/rcow_common.sh` — the lvstore identity no longer
  applies `hostname -s` to addresses: IPv4/IPv6 and dotted hostnames with a
  numeric short name are hashed in full. Previously `hostname -s` kept only
  the first octet of a dotted-quad hostname, giving every node in the same
  /8 one shared S3 prefix. DNS FQDNs still use `hostname -s` so existing
  one-click prefixes survive a domain-suffix change. Upgrade note: a node
  whose hostname is an IP and that already created a store under the old
  hash looks like a new machine; pin `RCOW_LVS_NAME` to keep the old
  prefix.
- `CubeS3lvol/scripts/rcow_start.sh` — pass `-r "${RCOW_RPC_SOCK}"` so a
  non-default RPC socket is honored.

## Tests

- `CubeS3lvol/test/tools/test_lvs_identity.sh` — offline suite for the
  identity rules (wired into `run_all.sh`).
- `images/scripts/test-cube-s3lvol-entrypoint.sh` — entrypoint helper and
  cubelet opt-in patch unit tests.
- `chart/scripts/test-s3lvol-sidecar-guard.sh` — render guard: default off;
  sidecar, socket, Secret, and `NODE_NAME` from `spec.nodeName` when on;
  failure paths for missing S3 and shared buckets.
- `chart/scripts/test-big-pod-inplace-guard.sh` — enabling `cubeS3lvol`
  recreates the Big Pod.

## Docs

Chart README `CubeS3lvol` section, CubeS3lvol README identity notes, en/zh
cross-node-snapshot and kubernetes architecture guides.

