### PR TITLE
ci(docker): publish envd base image as a multi-arch manifest

### DIFF
--- a/.github/workflows/build-envd-base-image.yml
+++ b/.github/workflows/build-envd-base-image.yml
@@ -30,7 +30,18 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.arch }} base image
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -41,8 +52,10 @@ jobs:
 
       - name: Resolve envd ref
         id: meta_ref
+        env:
+          ENVD_REF_INPUT: ${{ github.event.inputs.envd_ref }}
         run: |
-          envd_ref="${{ github.event.inputs.envd_ref || env.ENVD_REF_DEFAULT }}"
+          envd_ref="${ENVD_REF_INPUT:-${ENVD_REF_DEFAULT}}"
           echo "envd_ref=${envd_ref}" >> "${GITHUB_OUTPUT}"
           echo "Compiling envd from e2b-dev/infra@${envd_ref}"
 
@@ -62,28 +75,42 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=${{ steps.meta_ref.outputs.envd_ref }},enable=${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
-            type=raw,value=${{ steps.meta_ref.outputs.envd_ref }}-${{ env.BASE_OS_TAG_SUFFIX }},enable=${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
-            type=raw,value=latest,enable=${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
-            type=sha,prefix=sha-,format=short
           labels: |
             io.cubesandbox.envd.ref=${{ steps.meta_ref.outputs.envd_ref }}
+
+      - name: Prepare image tags
+        id: image_tags
+        env:
+          ARCH: ${{ matrix.arch }}
+          ENVD_REF: ${{ steps.meta_ref.outputs.envd_ref }}
+          IS_RELEASE_PUSH: ${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE_NAME}:sha-${short_sha}-${ARCH}"
+            if [[ "${IS_RELEASE_PUSH}" == "true" ]]; then
+              echo "${IMAGE_NAME}:latest-${ARCH}"
+              echo "${IMAGE_NAME}:${ENVD_REF}-${ARCH}"
+              echo "${IMAGE_NAME}:${ENVD_REF}-${BASE_OS_TAG_SUFFIX}-${ARCH}"
+            fi
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Build image (load locally for smoke test)
         uses: docker/build-push-action@v6
         with:
           context: docker
           file: docker/Dockerfile.cube-base
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: false
           load: true
           tags: cubesandbox-base:ci-smoke
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ENVD_REF=${{ steps.meta_ref.outputs.envd_ref }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=cube-base-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=cube-base-${{ matrix.arch }}
 
       - name: Smoke test envd /health
         run: |
@@ -92,7 +119,7 @@ jobs:
           trap 'docker rm -f "${cid}" >/dev/null 2>&1 || true' EXIT
 
           ok=""
-          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+          for attempt in {1..10}; do
             code="$(docker exec "${cid}" curl -s -o /dev/null -w "%{http_code}" \
                 http://127.0.0.1:49983/health || true)"
             echo "attempt ${attempt}: envd /health => ${code}"
@@ -113,17 +140,61 @@ jobs:
           docker exec "${cid}" /usr/bin/envd -version
           docker exec "${cid}" /usr/bin/envd -commit
 
-      - name: Push image
+      - name: Push per-arch image
         if: github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v6
         with:
           context: docker
           file: docker/Dockerfile.cube-base
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          # Plain per-arch manifests so publish_manifest can combine them.
+          # Attestations add unknown/unknown entries that break imagetools create.
+          provenance: false
+          tags: ${{ steps.image_tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ENVD_REF=${{ steps.meta_ref.outputs.envd_ref }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=cube-base-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=cube-base-${{ matrix.arch }}
+
+  publish_manifest:
+    name: Publish multi-arch base manifests
+    if: github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Resolve envd ref
+        id: meta_ref
+        env:
+          ENVD_REF_INPUT: ${{ github.event.inputs.envd_ref }}
+        run: |
+          envd_ref="${ENVD_REF_INPUT:-${ENVD_REF_DEFAULT}}"
+          echo "envd_ref=${envd_ref}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifests
+        env:
+          ENVD_REF: ${{ steps.meta_ref.outputs.envd_ref }}
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${ENVD_REF}" \
+            -t "${IMAGE_NAME}:${ENVD_REF}-${BASE_OS_TAG_SUFFIX}" \
+            -t "${IMAGE_NAME}:sha-${short_sha}" \
+            "${IMAGE_NAME}:sha-${short_sha}-amd64" \
+            "${IMAGE_NAME}:sha-${short_sha}-arm64"

--- a/docker/Dockerfile.cube-base
+++ b/docker/Dockerfile.cube-base
@@ -5,11 +5,12 @@
 # and can be turned into Cube templates without any extra wiring.
 #
 # envd is compiled from e2b-dev/infra@${ENVD_REF} in a builder stage,
-# producing a static linux/amd64 binary that is copied into the final
-# ubuntu:22.04 runtime stage alongside a generic entrypoint.
+# producing a static linux/${TARGETARCH} binary that is copied into the
+# final ubuntu:22.04 runtime stage alongside a generic entrypoint.
 #
-# Build example:
+# Build example (repeat with --platform linux/arm64 for ARM):
 #   docker build \
+#     --platform linux/amd64 \
 #     -f docker/Dockerfile.cube-base \
 #     -t ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
 #     docker/
@@ -17,12 +18,12 @@
 ARG ENVD_REF=2026.16
 ARG GO_VERSION=1.25.4
 ARG UBUNTU_VERSION=22.04
-ARG TARGETARCH
 
 # -------- Stage 1: compile envd from e2b-dev/infra --------
 FROM golang:${GO_VERSION}-bookworm AS envd-builder
 
 ARG ENVD_REF
+ARG TARGETARCH
 ARG ENVD_UPSTREAM_REPO=https://github.com/e2b-dev/infra.git
 
 RUN apt-get update \

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,13 +14,14 @@ by [`.github/workflows/build-builder-image.yml`](../.github/workflows/build-buil
 
 Base image for user-supplied sandbox templates. It is `ubuntu:22.04`
 with `envd` preinstalled on `:49983`, so any image built `FROM` it is
-already ready for Cube's readiness probe. Published as
+already ready for Cube's readiness probe. Published as a multi-arch
+(`linux/amd64` + `linux/arm64`) manifest list
 `ghcr.io/tencentcloud/cubesandbox-base` by
 [`.github/workflows/build-envd-base-image.yml`](../.github/workflows/build-envd-base-image.yml),
 which compiles `envd` in-place from
 [`e2b-dev/infra`](https://github.com/e2b-dev/infra) at tag `2026.16`
-(override via `workflow_dispatch` input `envd_ref`) before baking the
-image.
+(override via `workflow_dispatch` input `envd_ref`) on native amd64 and
+arm64 runners, then combines the per-arch images into one tag.
 
 Minimal consumer example:
 

--- a/docs/guide/tutorials/bring-your-own-image.md
+++ b/docs/guide/tutorials/bring-your-own-image.md
@@ -247,6 +247,7 @@ docker exec "$cid" cat /var/log/envd.log
 The base image is produced by a single GitHub Actions workflow in this
 repository: [`.github/workflows/build-envd-base-image.yml`](https://github.com/TencentCloud/CubeSandbox/blob/master/.github/workflows/build-envd-base-image.yml).
 It checks out `e2b-dev/infra` at the chosen tag (default `2026.16`),
-compiles `envd` with Go 1.25.4 in-place, builds
-`docker/Dockerfile.cube-base`, runs a `:49983/health` smoke test, then
-pushes to `ghcr.io/tencentcloud/cubesandbox-base`.
+compiles `envd` with Go 1.25.4 in-place on native `linux/amd64` and
+`linux/arm64` runners, builds `docker/Dockerfile.cube-base`, runs a
+`:49983/health` smoke test on each architecture, then publishes a
+multi-arch manifest list to `ghcr.io/tencentcloud/cubesandbox-base`.

--- a/docs/zh/guide/tutorials/bring-your-own-image.md
+++ b/docs/zh/guide/tutorials/bring-your-own-image.md
@@ -235,7 +235,8 @@ docker exec "$cid" cat /var/log/envd.log
 
 基础镜像由仓库内单个 GitHub Actions workflow 自动构建：
 [`.github/workflows/build-envd-base-image.yml`](https://github.com/TencentCloud/CubeSandbox/blob/master/.github/workflows/build-envd-base-image.yml)。
-它会 checkout `e2b-dev/infra` 的指定 tag（默认 `2026.16`），用 Go 1.25.4
-在同一个 job 里直接把 envd 编译进来，构建 `docker/Dockerfile.cube-base`，
-对 `:49983/health` 做 smoke test，然后推送到
+它会 checkout `e2b-dev/infra` 的指定 tag（默认 `2026.16`），在原生
+`linux/amd64` 与 `linux/arm64` runner 上用 Go 1.25.4 编译 envd，构建
+`docker/Dockerfile.cube-base`，分别对 `:49983/health` 做 smoke test，再
+合成 multi-arch manifest list 推送到
 `ghcr.io/tencentcloud/cubesandbox-base`。


### PR DESCRIPTION
## Summary

Build `docker/Dockerfile.cube-base` for both `linux/amd64` and `linux/arm64` and publish the base image as a single multi-arch manifest.

- `.github/workflows/build-envd-base-image.yml`: run the build on a native per-arch runner matrix (`amd64` on `ubuntu-latest`, `arm64` on `ubuntu-24.04-arm`), push plain per-arch images, then a follow-up `publish_manifest` job combines them with `docker buildx imagetools create` into one tag set (`latest`, envd-ref, envd-ref-os-suffix, `sha-<short>`).
- Per-arch cache scopes (`cube-base-<arch>`) keep the amd64/arm64 GHA cache layers separate.
- `docker/Dockerfile.cube-base`: declare `TARGETARCH` in the `envd-builder` stage so the `GOARCH`-sensitive build stage works when building for arm64.
- Docs (`docker/README.md`, bring-your-own-image tutorial in en/zh) updated to describe the multi-arch publish flow.

## Why multi-arch

Lets user-supplied sandbox templates built `FROM` the base image run on arm64 hosts, matching the envd base support already used elsewhere in the project.

## Verification

- The per-arch `build` matrix runs on every push/PR and loads the image for the `:49983/health` and `envd -version` smoke tests locally.
- The multi-arch manifest publish path only triggers on the default repository on `master`.