### PR TITLE
feat(pause): incremental memory dump like snapshot and keep XFS pause package

### DIFF
--- a/CubeMaster/pkg/base/constants/constants.go
+++ b/CubeMaster/pkg/base/constants/constants.go
@@ -77,6 +77,13 @@ const (
 	// Master (same snap-* format as normal snapshots). DB Kind=pause_snapshot;
 	// Cubelet only keeps the local catalog under that id.
 	CubeAnnotationPauseSnapshotID = "cube.master.pause.snapshot.id"
+	// CubeAnnotationLaunchMemorySnapshotID is the start-image id Cubelet
+	// stamps once. User Create must not set it (see checkAndGetAnnotation).
+	CubeAnnotationLaunchMemorySnapshotID = "cube.master.launch.memory.snapshot.id"
+	// CubeAnnotationRuntimeRestoreSnapshotID is the memory image the VM was
+	// last restored from. User Create must not set it.
+	CubeAnnotationRuntimeRestoreSnapshotID         = "cube.master.runtime.restore.snapshot.id"
+	CubeAnnotationRuntimeRestoreSnapshotAttachedAt = "cube.master.runtime.restore.snapshot.attached_at"
 	// CubeAnnotationStorageBackend is the CoW backend Master passes to Cubelet
 	// on Pause / Commit (xfs｜s3). Empty means xfs.
 	CubeAnnotationStorageBackend = "cube.master.storage.backend"

--- a/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
@@ -446,11 +446,14 @@ func resumeFromPauseSnapshot(ctx context.Context, req *types.UpdateRequest, host
 	// describes a sandbox that is by now running whatever the proxy thinks.
 	purgeErr := cubeproxy.InvalidateBackendCache(ctx, req.SandboxID, targetIP)
 
-	// After Create the sandbox runs on private disks. Drop the pause package
-	// on the node that still holds it: origin when that IP is known and not
-	// the target (also the PAUSED tombstone), otherwise this node. Do not
-	// key this off CrossNode — a cross-node placement with a blank origin
-	// would otherwise skip both cleanup paths and leak the package.
+	// After Create the sandbox runs on private disks. Ask Cubelet to drop
+	// the pause package on the node that still holds it: origin when that
+	// IP is known and not the target (also the PAUSED tombstone), otherwise
+	// this node. Cubelet decides whether the catalog actually goes away
+	// (S3 already cloned onto sb-*-memory; XFS Resume still mmaps the
+	// package and no-ops until the next Pause or Destroy). Do not key this
+	// off CrossNode — a cross-node placement with a blank origin would
+	// otherwise skip both cleanup paths and leak the package.
 	origin := strings.TrimSpace(rec.NodeIP)
 	if origin != "" && origin != targetIP {
 		if err := pausesnap.DropOriginTombstone(ctx, req.RequestID, req.SandboxID, origin, rec.SnapshotID, rec.Backend); err != nil {

--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -909,6 +909,9 @@ func checkAndGetAnnotation(req *types.CreateCubeSandboxReq, out *cubebox.RunCube
 
 		if strings.HasPrefix(k, constants.CubeAnnotationsPrefix) ||
 			strings.HasPrefix(k, constants.CubeAnnotationsCloadPrefix) {
+			if rejectUserCubeMasterAnnotation(k) {
+				continue
+			}
 			out.Annotations[k] = v
 		}
 	}
@@ -946,6 +949,22 @@ func setCreateTimeEnvVarsAnnotation(out map[string]string, envVars map[string]st
 	}
 	out[constants.CubeAnnotationCreateTimeEnvVars] = string(payload)
 	return nil
+}
+
+// rejectUserCubeMasterAnnotation drops Create annotations that only Master
+// or Cubelet may stamp. Forwarding them lets a client pin
+// cube.master.pause.snapshot.id on a running sandbox and make XFS
+// CleanupTemplate no-op for another tenant's pause catalog.
+func rejectUserCubeMasterAnnotation(key string) bool {
+	switch strings.TrimSpace(key) {
+	case constants.CubeAnnotationPauseSnapshotID,
+		constants.CubeAnnotationLaunchMemorySnapshotID,
+		constants.CubeAnnotationRuntimeRestoreSnapshotID,
+		constants.CubeAnnotationRuntimeRestoreSnapshotAttachedAt:
+		return true
+	default:
+		return false
+	}
 }
 
 func getBlkQosAnnotation(req *types.CreateCubeSandboxReq) string {

--- a/CubeMaster/pkg/service/sandbox/util_test.go
+++ b/CubeMaster/pkg/service/sandbox/util_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	cubebox "github.com/tencentcloud/CubeSandbox/pkgs/proto/services/cubebox/v1"
 )
@@ -285,5 +286,34 @@ func TestGetReqResourceRejectsCPUOverflowBeforeMemOverflow(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cpu") {
 		t.Fatalf("expected cpu validation error to win, got %v", err)
+	}
+}
+
+func TestCheckAndGetAnnotationStripsPlatformPauseKeys(t *testing.T) {
+	ensureSandboxTestConfig(t)
+	req := &types.CreateCubeSandboxReq{
+		Annotations: map[string]string{
+			constants.CubeAnnotationPauseSnapshotID:                  "snap-forged-pause",
+			constants.CubeAnnotationLaunchMemorySnapshotID:           "tpl-forged",
+			constants.CubeAnnotationRuntimeRestoreSnapshotID:         "snap-forged-restore",
+			constants.CubeAnnotationRuntimeRestoreSnapshotAttachedAt: "2026-09-04T00:00:00Z",
+			constants.CubeAnnotationRuntimeSnapshotID:                "snap-user-runtime",
+		},
+	}
+	out := &cubebox.RunCubeSandboxRequest{}
+	if err := checkAndGetAnnotation(req, out); err != nil {
+		t.Fatalf("checkAndGetAnnotation: %v", err)
+	}
+	if _, ok := out.Annotations[constants.CubeAnnotationPauseSnapshotID]; ok {
+		t.Fatal("user pause snapshot id must not be forwarded")
+	}
+	if _, ok := out.Annotations[constants.CubeAnnotationLaunchMemorySnapshotID]; ok {
+		t.Fatal("user launch ancestor must not be forwarded")
+	}
+	if _, ok := out.Annotations[constants.CubeAnnotationRuntimeRestoreSnapshotID]; ok {
+		t.Fatal("user restore-base must not be forwarded")
+	}
+	if got := out.Annotations[constants.CubeAnnotationRuntimeSnapshotID]; got != "snap-user-runtime" {
+		t.Fatalf("other cube.master keys still forward, got %q", got)
 	}
 }

--- a/CubeShim/shim/src/hypervisor/cube_hypervisor.rs
+++ b/CubeShim/shim/src/hypervisor/cube_hypervisor.rs
@@ -287,20 +287,24 @@ impl CubeHypervisor {
     }
 
     pub async fn pause_vm_cube(&self, path: &str) -> CResult<()> {
-        self.pause_vm_cube_with_config(path, None).await
+        self.pause_vm_cube_with_config(path, None, SnapshotType::Full)
+            .await
     }
 
     /// Pause the VM and write a snapshot. When `memory_vol_url` is set, memory
     /// ranges are stored on that CubeCow (or other) volume while config/state
     /// still land under `destination_url` — the same layout CommitSandbox /
-    /// cube-runtime snapshot uses.
+    /// cube-runtime snapshot uses. `snapshot_type` is the same Full /
+    /// Incremental / SoftDirty choice CommitSandbox sends via `--snapshot-type`.
     pub async fn pause_vm_cube_with_config(
         &self,
         destination_url: &str,
         memory_vol_url: Option<String>,
+        snapshot_type: SnapshotType,
     ) -> CResult<()> {
         let snap_config = Arc::new(SnapshotConfig {
             destination_url: destination_url.to_string(),
+            snapshot_type,
             memory_vol_url,
             ..Default::default()
         });

--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -1356,6 +1356,8 @@ impl SandBox {
     ///   `metadata.json` is written beside it — same layout as CommitSandbox
     ///   so Resume can use `get_snapshot_dir(base, cpu, mem)`.
     /// * `memory_vol_url` – optional CubeCow (or device) URL for memory ranges.
+    /// * `snapshot_type` – same Full / Incremental / SoftDirty choice as
+    ///   CommitSandbox (`--snapshot-type`).
     ///
     /// On success the MicroVM is deleted (`pause2snapshot`) and state stays
     /// `Paused`. Cubelet then reaps this shim via task Delete. On failure after
@@ -1364,6 +1366,7 @@ impl SandBox {
         &mut self,
         destination_path: &str,
         memory_vol_url: Option<String>,
+        snapshot_type: SnapshotType,
     ) -> CResult<()> {
         {
             let mut state = self.state.lock().await;
@@ -1378,7 +1381,7 @@ impl SandBox {
         }
 
         if let Err(e) = self
-            .pause_vm_to_snapshot_inner(destination_path, memory_vol_url)
+            .pause_vm_to_snapshot_inner(destination_path, memory_vol_url, snapshot_type)
             .await
         {
             let mut state = self.state.lock().await;
@@ -1392,6 +1395,7 @@ impl SandBox {
         &mut self,
         destination_path: &str,
         memory_vol_url: Option<String>,
+        snapshot_type: SnapshotType,
     ) -> CResult<()> {
         self.disconnect_agent(false).await?;
 
@@ -1413,7 +1417,7 @@ impl SandBox {
         })?;
 
         let destination_url = format!("file://{}", snapshot_dir.display());
-        ch.pause_vm_cube_with_config(&destination_url, memory_vol_url)
+        ch.pause_vm_cube_with_config(&destination_url, memory_vol_url, snapshot_type)
             .await?;
 
         // vmshutdown event after pause2snapshot deletes the MicroVM

--- a/CubeShim/shim/src/service/update_ext.rs
+++ b/CubeShim/shim/src/service/update_ext.rs
@@ -5,6 +5,7 @@
 use crate::log::Log;
 use crate::{common::CResult, errf, infof, sandbox::sb::SandBox};
 use cube_hypervisor::config::RestoreConfig;
+use cube_hypervisor::SnapshotType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -104,6 +105,20 @@ struct PauseSnapshotConfig {
     /// CommitSandbox layout (`--memory-vol`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory_vol_url: Option<String>,
+
+    /// Same values as cube-runtime `--snapshot-type`: `full`, `incremental`,
+    /// `soft-dirty`. Missing / empty / unknown defaults to Full so older
+    /// Cubelets keep the historical full dump.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_type: Option<String>,
+}
+
+fn parse_pause_snapshot_type(raw: Option<&str>) -> SnapshotType {
+    let s = raw.map(str::trim).unwrap_or("");
+    if s.is_empty() {
+        return SnapshotType::Full;
+    }
+    s.parse().unwrap_or(SnapshotType::Full)
 }
 
 /// Outcome of an extended update action.
@@ -204,14 +219,16 @@ async fn do_pause_to_snapshot(
         .into());
     }
 
+    let snapshot_type = parse_pause_snapshot_type(pause_cfg.snapshot_type.as_deref());
     infof!(
         log,
-        "pause to snapshot: destination={} memory_vol_url={:?}",
+        "pause to snapshot: destination={} memory_vol_url={:?} snapshot_type={}",
         destination_path,
-        pause_cfg.memory_vol_url
+        pause_cfg.memory_vol_url,
+        snapshot_type
     );
 
-    sb.pause_vm_to_snapshot(&destination_path, pause_cfg.memory_vol_url)
+    sb.pause_vm_to_snapshot(&destination_path, pause_cfg.memory_vol_url, snapshot_type)
         .await
         .map_err(|e| {
             errf!(log, "pause to snapshot failed: {}", e);
@@ -273,5 +290,28 @@ mod tests {
             cfg.memory_vol_url.as_deref(),
             Some("file:///dev/cubecow/mem1")
         );
+        assert_eq!(cfg.snapshot_type, None);
+        assert_eq!(
+            parse_pause_snapshot_type(cfg.snapshot_type.as_deref()),
+            SnapshotType::Full
+        );
+    }
+
+    #[test]
+    fn pause_snapshot_config_parses_soft_dirty() {
+        let raw = r#"{"destination_url":"/data/snap/pause-1","memory_vol_url":"file:///dev/cubecow/mem1","snapshot_type":"soft-dirty"}"#;
+        let cfg: PauseSnapshotConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(cfg.snapshot_type.as_deref(), Some("soft-dirty"));
+        assert_eq!(
+            parse_pause_snapshot_type(cfg.snapshot_type.as_deref()),
+            SnapshotType::SoftDirty
+        );
+        assert_eq!(
+            parse_pause_snapshot_type(Some("incremental")),
+            SnapshotType::Incremental
+        );
+        assert_eq!(parse_pause_snapshot_type(Some("weird")), SnapshotType::Full);
+        assert_eq!(parse_pause_snapshot_type(Some("")), SnapshotType::Full);
+        assert_eq!(parse_pause_snapshot_type(None), SnapshotType::Full);
     }
 }

--- a/Cubelet/pkg/constants/const.go
+++ b/Cubelet/pkg/constants/const.go
@@ -208,12 +208,12 @@ const (
 	// the local catalog under this id; Kind=pause_snapshot.
 	MasterAnnotationPauseSnapshotID = "cube.master.pause.snapshot.id"
 	// MasterAnnotationLaunchMemorySnapshotID is the template or customer
-	// snapshot the sandbox was first started from. Pause always clones
-	// this memory image and writes an incremental overlay. Resume and
-	// Commit must not overwrite it.
+	// snapshot the sandbox was first started from. Pause may clone it only
+	// when it is still the VM's last restore (first Pause after
+	// Create-from-template). Resume and Commit must not overwrite it.
 	MasterAnnotationLaunchMemorySnapshotID = "cube.master.launch.memory.snapshot.id"
 	// MasterAnnotationStorageBackend is the CoW backend Master passes on
-	// Pause / Commit (xfs｜s3). Empty means xfs.
+	// Pause / Commit (xfs/s3). Empty means xfs.
 	MasterAnnotationStorageBackend = "cube.master.storage.backend"
 	// MasterAnnotationSnapshotRemoteUUIDs is the JSON blob of remote
 	// volume uuids (rootfs/memory/metadata) for cubecow_import_lvol.

--- a/Cubelet/pkg/constants/const.go
+++ b/Cubelet/pkg/constants/const.go
@@ -207,6 +207,11 @@ const (
 	// id (same snap-* format as normal Commit snapshots). Cubelet only stores
 	// the local catalog under this id; Kind=pause_snapshot.
 	MasterAnnotationPauseSnapshotID = "cube.master.pause.snapshot.id"
+	// MasterAnnotationLaunchMemorySnapshotID is the template or customer
+	// snapshot the sandbox was first started from. Pause always clones
+	// this memory image and writes an incremental overlay. Resume and
+	// Commit must not overwrite it.
+	MasterAnnotationLaunchMemorySnapshotID = "cube.master.launch.memory.snapshot.id"
 	// MasterAnnotationStorageBackend is the CoW backend Master passes on
 	// Pause / Commit (xfs｜s3). Empty means xfs.
 	MasterAnnotationStorageBackend = "cube.master.storage.backend"

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -270,6 +270,7 @@ func (l *local) createContainers(ctx context.Context, flowOpts *workflow.CreateC
 	}
 
 	l.storeNumaQueues(ctx, sandBox, flowOpts)
+	stampLaunchMemoryAncestorOnce(sandBox, resolveLaunchAncestorSnapshotID(sandBox))
 	if snapshotID, ok := flowOpts.GetSnapshotTemplateID(); ok && flowOpts.IsRetoreSnapshot() {
 		now := time.Now().UTC()
 		setRuntimeSnapshotBindingLabels(sandBox, snapshotID, now)
@@ -280,9 +281,10 @@ func (l *local) createContainers(ctx context.Context, flowOpts *workflow.CreateC
 		// reflinkable base after the most recent commit's snapshot is
 		// deleted.
 		setRuntimeRestoreBaseLabels(sandBox, snapshotID, now)
-		// Resume-from-pause stamps pause snapshot id so Destroy can GC a
-		// leftover pause catalog if Pause-time CleanupTemplate of the
-		// previous live snap missed it.
+		// Resume-from-pause stamps pause snapshot id. XFS Resume still
+		// mmaps that package; CleanupTemplate no-ops while this label
+		// is live. Next Pause or Destroy GCs it. S3 already cloned onto
+		// sb-*-memory and CleanupTemplate deletes the package.
 		if pauseID := strings.TrimSpace(realReq.GetAnnotations()[constants.MasterAnnotationPauseSnapshotID]); pauseID != "" {
 			if sandBox.Labels == nil {
 				sandBox.Labels = map[string]string{}

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -281,10 +281,12 @@ func (l *local) createContainers(ctx context.Context, flowOpts *workflow.CreateC
 		// reflinkable base after the most recent commit's snapshot is
 		// deleted.
 		setRuntimeRestoreBaseLabels(sandBox, snapshotID, now)
-		// Resume-from-pause stamps pause snapshot id. XFS Resume still
-		// mmaps that package; CleanupTemplate no-ops while this label
-		// is live. Next Pause or Destroy GCs it. S3 already cloned onto
-		// sb-*-memory and CleanupTemplate deletes the package.
+		// Resume-from-pause stamps pause snapshot id. Master strips this
+		// key from user Create; only the thin Resume request carries it.
+		// XFS Resume still mmaps that package; CleanupTemplate no-ops
+		// while this label is live. Next Pause or Destroy GCs it. S3
+		// already cloned onto sb-*-memory and CleanupTemplate deletes
+		// the package.
 		if pauseID := strings.TrimSpace(realReq.GetAnnotations()[constants.MasterAnnotationPauseSnapshotID]); pauseID != "" {
 			if sandBox.Labels == nil {
 				sandBox.Labels = map[string]string{}

--- a/Cubelet/services/cubebox/pause_cow.go
+++ b/Cubelet/services/cubebox/pause_cow.go
@@ -31,6 +31,20 @@ import (
 type pauseSnapshotConfig struct {
 	DestinationURL string  `json:"destination_url"`
 	MemoryVolURL   *string `json:"memory_vol_url,omitempty"`
+	// SnapshotType is the same wire value CommitSandbox passes to
+	// cube-runtime (--snapshot-type): soft-dirty, incremental, or full.
+	SnapshotType string `json:"snapshot_type,omitempty"`
+}
+
+func newPauseSnapshotConfig(dest, memURL, snapshotType string) pauseSnapshotConfig {
+	cfg := pauseSnapshotConfig{
+		DestinationURL: dest,
+		SnapshotType:   normalizeSnapshotType(snapshotType),
+	}
+	if memURL != "" {
+		cfg.MemoryVolURL = &memURL
+	}
+	return cfg
 }
 
 // resolvePauseSnapshotID requires Master-allocated snap-* id (same format as
@@ -78,9 +92,57 @@ func stampedPauseSnapshotID(sb *cubeboxstore.CubeBox) string {
 	return strings.TrimSpace(sb.Annotations[constants.MasterAnnotationPauseSnapshotID])
 }
 
+func (s *service) listCubeboxes() []*cubeboxstore.CubeBox {
+	if s == nil || s.cubeboxMgr == nil || s.cubeboxMgr.cubeboxManger == nil {
+		return nil
+	}
+	return s.cubeboxMgr.cubeboxManger.List()
+}
+
+// keepLiveXFSPausePackage is true when Master's Resume-time CleanupTemplate
+// must leave this pause catalog on disk. XFS Resume mmaps the package file;
+// S3 already cloned onto sb-*-memory and must drop the package. PAUSED /
+// EXITED / UNKNOWN do not hold a live mmap, so DelPaused and leftover GC
+// still delete.
+func keepLiveXFSPausePackage(boxes []*cubeboxstore.CubeBox, snapID, backend string) bool {
+	if storage.IsS3Backend(backend) {
+		return false
+	}
+	snapID = strings.TrimSpace(snapID)
+	if snapID == "" {
+		return false
+	}
+	for _, sb := range boxes {
+		if sandboxHoldsLiveXFSPausePackage(sb, snapID) {
+			return true
+		}
+	}
+	return false
+}
+
+func sandboxHoldsLiveXFSPausePackage(sb *cubeboxstore.CubeBox, snapID string) bool {
+	if sb == nil || stampedPauseSnapshotID(sb) != snapID {
+		return false
+	}
+	st := sb.GetStatus()
+	if st == nil {
+		return false
+	}
+	switch st.Get().State() {
+	case cubebox.ContainerState_CONTAINER_CREATED,
+		cubebox.ContainerState_CONTAINER_RUNNING,
+		cubebox.ContainerState_CONTAINER_PAUSING:
+		return true
+	default:
+		return false
+	}
+}
+
 // replacedLivePauseSnapshotID is the pause snap Resume left as live. After a
 // new Pause succeeds, Cubelet CleanupTemplate's it (keep_tombstone already
 // tore down the running overlay). Empty on the first Pause from a template.
+// XFS Resume keeps that package on disk so this Pause can incremental-
+// overlay onto it; this GC is what finally removes it.
 func replacedLivePauseSnapshotID(prev, newID string) string {
 	prev = strings.TrimSpace(prev)
 	newID = strings.TrimSpace(newID)
@@ -122,6 +184,7 @@ func (s *service) updateWithPauseCow(
 	}
 	stepLog = stepLog.WithFields(CubeLog.Fields{"backend": backend})
 	prevLiveSnap := stampedPauseSnapshotID(sb)
+	stampLaunchMemoryAncestorOnce(sb, resolveLaunchAncestorSnapshotID(sb))
 	stampPauseSnapshotID(sb, snapID)
 	_ = s.cubeboxMgr.cubeboxManger.SyncByID(ctx, sb.ID)
 
@@ -172,7 +235,8 @@ func (s *service) updateWithPauseCow(
 		rsp.Ret.RetMsg = fmt.Sprintf("failed to resolve sandbox rootfs: %v", err)
 		return rsp, nil
 	}
-	memoryObject, err := storage.CreateMemoryVolumeFor(ctx, backend, snapID, memorySizeBytes)
+	// Own volume if this sandbox has one; otherwise the start template／snapshot.
+	memoryObject, snapshotType, err := preparePauseMemoryArtifact(ctx, stepLog, sb, snapID, memorySizeBytes, backend)
 	if err != nil {
 		if errors.Is(err, storage.ErrCowObjectAlreadyExists) {
 			rsp.Ret.RetCode = errorcode.ErrorCode_PreConditionFailed
@@ -182,7 +246,7 @@ func (s *service) updateWithPauseCow(
 		// cubecow may have left a partial tpl-<snapID>-memory after ENOSPC.
 		s.bestEffortCleanupPauseSnapshot(ctx, req.RequestID, snapID, backend)
 		rsp.Ret.RetCode = errorcode.ErrorCode_Unknown
-		rsp.Ret.RetMsg = fmt.Sprintf("failed to create pause memory volume: %v", err)
+		rsp.Ret.RetMsg = fmt.Sprintf("failed to prepare pause memory artifact: %v", err)
 		return rsp, nil
 	}
 	if err := validateSnapshotMemoryObject(memoryObject, memorySizeBytes); err != nil {
@@ -266,16 +330,14 @@ func (s *service) updateWithPauseCow(
 	}
 
 	memURL := snapshotMemoryVolURL(memoryObject.DevPath)
-	pauseCfg := pauseSnapshotConfig{
-		DestinationURL: layout.MetaWork,
-		MemoryVolURL:   &memURL,
-	}
+	pauseCfg := newPauseSnapshotConfig(layout.MetaWork, memURL, snapshotType)
 	cfgJSON, err := json.Marshal(pauseCfg)
 	if err != nil {
 		return failPause(errorcode.ErrorCode_Unknown, fmt.Sprintf("marshal pause snapshot config: %v", err))
 	}
 
-	stepLog.Infof("PauseToSnapshot destination=%s memory_vol=%s snapID=%s", layout.MetaWork, memURL, snapID)
+	stepLog.Infof("PauseToSnapshot destination=%s memory_vol=%s snapID=%s snapshot_type=%s",
+		layout.MetaWork, memURL, snapID, pauseCfg.SnapshotType)
 	// Shim returns Update OK and stays alive (Paused). Any error is Pause
 	// failure — do not treat ttrpc closed as success (shim no longer self-exits
 	// on PauseToSnapshot). Cubelet reaps the shim via keep_tombstone Delete below.
@@ -576,7 +638,9 @@ func cleanupBackendForPauseSnap(preferred, snapID string) string {
 // PAUSED without those flags is not expected on the user Destroy path; skip
 // GC so we cannot drop a live pause snap if someone cubecli-destroys a
 // tombstone. UNKNOWN / FAILED / RUNNING / PAUSING may hold half-finished
-// or leftover snaps.
+// or leftover snaps. After XFS Resume Master's CleanupTemplate no-ops
+// while this RUNNING sandbox still holds the pause id; a user Destroy
+// GCs it here (honorLiveXFSPause=false).
 func pauseSnapIDToGCOnDestroy(req *cubebox.DestroyCubeSandboxRequest, sb *cubeboxstore.CubeBox) string {
 	if sb == nil || isPauseKeepTombstone(req) || isPauseDeleteTombstone(req) {
 		return ""
@@ -595,11 +659,11 @@ func (s *service) bestEffortCleanupPauseSnapshot(ctx context.Context, requestID,
 	if snapID == "" {
 		return
 	}
-	cleanupRsp, err := s.CleanupTemplate(ctx, &cubebox.CleanupTemplateRequest{
+	cleanupRsp, err := s.cleanupTemplate(ctx, &cubebox.CleanupTemplateRequest{
 		RequestID:  requestID,
 		TemplateID: snapID,
 		Backend:    backend,
-	})
+	}, false)
 	if err != nil {
 		log.G(ctx).Warnf("pause-snap GC after destroy failed snap=%s: %v", snapID, err)
 		return

--- a/Cubelet/services/cubebox/pause_cow.go
+++ b/Cubelet/services/cubebox/pause_cow.go
@@ -104,6 +104,13 @@ func (s *service) listCubeboxes() []*cubeboxstore.CubeBox {
 // S3 already cloned onto sb-*-memory and must drop the package. PAUSED /
 // EXITED / UNKNOWN do not hold a live mmap, so DelPaused and leftover GC
 // still delete.
+//
+// Only Cubelet-stamped Labels count (not user Create annotations). Match
+// the current pause id or the restore-base: Pause overwrites the pause id
+// before the overlay finishes, so a delayed Cleanup of the previous package
+// must still see the mmap / incremental source. cleanupTemplate also
+// requires catalog Kind=pause_snapshot so a forged label cannot pin a
+// template or customer snap.
 func keepLiveXFSPausePackage(boxes []*cubeboxstore.CubeBox, snapID, backend string) bool {
 	if storage.IsS3Backend(backend) {
 		return false
@@ -121,9 +128,16 @@ func keepLiveXFSPausePackage(boxes []*cubeboxstore.CubeBox, snapID, backend stri
 }
 
 func sandboxHoldsLiveXFSPausePackage(sb *cubeboxstore.CubeBox, snapID string) bool {
-	if sb == nil || stampedPauseSnapshotID(sb) != snapID {
+	if sb == nil || !sandboxLiveForXFSPauseKeep(sb) {
 		return false
 	}
+	if cubeBoxLabel(sb, constants.MasterAnnotationPauseSnapshotID) == snapID {
+		return true
+	}
+	return cubeBoxLabel(sb, constants.MasterAnnotationRuntimeRestoreSnapshotID) == snapID
+}
+
+func sandboxLiveForXFSPauseKeep(sb *cubeboxstore.CubeBox) bool {
 	st := sb.GetStatus()
 	if st == nil {
 		return false
@@ -136,6 +150,22 @@ func sandboxHoldsLiveXFSPausePackage(sb *cubeboxstore.CubeBox, snapID string) bo
 	default:
 		return false
 	}
+}
+
+func cubeBoxLabel(sb *cubeboxstore.CubeBox, key string) string {
+	if sb == nil || key == "" {
+		return ""
+	}
+	sb.MetaLock.Lock()
+	defer sb.MetaLock.Unlock()
+	if sb.Labels == nil {
+		return ""
+	}
+	return strings.TrimSpace(sb.Labels[key])
+}
+
+func isPauseSnapshotCatalogKind(kind string) bool {
+	return strings.EqualFold(strings.TrimSpace(kind), storage.CatalogKindPauseSnapshot)
 }
 
 // replacedLivePauseSnapshotID is the pause snap Resume left as live. After a
@@ -235,7 +265,7 @@ func (s *service) updateWithPauseCow(
 		rsp.Ret.RetMsg = fmt.Sprintf("failed to resolve sandbox rootfs: %v", err)
 		return rsp, nil
 	}
-	// Own volume if this sandbox has one; otherwise the start template／snapshot.
+	// Own volume if this sandbox has one; otherwise the start template/snapshot.
 	memoryObject, snapshotType, err := preparePauseMemoryArtifact(ctx, stepLog, sb, snapID, memorySizeBytes, backend)
 	if err != nil {
 		if errors.Is(err, storage.ErrCowObjectAlreadyExists) {
@@ -406,7 +436,7 @@ func (s *service) updateWithPauseCow(
 		return failPause(errorcode.ErrorCode_Unknown,
 			fmt.Sprintf("failed to persist pause snapshot catalog for %s: %v", snapID, err))
 	}
-	// S3: seal memory／metadata work volumes to RO snapshots before Upload.
+	// S3: seal memory/metadata work volumes to RO snapshots before Upload.
 	if err := storage.FinalizeS3PackageSnapshots(workCtx, backend, snapID); err != nil {
 		_ = storage.UnmountS3Metadata(layout.MetaDir)
 		_ = os.RemoveAll(snapshotPath) // NOCC:Path Traversal()

--- a/Cubelet/services/cubebox/pause_cow_test.go
+++ b/Cubelet/services/cubebox/pause_cow_test.go
@@ -5,6 +5,7 @@
 package cubebox
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -180,5 +181,63 @@ func TestPauseCatalogBackendPrefersAnnotationThenLabel(t *testing.T) {
 	sb.AddAnnotations(map[string]string{constants.MasterAnnotationStorageBackend: "xfs"})
 	if got := pauseCatalogBackend(sb); got != "xfs" {
 		t.Fatalf("annotation should win, got %q", got)
+	}
+}
+
+func TestNewPauseSnapshotConfigCarriesSnapshotType(t *testing.T) {
+	t.Parallel()
+	cfg := newPauseSnapshotConfig("/data/snap/pause-1", "file:///dev/cubecow/mem1", snapshotTypeSoftDirty)
+	if cfg.DestinationURL != "/data/snap/pause-1" {
+		t.Fatalf("dest=%q", cfg.DestinationURL)
+	}
+	if cfg.MemoryVolURL == nil || *cfg.MemoryVolURL != "file:///dev/cubecow/mem1" {
+		t.Fatalf("memory_vol=%v", cfg.MemoryVolURL)
+	}
+	if cfg.SnapshotType != snapshotTypeSoftDirty {
+		t.Fatalf("snapshot_type=%q", cfg.SnapshotType)
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got pauseSnapshotConfig
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.SnapshotType != snapshotTypeSoftDirty {
+		t.Fatalf("roundtrip snapshot_type=%q", got.SnapshotType)
+	}
+
+	empty := newPauseSnapshotConfig("/data/snap/pause-1", "", "")
+	if empty.MemoryVolURL != nil {
+		t.Fatalf("empty mem url should omit pointer, got %v", empty.MemoryVolURL)
+	}
+	if empty.SnapshotType != snapshotTypeFull {
+		t.Fatalf("empty type must default to full, got %q", empty.SnapshotType)
+	}
+}
+
+func TestKeepLiveXFSPausePackage(t *testing.T) {
+	t.Parallel()
+	snap := "snap-keepxfs000000000000000001"
+	running := newCubeboxWithStatusForTest("sb-run", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(running, snap)
+	if !keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{running}, snap, "xfs") {
+		t.Fatal("XFS running resume must keep the pause package")
+	}
+	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{running}, snap, "s3") {
+		t.Fatal("S3 resume must drop the pause package")
+	}
+
+	paused := newCubeboxWithStatusForTest("sb-paused", cubeboxstore.Status{PausedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(paused, snap)
+	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{paused}, snap, "xfs") {
+		t.Fatal("PAUSED DelPaused must be allowed to delete the package")
+	}
+
+	other := newCubeboxWithStatusForTest("sb-other", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(other, "snap-other00000000000000000001")
+	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{other}, snap, "xfs") {
+		t.Fatal("unrelated sandbox must not pin this package")
 	}
 }

--- a/Cubelet/services/cubebox/pause_cow_test.go
+++ b/Cubelet/services/cubebox/pause_cow_test.go
@@ -240,4 +240,27 @@ func TestKeepLiveXFSPausePackage(t *testing.T) {
 	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{other}, snap, "xfs") {
 		t.Fatal("unrelated sandbox must not pin this package")
 	}
+
+	forged := newCubeboxWithStatusForTest("sb-forged", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	forged.AddAnnotations(map[string]string{constants.MasterAnnotationPauseSnapshotID: snap})
+	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{forged}, snap, "xfs") {
+		t.Fatal("user Create annotation must not pin an XFS pause package")
+	}
+
+	nextPause := newCubeboxWithStatusForTest("sb-next", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(nextPause, "snap-new000000000000000000000001")
+	nextPause.AddLabels(map[string]string{constants.MasterAnnotationRuntimeRestoreSnapshotID: snap})
+	if !keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{nextPause}, snap, "xfs") {
+		t.Fatal("restore-base must keep the previous package while Pause stamps a new id")
+	}
+}
+
+func TestIsPauseSnapshotCatalogKind(t *testing.T) {
+	t.Parallel()
+	if !isPauseSnapshotCatalogKind("pause_snapshot") {
+		t.Fatal("pause_snapshot must keep")
+	}
+	if isPauseSnapshotCatalogKind("snapshot") || isPauseSnapshotCatalogKind("template") || isPauseSnapshotCatalogKind("") {
+		t.Fatal("non-pause kinds must not keep")
+	}
 }

--- a/Cubelet/services/cubebox/pause_package_test.go
+++ b/Cubelet/services/cubebox/pause_package_test.go
@@ -104,8 +104,11 @@ func TestPauseRestoreBindingSurvivesPackedSpecSwap(t *testing.T) {
 	binding := pauseRestoreBindingFrom(thin, "snap-1", "s3")
 
 	packed := &cubebox.RunCubeSandboxRequest{
-		Containers:  []*cubebox.ContainerConfig{{Id: "c1", Name: "main"}},
-		Annotations: map[string]string{"kept": "yes"},
+		Containers: []*cubebox.ContainerConfig{{Id: "c1", Name: "main"}},
+		Annotations: map[string]string{
+			"kept": "yes",
+			constants.MasterAnnotationLaunchMemorySnapshotID: "tpl-T",
+		},
 	}
 	req := &cubebox.RunCubeSandboxRequest{}
 	*req = *packed
@@ -121,6 +124,7 @@ func TestPauseRestoreBindingSurvivesPackedSpecSwap(t *testing.T) {
 	assert.Equal(t, `{"rootfs":"r1","memory":"m1","metadata":"d1"}`,
 		req.Annotations[constants.MasterAnnotationSnapshotRemoteUUIDs])
 	assert.Equal(t, "true", req.Annotations[constants.MasterAnnotationSnapshotCrossNode])
+	assert.Equal(t, "tpl-T", req.Annotations[constants.MasterAnnotationLaunchMemorySnapshotID])
 	assert.NotEmpty(t, req.Annotations[constants.MasterAnnotationRuntimeSnapshotAttachedAt])
 }
 

--- a/Cubelet/services/cubebox/snapshot_base_memory.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory.go
@@ -115,6 +115,87 @@ func resolveRestoreBaseMemoryObject(ctx context.Context, cb *cubeboxstore.CubeBo
 	return resolveMemoryObjectFromSnapshotID(ctx, backend, resolveRestoreBaseSnapshotID(cb))
 }
 
+// resolveLaunchAncestorSnapshotID is the memory base Pause copies from:
+// the template or customer snapshot this sandbox was first started from.
+// It ignores last-commit / last-restore labels and the pause snap itself
+// (those change across Pause／Resume／Commit).
+func resolveLaunchAncestorSnapshotID(cb *cubeboxstore.CubeBox) string {
+	if cb == nil {
+		return ""
+	}
+	pauseID := stampedPauseSnapshotID(cb)
+	for _, id := range []string{
+		cb.Labels[constants.MasterAnnotationLaunchMemorySnapshotID],
+		cb.Annotations[constants.MasterAnnotationLaunchMemorySnapshotID],
+		cb.Annotations[constants.MasterAnnotationRuntimeSnapshotID],
+		cb.Annotations[constants.MasterAnnotationAppSnapshotTemplateID],
+	} {
+		if isUsableLaunchAncestorID(id, pauseID) {
+			return strings.TrimSpace(id)
+		}
+	}
+	return ""
+}
+
+// launchAncestorIsLastRestore reports whether an incremental overlay onto a
+// clone of the launch ancestor is valid. pagemap_anon records anon pages
+// dirty *since the last restore*; the dest must already hold every still-
+// clean page from that restore. The template／first customer snap only
+// satisfies that when the VM was last restored from the same image — the
+// first Pause after Create-from-template.
+//
+// After Resume the restore-base is the pause package. XFS keeps that
+// catalog so the next Pause clones it (S3 already has a live memory
+// volume). Cloning the template and asking for incremental would drop
+// every page that landed in the pause image and stayed clean. The next
+// restore then comes up holey: agent health can still answer, then
+// set_guest_date_time／reseed hang on ttrpc.
+func launchAncestorIsLastRestore(cb *cubeboxstore.CubeBox, ancestorID string) bool {
+	ancestorID = strings.TrimSpace(ancestorID)
+	if ancestorID == "" {
+		return false
+	}
+	restoreID := strings.TrimSpace(resolveRestoreBaseSnapshotID(cb))
+	if restoreID == runtimeSnapshotBindingInvalidID {
+		return false
+	}
+	if restoreID == "" {
+		// No restore-base label: image-based start, or a sandbox that
+		// predates the label. Ancestor incremental matches first Pause
+		// after Create-from-template. Do not consult the in-progress
+		// pause id — Pause stamps that *before* this function runs.
+		return true
+	}
+	return restoreID == ancestorID
+}
+
+func isUsableLaunchAncestorID(id, pauseID string) bool {
+	id = strings.TrimSpace(id)
+	if id == "" || id == runtimeSnapshotBindingInvalidID {
+		return false
+	}
+	if pauseID != "" && id == pauseID {
+		return false
+	}
+	return true
+}
+
+func stampLaunchMemoryAncestorOnce(cb *cubeboxstore.CubeBox, id string) {
+	if cb == nil {
+		return
+	}
+	id = strings.TrimSpace(id)
+	if !isUsableLaunchAncestorID(id, stampedPauseSnapshotID(cb)) {
+		return
+	}
+	if strings.TrimSpace(cb.Labels[constants.MasterAnnotationLaunchMemorySnapshotID]) != "" ||
+		strings.TrimSpace(cb.Annotations[constants.MasterAnnotationLaunchMemorySnapshotID]) != "" {
+		return
+	}
+	cb.AddLabels(map[string]string{constants.MasterAnnotationLaunchMemorySnapshotID: id})
+	cb.AddAnnotations(map[string]string{constants.MasterAnnotationLaunchMemorySnapshotID: id})
+}
+
 func resolveMemoryObjectFromSnapshotID(ctx context.Context, backend, snapshotID string) (*storage.CowSnapshotObject, error) {
 	if snapshotID == "" {
 		return nil, fmt.Errorf("%w: sandbox is not bound to any snapshot or template", ErrNoBaseMemoryForIncremental)
@@ -142,9 +223,97 @@ func resolveMemoryObjectFromSnapshotID(ctx context.Context, backend, snapshotID 
 	}, nil
 }
 
+// preparePauseMemoryArtifact builds the dest the VMM writes an incremental
+// overlay into.
+//
+//  1. Own memory volume (S3 same-node resume clone or cross-node import).
+//     S3 Resume deletes the pause package after cloning onto this disk.
+//  2. Launch ancestor, but only when that image is the VM's last restore
+//     (first Pause after Create-from-template). See
+//     [launchAncestorIsLastRestore].
+//  3. Last-restore catalog. XFS Resume keeps the pause package so this
+//     Pause can incremental-overlay onto that image; Cubelet GCs the
+//     old package after this Pause succeeds (or on Destroy).
+//  4. Full dump into an empty volume when no catalog／volume base is
+//     left (template gone, or an S3 own-volume clone that failed).
+func preparePauseMemoryArtifact(
+	ctx context.Context,
+	stepLog *log.CubeWrapperLogEntry,
+	cb *cubeboxstore.CubeBox,
+	templateID string,
+	memorySizeBytes uint64,
+	backend string,
+) (*storage.CowSnapshotObject, string, error) {
+	stampLaunchMemoryAncestorOnce(cb, resolveLaunchAncestorSnapshotID(cb))
+	sandboxID := ""
+	if cb != nil {
+		sandboxID = strings.TrimSpace(cb.ID)
+		if sandboxID == "" {
+			sandboxID = strings.TrimSpace(cb.SandboxID)
+		}
+	}
+	if live, liveErr := storage.GetImportedSandboxMemoryFor(ctx, backend, sandboxID); liveErr != nil {
+		stepLog.Warnf("pause memory artifact: own volume lookup failed (%v); trying a catalog base", liveErr)
+	} else if live != nil {
+		memoryObject, cloneErr := storage.CommitMemoryFromBaseFor(ctx, backend, live, templateID, memorySizeBytes)
+		if cloneErr == nil {
+			stepLog.Infof("pause memory artifact: cloned own volume %s/%s -> %s, snapshot type=%s",
+				live.Name, live.Kind, memoryObject.Name, snapshotTypeIncremental)
+			return memoryObject, snapshotTypeIncremental, nil
+		}
+		stepLog.Warnf("pause memory artifact: own volume %s clone failed (%v); trying a catalog base", live.Name, cloneErr)
+	}
+
+	ancestorID := resolveLaunchAncestorSnapshotID(cb)
+	restoreID := resolveRestoreBaseSnapshotID(cb)
+	if launchAncestorIsLastRestore(cb, ancestorID) {
+		base, err := resolveMemoryObjectFromSnapshotID(ctx, backend, ancestorID)
+		if err == nil {
+			memoryObject, cloneErr := storage.CommitMemoryFromBaseFor(ctx, backend, base, templateID, memorySizeBytes)
+			if cloneErr != nil {
+				return nil, "", cloneErr
+			}
+			stepLog.Infof("pause memory artifact: cloned launch ancestor %s (%s/%s) -> %s, snapshot type=%s",
+				ancestorID, base.Name, base.Kind, memoryObject.Name, snapshotTypeIncremental)
+			return memoryObject, snapshotTypeIncremental, nil
+		}
+		if !errors.Is(err, ErrNoBaseMemoryForIncremental) {
+			return nil, "", err
+		}
+		stepLog.Warnf("pause memory artifact: launch ancestor unavailable (%v); falling back to full snapshot", err)
+	} else {
+		stepLog.Warnf("pause memory artifact: launch ancestor %s is not last restore %s; skipping ancestor incremental",
+			ancestorID, restoreID)
+		if restoreID != "" && restoreID != runtimeSnapshotBindingInvalidID {
+			base, err := resolveMemoryObjectFromSnapshotID(ctx, backend, restoreID)
+			if err == nil {
+				memoryObject, cloneErr := storage.CommitMemoryFromBaseFor(ctx, backend, base, templateID, memorySizeBytes)
+				if cloneErr != nil {
+					return nil, "", cloneErr
+				}
+				stepLog.Infof("pause memory artifact: cloned last restore %s (%s/%s) -> %s, snapshot type=%s",
+					restoreID, base.Name, base.Kind, memoryObject.Name, snapshotTypeIncremental)
+				return memoryObject, snapshotTypeIncremental, nil
+			}
+			if !errors.Is(err, ErrNoBaseMemoryForIncremental) {
+				return nil, "", err
+			}
+			stepLog.Warnf("pause memory artifact: last restore %s unavailable (%v); falling back to full snapshot", restoreID, err)
+		}
+	}
+
+	memoryObject, createErr := storage.CreateMemoryVolumeFor(ctx, backend, templateID, memorySizeBytes)
+	if createErr != nil {
+		return nil, "", createErr
+	}
+	stepLog.Infof("pause memory artifact: created empty memory volume %s/%s, snapshot type=%s",
+		memoryObject.Name, memoryObject.Kind, snapshotTypeFull)
+	return memoryObject, snapshotTypeFull, nil
+}
+
 // prepareCommitMemoryArtifact returns the cubecow memory object that
-// cube-runtime will write its memory snapshot into, plus the snapshot type
-// flag to pass to cube-runtime for this commit.
+// cube-runtime (CommitSandbox) will write its memory snapshot into, plus
+// the snapshot type flag for this capture.
 //
 // Three-tier degradation:
 //
@@ -166,9 +335,10 @@ func resolveMemoryObjectFromSnapshotID(ctx context.Context, backend, snapshotID 
 // pagemap_anon's bitmap captures every anon page dirty *since the last
 // restore*, which is exactly the delta we need to overlay onto that base to
 // produce a self-contained image. If the VM is later restored from an
-// opaque source that Cubelet cannot reflink from (pause/resume's internal
-// full snapshot), that restore path invalidates this label so this tier is
-// skipped.
+// opaque source that Cubelet cannot reflink from, that restore path
+// invalidates this label so this tier is skipped. Pause uses
+// preparePauseMemoryArtifact: own vol, then ancestor only when it is
+// the last restore, otherwise last-restore catalog or full.
 //
 // Tier 3 — full + fresh empty volume. The last-resort fallback when even
 // the last-restore base file is gone (e.g. the source template was deleted
@@ -180,8 +350,7 @@ func resolveMemoryObjectFromSnapshotID(ctx context.Context, backend, snapshotID 
 // failures surface to the caller.
 //
 // The caller owns the returned cubecow object: any subsequent failure in
-// the CommitSandbox flow must call DeleteCowObject to avoid orphaned
-// cubecow state.
+// CommitSandbox must delete it to avoid orphaned cubecow state.
 func prepareCommitMemoryArtifact(
 	ctx context.Context,
 	stepLog *log.CubeWrapperLogEntry,
@@ -197,7 +366,7 @@ func prepareCommitMemoryArtifact(
 		if err != nil {
 			return nil, "", err
 		}
-		stepLog.Infof("CommitSandbox: reflink-cloned base memory %s/%s -> %s, snapshot type=%s",
+		stepLog.Infof("memory artifact: reflink-cloned base memory %s/%s -> %s, snapshot type=%s",
 			baseMemoryObject.Name, baseMemoryObject.Kind, memoryObject.Name, snapshotTypeSoftDirty)
 		return memoryObject, snapshotTypeSoftDirty, nil
 	}
@@ -218,7 +387,7 @@ func prepareCommitMemoryArtifact(
 		if err != nil {
 			return nil, "", err
 		}
-		stepLog.Warnf("CommitSandbox: previous-snapshot base unavailable (%v); "+
+		stepLog.Warnf("memory artifact: previous-snapshot base unavailable (%v); "+
 			"falling back to incremental(pagemap_anon) over last-restore base %s/%s -> %s",
 			baseErr, restoreBase.Name, restoreBase.Kind, memoryObject.Name)
 		return memoryObject, snapshotTypeIncremental, nil
@@ -228,13 +397,13 @@ func prepareCommitMemoryArtifact(
 	}
 
 	// ─── Tier 3: full + fresh empty volume ────────────────────────────
-	stepLog.Warnf("CommitSandbox: both previous-snapshot base (%v) and last-restore base (%v) "+
+	stepLog.Warnf("memory artifact: both previous-snapshot base (%v) and last-restore base (%v) "+
 		"unavailable; falling back to full snapshot", baseErr, restoreErr)
 	memoryObject, err := storage.CreateMemoryVolumeFor(ctx, backend, templateID, memorySizeBytes)
 	if err != nil {
 		return nil, "", err
 	}
-	stepLog.Infof("CommitSandbox: created empty memory volume %s/%s, snapshot type=%s",
+	stepLog.Infof("memory artifact: created empty memory volume %s/%s, snapshot type=%s",
 		memoryObject.Name, memoryObject.Kind, snapshotTypeFull)
 	return memoryObject, snapshotTypeFull, nil
 }

--- a/Cubelet/services/cubebox/snapshot_base_memory.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory.go
@@ -118,7 +118,7 @@ func resolveRestoreBaseMemoryObject(ctx context.Context, cb *cubeboxstore.CubeBo
 // resolveLaunchAncestorSnapshotID is the memory base Pause copies from:
 // the template or customer snapshot this sandbox was first started from.
 // It ignores last-commit / last-restore labels and the pause snap itself
-// (those change across Pause／Resume／Commit).
+// (those change across Pause/Resume/Commit).
 func resolveLaunchAncestorSnapshotID(cb *cubeboxstore.CubeBox) string {
 	if cb == nil {
 		return ""
@@ -140,7 +140,7 @@ func resolveLaunchAncestorSnapshotID(cb *cubeboxstore.CubeBox) string {
 // launchAncestorIsLastRestore reports whether an incremental overlay onto a
 // clone of the launch ancestor is valid. pagemap_anon records anon pages
 // dirty *since the last restore*; the dest must already hold every still-
-// clean page from that restore. The template／first customer snap only
+// clean page from that restore. The template/first customer snap only
 // satisfies that when the VM was last restored from the same image — the
 // first Pause after Create-from-template.
 //
@@ -149,7 +149,7 @@ func resolveLaunchAncestorSnapshotID(cb *cubeboxstore.CubeBox) string {
 // volume). Cloning the template and asking for incremental would drop
 // every page that landed in the pause image and stayed clean. The next
 // restore then comes up holey: agent health can still answer, then
-// set_guest_date_time／reseed hang on ttrpc.
+// set_guest_date_time/reseed hang on ttrpc.
 func launchAncestorIsLastRestore(cb *cubeboxstore.CubeBox, ancestorID string) bool {
 	ancestorID = strings.TrimSpace(ancestorID)
 	if ancestorID == "" {
@@ -234,7 +234,7 @@ func resolveMemoryObjectFromSnapshotID(ctx context.Context, backend, snapshotID 
 //  3. Last-restore catalog. XFS Resume keeps the pause package so this
 //     Pause can incremental-overlay onto that image; Cubelet GCs the
 //     old package after this Pause succeeds (or on Destroy).
-//  4. Full dump into an empty volume when no catalog／volume base is
+//  4. Full dump into an empty volume when no catalog/volume base is
 //     left (template gone, or an S3 own-volume clone that failed).
 func preparePauseMemoryArtifact(
 	ctx context.Context,

--- a/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
@@ -289,3 +289,75 @@ func TestOpaqueRestoreInvalidatesIncrementalBases(t *testing.T) {
 	assert.Equal(t, "snap-full-after-resume", resolveBaseSnapshotID(cb))
 	assert.Equal(t, runtimeSnapshotBindingInvalidID, resolveRestoreBaseSnapshotID(cb))
 }
+
+func TestResolveLaunchAncestorKeepsStartImage(t *testing.T) {
+	fromTpl := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			Annotations: map[string]string{
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-T",
+			},
+		},
+	}
+	assert.Equal(t, "tpl-T", resolveLaunchAncestorSnapshotID(fromTpl))
+
+	fromSnap := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			Annotations: map[string]string{
+				constants.MasterAnnotationRuntimeSnapshotID:     "snap-customer",
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-T",
+			},
+		},
+	}
+	assert.Equal(t, "snap-customer", resolveLaunchAncestorSnapshotID(fromSnap))
+
+	// Commit／Resume rewrite runtime labels; Pause must still copy the start image.
+	now := time.Now().UTC()
+	setRuntimeSnapshotBindingLabels(fromTpl, "snap-after-commit", now)
+	invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(fromTpl, now.Add(time.Second))
+	fromTpl.AddAnnotations(map[string]string{
+		constants.MasterAnnotationRuntimeSnapshotID: runtimeSnapshotBindingInvalidID,
+	})
+	assert.Equal(t, "tpl-T", resolveLaunchAncestorSnapshotID(fromTpl))
+
+	stampLaunchMemoryAncestorOnce(fromSnap, "snap-customer")
+	stampPauseSnapshotID(fromSnap, "snap-pause-1")
+	fromSnap.AddAnnotations(map[string]string{
+		constants.MasterAnnotationRuntimeSnapshotID: "snap-pause-1",
+	})
+	invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(fromSnap, now)
+	assert.Equal(t, "snap-customer", resolveLaunchAncestorSnapshotID(fromSnap),
+		"Resume must not replace the FromSnap ancestor with the pause package")
+
+	stampLaunchMemoryAncestorOnce(fromSnap, "tpl-T")
+	assert.Equal(t, "snap-customer", fromSnap.Labels[constants.MasterAnnotationLaunchMemorySnapshotID],
+		"launch ancestor is written once and never overwritten")
+}
+
+func TestLaunchAncestorIsLastRestore(t *testing.T) {
+	fromTpl := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			Annotations: map[string]string{
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-T",
+			},
+		},
+	}
+	assert.True(t, launchAncestorIsLastRestore(fromTpl, "tpl-T"),
+		"first Pause after Create-from-template: no restore-base yet is OK")
+
+	now := time.Now().UTC()
+	setRuntimeRestoreBaseLabels(fromTpl, "tpl-T", now)
+	assert.True(t, launchAncestorIsLastRestore(fromTpl, "tpl-T"),
+		"Create-from-template stamps restore-base to the same ancestor")
+
+	setRuntimeRestoreBaseLabels(fromTpl, "snap-pause-1", now.Add(time.Second))
+	stampPauseSnapshotID(fromTpl, "snap-pause-1")
+	assert.False(t, launchAncestorIsLastRestore(fromTpl, "tpl-T"),
+		"after Resume the restore-base is the pause package, not the template")
+
+	invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(fromTpl, now.Add(2*time.Second))
+	assert.False(t, launchAncestorIsLastRestore(fromTpl, "tpl-T"),
+		"opaque restore must not incremental-overlay onto the ancestor")
+
+	assert.False(t, launchAncestorIsLastRestore(fromTpl, ""),
+		"empty ancestor is never a valid incremental dest")
+}

--- a/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
@@ -310,7 +310,7 @@ func TestResolveLaunchAncestorKeepsStartImage(t *testing.T) {
 	}
 	assert.Equal(t, "snap-customer", resolveLaunchAncestorSnapshotID(fromSnap))
 
-	// Commit／Resume rewrite runtime labels; Pause must still copy the start image.
+	// Commit/Resume rewrite runtime labels; Pause must still copy the start image.
 	now := time.Now().UTC()
 	setRuntimeSnapshotBindingLabels(fromTpl, "snap-after-commit", now)
 	invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(fromTpl, now.Add(time.Second))

--- a/Cubelet/services/cubebox/snapshot_runtime_binding.go
+++ b/Cubelet/services/cubebox/snapshot_runtime_binding.go
@@ -78,10 +78,10 @@ func setRuntimeRestoreBaseLabels(cb *cubeboxstore.CubeBox, snapshotID string, at
 
 // invalidateRuntimeSnapshotBindingsAfterOpaqueRestore marks both runtime
 // memory bases as unusable after the VM has been restored from a source that
-// Cubelet cannot later reflink from (for example CubeShim's pause/resume path,
-// which restores from /data/cubelet/root/pausevm/<sandbox> with no cubecow
-// memory_vol_url). The next CommitSandbox must therefore produce a full
-// snapshot unless it first establishes a new runtime snapshot binding.
+// Cubelet cannot later reflink from. CoW Pause/Resume now writes a catalog
+// memory object like CommitSandbox; Create-from-pause-snap stamps a real
+// restore-base id. This helper remains for leftover in-place resume
+// convergence (TaskResumed) that still has no cubecow dest.
 func invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(cb *cubeboxstore.CubeBox, attachedAt time.Time) {
 	if cb == nil {
 		return

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -502,14 +502,17 @@ func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 		rsp.Ret.RetMsg = err.Error()
 		return rsp, nil
 	}
-	if _, catErr := storage.GetLocalSnapshotFor(ctx, backend, rsp.TemplateID); errors.Is(catErr, storage.ErrSnapshotCatalogNotFound) {
+	entry, catErr := storage.GetLocalSnapshotFor(ctx, backend, rsp.TemplateID)
+	if errors.Is(catErr, storage.ErrSnapshotCatalogNotFound) {
 		if other := otherCowBackend(backend); other != backend {
-			if _, altErr := storage.GetLocalSnapshotFor(ctx, other, rsp.TemplateID); altErr == nil {
+			if alt, altErr := storage.GetLocalSnapshotFor(ctx, other, rsp.TemplateID); altErr == nil {
 				backend = other
+				entry = alt
 			}
 		}
 	}
-	if honorLiveXFSPause && keepLiveXFSPausePackage(s.listCubeboxes(), rsp.TemplateID, backend) {
+	if honorLiveXFSPause && keepLiveXFSPausePackage(s.listCubeboxes(), rsp.TemplateID, backend) &&
+		entry != nil && isPauseSnapshotCatalogKind(entry.Kind) {
 		log.G(ctx).Infof("CleanupTemplate %s: keeping XFS pause package; a live sandbox still restores from it",
 			rsp.TemplateID)
 		return rsp, nil

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -463,6 +463,14 @@ func validateNoHostPathVolumes(config *cubebox.ContainerConfig) error {
 }
 
 func (s *service) CleanupTemplate(ctx context.Context, req *cubebox.CleanupTemplateRequest) (*cubebox.CleanupTemplateResponse, error) {
+	return s.cleanupTemplate(ctx, req, true)
+}
+
+// cleanupTemplate removes a catalog package. honorLiveXFSPause is true for
+// the Master RPC: XFS Resume still mmaps the pause file, so a Cleanup of
+// that snap while a live sandbox holds cube.master.pause.snapshot.id is a
+// successful no-op. Cubelet's own next-Pause / Destroy GC passes false.
+func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTemplateRequest, honorLiveXFSPause bool) (*cubebox.CleanupTemplateResponse, error) {
 	rsp := &cubebox.CleanupTemplateResponse{
 		RequestID:  req.GetRequestID(),
 		TemplateID: strings.TrimSpace(req.GetTemplateID()),
@@ -500,6 +508,11 @@ func (s *service) CleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 				backend = other
 			}
 		}
+	}
+	if honorLiveXFSPause && keepLiveXFSPausePackage(s.listCubeboxes(), rsp.TemplateID, backend) {
+		log.G(ctx).Infof("CleanupTemplate %s: keeping XFS pause package; a live sandbox still restores from it",
+			rsp.TemplateID)
+		return rsp, nil
 	}
 	refs, snapshotPath, err := resolveCleanupRefs(ctx, backend, rsp.TemplateID, req.GetObjects(), req.GetSnapshotPath())
 	if err != nil {

--- a/Cubelet/storage/cow_store_ops.go
+++ b/Cubelet/storage/cow_store_ops.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/cubecow"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/storage/cow"
 )
 
@@ -187,6 +188,43 @@ func GetSandboxRootfsFor(ctx context.Context, backend, sandboxID, preferredVolum
 		return nil, err
 	}
 	return backendFileInfoToSnapshotObject(ctx, store, rootfs)
+}
+
+// GetImportedSandboxMemoryFor returns the sandbox-private memory disk Create
+// minted (cross-node import or same-node S3 pause-resume clone). Empty / missing
+// is not an error: XFS template start and XFS Resume never create one.
+func GetImportedSandboxMemoryFor(ctx context.Context, backend, sandboxID string) (*CowSnapshotObject, error) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if localStorage == nil || sandboxID == "" {
+		return nil, nil
+	}
+	info, err := localStorage.readBackendFileInfo(ctx, sandboxID)
+	if err != nil {
+		if errors.Is(err, utils.ErrorKeyNotFound) || errors.Is(err, utils.ErrorBucketNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if info == nil {
+		return nil, nil
+	}
+	name := strings.TrimSpace(info.ImportedMemoryVol)
+	if name == "" {
+		return nil, nil
+	}
+	store, err := requireCowStoreFor(backend)
+	if err != nil {
+		return nil, err
+	}
+	devPath, err := store.ResolveDevPath(ctx, name, cowKindVolume)
+	if err != nil {
+		return nil, fmt.Errorf("resolve imported memory %s: %w", name, err)
+	}
+	return &CowSnapshotObject{
+		Name:    name,
+		Kind:    CowKindVolume,
+		DevPath: devPath,
+	}, nil
 }
 
 // CommitRootfs commits source rootfs into tpl-<id>-rootfs on the default (XFS) Store.

--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -994,10 +994,11 @@ func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.
 	backend := createContextStorageBackend(opts)
 	// Cross-node imports a sandbox-private memory volume. XFS template
 	// start / pause resume / FromSnap mmap the original snapshot file
-	// MAP_PRIVATE; CH keeps it open so later unlink of the package is
-	// safe and a clone would only duplicate bytes. Same-node S3 pause
-	// resume still clones onto sb-<id>-memory: deactivate of an NVMe
-	// lvol would yank the live disk, unlike an unlinked XFS file.
+	// MAP_PRIVATE. Master's Resume CleanupTemplate is a no-op on XFS
+	// while the live sandbox still holds that pause id; next Pause or
+	// Destroy unlinks the package (CH keeps the fd open). Same-node S3
+	// pause resume still clones onto sb-<id>-memory: deactivate of an
+	// NVMe lvol would yank the live disk, unlike an unlinked XFS file.
 	if imp := CrossNodeSandboxImport(annotations); imp != nil {
 		name, devPath, err := imp.Memory(ctx)
 		if err != nil {

--- a/Cubelet/storage/s3_pause_memory_src_test.go
+++ b/Cubelet/storage/s3_pause_memory_src_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package storage
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsS3CloneSourceMustBeSnapshot(t *testing.T) {
+	if isS3CloneSourceMustBeSnapshot(nil) {
+		t.Fatal("nil must not match")
+	}
+	volErr := errors.New("invalid argument: 'sb-abc-memory' is a volume; create_volume_from_snapshot requires a snapshot as source")
+	if !isS3CloneSourceMustBeSnapshot(volErr) {
+		t.Fatalf("volume source should retry via snapshot, err=%v", volErr)
+	}
+	if isS3CloneSourceMustBeSnapshot(errors.New("not found: lvol not found")) {
+		t.Fatal("unrelated errors must not look like a volume-source mismatch")
+	}
+}

--- a/Cubelet/storage/s3_volume_manager.go
+++ b/Cubelet/storage/s3_volume_manager.go
@@ -173,11 +173,14 @@ func (m *S3Cow) CreateMemoryVolume(ctx context.Context, templateID string, sizeB
 }
 
 // CommitTemplateMemory derives a writable memory volume for templateID from
-// a RO memory snapshot (create_volume_from_snapshot). Source must be a
-// snapshot — seal prior package memory before using it as a clone base.
+// a RO memory snapshot (create_volume_from_snapshot). A live sandbox volume
+// (imported / cloned sb-*-memory) is snapshotted first, then cloned.
 func (m *S3Cow) CommitTemplateMemory(ctx context.Context, sourceName, templateID string, sizeBytes uint64) (*cowVolume, error) {
 	volumeName := cowTemplateMemoryName(templateID)
 	devPath, err := m.createOrResolveVolumeFromSnapshot(ctx, sourceName, volumeName)
+	if err != nil && isS3CloneSourceMustBeSnapshot(err) {
+		devPath, err = m.cloneVolumeFromWritableSource(ctx, sourceName, volumeName)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -213,6 +216,17 @@ func (m *S3Cow) CommitTemplateMemory(ctx context.Context, sourceName, templateID
 
 func (m *S3Cow) CloneSandboxMemory(ctx context.Context, sandboxID, sourceName string) (*cowVolume, error) {
 	return cloneSandboxMemory(ctx, m, sandboxID, sourceName)
+}
+
+// cloneVolumeFromWritableSource snapshots a live volume, clones that snap
+// into dest, then deletes the snap. The snap exists only inside this call.
+func (m *S3Cow) cloneVolumeFromWritableSource(ctx context.Context, sourceVol, destVol string) (string, error) {
+	srcSnap := destVol + "-src"
+	if _, err := m.createOrResolveSnapshotPathFromSource(ctx, sourceVol, srcSnap); err != nil {
+		return "", fmt.Errorf("snapshot live memory %s: %w", sourceVol, err)
+	}
+	defer func() { _ = m.DeleteByKind(ctx, srcSnap, cowKindSnapshot) }()
+	return m.createOrResolveVolumeFromSnapshot(ctx, srcSnap, destVol)
 }
 
 func (m *S3Cow) createInitializedTemplateVolume(ctx context.Context, name string, sizeBytes uint64) (*cowVolume, error) {
@@ -489,4 +503,12 @@ func (m *S3Cow) oppositeDeleteFunc(kind string) func(string) error {
 	default:
 		return nil
 	}
+}
+
+func isS3CloneSourceMustBeSnapshot(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "is a volume") && strings.Contains(msg, "snapshot")
 }


### PR DESCRIPTION
## Summary
- Pause now writes memory the same way CommitSandbox does: clone a dest, then incremental-overlay dirty pages (`snapshot_type` on the shim Pause path).
- After Resume, the next Pause overlays onto the last-restore image (XFS keeps the pause package on disk; S3 already cloned onto `sb-*-memory` and still drops the package).
- Master still always sends `CleanupTemplate`. Cubelet no-ops that RPC on XFS while a live sandbox holds `cube.master.pause.snapshot.id`; the next Pause or Destroy actually deletes the package.

## Test plan
- [x] `make cubelet` / `make cubemaster` on builder
- [x] Cubelet `go test ./pkg/constants/ ./services/cubebox/`
- [x] Cubelet storage unit tests for the S3 volume-source clone path
- [x] CubeMaster `go test ./pkg/service/sandbox/ -run Resume|Pause`
- [x] Shim `cargo test pause_snapshot_config`
- [x] Cluster: XFS keep-package loop, Pause1–4 + write load, S3 same-node / cross-node Resume; wiki combo minus known Device-busy skips; B6 after cubelet restart once cubelet is ready

Signed-off-by: ls-ggg <335814617@qq.com>