### PR TITLE
feat(one-click): support external PostgreSQL via CUBE_DATABASE_DRIVER

### DIFF
--- a/configs/single-node/cubemaster.yaml
+++ b/configs/single-node/cubemaster.yaml
@@ -54,6 +54,8 @@ req_template_conf:
     {"volumes":[{"name":"tmp","volume_source":{"empty_dir":{"medium":0}}}],"containers":[{"name":"cubebox-default","envs":[{"key":"TZ","value":"Asia/Shanghai"},{"key":"TERM","value":"xterm"}],"volume_mounts":[{"name":"tmp","container_path":"/"}],"security_context":{"privileged":true,"readonly_rootfs":false,"no_new_privs":false}}],"network_type":"tap","cube_network_config":{"allowInternetAccess":true,"denyOut":["10.0.0.0/8","100.64.0.0/10","172.16.0.0/12","192.168.0.0/16"]}}
 
 instance_db_config:
+  # mysql (default / bundled) or postgres (external only; one-click never ships PG).
+  driver: "mysql"
   addr: "127.0.0.1:__CUBE_SANDBOX_MYSQL_PORT__"
   user: "__CUBE_SANDBOX_MYSQL_USER__"
   pwd: "__CUBE_SANDBOX_MYSQL_PASSWORD__"

--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -335,19 +335,29 @@ During installation, runtime files are prepared in this directory and the follow
 - `redis:7-alpine`
 - `minio` (S3-compatible volume backend; explicit via `CUBE_SANDBOX_MINIO_ENABLED`, default on)
 
-### Using an external MySQL / Redis
+### Using an external MySQL / PostgreSQL / Redis
 
-To point CubeSandbox at an existing MySQL/Redis server instead of the bundled
-local containers, set the following in `.env` before running `install.sh`
-(see `env.example`):
+To point CubeSandbox at an existing MySQL, PostgreSQL, or Redis server instead
+of the bundled local containers, set the following in `.env` before running
+`install.sh` (see `env.example`). `CUBE_DATABASE_DRIVER` mirrors Helm
+`database.driver`: `mysql` (default) or `postgres` (always external).
 
 ```bash
-# External MySQL (any subset of the credential fields may be overridden)
+# External MySQL (default driver; any subset of the credential fields may be overridden)
+# CUBE_DATABASE_DRIVER=mysql
 CUBE_EXTERNAL_MYSQL_HOST=10.0.0.20
 CUBE_EXTERNAL_MYSQL_PORT=3306
 CUBE_EXTERNAL_MYSQL_USER=cube
 CUBE_EXTERNAL_MYSQL_PASSWORD=cube_pass
 CUBE_EXTERNAL_MYSQL_DB=cube_mvp
+
+# External PostgreSQL (one-click never ships a local PostgreSQL)
+# CUBE_DATABASE_DRIVER=postgres
+# CUBE_EXTERNAL_POSTGRES_HOST=10.0.0.20
+# CUBE_EXTERNAL_POSTGRES_PORT=5432
+# CUBE_EXTERNAL_POSTGRES_USER=cube
+# CUBE_EXTERNAL_POSTGRES_PASSWORD=cube_pass
+# CUBE_EXTERNAL_POSTGRES_DB=cube_mvp
 
 # External Redis
 CUBE_EXTERNAL_REDIS_HOST=10.0.0.21
@@ -355,15 +365,24 @@ CUBE_EXTERNAL_REDIS_PORT=6379
 CUBE_EXTERNAL_REDIS_PASSWORD=ceuhvu123
 ```
 
-When `CUBE_EXTERNAL_MYSQL_HOST` (and/or `CUBE_EXTERNAL_REDIS_HOST`) is set, `install.sh`:
+When `CUBE_EXTERNAL_MYSQL_HOST`, `CUBE_EXTERNAL_POSTGRES_HOST` (with
+`CUBE_DATABASE_DRIVER=postgres`), and/or `CUBE_EXTERNAL_REDIS_HOST` is set,
+`install.sh`:
 
-- patches `CubeMaster/conf.yaml` with the external MySQL/Redis endpoint;
-- writes `DATABASE_URL` (CubeAPI) and `CUBE_PROXY_REDIS_*` (cube proxy) to `.one-click.env` so every service consumes the external endpoint;
-- masks the corresponding `cube-sandbox-mysql.service` / `cube-sandbox-redis.service` so the local container is never started; and
-- makes `quickcheck.sh` and `up-support.sh` skip lifecycle management of the now-external dependency. (`down-support.sh` has no external-dep awareness and still issues a `docker compose down`, but this is a harmless no-op because the local containers were never started for the external dependency.)
+- patches `CubeMaster/conf.yaml` with the external endpoint and sets
+  `instance_db_config.driver` for SQL engines;
+- writes `DATABASE_URL` (`mysql://` or `postgresql://`) and `CUBE_PROXY_REDIS_*`
+  to `.one-click.env` so every service consumes the external endpoint;
+- masks the corresponding `cube-sandbox-mysql.service` / `cube-sandbox-redis.service`
+  so the local container is never started; and
+- makes `quickcheck.sh` and `up-support.sh` skip lifecycle management of the
+  now-external dependency. (`down-support.sh` has no external-dep awareness and
+  still issues a `docker compose down`, but this is a harmless no-op because the
+  local containers were never started for the external dependency.)
 
-The external MySQL must already grant the configured user access to the target
-database. CubeMaster runs its own embedded schema migrations on first start.
+The external database must already grant the configured user access to the
+target database. CubeMaster runs its own embedded schema migrations on first
+start.
 
 ### Bundled MinIO vs the S3 volume plugin
 

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -293,18 +293,29 @@ MySQL/Redis 依赖默认会部署到：
 - `redis:7-alpine`
 - `minio`（S3 兼容 Volume 后端；由 `CUBE_SANDBOX_MINIO_ENABLED` 显式开关，默认开启）
 
-### 使用外部 MySQL / Redis
+### 使用外部 MySQL / PostgreSQL / Redis
 
-如果希望使用已有的 MySQL/Redis 服务器，而不是内置的本地容器，可在执行
-`install.sh` 之前在 `.env` 中设置以下变量（参见 `env.example`）：
+如果希望使用已有的 MySQL、PostgreSQL 或 Redis 服务器，而不是内置的本地容器，
+可在执行 `install.sh` 之前在 `.env` 中设置以下变量（参见 `env.example`）。
+`CUBE_DATABASE_DRIVER` 对齐 Helm 的 `database.driver`：`mysql`（默认）或
+`postgres`（始终外置，one-click 从不自带本地 PostgreSQL）。
 
 ```bash
-# 外部 MySQL（凭据字段可按需覆盖）
+# 外部 MySQL（默认驱动；凭据字段可按需覆盖）
+# CUBE_DATABASE_DRIVER=mysql
 CUBE_EXTERNAL_MYSQL_HOST=10.0.0.20
 CUBE_EXTERNAL_MYSQL_PORT=3306
 CUBE_EXTERNAL_MYSQL_USER=cube
 CUBE_EXTERNAL_MYSQL_PASSWORD=cube_pass
 CUBE_EXTERNAL_MYSQL_DB=cube_mvp
+
+# 外部 PostgreSQL
+# CUBE_DATABASE_DRIVER=postgres
+# CUBE_EXTERNAL_POSTGRES_HOST=10.0.0.20
+# CUBE_EXTERNAL_POSTGRES_PORT=5432
+# CUBE_EXTERNAL_POSTGRES_USER=cube
+# CUBE_EXTERNAL_POSTGRES_PASSWORD=cube_pass
+# CUBE_EXTERNAL_POSTGRES_DB=cube_mvp
 
 # 外部 Redis
 CUBE_EXTERNAL_REDIS_HOST=10.0.0.21
@@ -312,14 +323,15 @@ CUBE_EXTERNAL_REDIS_PORT=6379
 CUBE_EXTERNAL_REDIS_PASSWORD=ceuhvu123
 ```
 
-当设置了 `CUBE_EXTERNAL_MYSQL_HOST`（和/或 `CUBE_EXTERNAL_REDIS_HOST`）时，`install.sh` 会：
+当设置了 `CUBE_EXTERNAL_MYSQL_HOST`、`CUBE_EXTERNAL_POSTGRES_HOST`（且
+`CUBE_DATABASE_DRIVER=postgres`）和/或 `CUBE_EXTERNAL_REDIS_HOST` 时，`install.sh` 会：
 
-- 用外部 MySQL/Redis 地址改写 `CubeMaster/conf.yaml`；
-- 将 `DATABASE_URL`（CubeAPI）和 `CUBE_PROXY_REDIS_*`（cube proxy）写入 `.one-click.env`，让各服务都连接外部地址；
+- 用外部地址改写 `CubeMaster/conf.yaml`，并设置 `instance_db_config.driver`；
+- 将 `DATABASE_URL`（`mysql://` 或 `postgresql://`）和 `CUBE_PROXY_REDIS_*` 写入 `.one-click.env`，让各服务都连接外部地址；
 - mask 对应的 `cube-sandbox-mysql.service` / `cube-sandbox-redis.service`，本地容器不会再被启动；
 - 让 `quickcheck.sh` 和 `up-support.sh` 跳过对已外置依赖的本地生命周期管理（`down-support.sh` 未感知外部依赖，仍会执行 `docker compose down`，但由于本地容器从未被启动，这是无害的空操作）。
 
-外部 MySQL 需要预先授予所配置用户对目标库的访问权限；CubeMaster 首次启动会自行执行内置 schema 迁移。
+外部数据库需要预先授予所配置用户对目标库的访问权限；CubeMaster 首次启动会自行执行内置 schema 迁移。
 
 ### 内置 MinIO 与 S3 Volume 插件
 

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -75,18 +75,33 @@ CUBE_SANDBOX_REDIS_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/redis:
 # CUBE_SANDBOX_MINIO_IMAGE=cube-sandbox-int.tencentcloudcr.com/cube-sandbox/minio:RELEASE.2025-09-07T16-13-09Z
 WEB_UI_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat
 
-# ---- External MySQL / Redis ----
+# ---- External MySQL / PostgreSQL / Redis ----
 # By default install.sh starts a local MySQL and Redis container (managed by
