### PR TITLE
fix(volume-s3): remove s3fs -ononempty mount flag

### DIFF
--- a/examples/volume/s3/internal/s3fsmnt/mount.go
+++ b/examples/volume/s3/internal/s3fsmnt/mount.go
@@ -55,7 +55,6 @@ func (m *Manager) EnsurePasswdFile() error {
 //	-o passwd_file  per-bucket credential file
 //	-o allow_other  Cubelet (a different user) must traverse the mount to bind
 //	                it into the microVM via virtiofs
-//	-o nonempty     the mountpoint may already hold a stale dir entry
 //
 // Create already PUT volumes/<id>/, the same object s3fs mkdir would write, so
 // no compat_dir option is needed.
@@ -67,7 +66,6 @@ func (m *Manager) MountArgs(mnt, volumeID string) []string {
 		"-oendpoint=" + m.cfg.Region,
 		"-opasswd_file=" + m.cfg.PasswdFile,
 		"-oallow_other",
-		"-ononempty",
 	}
 	return append(args, m.cfg.S3FSExtraOpts...)
 }

--- a/examples/volume/s3/internal/s3fsmnt/mount_test.go
+++ b/examples/volume/s3/internal/s3fsmnt/mount_test.go
@@ -44,7 +44,6 @@ func TestMountArgs(t *testing.T) {
 		"-oendpoint=us-east-1",
 		"-opasswd_file=" + m.cfg.PasswdFile,
 		"-oallow_other",
-		"-ononempty",
 		"-ouse_path_request_style",
 	} {
 		if !strings.Contains(joined, want) {


### PR DESCRIPTION
s3fs 1.97 with FUSE3 rejects the legacy -ononempty option:

    fuse: unknown option(s): '-o nonempty'

Remove it from MountArgs and the matching unit test expectation. The MinIO compatibility flag (-ocompat_dir) remains operator configurable through S3FS_EXTRA_OPTS / CUBE_S3_S3FS_EXTRA_OPTS, so it is not hardcoded in the plugin.