### PR TITLE
feat(chart): wire top-level redis.db for Master, Proxy, and LCM

### DIFF
--- a/deploy/kubernetes/chart/files/cube-master/conf.yaml
+++ b/deploy/kubernetes/chart/files/cube-master/conf.yaml
@@ -72,7 +72,7 @@ redis:
   sentinel_nodes: {{ .Values.redis.sentinelNodes | default "" | quote }}
   sentinel_password: {{ .Values.redis.sentinelPassword | default "" | quote }}
   password: {{ .Values.redis.password | quote }}
-  db_no: 0
+  db_no: {{ include "cube.redisDB" . }}
   max_idle: 8
   max_active: 32
   idle_timeout: 30

--- a/deploy/kubernetes/chart/scripts/test-redis-db-guard.sh
+++ b/deploy/kubernetes/chart/scripts/test-redis-db-guard.sh
@@ -60,7 +60,7 @@ helm template redis-db-default "$CHART_DIR" $COMMON_SETS \
   --set cubeOps.enabled=true \
   > "$TMP_DIR/default.yaml"
 
-grep -q 'db_no: 0' "$TMP_DIR/default.yaml" || {
+grep -Eq '^[[:space:]]*db_no: 0[[:space:]]*$' "$TMP_DIR/default.yaml" || {
   echo "CubeMaster conf missing default db_no: 0" >&2
   exit 1
 }
@@ -82,7 +82,7 @@ helm template redis-db-override "$CHART_DIR" $COMMON_SETS \
   --set cubeOps.enabled=true \
   > "$TMP_DIR/override.yaml"
 
-grep -q 'db_no: 3' "$TMP_DIR/override.yaml" || {
+grep -Eq '^[[:space:]]*db_no: 3[[:space:]]*$' "$TMP_DIR/override.yaml" || {
   echo "CubeMaster conf missing db_no: 3" >&2
   exit 1
 }
@@ -124,9 +124,39 @@ helm template redis-db-upgrade-leftover "$CHART_DIR" $COMMON_SETS \
   --set lifecycleManager.redis.db=0 \
   > "$TMP_DIR/upgrade-leftover.yaml"
 
-grep -q 'db_no: 0' "$TMP_DIR/upgrade-leftover.yaml" || {
+grep -Eq '^[[:space:]]*db_no: 0[[:space:]]*$' "$TMP_DIR/upgrade-leftover.yaml" || {
   echo "upgrade leftover db:0 should still render Master db_no: 0" >&2
   exit 1
 }
+
+# Leftover nested db:0 must not block overriding to a non-zero top-level db.
+helm template redis-db-leftover-override "$CHART_DIR" $COMMON_SETS \
+  --set redis.db=3 \
+  --set cubeProxy.enabled=true \
+  --set lifecycleManager.enabled=true \
+  --set cubeProxy.redis.db=0 \
+  --set lifecycleManager.redis.db=0 \
+  > "$TMP_DIR/leftover-override.yaml"
+
+grep -Eq '^[[:space:]]*db_no: 3[[:space:]]*$' "$TMP_DIR/leftover-override.yaml" || {
+  echo "leftover db:0 + redis.db=3 should render Master db_no: 3" >&2
+  exit 1
+}
+assert_all_redis_db_env "$TMP_DIR/leftover-override.yaml" 3 REDIS_DB
+assert_all_redis_db_env "$TMP_DIR/leftover-override.yaml" 3 CUBE_PROXY_REGISTRY_REDIS_DB
+assert_all_redis_db_env "$TMP_DIR/leftover-override.yaml" 3 CUBE_LCM_REDIS_DB
+
+# Invalid redis.db values must fail at render time.
+expect_fail redis-db-non-integer "$TMP_DIR/db-foo.err" \
+  'redis.db must be an integer' \
+  --set redis.db=foo
+
+expect_fail redis-db-negative "$TMP_DIR/db-neg.err" \
+  'redis.db must be an integer' \
+  --set redis.db=-1
+
+expect_fail redis-db-out-of-range "$TMP_DIR/db-16.err" \
+  'redis.db must be an integer' \
+  --set redis.db=16
 
 echo "ok: redis.db wires Master/Proxy/LCM/Ops; non-zero nested db fails even without Ops"

--- a/deploy/kubernetes/chart/scripts/test-redis-db-guard.sh
+++ b/deploy/kubernetes/chart/scripts/test-redis-db-guard.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# Guard: top-level redis.db is rendered into CubeMaster conf and
+# Proxy / LCM / CubeOps env so control-plane components share one logical
+# Redis DB. Non-zero nested cubeProxy.redis.db / lifecycleManager.redis.db
+# fail render (zero is tolerated for helm upgrade leftover defaults).
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+CHART_DIR="$(dirname "$SCRIPT_DIR")"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+COMMON_SETS="--set-string mysql.password=test --set-string mysql.rootPassword=test --set-string redis.password=test"
+
+expect_fail() {
+  name="$1"
+  err_file="$2"
+  needle="$3"
+  shift 3
+  if helm template "$name" "$CHART_DIR" $COMMON_SETS "$@" >/dev/null 2>"$err_file"; then
+    echo "expected fail: $name" >&2
+    exit 1
+  fi
+  grep -qi "$needle" "$err_file" || {
+    echo "unexpected error for $name (wanted /$needle/):" >&2
+    cat "$err_file" >&2
+    exit 1
+  }
+}
+
+# Assert every occurrence of env name carries the expected value.
+assert_all_redis_db_env() {
+  file="$1"
+  want="$2"
+  name="$3"
+  awk -v name="$name" -v want="$want" '
+    $0 ~ ("name: " name "$") {
+      getline
+      if ($0 !~ ("value: \"" want "\"")) {
+        printf "%s occurrence %d missing value %s (got: %s)\n", name, ++n, want, $0 > "/dev/stderr"
+        bad=1
+      } else {
+        n++
+      }
+    }
+    END {
+      if (n < 1) {
+        printf "%s missing entirely (wanted value %s)\n", name, want > "/dev/stderr"
+        exit 1
+      }
+      if (bad) exit 1
+    }
+  ' "$file"
+}
+
+# Default redis.db is 0 for Master / Proxy / LCM / Ops.
+helm template redis-db-default "$CHART_DIR" $COMMON_SETS \
+  --set cubeProxy.enabled=true \
+  --set lifecycleManager.enabled=true \
+  --set cubeOps.enabled=true \
+  > "$TMP_DIR/default.yaml"
+
+grep -q 'db_no: 0' "$TMP_DIR/default.yaml" || {
+  echo "CubeMaster conf missing default db_no: 0" >&2
+  exit 1
+}
+assert_all_redis_db_env "$TMP_DIR/default.yaml" 0 REDIS_DB
+assert_all_redis_db_env "$TMP_DIR/default.yaml" 0 CUBE_PROXY_REGISTRY_REDIS_DB
+assert_all_redis_db_env "$TMP_DIR/default.yaml" 0 CUBE_LCM_REDIS_DB
+# Proxy + Ops both emit REDIS_DB.
+redis_db_count="$(grep -c 'name: REDIS_DB' "$TMP_DIR/default.yaml" || true)"
+[ "$redis_db_count" -ge 2 ] || {
+  echo "expected REDIS_DB on both CubeProxy and CubeOps, got ${redis_db_count}" >&2
+  exit 1
+}
+
+# redis.db=3 overrides Master / Proxy / LCM / Ops together.
+helm template redis-db-override "$CHART_DIR" $COMMON_SETS \
+  --set redis.db=3 \
+  --set cubeProxy.enabled=true \
+  --set lifecycleManager.enabled=true \
+  --set cubeOps.enabled=true \
+  > "$TMP_DIR/override.yaml"
+
+grep -q 'db_no: 3' "$TMP_DIR/override.yaml" || {
+  echo "CubeMaster conf missing db_no: 3" >&2
+  exit 1
+}
+assert_all_redis_db_env "$TMP_DIR/override.yaml" 3 REDIS_DB
+assert_all_redis_db_env "$TMP_DIR/override.yaml" 3 CUBE_PROXY_REGISTRY_REDIS_DB
+assert_all_redis_db_env "$TMP_DIR/override.yaml" 3 CUBE_LCM_REDIS_DB
+
+# Non-zero nested keys must fail render (not silently ignored).
+expect_fail proxy-redis-db-removed "$TMP_DIR/proxy-db.err" \
+  'cubeProxy.redis.db was removed' \
+  --set cubeProxy.enabled=true \
+  --set lifecycleManager.enabled=true \
+  --set cubeProxy.redis.db=9
+
+expect_fail lcm-redis-db-removed "$TMP_DIR/lcm-db.err" \
+  'lifecycleManager.redis.db was removed' \
+  --set cubeProxy.enabled=true \
+  --set lifecycleManager.enabled=true \
+  --set lifecycleManager.redis.db=9
+
+# Guards must run even when CubeOps is disabled.
+expect_fail proxy-redis-db-no-ops "$TMP_DIR/proxy-db-noops.err" \
+  'cubeProxy.redis.db was removed' \
+  --set cubeProxy.enabled=true \
+  --set lifecycleManager.enabled=true \
+  --set cubeOps.enabled=false \
+  --set webui.enabled=false \
+  --set cubeNode.enabled=false \
+  --set cubeProxy.redis.db=9
+
+# Leftover nested db:0 from a prior chart default must not block helm upgrade.
+helm template redis-db-upgrade-leftover "$CHART_DIR" $COMMON_SETS \
+  --set cubeProxy.enabled=true \
+  --set lifecycleManager.enabled=true \
+  --set cubeOps.enabled=false \
+  --set webui.enabled=false \
+  --set cubeNode.enabled=false \
+  --set cubeProxy.redis.db=0 \
+  --set lifecycleManager.redis.db=0 \
+  > "$TMP_DIR/upgrade-leftover.yaml"
+
+grep -q 'db_no: 0' "$TMP_DIR/upgrade-leftover.yaml" || {
+  echo "upgrade leftover db:0 should still render Master db_no: 0" >&2
+  exit 1
+}
+
+echo "ok: redis.db wires Master/Proxy/LCM/Ops; non-zero nested db fails even without Ops"

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -881,6 +881,11 @@ CUBE_SANDBOX_MYSQL_* alone is always assembled as mysql://.
 {{- if eq (include "cube.redisSentinelEnabled" .) "true" -}}{{- else -}}{{ printf "%s:%v" (include "cube.redisHost" .) .Values.redis.port }}{{- end -}}
 {{- end -}}
 
+{{- /* Logical Redis DB for Master / Proxy / LCM (same instance isolation). */ -}}
+{{- define "cube.redisDB" -}}
+{{- .Values.redis.db | default 0 -}}
+{{- end -}}
+
 {{- define "cube.egressNetProbeCommand" -}}
 set -e
 iface="${CUBE_INGRESS_IFACE:-cube-dev}"

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -881,9 +881,9 @@ CUBE_SANDBOX_MYSQL_* alone is always assembled as mysql://.
 {{- if eq (include "cube.redisSentinelEnabled" .) "true" -}}{{- else -}}{{ printf "%s:%v" (include "cube.redisHost" .) .Values.redis.port }}{{- end -}}
 {{- end -}}
 
-{{- /* Logical Redis DB for Master / Proxy / LCM (same instance isolation). */ -}}
+{{- /* Logical Redis DB for Master / Proxy / LCM / Ops (same instance isolation). */ -}}
 {{- define "cube.redisDB" -}}
-{{- .Values.redis.db | default 0 -}}
+{{- .Values.redis.db | default 0 | int -}}
 {{- end -}}
 
 {{- define "cube.egressNetProbeCommand" -}}

--- a/deploy/kubernetes/chart/templates/lifecycle-manager.yaml
+++ b/deploy/kubernetes/chart/templates/lifecycle-manager.yaml
@@ -48,7 +48,7 @@ spec:
                   name: {{ include "cube.secretName" . }}
                   key: redis-password
             - name: CUBE_LCM_REDIS_DB
-              value: {{ .Values.lifecycleManager.redis.db | quote }}
+              value: {{ include "cube.redisDB" . | quote }}
             - name: CUBE_LCM_REDIS_MASTER_NAME
               value: {{ .Values.redis.masterName | default "" | quote }}
             - name: CUBE_LCM_REDIS_SENTINEL_NODES

--- a/deploy/kubernetes/chart/templates/ops.yaml
+++ b/deploy/kubernetes/chart/templates/ops.yaml
@@ -139,6 +139,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "cube.secretName" . }}
                   key: redis-password
+            - name: REDIS_DB
+              value: {{ include "cube.redisDB" . | quote }}
             - name: REDIS_MASTER_NAME
               value: {{ .Values.redis.masterName | default "" | quote }}
             - name: REDIS_SENTINEL_NODES

--- a/deploy/kubernetes/chart/templates/proxy.yaml
+++ b/deploy/kubernetes/chart/templates/proxy.yaml
@@ -168,7 +168,7 @@ spec:
                   name: {{ include "cube.secretName" . }}
                   key: redis-password
             - name: REDIS_DB
-              value: {{ .Values.cubeProxy.redis.db | quote }}
+              value: {{ include "cube.redisDB" . | quote }}
             - name: REDIS_MASTER_NAME
               value: {{ .Values.redis.masterName | default "" | quote }}
             - name: REDIS_SENTINEL_NODES
@@ -235,7 +235,7 @@ spec:
                   name: {{ include "cube.secretName" . }}
                   key: redis-password
             - name: CUBE_PROXY_REGISTRY_REDIS_DB
-              value: {{ .Values.cubeProxy.redis.db | quote }}
+              value: {{ include "cube.redisDB" . | quote }}
             - name: CUBE_PROXY_REGISTRY_REDIS_MASTER_NAME
               value: {{ .Values.redis.masterName | default "" | quote }}
             - name: CUBE_PROXY_REGISTRY_REDIS_SENTINEL_NODES

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -68,6 +68,13 @@
 {{- if hasKey (.Values.images | default dict) "pause" }}
 {{- fail "images.pause was removed; Big Pod placeholder slots (cube-slot-*) are gone. Remove images.pause from your values." }}
 {{- end }}
+{{- /* Only fail on non-zero nested db: old chart defaults shipped db:0, and helm upgrade keeps those keys in release values. */}}
+{{- if and (hasKey ((.Values.cubeProxy).redis | default dict) "db") (ne (((.Values.cubeProxy).redis).db | default 0 | int) 0) }}
+{{- fail "cubeProxy.redis.db was removed; set top-level redis.db instead (Master / Proxy / LCM / Ops share one logical DB)." }}
+{{- end }}
+{{- if and (hasKey ((.Values.lifecycleManager).redis | default dict) "db") (ne (((.Values.lifecycleManager).redis).db | default 0 | int) 0) }}
+{{- fail "lifecycleManager.redis.db was removed; set top-level redis.db instead (Master / Proxy / LCM / Ops share one logical DB)." }}
+{{- end }}
 {{- if hasKey (.Values.cubeNode | default dict) "placeholderSlots" }}
 {{- fail "cubeNode.placeholderSlots was removed; Big Pod no longer reserves cube-slot-1..6. Remove cubeNode.placeholderSlots from your values." }}
 {{- end }}

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -133,6 +133,12 @@
 {{- if and (or (eq (include "cube.redisBuiltinEnabled" .) "true") .Values.redis.host (eq (include "cube.redisSentinelEnabled" .) "true")) (hasPrefix "CHANGE_ME" (default "" .Values.redis.password)) }}
 {{- fail "redis.password still equals the CHANGE_ME_* default sentinel. Override it before deploying." }}
 {{- end }}
+{{- /* redis.db fans out to Master / Proxy / LCM / Ops; reject non-integer and out-of-range values at render time. */ -}}
+{{- $redisDBRaw := .Values.redis.db | default 0 -}}
+{{- $redisDB := $redisDBRaw | int -}}
+{{- if or (not (eq ($redisDBRaw | toString) ($redisDB | toString))) (lt $redisDB 0) (gt $redisDB 15) }}
+{{- fail (printf "redis.db must be an integer in 0-15 (got %v)" $redisDBRaw) }}
+{{- end }}
 {{- /* Fixed Service nodePorts are only valid for NodePort / LoadBalancer. */ -}}
 {{- $apiSvcType := .Values.controlPlane.api.service.type | default "ClusterIP" -}}
 {{- $apiNodePort := .Values.controlPlane.api.service.nodePort | default "" | toString -}}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -421,7 +421,6 @@ lifecycleManager:
     # Empty host uses redis.host or chart-managed cube-redis.
     host: ""
     port: ""
-    db: 0
   defaultIdleTimeout: 5m
   heartbeatTTL: 15s
   discoveryRefresh: 3s
@@ -533,6 +532,9 @@ redis:
   # AUTH against Sentinel instances only. Leave empty when Sentinel has no requirepass
   # (master password still uses redis.password).
   sentinelPassword: ""
+  # Logical Redis DB (0-15 on standalone/Sentinel masters). Master / Proxy / LCM / Ops share this.
+  # Use a distinct db per Cube cluster when sharing one Redis instance.
+  db: 0
   # SECURITY: Override before any non-throwaway deployment. templates/validate.yaml
   # refuses to render when this equals the CHANGE_ME_* sentinel.
   password: CHANGE_ME_REDIS_PASSWORD
@@ -797,7 +799,6 @@ cubeProxy:
     # Overrides must be an FQDN or IP literal (nginx resolver has no search domains).
     host: ""
     port: ""
-    db: 0
   timeout:
     min: 500
     max: 700


### PR DESCRIPTION
## Summary

- CubeMaster Helm conf previously hard-coded `db_no: 0`, while CubeProxy / cube-lifecycle-manager read nested `*.redis.db` values. Sharing one Redis/Sentinel across Cube clusters therefore could not select a non-zero logical DB without risking Master vs Proxy/LCM split-brain.
- Add top-level `redis.db` (default `0`) and render it into Master conf plus Proxy / LCM / Ops Redis env via `cube.redisDB`.
- Remove nested `cubeProxy.redis.db` / `lifecycleManager.redis.db` from values. `validate.yaml` fails at render when a non-zero leftover is set (points to top-level `redis.db`); nested `db: 0` is tolerated so ordinary `helm upgrade` of existing releases is not blocked by chart-default leftovers.

## Test plan

- [x] `helm lint deploy/kubernetes/chart --set-string mysql.password=test --set-string mysql.rootPassword=test --set-string redis.password=test` — passed
- [x] `bash deploy/kubernetes/chart/scripts/test-redis-db-guard.sh` — passed (default `0`, override `3`, non-zero nested fails even with Ops off, nested `db:0` upgrade leftover renders)
- [x] `bash deploy/kubernetes/chart/scripts/test-redis-sentinel-guard.sh` — passed