-# systemd). To use an existing MySQL/Redis server instead, set the *_HOST
-# variables below. When set, install.sh patches CubeMaster conf.yaml, points
-# CubeAPI (DATABASE_URL) and cube-proxy at the external endpoint, masks the
-# corresponding local systemd service, and the up/down/quickcheck helpers stop
-# managing the local container. Leave unset to keep the bundled local services.
+# systemd). To use an existing server instead, set the *_HOST variables below.
+# CUBE_DATABASE_DRIVER mirrors Helm database.driver (set once):
+#   mysql    (default) -> bundled MySQL, or CUBE_EXTERNAL_MYSQL_* when HOST is set
+#   postgres           -> always external; requires CUBE_EXTERNAL_POSTGRES_HOST
+#                         (one-click never ships a local PostgreSQL)
+# Each engine keeps its own host/port/database/user/password keys. If DRIVER is
+# omitted, a non-empty CUBE_EXTERNAL_POSTGRES_HOST (or MYSQL_HOST) implies the
+# matching driver on upgrade/install. When an external SQL host is set,
+# install.sh patches CubeMaster conf.yaml (instance_db_config.driver), points
+# CubeAPI/CubeOps (DATABASE_URL) at the external endpoint, masks the local
+# MySQL systemd service, and the up/down/quickcheck helpers stop managing the
+# local container. Leave unset to keep the bundled local services.
+# CUBE_DATABASE_DRIVER=mysql
+# --- external MySQL (optional) ---
 # CUBE_EXTERNAL_MYSQL_HOST=10.0.0.20
 # CUBE_EXTERNAL_MYSQL_PORT=3306
 # CUBE_EXTERNAL_MYSQL_USER=cube
 # CUBE_EXTERNAL_MYSQL_PASSWORD=cube_pass
 # CUBE_EXTERNAL_MYSQL_DB=cube_mvp
+# --- external PostgreSQL (optional; set DRIVER=postgres or rely on HOST imply) ---
+# CUBE_EXTERNAL_POSTGRES_HOST=10.0.0.20
+# CUBE_EXTERNAL_POSTGRES_PORT=5432
+# CUBE_EXTERNAL_POSTGRES_USER=cube
+# CUBE_EXTERNAL_POSTGRES_PASSWORD=cube_pass
+# CUBE_EXTERNAL_POSTGRES_DB=cube_mvp
 # CUBE_EXTERNAL_REDIS_HOST=10.0.0.21
 # CUBE_EXTERNAL_REDIS_PORT=6379
 # CUBE_EXTERNAL_REDIS_PASSWORD=ceuhvu123

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -47,11 +47,14 @@ ENV_FILE="${ONE_CLICK_ENV_FILE:-${SCRIPT_DIR}/.env}"
 # sourced: the upgrade merge later loads the old .one-click.env, which would
 # otherwise clobber both `VAR=x ./install.sh` and toggle keys carried in .env.
 snapshot_one_click_toggles "${ENV_FILE}"
+snapshot_one_click_database_intent "${ENV_FILE}"
 if [[ -f "${ENV_FILE}" ]]; then
   load_env_file "${ENV_FILE}"
   # CLI flags must win over .env values: load_env_file uses `set -a; source`,
   # which would otherwise clobber the CLI-provided values set above.
   apply_cli_overrides
+  # Shell-interpret .env DB values (quotes stripped) into the dotenv snapshot.
+  capture_one_click_database_dotenv_values
   case "${ONE_CLICK_MODE}" in
     ""|install|upgrade|auto) ;;
     *) die "unsupported --mode: ${ONE_CLICK_MODE} (expected install|upgrade|auto)" ;;
@@ -61,11 +64,15 @@ fi
 DEPLOY_ROLE="$(one_click_deploy_role)"
 
 # ---- External MySQL / Redis support ----
-# Set CUBE_EXTERNAL_MYSQL_HOST / CUBE_EXTERNAL_REDIS_HOST to use external
-# services instead of the bundled local Docker containers. Defaults are filled
-# after the optional upgrade env merge so they are based on the final runtime
-# configuration.
+# Set CUBE_EXTERNAL_MYSQL_HOST / CUBE_EXTERNAL_POSTGRES_HOST /
+# CUBE_EXTERNAL_REDIS_HOST to use external services instead of the bundled
+# local Docker containers. Defaults are filled after the optional upgrade env
+# merge so they are based on the final runtime configuration.
+# CUBE_DATABASE_DRIVER mirrors Helm database.driver (mysql|postgres); postgres
+# is always external (one-click never ships a local PostgreSQL).
 init_external_dep_defaults() {
+  CUBE_DATABASE_DRIVER="${CUBE_DATABASE_DRIVER:-mysql}"
+
   CUBE_EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
   CUBE_EXTERNAL_MYSQL_PORT="${CUBE_EXTERNAL_MYSQL_PORT:-3306}"
   CUBE_EXTERNAL_MYSQL_USER="${CUBE_EXTERNAL_MYSQL_USER:-cube}"
@@ -75,6 +82,14 @@ init_external_dep_defaults() {
   # CUBE_SANDBOX_MYSQL_DB (without an explicit CUBE_EXTERNAL_MYSQL_DB) would make
   # the persisted .one-click.env and the seed step disagree on the database name.
   CUBE_EXTERNAL_MYSQL_DB="${CUBE_EXTERNAL_MYSQL_DB:-${CUBE_SANDBOX_MYSQL_DB:-cube_mvp}}"
+
+  # External PostgreSQL (CUBE_DATABASE_DRIVER=postgres). Separate keys from
+  # MySQL so nothing is shared or inferred across engines (same as Helm).
+  CUBE_EXTERNAL_POSTGRES_HOST="${CUBE_EXTERNAL_POSTGRES_HOST:-}"
+  CUBE_EXTERNAL_POSTGRES_PORT="${CUBE_EXTERNAL_POSTGRES_PORT:-5432}"
+  CUBE_EXTERNAL_POSTGRES_USER="${CUBE_EXTERNAL_POSTGRES_USER:-cube}"
+  CUBE_EXTERNAL_POSTGRES_PASSWORD="${CUBE_EXTERNAL_POSTGRES_PASSWORD:-cube_pass}"
+  CUBE_EXTERNAL_POSTGRES_DB="${CUBE_EXTERNAL_POSTGRES_DB:-cube_mvp}"
 
   # Mirrors the MySQL behaviour above (patch conf.yaml, persist env, mask local
   # redis unit).
@@ -114,6 +129,10 @@ warn_default_external_credentials() {
   if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" && "${CUBE_EXTERNAL_MYSQL_PASSWORD}" == "cube_pass" ]]; then
     log "WARNING: external MySQL (${CUBE_EXTERNAL_MYSQL_HOST}) configured with the default password 'cube_pass'."
     log "WARNING: set CUBE_EXTERNAL_MYSQL_PASSWORD to a strong value in your .env before exposing this deployment."
+  fi
+  if [[ -n "${CUBE_EXTERNAL_POSTGRES_HOST}" && "${CUBE_EXTERNAL_POSTGRES_PASSWORD}" == "cube_pass" ]]; then
+    log "WARNING: external PostgreSQL (${CUBE_EXTERNAL_POSTGRES_HOST}) configured with the default password 'cube_pass'."
+    log "WARNING: set CUBE_EXTERNAL_POSTGRES_PASSWORD to a strong value in your .env before exposing this deployment."
   fi
   if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" && "${CUBE_EXTERNAL_REDIS_PASSWORD}" == "ceuhvu123" ]]; then
     log "WARNING: external Redis (${CUBE_EXTERNAL_REDIS_HOST}) configured with the default password 'ceuhvu123'."
@@ -257,8 +276,16 @@ fi
 # above preserves the old runtime values for keys whose .env value equals the
 # env.example default, which would otherwise ignore an explicit flip back.
 apply_one_click_toggles
+# Re-apply this-run DB engine intent so upgrade merge cannot keep a stale
+# opposite-engine CUBE_EXTERNAL_* marker from .one-click.env.
+apply_one_click_database_intent
 
 init_external_dep_defaults
+# Compute nodes never open the control-plane DB; skip driver/host validation
+# so a mirrored CUBE_DATABASE_DRIVER=postgres without local reachability works.
+if [[ "${DEPLOY_ROLE}" != "compute" ]]; then
+  validate_one_click_database_config
+fi
 if [[ "${DEPLOY_ROLE}" == "compute" ]]; then
   if [[ "${CUBE_SANDBOX_MINIO_ENABLED}" == "1" ]]; then
     log "compute role does not deploy MinIO; ignoring CUBE_SANDBOX_MINIO_ENABLED (volume plugin uses CUBE_S3_*)"
@@ -448,9 +475,10 @@ generate_cubemaster_config_ports() {
     "${cfg}"
 }
 
-# When external MySQL/Redis is configured, patch CubeMaster conf.yaml to replace
-# the default 127.0.0.1 endpoints with the external connection details. Must run
-# after generate_cubemaster_config_ports so the port placeholders are resolved.
+# When external MySQL/PostgreSQL/Redis is configured, patch CubeMaster conf.yaml
+# to replace the default 127.0.0.1 endpoints with the external connection
+# details. Must run after generate_cubemaster_config_ports so the port
+# placeholders are resolved.
 patch_cubemaster_external_deps() {
   [[ "${DEPLOY_ROLE}" != "compute" ]] || return 0
 
@@ -475,41 +503,47 @@ patch_cubemaster_external_deps() {
     fi
   fi
 
+  # Bundled MySQL restore from a previously externalized conf.yaml is not needed:
+  # PKG_ROOT is a fresh unpack every run, so the template already has driver=mysql
+  # and addr=127.0.0.1:<port>. (Upgrade does not restore an old conf.yaml into PKG_ROOT.)
+
   # Validate once up front; both branches patch the same file.
-  if [[ -z "${CUBE_EXTERNAL_MYSQL_HOST}" && -z "${CUBE_EXTERNAL_REDIS_HOST}" \
+  if [[ -z "${CUBE_EXTERNAL_MYSQL_HOST}" && -z "${CUBE_EXTERNAL_POSTGRES_HOST}" \
+      && -z "${CUBE_EXTERNAL_REDIS_HOST}" \
       && -z "${CUBE_EXTERNAL_REDIS_MASTER_NAME}" \
       && "${scrub_stale_sentinel}" -eq 0 && "${restore_bundled_redis}" -eq 0 ]]; then
     return 0
   fi
+
   ensure_file "${cfg}"
+
+  # Older packages may lack instance_db_config.driver; insert before addr so
+  # subsequent s||| patches always have a target (mirrors Helm conf template).
+  if ! grep -qE '^[[:space:]]*driver:' "${cfg}"; then
+    sed -i '/^instance_db_config:/a\  driver: "mysql"' "${cfg}"
+  fi
 
   if [[ "${scrub_stale_sentinel}" -eq 1 ]]; then
     log "removing stale Redis Sentinel keys from conf.yaml (not in Sentinel mode)"
     sed -i '/^  master_name:/d; /^  sentinel_nodes:/d; /^  sentinel_password:/d' "${cfg}"
   fi
 
-  if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
+  if [[ -n "${CUBE_EXTERNAL_POSTGRES_HOST}" ]]; then
+    log "patching conf.yaml for external PostgreSQL: ${CUBE_EXTERNAL_POSTGRES_HOST}:${CUBE_EXTERNAL_POSTGRES_PORT}/${CUBE_EXTERNAL_POSTGRES_DB}"
+    patch_cubemaster_instance_db_config "${cfg}" "postgres" \
+      "${CUBE_EXTERNAL_POSTGRES_HOST}:${CUBE_EXTERNAL_POSTGRES_PORT}" \
+      "${CUBE_EXTERNAL_POSTGRES_USER}" \
+      "${CUBE_EXTERNAL_POSTGRES_PASSWORD}" \
+      "${CUBE_EXTERNAL_POSTGRES_DB}"
+  elif [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
     log "patching conf.yaml for external MySQL: ${CUBE_EXTERNAL_MYSQL_HOST}:${CUBE_EXTERNAL_MYSQL_PORT}/${CUBE_EXTERNAL_MYSQL_DB}"
-    # SECURITY: escape user-supplied values for the sed '|' delimiter so that a
-    # '|', '\', '&' or '"' in a host/user/password does not corrupt conf.yaml
-    # or break the double-quoted sed replacement strings below.
-    local mysql_addr_esc mysql_user_esc mysql_pwd_esc mysql_db_esc
-    mysql_addr_esc="$(escape_sed "${CUBE_EXTERNAL_MYSQL_HOST}:${CUBE_EXTERNAL_MYSQL_PORT}")"
-    mysql_user_esc="$(escape_sed "${CUBE_EXTERNAL_MYSQL_USER}")"
-    mysql_pwd_esc="$(escape_sed "${CUBE_EXTERNAL_MYSQL_PASSWORD}")"
-    mysql_db_esc="$(escape_sed "${CUBE_EXTERNAL_MYSQL_DB}")"
-    # Match only on the YAML key prefix ('addr:'/'user:'/'pwd:'/'db_name:') and
-    # accept any current value, so these patterns keep working even if the
-    # conf.yaml template is regenerated with different defaults. These keys only
-    # appear in the MySQL section (instance_db_config), so without
-    # a trailing 'g' flag each line is patched exactly once and Redis fields
-    # (nodes:/password:) are never touched.
-    sed -i \
-      -e "s|addr: \".*\"|addr: \"${mysql_addr_esc}\"|" \
-      -e "s|user: \".*\"|user: \"${mysql_user_esc}\"|" \
-      -e "s|pwd: \".*\"|pwd: \"${mysql_pwd_esc}\"|" \
-      -e "s|db_name: \".*\"|db_name: \"${mysql_db_esc}\"|" \
-      "${cfg}"
+    # Anchored line-start patterns (see patch_cubemaster_instance_db_config) so
+    # common.cube_ops_addr is not clobbered by the addr: rewrite.
+    patch_cubemaster_instance_db_config "${cfg}" "mysql" \
+      "${CUBE_EXTERNAL_MYSQL_HOST}:${CUBE_EXTERNAL_MYSQL_PORT}" \
+      "${CUBE_EXTERNAL_MYSQL_USER}" \
+      "${CUBE_EXTERNAL_MYSQL_PASSWORD}" \
+      "${CUBE_EXTERNAL_MYSQL_DB}"
   fi
 
   if [[ -n "${CUBE_EXTERNAL_REDIS_MASTER_NAME}" ]]; then
@@ -580,7 +614,40 @@ patch_cubemaster_external_deps() {
 check_external_deps_preflight() {
   local connect_timeout="${ONE_CLICK_EXTERNAL_DEP_TIMEOUT:-5}"
 
-  if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
+  if [[ "${DEPLOY_ROLE:-}" != "compute" && -n "${CUBE_EXTERNAL_POSTGRES_HOST}" ]]; then
+    # Prefer psql: it authenticates (user/password/db). pg_isready only checks
+    # that the server accepts TCP and would otherwise mask bad credentials.
+    if command -v psql >/dev/null 2>&1; then
+      log "checking connectivity to external PostgreSQL ${CUBE_EXTERNAL_POSTGRES_HOST}:${CUBE_EXTERNAL_POSTGRES_PORT} (psql)"
+      if ! PGPASSWORD="${CUBE_EXTERNAL_POSTGRES_PASSWORD}" \
+          PGCONNECT_TIMEOUT="${connect_timeout}" psql \
+          -h "${CUBE_EXTERNAL_POSTGRES_HOST}" \
+          -p "${CUBE_EXTERNAL_POSTGRES_PORT}" \
+          -U "${CUBE_EXTERNAL_POSTGRES_USER}" \
+          -d "${CUBE_EXTERNAL_POSTGRES_DB}" \
+          -c 'SELECT 1' >/dev/null 2>&1; then
+        die "cannot reach external PostgreSQL at ${CUBE_EXTERNAL_POSTGRES_HOST}:${CUBE_EXTERNAL_POSTGRES_PORT} as user '${CUBE_EXTERNAL_POSTGRES_USER}'.
+  Verify CUBE_EXTERNAL_POSTGRES_HOST / _PORT / _USER / _PASSWORD / _DB and that the server is reachable from this host."
+      fi
+      log "external PostgreSQL connectivity OK"
+    elif command -v pg_isready >/dev/null 2>&1; then
+      log "checking reachability of external PostgreSQL ${CUBE_EXTERNAL_POSTGRES_HOST}:${CUBE_EXTERNAL_POSTGRES_PORT} (pg_isready; does not verify credentials)"
+      if ! PGPASSWORD="${CUBE_EXTERNAL_POSTGRES_PASSWORD}" pg_isready \
+          -h "${CUBE_EXTERNAL_POSTGRES_HOST}" \
+          -p "${CUBE_EXTERNAL_POSTGRES_PORT}" \
+          -U "${CUBE_EXTERNAL_POSTGRES_USER}" \
+          -d "${CUBE_EXTERNAL_POSTGRES_DB}" \
+          -t "${connect_timeout}" >/dev/null 2>&1; then
+        die "cannot reach external PostgreSQL at ${CUBE_EXTERNAL_POSTGRES_HOST}:${CUBE_EXTERNAL_POSTGRES_PORT} as user '${CUBE_EXTERNAL_POSTGRES_USER}'.
+  Verify CUBE_EXTERNAL_POSTGRES_HOST / _PORT / _USER / _PASSWORD / _DB and that the server is reachable from this host."
+      fi
+      log "external PostgreSQL server reachable (credentials not verified; install psql for a full check)"
+    else
+      log "WARNING: psql/pg_isready not found; skipping external PostgreSQL connectivity preflight (credentials unchecked until CubeMaster/CubeAPI start)"
+    fi
+  fi
+
+  if [[ "${DEPLOY_ROLE:-}" != "compute" && -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
     if command -v mysqladmin >/dev/null 2>&1; then
       log "checking connectivity to external MySQL ${CUBE_EXTERNAL_MYSQL_HOST}:${CUBE_EXTERNAL_MYSQL_PORT}"
       local mysql_cnf
@@ -1462,8 +1529,12 @@ mask_local_dep_service() {
 }
 
 mask_external_dep_services() {
-  if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
-    log "masking local MySQL service (external MySQL at ${CUBE_EXTERNAL_MYSQL_HOST} in use)"
+  if one_click_skip_local_mysql; then
+    if [[ -n "${CUBE_EXTERNAL_POSTGRES_HOST}" ]]; then
+      log "masking local MySQL service (external PostgreSQL at ${CUBE_EXTERNAL_POSTGRES_HOST} in use)"
+    else
+      log "masking local MySQL service (external MySQL at ${CUBE_EXTERNAL_MYSQL_HOST} in use)"
+    fi
     mask_local_dep_service cube-sandbox-mysql.service
   else
     # Re-enable in case a previous install masked it and the user switched back.
@@ -1826,36 +1897,11 @@ if [[ -n "${CUBE_SANDBOX_CUBE_ROUTER_CIDR:-}" ]]; then
 fi
 upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EGRESS_ADMIN_PORT" "${CUBE_EGRESS_ADMIN_PORT}"
 
-# Persist external MySQL config so every systemd unit / helper picks it up
-# instead of the local container. The CUBE_EXTERNAL_* markers let quickcheck
-# and the up/down helpers skip the local service entirely; DATABASE_URL points
-# CubeAPI at the external server (CubeMaster reads the patched conf.yaml).
-if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
-  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_HOST" "${CUBE_EXTERNAL_MYSQL_HOST}"
-  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_PORT" "${CUBE_EXTERNAL_MYSQL_PORT}"
-  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_USER" "${CUBE_EXTERNAL_MYSQL_USER}"
-  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_PASSWORD" "${CUBE_EXTERNAL_MYSQL_PASSWORD}"
-  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_DB" "${CUBE_EXTERNAL_MYSQL_DB}"
-  # Percent-encode every URI component so values containing URL metacharacters
-  # (@, :, /, #, %, ...) cannot corrupt the connection string. This covers the
-  # userinfo (user/password) as well as the host, port, and database name (e.g.
-  # a '/' in the db name would otherwise be parsed as a path separator).
-  database_url_user="$(urlencode "${CUBE_EXTERNAL_MYSQL_USER}")"
-  database_url_pass="$(urlencode "${CUBE_EXTERNAL_MYSQL_PASSWORD}")"
-  database_url_host="$(urlencode "${CUBE_EXTERNAL_MYSQL_HOST}")"
-  database_url_port="$(urlencode "${CUBE_EXTERNAL_MYSQL_PORT}")"
-  database_url_db="$(urlencode "${CUBE_EXTERNAL_MYSQL_DB}")"
-  upsert_env_kv "${RUNTIME_ENV_FILE}" "DATABASE_URL" "mysql://${database_url_user}:${database_url_pass}@${database_url_host}:${database_url_port}/${database_url_db}"
-else
-  # Local MySQL (bundled container): persist DATABASE_URL so CubeAPI and other
-  # components can reach the database without relying on per-script defaults.
-  local_mysql_host="127.0.0.1"
-  local_mysql_port="${CUBE_SANDBOX_MYSQL_PORT:-3306}"
-  local_mysql_user="${CUBE_SANDBOX_MYSQL_USER:-cube}"
-  local_mysql_password="${CUBE_SANDBOX_MYSQL_PASSWORD:-cube_pass}"
-  local_mysql_db="${CUBE_SANDBOX_MYSQL_DB:-cube_mvp}"
-  upsert_env_kv "${RUNTIME_ENV_FILE}" "DATABASE_URL" "mysql://$(urlencode "${local_mysql_user}"):$(urlencode "${local_mysql_password}")@$(urlencode "${local_mysql_host}"):$(urlencode "${local_mysql_port}")/$(urlencode "${local_mysql_db}")"
-fi
+# Persist database driver + engine endpoints. CubeMaster reads the patched
+# conf.yaml; CubeAPI/CubeOps consume DATABASE_URL from .one-click.env.
+# Opposite-engine CUBE_EXTERNAL_* keys are scrubbed so a driver switch cannot
+# keep the previous endpoint alive via ":-" fallbacks.
+persist_one_click_database_runtime_env "${RUNTIME_ENV_FILE}"
 
 # Persist Redis for the current mode (Sentinel / standalone / local) and
 # drop opposite-mode keys so stale values cannot keep the previous mode

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -547,7 +547,8 @@ snapshot_one_click_toggles() {
 }
 
 # apply_one_click_toggles: re-apply the snapshotted operator intent after the
-# env files (including the upgrade merge output) have been sourced. Precedence
+# env files (including the upgrade merge output) have been sourced. Same
+# snapshot/replay shape as apply_one_click_database_intent (change both together). Precedence
 # mirrors install.sh's documented channel order (CLI flags > .env > process
 # environment > defaults): .env key > process environment > merged/loaded
 # value. The final value is persisted by install.sh's upsert_env_kv, so this
@@ -563,6 +564,168 @@ apply_one_click_toggles() {
       log "toggle ${key}=${!key} (explicit in process environment)"
     fi
   done
+  return 0
+}
+
+# Database engine keys are commented out of env.example, so merge_env_three_way
+# always re-appends the previous .one-click.env markers as "preserved custom
+# settings". Without a this-run snapshot, MySQL↔Postgres (or external→bundled)
+# switches expressed only in the new .env die as "mutually exclusive" or keep
+# the old engine. Mirror the toggle snapshot: capture .env / process intent
+# before merge, then scrub the opposite engine after merge.
+ONE_CLICK_DB_INTENT_KEYS=(
+  CUBE_DATABASE_DRIVER
+  CUBE_EXTERNAL_MYSQL_HOST
+  CUBE_EXTERNAL_MYSQL_PORT
+  CUBE_EXTERNAL_MYSQL_USER
+  CUBE_EXTERNAL_MYSQL_PASSWORD
+  CUBE_EXTERNAL_MYSQL_DB
+  CUBE_EXTERNAL_POSTGRES_HOST
+  CUBE_EXTERNAL_POSTGRES_PORT
+  CUBE_EXTERNAL_POSTGRES_USER
+  CUBE_EXTERNAL_POSTGRES_PASSWORD
+  CUBE_EXTERNAL_POSTGRES_DB
+)
+
+# snapshot_one_click_database_intent records process-env values and which DB
+# keys are present as active KEY= lines in .env. It must NOT store raw RHS text
+# from read_env_key: quoted passwords would round-trip with the quote chars.
+# Call capture_one_click_database_dotenv_values after load_env_file so dotenv
+# values are the shell-interpreted ones.
+snapshot_one_click_database_intent() {
+  local env_file="$1"
+  local key
+  declare -gA ONE_CLICK_DB_ENV_SNAPSHOT
+  declare -gA ONE_CLICK_DB_DOTENV_SNAPSHOT
+  declare -gA ONE_CLICK_DB_DOTENV_PRESENT
+  ONE_CLICK_DB_ENV_SNAPSHOT=()
+  ONE_CLICK_DB_DOTENV_SNAPSHOT=()
+  ONE_CLICK_DB_DOTENV_PRESENT=()
+  for key in "${ONE_CLICK_DB_INTENT_KEYS[@]}"; do
+    if [[ -n "${!key+x}" ]]; then
+      ONE_CLICK_DB_ENV_SNAPSHOT["${key}"]="${!key}"
+    fi
+    if [[ -f "${env_file}" ]] && grep -q "^${key}=" "${env_file}"; then
+      ONE_CLICK_DB_DOTENV_PRESENT["${key}"]=1
+    fi
+  done
+  return 0
+}
+
+# capture_one_click_database_dotenv_values fills DOTENV_SNAPSHOT from the live
+# shell environment for keys marked present in .env. Must run after
+# load_env_file (+ CLI re-apply) and before the upgrade merge re-sources
+# .one-click.env.
+capture_one_click_database_dotenv_values() {
+  local key
+  for key in "${ONE_CLICK_DB_INTENT_KEYS[@]}"; do
+    if [[ -n "${ONE_CLICK_DB_DOTENV_PRESENT[${key}]+x}" ]]; then
+      ONE_CLICK_DB_DOTENV_SNAPSHOT["${key}"]="${!key-}"
+    fi
+  done
+  return 0
+}
+
+_clear_one_click_external_mysql_env() {
+  CUBE_EXTERNAL_MYSQL_HOST=""
+  CUBE_EXTERNAL_MYSQL_PORT=""
+  CUBE_EXTERNAL_MYSQL_USER=""
+  CUBE_EXTERNAL_MYSQL_PASSWORD=""
+  CUBE_EXTERNAL_MYSQL_DB=""
+}
+
+_clear_one_click_external_postgres_env() {
+  CUBE_EXTERNAL_POSTGRES_HOST=""
+  CUBE_EXTERNAL_POSTGRES_PORT=""
+  CUBE_EXTERNAL_POSTGRES_USER=""
+  CUBE_EXTERNAL_POSTGRES_PASSWORD=""
+  CUBE_EXTERNAL_POSTGRES_DB=""
+}
+
+_one_click_db_intent_declared() {
+  local key="$1"
+  [[ -n "${ONE_CLICK_DB_DOTENV_PRESENT[${key}]+x}" || -n "${ONE_CLICK_DB_ENV_SNAPSHOT[${key}]+x}" ]]
+}
+
+# apply_one_click_database_intent re-applies this-run DB engine intent after the
+# upgrade merge. Same snapshot/replay shape as apply_one_click_toggles (change both
+# together); DB-specific pieces are the no-intent no-op, host→driver inference, and
+# opposite-engine scrub. No-op when neither .env nor the process environment named any
+# DB intent key (preserve prior runtime markers).
+#
+# Per-key resolution matches apply_one_click_toggles: dotenv wins, process env
+# fills gaps, otherwise the merge-preserved value is kept. Only the *opposite*
+# engine's CUBE_EXTERNAL_* markers are scrubbed so same-engine credentials that
+# lived only in .one-click.env are not wiped back to cube_pass defaults.
+# When DRIVER is only merge-preserved but this run declares a host for the other
+# engine, the host implies the driver (stale DRIVER must not scrub the host).
+apply_one_click_database_intent() {
+  local key
+  local has_intent=0
+
+  if [[ ${#ONE_CLICK_DB_DOTENV_PRESENT[@]} -gt 0 || ${#ONE_CLICK_DB_DOTENV_SNAPSHOT[@]} -gt 0 || ${#ONE_CLICK_DB_ENV_SNAPSHOT[@]} -gt 0 ]]; then
+    has_intent=1
+  fi
+  [[ "${has_intent}" -eq 1 ]] || return 0
+
+  for key in "${ONE_CLICK_DB_INTENT_KEYS[@]}"; do
+    if [[ -n "${ONE_CLICK_DB_DOTENV_SNAPSHOT[${key}]+x}" ]]; then
+      printf -v "${key}" '%s' "${ONE_CLICK_DB_DOTENV_SNAPSHOT[${key}]}"
+    elif [[ -n "${ONE_CLICK_DB_ENV_SNAPSHOT[${key}]+x}" ]]; then
+      printf -v "${key}" '%s' "${ONE_CLICK_DB_ENV_SNAPSHOT[${key}]}"
+    fi
+  done
+
+  if ! _one_click_db_intent_declared CUBE_DATABASE_DRIVER; then
+    if _one_click_db_intent_declared CUBE_EXTERNAL_POSTGRES_HOST; then
+      CUBE_DATABASE_DRIVER="postgres"
+      log "database intent: inferred driver=postgres from this-run CUBE_EXTERNAL_POSTGRES_HOST"
+    elif _one_click_db_intent_declared CUBE_EXTERNAL_MYSQL_HOST; then
+      CUBE_DATABASE_DRIVER="mysql"
+      log "database intent: inferred driver=mysql from this-run CUBE_EXTERNAL_MYSQL_HOST"
+    elif [[ -z "${CUBE_DATABASE_DRIVER:-}" ]]; then
+      if [[ -n "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]; then
+        CUBE_DATABASE_DRIVER="postgres"
+      else
+        CUBE_DATABASE_DRIVER="mysql"
+      fi
+    fi
+  elif [[ -z "${CUBE_DATABASE_DRIVER:-}" ]]; then
+    if [[ -n "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]; then
+      CUBE_DATABASE_DRIVER="postgres"
+    else
+      CUBE_DATABASE_DRIVER="mysql"
+    fi
+  fi
+
+  # Fail fast on this-run contradictions before scrubbing so validate_*'s
+  # mutually-exclusive / wrong-driver die paths remain reachable for .env input.
+  if _one_click_db_intent_declared CUBE_EXTERNAL_MYSQL_HOST       && _one_click_db_intent_declared CUBE_EXTERNAL_POSTGRES_HOST       && [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" && -n "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]; then
+    die "CUBE_EXTERNAL_MYSQL_HOST and CUBE_EXTERNAL_POSTGRES_HOST are mutually exclusive; set CUBE_DATABASE_DRIVER to select one engine"
+  fi
+  if _one_click_db_intent_declared CUBE_DATABASE_DRIVER; then
+    if [[ "${CUBE_DATABASE_DRIVER}" == "postgres" ]]; then
+      if _one_click_db_intent_declared CUBE_EXTERNAL_MYSQL_HOST           && [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]]; then
+        die "CUBE_DATABASE_DRIVER=postgres cannot be combined with CUBE_EXTERNAL_MYSQL_HOST"
+      fi
+    else
+      if _one_click_db_intent_declared CUBE_EXTERNAL_POSTGRES_HOST           && [[ -n "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]; then
+        die "CUBE_EXTERNAL_POSTGRES_HOST requires CUBE_DATABASE_DRIVER=postgres"
+      fi
+    fi
+  fi
+
+  if [[ "${CUBE_DATABASE_DRIVER}" == "postgres" ]]; then
+    _clear_one_click_external_mysql_env
+    log "database intent: driver=postgres host=${CUBE_EXTERNAL_POSTGRES_HOST:-}; cleared opposite CUBE_EXTERNAL_MYSQL_*"
+  else
+    _clear_one_click_external_postgres_env
+    if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]]; then
+      log "database intent: external MySQL host=${CUBE_EXTERNAL_MYSQL_HOST}; cleared opposite CUBE_EXTERNAL_POSTGRES_*"
+    else
+      log "database intent: driver=mysql (no external host); cleared opposite CUBE_EXTERNAL_POSTGRES_*"
+    fi
+  fi
   return 0
 }
 
@@ -973,6 +1136,150 @@ _remove_env_keys() {
   for key in "$@"; do
     remove_env_kv "${env_file}" "${key}"
   done
+}
+
+# patch_cubemaster_instance_db_config rewrites instance_db_config.{driver,addr,user,pwd,db_name}
+# in a CubeMaster conf.yaml. Patterns are anchored at line start so keys like
+# common.cube_ops_addr (which contain the substring "addr:") are never matched.
+patch_cubemaster_instance_db_config() {
+  local cfg="$1"
+  local driver="$2"
+  local addr="$3"
+  local user="$4"
+  local pwd="$5"
+  local db_name="$6"
+  local addr_esc user_esc pwd_esc db_esc
+  ensure_file "${cfg}"
+  addr_esc="$(escape_sed "${addr}")"
+  user_esc="$(escape_sed "${user}")"
+  pwd_esc="$(escape_sed "${pwd}")"
+  db_esc="$(escape_sed "${db_name}")"
+  sed -i \
+    -e "s|^\([[:space:]]*\)driver: \".*\"|\1driver: \"${driver}\"|" \
+    -e "s|^\([[:space:]]*\)addr: \".*\"|\1addr: \"${addr_esc}\"|" \
+    -e "s|^\([[:space:]]*\)user: \".*\"|\1user: \"${user_esc}\"|" \
+    -e "s|^\([[:space:]]*\)pwd: \".*\"|\1pwd: \"${pwd_esc}\"|" \
+    -e "s|^\([[:space:]]*\)db_name: \".*\"|\1db_name: \"${db_esc}\"|" \
+    "${cfg}"
+}
+
+# one_click_skip_local_mysql is true when an external DB endpoint is configured.
+# Key off host presence (not bare CUBE_DATABASE_DRIVER): driver=postgres with an
+# empty host must not skip bundled MySQL if this env is later reused on control.
+one_click_skip_local_mysql() {
+  [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" || -n "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]
+}
+
+# validate_one_click_database_config mirrors Helm database.driver / postgres.*:
+# mysql keeps bundled or CUBE_EXTERNAL_MYSQL_*; postgres is external-only and
+# requires CUBE_EXTERNAL_POSTGRES_HOST. Engines do not share host/credential keys.
+validate_one_click_database_config() {
+  local driver="${CUBE_DATABASE_DRIVER:-mysql}"
+  case "${driver}" in
+    mysql|postgres) ;;
+    *)
+      die "CUBE_DATABASE_DRIVER must be mysql or postgres (got '${driver}')"
+      ;;
+  esac
+  CUBE_DATABASE_DRIVER="${driver}"
+
+  if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" && -n "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]; then
+    die "CUBE_EXTERNAL_MYSQL_HOST and CUBE_EXTERNAL_POSTGRES_HOST are mutually exclusive; set CUBE_DATABASE_DRIVER to select one engine"
+  fi
+
+  if [[ "${driver}" == "postgres" ]]; then
+    if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]]; then
+      die "CUBE_DATABASE_DRIVER=postgres cannot be combined with CUBE_EXTERNAL_MYSQL_HOST"
+    fi
+    if [[ -z "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]; then
+      die "CUBE_DATABASE_DRIVER=postgres requires CUBE_EXTERNAL_POSTGRES_HOST (one-click never ships a local PostgreSQL)"
+    fi
+  else
+    if [[ -n "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]; then
+      die "CUBE_EXTERNAL_POSTGRES_HOST requires CUBE_DATABASE_DRIVER=postgres"
+    fi
+  fi
+}
+
+# persist_one_click_database_runtime_env writes CUBE_DATABASE_DRIVER, the active
+# engine's CUBE_EXTERNAL_* markers, and DATABASE_URL for CubeAPI/CubeOps.
+# Opposite-engine keys are scrubbed so a driver switch cannot keep the previous
+# endpoint alive via ":-" fallbacks.
+persist_one_click_database_runtime_env() {
+  local env_file="$1"
+  local driver="${CUBE_DATABASE_DRIVER:-mysql}"
+  local database_url_user database_url_pass database_url_host database_url_port database_url_db
+  [[ -n "${env_file}" ]] || die "persist_one_click_database_runtime_env: env file path required"
+
+  # driver=postgres with no host is not a usable external endpoint (compute
+  # mirror). Persist bundled MySQL markers so reuse on control cannot skip
+  # local MySQL or fail validate on a bare driver=postgres.
+  if [[ "${driver}" == "postgres" && -z "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]; then
+    driver="mysql"
+    CUBE_DATABASE_DRIVER="mysql"
+  fi
+
+  upsert_env_kv "${env_file}" "CUBE_DATABASE_DRIVER" "${driver}"
+
+  if [[ "${driver}" == "postgres" ]]; then
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_POSTGRES_HOST" "${CUBE_EXTERNAL_POSTGRES_HOST}"
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_POSTGRES_PORT" "${CUBE_EXTERNAL_POSTGRES_PORT:-5432}"
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_POSTGRES_USER" "${CUBE_EXTERNAL_POSTGRES_USER:-cube}"
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_POSTGRES_PASSWORD" "${CUBE_EXTERNAL_POSTGRES_PASSWORD:-}"
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_POSTGRES_DB" "${CUBE_EXTERNAL_POSTGRES_DB:-cube_mvp}"
+    database_url_user="$(urlencode "${CUBE_EXTERNAL_POSTGRES_USER:-cube}")"
+    database_url_pass="$(urlencode "${CUBE_EXTERNAL_POSTGRES_PASSWORD:-}")"
+    database_url_host="$(urlencode "${CUBE_EXTERNAL_POSTGRES_HOST}")"
+    database_url_port="$(urlencode "${CUBE_EXTERNAL_POSTGRES_PORT:-5432}")"
+    database_url_db="$(urlencode "${CUBE_EXTERNAL_POSTGRES_DB:-cube_mvp}")"
+    # Scheme matches Helm cube.databaseURL (postgresql://...).
+    upsert_env_kv "${env_file}" "DATABASE_URL" \
+      "postgresql://${database_url_user}:${database_url_pass}@${database_url_host}:${database_url_port}/${database_url_db}"
+    _remove_env_keys "${env_file}" \
+      CUBE_EXTERNAL_MYSQL_HOST \
+      CUBE_EXTERNAL_MYSQL_PORT \
+      CUBE_EXTERNAL_MYSQL_USER \
+      CUBE_EXTERNAL_MYSQL_PASSWORD \
+      CUBE_EXTERNAL_MYSQL_DB
+  elif [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]]; then
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_MYSQL_HOST" "${CUBE_EXTERNAL_MYSQL_HOST}"
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_MYSQL_PORT" "${CUBE_EXTERNAL_MYSQL_PORT:-3306}"
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_MYSQL_USER" "${CUBE_EXTERNAL_MYSQL_USER:-cube}"
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_MYSQL_PASSWORD" "${CUBE_EXTERNAL_MYSQL_PASSWORD:-}"
+    upsert_env_kv "${env_file}" "CUBE_EXTERNAL_MYSQL_DB" "${CUBE_EXTERNAL_MYSQL_DB:-cube_mvp}"
+    database_url_user="$(urlencode "${CUBE_EXTERNAL_MYSQL_USER:-cube}")"
+    database_url_pass="$(urlencode "${CUBE_EXTERNAL_MYSQL_PASSWORD:-}")"
+    database_url_host="$(urlencode "${CUBE_EXTERNAL_MYSQL_HOST}")"
+    database_url_port="$(urlencode "${CUBE_EXTERNAL_MYSQL_PORT:-3306}")"
+    database_url_db="$(urlencode "${CUBE_EXTERNAL_MYSQL_DB:-cube_mvp}")"
+    upsert_env_kv "${env_file}" "DATABASE_URL" \
+      "mysql://${database_url_user}:${database_url_pass}@${database_url_host}:${database_url_port}/${database_url_db}"
+    _remove_env_keys "${env_file}" \
+      CUBE_EXTERNAL_POSTGRES_HOST \
+      CUBE_EXTERNAL_POSTGRES_PORT \
+      CUBE_EXTERNAL_POSTGRES_USER \
+      CUBE_EXTERNAL_POSTGRES_PASSWORD \
+      CUBE_EXTERNAL_POSTGRES_DB
+  else
+    local local_mysql_host="127.0.0.1"
+    local local_mysql_port="${CUBE_SANDBOX_MYSQL_PORT:-3306}"
+    local local_mysql_user="${CUBE_SANDBOX_MYSQL_USER:-cube}"
+    local local_mysql_password="${CUBE_SANDBOX_MYSQL_PASSWORD:-cube_pass}"
+    local local_mysql_db="${CUBE_SANDBOX_MYSQL_DB:-cube_mvp}"
+    upsert_env_kv "${env_file}" "DATABASE_URL" \
+      "mysql://$(urlencode "${local_mysql_user}"):$(urlencode "${local_mysql_password}")@$(urlencode "${local_mysql_host}"):$(urlencode "${local_mysql_port}")/$(urlencode "${local_mysql_db}")"
+    _remove_env_keys "${env_file}" \
+      CUBE_EXTERNAL_MYSQL_HOST \
+      CUBE_EXTERNAL_MYSQL_PORT \
+      CUBE_EXTERNAL_MYSQL_USER \
+      CUBE_EXTERNAL_MYSQL_PASSWORD \
+      CUBE_EXTERNAL_MYSQL_DB \
+      CUBE_EXTERNAL_POSTGRES_HOST \
+      CUBE_EXTERNAL_POSTGRES_PORT \
+      CUBE_EXTERNAL_POSTGRES_USER \
+      CUBE_EXTERNAL_POSTGRES_PASSWORD \
+      CUBE_EXTERNAL_POSTGRES_DB
+  fi
 }
 
 # persist_one_click_redis_runtime_env writes Redis keys for systemd

--- a/deploy/one-click/scripts/one-click/quickcheck.sh
+++ b/deploy/one-click/scripts/one-click/quickcheck.sh
@@ -335,11 +335,16 @@ quickcheck_main() {
     OPS_ADDR="$(resolve_control_plane_cubeops_addr)"
   fi
 
-  # When external MySQL/Redis is configured the local container + systemd unit do
-  # not exist, so the corresponding checks must be skipped.
+  # When external MySQL/PostgreSQL/Redis is configured the local container +
+  # systemd unit do not exist, so the corresponding checks must be skipped.
   local EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
+  local EXTERNAL_POSTGRES_HOST="${CUBE_EXTERNAL_POSTGRES_HOST:-}"
   local EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
   local EXTERNAL_REDIS_MASTER_NAME="${CUBE_EXTERNAL_REDIS_MASTER_NAME:-}"
+  local SKIP_LOCAL_MYSQL=0
+  if [[ -n "${EXTERNAL_MYSQL_HOST}" || -n "${EXTERNAL_POSTGRES_HOST}" ]]; then
+    SKIP_LOCAL_MYSQL=1
+  fi
 
   # Validate the host:port / IP values before they are interpolated into curl
   # URLs and grep patterns. resolve_control_plane_cubemaster_addr already
@@ -383,8 +388,12 @@ quickcheck_main() {
       s3lvol_recovery_verify_ok
   fi
   if [[ "${ROLE}" != "compute" ]]; then
-    if [[ -n "${EXTERNAL_MYSQL_HOST}" ]]; then
-      echo "[quickcheck] external MySQL (${EXTERNAL_MYSQL_HOST}); skipping local mysql unit check"
+    if [[ "${SKIP_LOCAL_MYSQL}" -eq 1 ]]; then
+      if [[ -n "${EXTERNAL_POSTGRES_HOST}" ]]; then
+        echo "[quickcheck] external PostgreSQL (${EXTERNAL_POSTGRES_HOST}); skipping local mysql unit check"
+      else
+        echo "[quickcheck] external MySQL (${EXTERNAL_MYSQL_HOST}); skipping local mysql unit check"
+      fi
     else
       check_unit_active cube-sandbox-mysql.service
     fi
@@ -415,7 +424,7 @@ quickcheck_main() {
 
   if command -v docker >/dev/null 2>&1 && [[ "${ROLE}" != "compute" ]]; then
     echo "[quickcheck] check container runtime state"
-    [[ -n "${EXTERNAL_MYSQL_HOST}" ]] || check_container_ready "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}"
+    [[ "${SKIP_LOCAL_MYSQL}" -eq 1 ]] || check_container_ready "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}"
     [[ -n "${EXTERNAL_REDIS_HOST}" || -n "${EXTERNAL_REDIS_MASTER_NAME}" ]] || check_container_ready "${CUBE_SANDBOX_REDIS_CONTAINER:-cube-sandbox-redis}"
     [[ "${CUBE_SANDBOX_MINIO_ENABLED:-1}" == "1" ]] && check_container_ready "${CUBE_SANDBOX_MINIO_CONTAINER:-cube-sandbox-minio}"
     check_container_ready "${CUBE_PROXY_CONTAINER_NAME:-cube-proxy}"

--- a/deploy/one-click/scripts/one-click/up-support.sh
+++ b/deploy/one-click/scripts/one-click/up-support.sh
@@ -106,11 +106,18 @@ esac
 # "mysql redis minio", then drop external/disabled ones so a conflicting
 # container is never launched.
 CUBE_EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
+CUBE_EXTERNAL_POSTGRES_HOST="${CUBE_EXTERNAL_POSTGRES_HOST:-}"
+CUBE_DATABASE_DRIVER="${CUBE_DATABASE_DRIVER:-mysql}"
 CUBE_EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
 CUBE_EXTERNAL_REDIS_MASTER_NAME="${CUBE_EXTERNAL_REDIS_MASTER_NAME:-}"
 CUBE_SANDBOX_MINIO_ENABLED="${CUBE_SANDBOX_MINIO_ENABLED:-1}"
+# Skip bundled MySQL only when an external DB host is configured.
+skip_local_mysql=0
+if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" || -n "${CUBE_EXTERNAL_POSTGRES_HOST}" ]]; then
+  skip_local_mysql=1
+fi
 minio_dropped=0
-if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" || -n "${CUBE_EXTERNAL_REDIS_HOST}" \
+if [[ "${skip_local_mysql}" -eq 1 || -n "${CUBE_EXTERNAL_REDIS_HOST}" \
     || -n "${CUBE_EXTERNAL_REDIS_MASTER_NAME}" || "${CUBE_SANDBOX_MINIO_ENABLED}" != "1" \
     || -z "${SUPPORT_SERVICES}" ]]; then
   requested_services="${SUPPORT_SERVICES:-mysql redis minio}"
@@ -121,8 +128,12 @@ if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" || -n "${CUBE_EXTERNAL_REDIS_HOST}" \
   for svc in "${requested_services_arr[@]}"; do
     case "${svc}" in
       mysql)
-        if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
-          log "using external MySQL (${CUBE_EXTERNAL_MYSQL_HOST}), skipping local mysql container"
+        if [[ "${skip_local_mysql}" -eq 1 ]]; then
+          if [[ -n "${CUBE_EXTERNAL_POSTGRES_HOST}" ]]; then
+            log "using external PostgreSQL (${CUBE_EXTERNAL_POSTGRES_HOST}), skipping local mysql container"
+          else
+            log "using external MySQL (${CUBE_EXTERNAL_MYSQL_HOST}), skipping local mysql container"
+          fi
           continue
         fi
         ;;

--- a/deploy/one-click/scripts/systemd/mysql-postcheck.sh
+++ b/deploy/one-click/scripts/systemd/mysql-postcheck.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
-# External MySQL: the local container is never started (see up-support.sh), so
-# there is nothing local to health-check. Skip rather than block ~80s on a
-# missing container and then trigger Restart=on-failure.
-if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]]; then
+# External MySQL/PostgreSQL: the local container is never started (see
+# up-support.sh), so there is nothing local to health-check. Skip rather than
+# block ~80s on a missing container and then trigger Restart=on-failure.
+if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" || -n "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]]; then
   exit 0
 fi
 wait_for_container_health "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}" 40 2 || die "mysql container not ready"

--- a/deploy/one-click/tests/test_external_postgres.sh
+++ b/deploy/one-click/tests/test_external_postgres.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Unit tests for one-click external PostgreSQL (CUBE_DATABASE_DRIVER /
+# CUBE_EXTERNAL_POSTGRES_*), mirroring Helm database.driver / postgres.*.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ONE_CLICK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+# shellcheck source=../lib/common.sh
+source "${ONE_CLICK_DIR}/lib/common.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_value() {
+  local file="$1" key="$2" expected="$3"
+  local actual
+  actual="$(read_env_key "${file}" "${key}")"
+  [[ "${actual}" == "${expected}" ]] || fail "expected ${key}='${expected}', got '${actual}'"
+}
+
+assert_not_contains() {
+  if grep -Fq -- "$2" "$1"; then
+    fail "expected $1 NOT to contain: $2"
+  fi
+}
+
+assert_contains() {
+  if ! grep -Fq -- "$2" "$1"; then
+    fail "expected $1 to contain: $2"
+  fi
+}
+
+persist_db_clean() {
+  local env_file="$1"
+  shift
+  (
+    unset CUBE_DATABASE_DRIVER \
+      CUBE_EXTERNAL_MYSQL_HOST CUBE_EXTERNAL_MYSQL_PORT \
+      CUBE_EXTERNAL_MYSQL_USER CUBE_EXTERNAL_MYSQL_PASSWORD CUBE_EXTERNAL_MYSQL_DB \
+      CUBE_EXTERNAL_POSTGRES_HOST CUBE_EXTERNAL_POSTGRES_PORT \
+      CUBE_EXTERNAL_POSTGRES_USER CUBE_EXTERNAL_POSTGRES_PASSWORD CUBE_EXTERNAL_POSTGRES_DB \
+      CUBE_SANDBOX_MYSQL_HOST CUBE_SANDBOX_MYSQL_PORT \
+      CUBE_SANDBOX_MYSQL_USER CUBE_SANDBOX_MYSQL_PASSWORD CUBE_SANDBOX_MYSQL_DB \
+      DATABASE_URL
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    if [[ "$#" -gt 0 ]]; then
+      export "$@"
+    fi
+    persist_one_click_database_runtime_env "${env_file}"
+  )
+}
+
+expect_validate_fail() {
+  local label="$1"
+  shift
+  if (
+    unset CUBE_DATABASE_DRIVER \
+      CUBE_EXTERNAL_MYSQL_HOST CUBE_EXTERNAL_POSTGRES_HOST
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    export "$@"
+    validate_one_click_database_config
+  ) >/dev/null 2>&1; then
+    fail "expected validate to fail: ${label}"
+  fi
+}
+
+test_validate_rejects_bad_driver() {
+  expect_validate_fail "bad driver" CUBE_DATABASE_DRIVER=sqlite
+}
+
+test_validate_postgres_requires_host() {
+  expect_validate_fail "postgres without host" CUBE_DATABASE_DRIVER=postgres
+}
+
+test_validate_postgres_rejects_mysql_host() {
+  expect_validate_fail "both hosts" \
+    CUBE_DATABASE_DRIVER=postgres \
+    CUBE_EXTERNAL_POSTGRES_HOST=pg.example.com \
+    CUBE_EXTERNAL_MYSQL_HOST=db.example.com
+}
+
+test_validate_mysql_rejects_postgres_host_without_driver() {
+  expect_validate_fail "postgres host with mysql driver" \
+    CUBE_DATABASE_DRIVER=mysql \
+    CUBE_EXTERNAL_POSTGRES_HOST=pg.example.com
+}
+
+test_validate_postgres_ok() {
+  (
+    unset CUBE_EXTERNAL_MYSQL_HOST
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    export CUBE_DATABASE_DRIVER=postgres
+    export CUBE_EXTERNAL_POSTGRES_HOST=pg.example.com
+    validate_one_click_database_config
+    [[ "${CUBE_DATABASE_DRIVER}" == "postgres" ]] || fail "driver not normalized"
+  ) || fail "postgres validate should succeed"
+}
+
+test_persist_postgres_url_and_scrub_mysql() {
+  local env_file="${TMP_DIR}/pg.env"
+  : > "${env_file}"
+  upsert_env_kv "${env_file}" "CUBE_EXTERNAL_MYSQL_HOST" "stale.mysql"
+  upsert_env_kv "${env_file}" "CUBE_EXTERNAL_MYSQL_PASSWORD" "stale"
+
+  persist_db_clean "${env_file}" \
+    CUBE_DATABASE_DRIVER=postgres \
+    CUBE_EXTERNAL_POSTGRES_HOST=10.0.0.20 \
+    CUBE_EXTERNAL_POSTGRES_PORT=5432 \
+    CUBE_EXTERNAL_POSTGRES_USER=cube \
+    CUBE_EXTERNAL_POSTGRES_PASSWORD='p@ss:word/#' \
+    CUBE_EXTERNAL_POSTGRES_DB=cube_mvp
+
+  assert_value "${env_file}" CUBE_DATABASE_DRIVER postgres
+  assert_value "${env_file}" CUBE_EXTERNAL_POSTGRES_HOST 10.0.0.20
+  assert_value "${env_file}" DATABASE_URL \
+    'postgresql://cube:p%40ss%3Aword%2F%23@10.0.0.20:5432/cube_mvp'
+  assert_not_contains "${env_file}" "CUBE_EXTERNAL_MYSQL_HOST="
+  assert_not_contains "${env_file}" "CUBE_EXTERNAL_MYSQL_PASSWORD="
+}
+
+test_persist_mysql_scrubs_postgres() {
+  local env_file="${TMP_DIR}/mysql.env"
+  : > "${env_file}"
+  upsert_env_kv "${env_file}" "CUBE_EXTERNAL_POSTGRES_HOST" "stale.pg"
+  upsert_env_kv "${env_file}" "CUBE_EXTERNAL_POSTGRES_PASSWORD" "stale"
+
+  persist_db_clean "${env_file}" \
+    CUBE_DATABASE_DRIVER=mysql \
+    CUBE_EXTERNAL_MYSQL_HOST=10.0.0.21 \
+    CUBE_EXTERNAL_MYSQL_PORT=3306 \
+    CUBE_EXTERNAL_MYSQL_USER=cube \
+    CUBE_EXTERNAL_MYSQL_PASSWORD=secret \
+    CUBE_EXTERNAL_MYSQL_DB=cube_mvp
+
+  assert_value "${env_file}" CUBE_DATABASE_DRIVER mysql
+  assert_value "${env_file}" DATABASE_URL \
+    'mysql://cube:secret@10.0.0.21:3306/cube_mvp'
+  assert_not_contains "${env_file}" "CUBE_EXTERNAL_POSTGRES_HOST="
+}
+
+test_persist_local_mysql_default() {
+  local env_file="${TMP_DIR}/local.env"
+  : > "${env_file}"
+
+  persist_db_clean "${env_file}"
+
+  assert_value "${env_file}" CUBE_DATABASE_DRIVER mysql
+  assert_value "${env_file}" DATABASE_URL \
+    'mysql://cube:cube_pass@127.0.0.1:3306/cube_mvp'
+  assert_not_contains "${env_file}" "CUBE_EXTERNAL_POSTGRES_HOST="
+  assert_not_contains "${env_file}" "CUBE_EXTERNAL_MYSQL_HOST="
+}
+
+test_skip_local_mysql_helper() {
+  (
+    unset CUBE_EXTERNAL_MYSQL_HOST CUBE_EXTERNAL_POSTGRES_HOST CUBE_DATABASE_DRIVER
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    one_click_skip_local_mysql && fail "default must not skip"
+    export CUBE_DATABASE_DRIVER=postgres
+    one_click_skip_local_mysql && fail "bare driver=postgres must not skip"
+    export CUBE_EXTERNAL_POSTGRES_HOST=pg.example.com
+    one_click_skip_local_mysql || fail "postgres host must skip"
+  ) || fail "skip helper checks failed"
+}
+
+test_contract_wiring() {
+  local install_sh="${ONE_CLICK_DIR}/install.sh"
+  local up_support="${ONE_CLICK_DIR}/scripts/one-click/up-support.sh"
+  local env_example="${ONE_CLICK_DIR}/env.example"
+  local cfg="${ONE_CLICK_DIR}/../../configs/single-node/cubemaster.yaml"
+  assert_contains "${env_example}" "CUBE_DATABASE_DRIVER=mysql"
+  assert_contains "${env_example}" "CUBE_EXTERNAL_POSTGRES_HOST"
+  # Single DRIVER knob (not duplicated inside each engine block).
+  local driver_lines
+  driver_lines="$(grep -cE '^#?[[:space:]]*CUBE_DATABASE_DRIVER=' "${env_example}" || true)"
+  [[ "${driver_lines}" -eq 1 ]] || fail "env.example should declare CUBE_DATABASE_DRIVER once (got ${driver_lines})"
+  assert_contains "${install_sh}" "CUBE_EXTERNAL_POSTGRES_HOST"
+  assert_contains "${install_sh}" "patch_cubemaster_instance_db_config"
+  assert_contains "${install_sh}" "apply_one_click_database_intent"
+  assert_contains "${install_sh}" "capture_one_click_database_dotenv_values"
+  assert_contains "${install_sh}" "PGCONNECT_TIMEOUT"
+  assert_contains "${up_support}" "CUBE_EXTERNAL_POSTGRES_HOST"
+  assert_contains "${cfg}" 'driver: "mysql"'
+}
+
+
+# Simulate install.sh: snapshot presence+process env, source .env (quotes
+# stripped), capture shell-interpreted dotenv values, then apply after merge.
+run_db_intent_roundtrip() {
+  local env_file="$1"
+  snapshot_one_click_database_intent "${env_file}"
+  if [[ -f "${env_file}" ]]; then
+    # shellcheck disable=SC1090
+    set -a
+    # shellcheck disable=SC1091
+    source "${env_file}"
+    set +a
+    capture_one_click_database_dotenv_values
+  fi
+}
+
+test_upgrade_intent_clears_opposite_mysql() {
+  local env_file="${TMP_DIR}/intent.env"
+  cat > "${env_file}" <<'EOF'
+CUBE_DATABASE_DRIVER=postgres
+CUBE_EXTERNAL_POSTGRES_HOST=pg.example.com
+CUBE_EXTERNAL_POSTGRES_PASSWORD=secret
+EOF
+  (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    run_db_intent_roundtrip "${env_file}"
+    # Simulate upgrade merge re-injecting the previous MySQL marker.
+    export CUBE_DATABASE_DRIVER=mysql
+    export CUBE_EXTERNAL_MYSQL_HOST=stale.mysql
+    export CUBE_EXTERNAL_MYSQL_PASSWORD=stale
+    export CUBE_EXTERNAL_POSTGRES_HOST=""
+    apply_one_click_database_intent
+    [[ "${CUBE_DATABASE_DRIVER}" == "postgres" ]] || fail "driver not restored"
+    [[ "${CUBE_EXTERNAL_POSTGRES_HOST}" == "pg.example.com" ]] || fail "postgres host not restored"
+    [[ -z "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]] || fail "stale mysql host not cleared"
+  ) || fail "upgrade intent mysql→postgres failed"
+}
+
+test_upgrade_intent_keeps_undeclared_mysql_password() {
+  local env_file="${TMP_DIR}/partial.env"
+  cat > "${env_file}" <<'EOF'
+CUBE_DATABASE_DRIVER=mysql
+CUBE_EXTERNAL_MYSQL_HOST=db.example.com
+EOF
+  (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    run_db_intent_roundtrip "${env_file}"
+    export CUBE_EXTERNAL_MYSQL_HOST=old.mysql
+    export CUBE_EXTERNAL_MYSQL_PASSWORD='keep-me'
+    export CUBE_EXTERNAL_POSTGRES_HOST=stale.pg
+    apply_one_click_database_intent
+    [[ "${CUBE_EXTERNAL_MYSQL_HOST}" == "db.example.com" ]] || fail "host from .env not applied"
+    [[ "${CUBE_EXTERNAL_MYSQL_PASSWORD}" == "keep-me" ]] || fail "undeclared password must stay merge-preserved"
+    [[ -z "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]] || fail "opposite postgres host not cleared"
+  ) || fail "upgrade intent keep password failed"
+}
+
+test_upgrade_intent_process_env_fills_gap() {
+  local env_file="${TMP_DIR}/driver-only.env"
+  cat > "${env_file}" <<'EOF'
+CUBE_DATABASE_DRIVER=postgres
+EOF
+  (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    export CUBE_EXTERNAL_POSTGRES_HOST=from-cli.example.com
+    run_db_intent_roundtrip "${env_file}"
+    # Merge left stale mysql; CLI host must survive alongside dotenv driver.
+    export CUBE_EXTERNAL_MYSQL_HOST=stale.mysql
+    export CUBE_EXTERNAL_POSTGRES_HOST=""
+    apply_one_click_database_intent
+    [[ "${CUBE_DATABASE_DRIVER}" == "postgres" ]] || fail "driver from .env"
+    [[ "${CUBE_EXTERNAL_POSTGRES_HOST}" == "from-cli.example.com" ]] || fail "process env host not applied"
+    [[ -z "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]] || fail "opposite mysql not cleared"
+  ) || fail "upgrade intent process env gap failed"
+}
+
+test_upgrade_intent_bundled_via_empty_host() {
+  local env_file="${TMP_DIR}/bundled.env"
+  cat > "${env_file}" <<'EOF'
+CUBE_DATABASE_DRIVER=mysql
+CUBE_EXTERNAL_MYSQL_HOST=
+EOF
+  (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    run_db_intent_roundtrip "${env_file}"
+    export CUBE_EXTERNAL_MYSQL_HOST=stale.mysql
+    export CUBE_EXTERNAL_POSTGRES_HOST=stale.pg
+    apply_one_click_database_intent
+    [[ -z "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]] || fail "empty .env host must clear mysql"
+    [[ -z "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]] || fail "postgres host should clear for mysql driver"
+  ) || fail "upgrade intent bundled failed"
+}
+
+test_upgrade_intent_quoted_password_survives() {
+  local env_file="${TMP_DIR}/quoted.env"
+  cat > "${env_file}" <<'EOF'
+CUBE_DATABASE_DRIVER=postgres
+CUBE_EXTERNAL_POSTGRES_HOST=pg.example.com
+CUBE_EXTERNAL_POSTGRES_PASSWORD='p@ss word#'
+EOF
+  (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    run_db_intent_roundtrip "${env_file}"
+    export CUBE_EXTERNAL_POSTGRES_PASSWORD='corrupted-from-merge'
+    apply_one_click_database_intent
+    [[ "${CUBE_EXTERNAL_POSTGRES_PASSWORD}" == 'p@ss word#' ]]       || fail "quoted .env password must round-trip without quote chars (got: ${CUBE_EXTERNAL_POSTGRES_PASSWORD})"
+  ) || fail "upgrade intent quoted password failed"
+}
+
+test_upgrade_intent_host_implies_driver() {
+  local env_file="${TMP_DIR}/host-only.env"
+  cat > "${env_file}" <<'EOF'
+CUBE_EXTERNAL_MYSQL_HOST=db2.example.com
+EOF
+  (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    run_db_intent_roundtrip "${env_file}"
+    # Stale merge-preserved postgres driver must not scrub the new MySQL host.
+    export CUBE_DATABASE_DRIVER=postgres
+    export CUBE_EXTERNAL_POSTGRES_HOST=stale.pg
+    export CUBE_EXTERNAL_MYSQL_HOST=""
+    apply_one_click_database_intent
+    [[ "${CUBE_DATABASE_DRIVER}" == "mysql" ]] || fail "host must imply mysql driver"
+    [[ "${CUBE_EXTERNAL_MYSQL_HOST}" == "db2.example.com" ]] || fail "mysql host not restored"
+    [[ -z "${CUBE_EXTERNAL_POSTGRES_HOST:-}" ]] || fail "stale postgres host not cleared"
+  ) || fail "upgrade intent host implies driver failed"
+}
+
+test_upgrade_intent_rejects_driver_host_conflict() {
+  local env_file="${TMP_DIR}/conflict.env"
+  cat > "${env_file}" <<'EOF'
+CUBE_DATABASE_DRIVER=mysql
+CUBE_EXTERNAL_POSTGRES_HOST=pg.example.com
+EOF
+  if (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    run_db_intent_roundtrip "${env_file}"
+    apply_one_click_database_intent
+  ) >/dev/null 2>&1; then
+    fail "expected die on DRIVER=mysql + POSTGRES_HOST"
+  fi
+}
+
+test_upgrade_intent_noop_without_dotenv_keys() {
+  local env_file="${TMP_DIR}/empty.env"
+  : > "${env_file}"
+  (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    run_db_intent_roundtrip "${env_file}"
+    export CUBE_EXTERNAL_MYSQL_HOST=keep.mysql
+    apply_one_click_database_intent
+    [[ "${CUBE_EXTERNAL_MYSQL_HOST}" == "keep.mysql" ]] || fail "should preserve when .env has no DB keys"
+  ) || fail "upgrade intent noop failed"
+}
+
+test_persist_postgres_skips_empty_host() {
+  local env_file="${TMP_DIR}/empty-pg-host.env"
+  cat > "${env_file}" <<'EOF'
+DATABASE_URL=postgresql://stale@old:5432/db
+CUBE_EXTERNAL_POSTGRES_HOST=stale.pg
+EOF
+  persist_db_clean "${env_file}" CUBE_DATABASE_DRIVER=postgres
+  # Empty host → bundled MySQL markers (safe for later control-role reuse).
+  assert_value "${env_file}" CUBE_DATABASE_DRIVER mysql
+  assert_not_contains "${env_file}" "CUBE_EXTERNAL_POSTGRES_HOST="
+  assert_value "${env_file}" DATABASE_URL 'mysql://cube:cube_pass@127.0.0.1:3306/cube_mvp'
+}
+
+
+test_patch_conf_postgres_preserves_cube_ops_addr() {
+  local cfg="${TMP_DIR}/cubemaster-pg.conf.yaml"
+  local ops_addr='http://127.0.0.1:3010'
+  cat > "${cfg}" <<EOF
+common:
+  cube_ops_addr: "${ops_addr}"
+instance_db_config:
+  driver: "mysql"
+  addr: "127.0.0.1:3306"
+  user: "cube"
+  pwd: "cube_pass"
+  db_name: "cube_mvp"
+EOF
+  (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    patch_cubemaster_instance_db_config "${cfg}" "postgres" \
+      "10.0.0.20:5432" "pguser" "pg/pass|x" "cube_mvp"
+  ) || fail "patch postgres failed"
+  grep -Fq 'cube_ops_addr: "http://127.0.0.1:3010"' "${cfg}" \
+    || fail "cube_ops_addr must not be clobbered"
+  grep -Fq 'driver: "postgres"' "${cfg}" || fail "driver not patched"
+  grep -Fq 'addr: "10.0.0.20:5432"' "${cfg}" || fail "addr not patched"
+  grep -Fq 'user: "pguser"' "${cfg}" || fail "user not patched"
+  grep -Fq 'pwd: "pg/pass|x"' "${cfg}" || fail "pwd not patched"
+  grep -Fq 'db_name: "cube_mvp"' "${cfg}" || fail "db_name not patched"
+}
+
+test_patch_conf_mysql_preserves_cube_ops_addr() {
+  local cfg="${TMP_DIR}/cubemaster-mysql.conf.yaml"
+  cat > "${cfg}" <<'EOF'
+common:
+  cube_ops_addr: "http://10.1.2.3:3010"
+instance_db_config:
+  driver: "postgres"
+  addr: "10.0.0.20:5432"
+  user: "pg"
+  pwd: "x"
+  db_name: "cube_mvp"
+EOF
+  (
+    # shellcheck disable=SC1091
+    source "${ONE_CLICK_DIR}/lib/common.sh"
+    patch_cubemaster_instance_db_config "${cfg}" "mysql" \
+      "10.0.0.30:3306" "cube" "cube_pass" "cube_mvp"
+  ) || fail "patch mysql failed"
+  grep -Fq 'cube_ops_addr: "http://10.1.2.3:3010"' "${cfg}" \
+    || fail "cube_ops_addr must not be clobbered by mysql patch"
+  grep -Fq 'driver: "mysql"' "${cfg}" || fail "driver not patched to mysql"
+  grep -Fq 'addr: "10.0.0.30:3306"' "${cfg}" || fail "mysql addr not patched"
+}
+
+test_skip_local_mysql_predicate_consistency() {
+  local helper up_support quickcheck postcheck
+  helper="$(sed -n '/^one_click_skip_local_mysql()/,/^}/p' "${ONE_CLICK_DIR}/lib/common.sh")"
+  echo "${helper}" | grep -Fq 'CUBE_EXTERNAL_MYSQL_HOST' \
+    || fail "helper must key off MYSQL host"
+  echo "${helper}" | grep -Fq 'CUBE_EXTERNAL_POSTGRES_HOST' \
+    || fail "helper must key off POSTGRES host"
+  echo "${helper}" | grep -q 'CUBE_DATABASE_DRIVER' \
+    && fail "helper must not key off bare DRIVER"
+  up_support="${ONE_CLICK_DIR}/scripts/one-click/up-support.sh"
+  quickcheck="${ONE_CLICK_DIR}/scripts/one-click/quickcheck.sh"
+  postcheck="${ONE_CLICK_DIR}/scripts/systemd/mysql-postcheck.sh"
+  for f in "${up_support}" "${quickcheck}" "${postcheck}"; do
+    grep -Fq 'CUBE_EXTERNAL_MYSQL_HOST' "${f}" || fail "${f}: missing MYSQL host check"
+    grep -Fq 'CUBE_EXTERNAL_POSTGRES_HOST' "${f}" || fail "${f}: missing POSTGRES host check"
+  done
+  # skip assignment must not reference bare DRIVER anymore
+  ! grep -E 'skip_local_mysql=1|SKIP_LOCAL_MYSQL=1' -A1 -B3 "${up_support}" "${quickcheck}" \
+    | grep -E 'CUBE_DATABASE_DRIVER|DATABASE_DRIVER' \
+    || fail "up-support/quickcheck skip still references DRIVER"
+  ! grep -E 'CUBE_DATABASE_DRIVER.*postgres' "${postcheck}" \
+    || fail "mysql-postcheck still references bare DRIVER"
+}
+
+
+test_validate_rejects_bad_driver
+test_validate_postgres_requires_host
+test_validate_postgres_rejects_mysql_host
+test_validate_mysql_rejects_postgres_host_without_driver
+test_validate_postgres_ok
+test_persist_postgres_url_and_scrub_mysql
+test_persist_mysql_scrubs_postgres
+test_persist_local_mysql_default
+test_skip_local_mysql_helper
+test_contract_wiring
+test_upgrade_intent_clears_opposite_mysql
+test_upgrade_intent_keeps_undeclared_mysql_password
+test_upgrade_intent_process_env_fills_gap
+test_upgrade_intent_bundled_via_empty_host
+test_upgrade_intent_quoted_password_survives
+test_upgrade_intent_host_implies_driver
+test_upgrade_intent_rejects_driver_host_conflict
+test_upgrade_intent_noop_without_dotenv_keys
+test_persist_postgres_skips_empty_host
+test_patch_conf_postgres_preserves_cube_ops_addr
+test_patch_conf_mysql_preserves_cube_ops_addr
+test_skip_local_mysql_predicate_consistency
+
+echo "external postgres tests OK"

--- a/deploy/one-click/tests/test_runtime_file_safety.sh
+++ b/deploy/one-click/tests/test_runtime_file_safety.sh
@@ -904,6 +904,10 @@ test_postcheck_skips_when_external_host_set() {
   CUBE_EXTERNAL_MYSQL_HOST=db.example.com \
     bash "${ONE_CLICK_DIR}/scripts/systemd/mysql-postcheck.sh" \
     || fail "mysql-postcheck must exit 0 when CUBE_EXTERNAL_MYSQL_HOST is set"
+  CUBE_EXTERNAL_POSTGRES_HOST=pg.example.com \
+    CUBE_DATABASE_DRIVER=postgres \
+    bash "${ONE_CLICK_DIR}/scripts/systemd/mysql-postcheck.sh" \
+    || fail "mysql-postcheck must exit 0 when CUBE_EXTERNAL_POSTGRES_HOST is set"
   CUBE_EXTERNAL_REDIS_HOST=cache.example.com \
     bash "${ONE_CLICK_DIR}/scripts/systemd/redis-postcheck.sh" \
     || fail "redis-postcheck must exit 0 when CUBE_EXTERNAL_REDIS_HOST is set"


### PR DESCRIPTION
## Summary
- Add `CUBE_DATABASE_DRIVER` (`mysql` | `postgres`) to one-click, mirroring Helm `database.driver` / `postgres.*`.
- When `postgres` is selected (or implied by a this-run `CUBE_EXTERNAL_POSTGRES_HOST`), require/use `CUBE_EXTERNAL_POSTGRES_*`, patch CubeMaster `instance_db_config` with **line-anchored** sed (so `common.cube_ops_addr` is not clobbered), persist a `postgresql://` `DATABASE_URL`, and skip/mask the bundled MySQL container (one-click never ships local PostgreSQL).
- Keep MySQL and PostgreSQL credential keys separate; opposite-engine markers are scrubbed on switch. If `CUBE_DATABASE_DRIVER` is omitted, a this-run external host implies the matching driver.
- Drop unreachable `restore_bundled_mysql` (PKG_ROOT is a fresh unpack every run; the packaged template is already clean).
- Compute nodes skip external DB connectivity preflight for both PostgreSQL and MySQL (control-plane DB is not used on compute).

## Test plan
- [x] `bash deploy/one-click/tests/test_external_postgres.sh` (incl. conf.yaml `cube_ops_addr` regression + intent/persist fixtures)
- [x] `bash deploy/one-click/tests/test_toggle_inputs.sh`
- [x] Docker self-test on ubuntu22 via `cube-compiler:ubuntu22`
- [ ] CI: DCO + fmt/validate/shellcheck