### PR TITLE
feat(host-mount): support snapshot restore and cloning

### DIFF
--- a/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
@@ -480,7 +480,8 @@ func dealCubeboxCreateReqWithTemplateCenter(ctx context.Context, templateID stri
 		templatecenter.ReportResolveStageMetric(ctx, constants.ActionTemplateResolveBind, time.Since(bindStart))
 	}()
 	if strings.EqualFold(templateKind, templatecenter.TemplateKindSnapshot) {
-		if err := bindSnapshotCreateReplica(ctx, templateID, reqInOut); err != nil {
+		pinToOrigin := snapshotRestoreHasHostMount(reqInOut, templateReq)
+		if err := bindSnapshotCreateReplicaWithHostMount(ctx, templateID, reqInOut, pinToOrigin); err != nil {
 			return err
 		}
 	}
@@ -536,6 +537,11 @@ func dealCubeboxCreateReqWithTemplateCenter(ctx context.Context, templateID stri
 	return nil
 }
 
+func snapshotRestoreHasHostMount(req, templateReq *types.CreateCubeSandboxReq) bool {
+	return sandbox.CreateRequestHasHostMount(req) ||
+		sandbox.CreateRequestHasHostMount(templateReq)
+}
+
 func skipTemplateLocalityReady(ctx context.Context, templateID string) bool {
 	src, err := getSnapshotRestoreSourceFn(ctx, templateID)
 	if err != nil || src == nil {
@@ -584,14 +590,26 @@ func constrainSnapshotCreateScope(ctx context.Context, snapshotID string, reqInO
 // keys are explicitly deleted so any stale value supplied by the caller
 // cannot reach the cubelet.
 func bindSnapshotCreateReplica(ctx context.Context, snapshotID string, reqInOut *types.CreateCubeSandboxReq) error {
+	return bindSnapshotCreateReplicaWithHostMount(
+		ctx,
+		snapshotID,
+		reqInOut,
+		sandbox.CreateRequestHasHostMount(reqInOut),
+	)
+}
+
+func bindSnapshotCreateReplicaWithHostMount(ctx context.Context, snapshotID string, reqInOut *types.CreateCubeSandboxReq, pinToOrigin bool) error {
 	if err := ensureSnapshotReadyForNewUseFn(ctx, snapshotID); err != nil {
 		return err
 	}
 	if src, err := getSnapshotRestoreSourceFn(ctx, snapshotID); err == nil && src != nil {
-		return bindSnapshotCreateReplicaWithPlacement(ctx, snapshotID, reqInOut, src)
+		return bindSnapshotCreateReplicaWithPlacement(ctx, snapshotID, reqInOut, src, pinToOrigin)
 	} else if err != nil && !errors.Is(err, templatecenter.ErrSnapshotNotFound) &&
 		!errors.Is(err, templatecenter.ErrTemplateStoreNotInitialized) {
 		return err
+	}
+	if pinToOrigin {
+		return fmt.Errorf("snapshot %s with host-mount requires origin restore metadata", snapshotID)
 	}
 	return bindSnapshotCreateReplicaLocal(ctx, snapshotID, reqInOut)
 }
@@ -601,7 +619,7 @@ func bindSnapshotCreateReplica(ctx context.Context, snapshotID string, reqInOut 
 // must not call Decide: after a Master restart the heartbeat cache is
 // empty and Decide would fail even though the snapshot row already has
 // OriginNodeIP.
-func fromSnapshotPlacement(ctx context.Context, snapshotID string, reqInOut *types.CreateCubeSandboxReq, src *templatecenter.RestoreSource, instanceType string, reqRes *selctx.RequestResource) (*restoreplace.Placement, error) {
+func fromSnapshotPlacement(ctx context.Context, snapshotID string, reqInOut *types.CreateCubeSandboxReq, src *templatecenter.RestoreSource, instanceType string, reqRes *selctx.RequestResource, pinToOrigin bool) (*restoreplace.Placement, error) {
 	if src == nil {
 		return nil, fmt.Errorf("snapshot %s: restore source is nil", snapshotID)
 	}
@@ -629,10 +647,11 @@ func fromSnapshotPlacement(ctx context.Context, snapshotID string, reqInOut *typ
 		InstanceType:        instanceType,
 		ReqRes:              reqRes,
 		RequestedScope:      requestedScope,
+		PinToOrigin:         pinToOrigin,
 	})
 }
 
-func bindSnapshotCreateReplicaWithPlacement(ctx context.Context, snapshotID string, reqInOut *types.CreateCubeSandboxReq, src *templatecenter.RestoreSource) error {
+func bindSnapshotCreateReplicaWithPlacement(ctx context.Context, snapshotID string, reqInOut *types.CreateCubeSandboxReq, src *templatecenter.RestoreSource, pinToOrigin bool) error {
 	var reqRes *selctx.RequestResource
 	if config.GetConfig() != nil {
 		if r, err := sandbox.RequestResources(reqInOut); err == nil {
@@ -643,7 +662,7 @@ func bindSnapshotCreateReplicaWithPlacement(ctx context.Context, snapshotID stri
 	if instanceType == "" {
 		instanceType = src.InstanceType
 	}
-	placement, err := fromSnapshotPlacement(ctx, snapshotID, reqInOut, src, instanceType, reqRes)
+	placement, err := fromSnapshotPlacement(ctx, snapshotID, reqInOut, src, instanceType, reqRes, pinToOrigin)
 	if err != nil {
 		return err
 	}

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/nodemeta"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/restoreplace"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
 	CubeLog "github.com/tencentcloud/CubeSandbox/pkgs/CubeLog"
@@ -401,6 +402,71 @@ func TestBindSnapshotCreateReplicaCrossNodeWhenOriginCannotSchedule(t *testing.T
 	assert.Equal(t, constants.SnapshotBackendS3, req.Annotations[constants.CubeAnnotationStorageBackend])
 	assert.Equal(t, `{"rootfs":"r1","memory":"m1"}`, req.Annotations[constants.CubeAnnotationSnapshotRemoteUUIDs])
 	assert.Equal(t, "snap-1", req.Annotations[constants.CubeAnnotationRuntimeSnapshotID])
+}
+
+func TestBindSnapshotCreateReplicaPinsRawHostMountToOrigin(t *testing.T) {
+	stubSnapshotReadyForNewUse(t)
+	origSource := getSnapshotRestoreSourceFn
+	origDecide := decideRestorePlacementFn
+	origReplica := resolveSnapshotReadyReplicaFn
+	t.Cleanup(func() {
+		getSnapshotRestoreSourceFn = origSource
+		decideRestorePlacementFn = origDecide
+		resolveSnapshotReadyReplicaFn = origReplica
+	})
+	getSnapshotRestoreSourceFn = func(context.Context, string) (*templatecenter.RestoreSource, error) {
+		return &templatecenter.RestoreSource{
+			SnapshotID: "snap-1", Backend: constants.SnapshotBackendS3,
+			RemoteStatus: constants.RemoteStatusReady, OriginNodeID: "node-a", OriginNodeIP: "10.0.0.1",
+		}, nil
+	}
+	decideRestorePlacementFn = func(_ context.Context, in restoreplace.Input) (*restoreplace.Placement, error) {
+		assert.True(t, in.PinToOrigin)
+		return &restoreplace.Placement{NodeID: "node-a", NodeIP: "10.0.0.1"}, nil
+	}
+	resolveSnapshotReadyReplicaFn = func(context.Context, string, string) (templatecenter.ReplicaStatus, error) {
+		return templatecenter.ReplicaStatus{NodeID: "node-a"}, nil
+	}
+	req := &types.CreateCubeSandboxReq{Annotations: map[string]string{
+		sandbox.AnnotationHostDirMount: `[{"hostPath":"/data/shared","mountPath":"/mnt"}]`,
+	}}
+
+	require.NoError(t, bindSnapshotCreateReplica(context.Background(), "snap-1", req))
+	assert.Equal(t, []string{"node-a"}, req.DistributionScope)
+	assert.Empty(t, req.Annotations[constants.CubeAnnotationSnapshotAllowNonLocal])
+}
+
+func TestSnapshotRestoreHasHostMountFromStoredTemplate(t *testing.T) {
+	req := &types.CreateCubeSandboxReq{Annotations: map[string]string{}}
+	templateReq := &types.CreateCubeSandboxReq{Annotations: map[string]string{
+		sandbox.AnnotationHostDirMount: `[{"hostPath":"/data/shared","mountPath":"/mnt"}]`,
+	}}
+
+	assert.True(t, snapshotRestoreHasHostMount(req, templateReq))
+}
+
+func TestBindSnapshotCreateReplicaHostMountFailsWithoutOriginMetadata(t *testing.T) {
+	stubSnapshotReadyForNewUse(t)
+	origSource := getSnapshotRestoreSourceFn
+	origReplica := resolveSnapshotReadyReplicaFn
+	t.Cleanup(func() {
+		getSnapshotRestoreSourceFn = origSource
+		resolveSnapshotReadyReplicaFn = origReplica
+	})
+	getSnapshotRestoreSourceFn = func(context.Context, string) (*templatecenter.RestoreSource, error) {
+		return nil, templatecenter.ErrTemplateStoreNotInitialized
+	}
+	resolveSnapshotReadyReplicaFn = func(context.Context, string, string) (templatecenter.ReplicaStatus, error) {
+		t.Fatal("host-mount restore must not use an unpinned legacy replica")
+		return templatecenter.ReplicaStatus{}, nil
+	}
+	req := &types.CreateCubeSandboxReq{Annotations: map[string]string{
+		sandbox.AnnotationHostDirMount: `[{"hostPath":"/data/shared","mountPath":"/mnt"}]`,
+	}}
+
+	err := bindSnapshotCreateReplica(context.Background(), "snap-1", req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires origin restore metadata")
 }
 
 func TestBindSnapshotCreateReplicaKeepsOriginWhenPlacementSaysOrigin(t *testing.T) {

--- a/CubeMaster/pkg/service/sandbox/hostdir_mount.go
+++ b/CubeMaster/pkg/service/sandbox/hostdir_mount.go
@@ -67,6 +67,13 @@ func createRequestHasHostMount(req *types.CreateCubeSandboxReq) bool {
 	return false
 }
 
+// CreateRequestHasHostMount reports whether a create request carries a raw
+// host-mount dependency. Snapshot restore uses it to keep that dependency on
+// its origin node.
+func CreateRequestHasHostMount(req *types.CreateCubeSandboxReq) bool {
+	return createRequestHasHostMount(req)
+}
+
 func injectHostDirMounts(ctx context.Context, req *types.CreateCubeSandboxReq) error {
 	if req.Annotations == nil {
 		log.G(ctx).Infof("[hostdir] no annotations, skip")
@@ -107,38 +114,89 @@ func injectHostDirMounts(ctx context.Context, req *types.CreateCubeSandboxReq) e
 
 	for i, o := range opts {
 		name := fmt.Sprintf("hostdir-%d", i)
-		vol := &types.Volume{
+		if err := ensureHostDirVolume(req, name, o.HostPath); err != nil {
+			return err
+		}
+		for _, c := range req.Containers {
+			if err := ensureHostDirVolumeMount(c, name, o); err != nil {
+				return err
+			}
+		}
+		log.G(ctx).Infof("[hostdir] ensured Volume and VolumeMount %q hostPath=%s containerPath=%s readOnly=%v",
+			name, o.HostPath, o.MountPath, o.ReadOnly)
+	}
+
+	return nil
+}
+
+func ensureHostDirVolume(req *types.CreateCubeSandboxReq, name, hostPath string) error {
+	var existing *types.Volume
+	for _, volume := range req.Volumes {
+		if volume == nil || volume.Name != name {
+			continue
+		}
+		if existing != nil {
+			return fmt.Errorf("host-mount volume %q is duplicated before injection", name)
+		}
+		existing = volume
+	}
+	if existing == nil {
+		req.Volumes = append(req.Volumes, &types.Volume{
 			Name: name,
 			VolumeSource: &types.VolumeSource{
 				HostDirVolumeSources: &types.HostDirVolumeSources{
-					VolumeSources: []*types.HostDirSource{
-						{
-							Name:     name,
-							HostPath: o.HostPath,
-						},
-					},
+					VolumeSources: []*types.HostDirSource{{
+						Name:     name,
+						HostPath: hostPath,
+					}},
 				},
 			},
-		}
-		req.Volumes = append(req.Volumes, vol)
-		log.G(ctx).Infof("[hostdir] injected Volume %q hostPath=%s", name, o.HostPath)
-	}
-
-	vm := make([]*cubeboxv1.VolumeMounts, 0, len(opts))
-	for i, o := range opts {
-		name := fmt.Sprintf("hostdir-%d", i)
-		vm = append(vm, &cubeboxv1.VolumeMounts{
-			Name:          name,
-			ContainerPath: o.MountPath,
-			HostPath:      o.HostPath,
-			Readonly:      o.ReadOnly,
 		})
-		log.G(ctx).Infof("[hostdir] injected VolumeMount %q containerPath=%s readOnly=%v", name, o.MountPath, o.ReadOnly)
-	}
-	for _, c := range req.Containers {
-		c.VolumeMounts = append(c.VolumeMounts, vm...)
+		return nil
 	}
 
+	if existing.VolumeSource == nil {
+		return fmt.Errorf("host-mount volume %q conflicts with existing volume source", name)
+	}
+	hostDirs := existing.VolumeSource.HostDirVolumeSources
+	if hostDirs == nil || len(hostDirs.VolumeSources) != 1 {
+		return fmt.Errorf("host-mount volume %q conflicts with existing volume source", name)
+	}
+	source := hostDirs.VolumeSources[0]
+	if source == nil || source.Name != name || filepath.Clean(source.HostPath) != hostPath {
+		return fmt.Errorf("host-mount volume %q conflicts with existing hostPath", name)
+	}
+	return nil
+}
+
+func ensureHostDirVolumeMount(container *types.Container, name string, option HostDirMountOption) error {
+	if container == nil {
+		return nil
+	}
+	var existing *cubeboxv1.VolumeMounts
+	for _, mount := range container.VolumeMounts {
+		if mount == nil || mount.GetName() != name {
+			continue
+		}
+		if existing != nil {
+			return fmt.Errorf("host-mount volume mount %q is duplicated before injection", name)
+		}
+		existing = mount
+	}
+	if existing == nil {
+		container.VolumeMounts = append(container.VolumeMounts, &cubeboxv1.VolumeMounts{
+			Name:          name,
+			ContainerPath: option.MountPath,
+			HostPath:      option.HostPath,
+			Readonly:      option.ReadOnly,
+		})
+		return nil
+	}
+	if filepath.Clean(existing.GetHostPath()) != option.HostPath ||
+		filepath.Clean(existing.GetContainerPath()) != filepath.Clean(option.MountPath) ||
+		existing.GetReadonly() != option.ReadOnly {
+		return fmt.Errorf("host-mount volume mount %q conflicts with existing mount", name)
+	}
 	return nil
 }
 

--- a/CubeMaster/pkg/service/sandbox/hostdir_mount_test.go
+++ b/CubeMaster/pkg/service/sandbox/hostdir_mount_test.go
@@ -234,6 +234,31 @@ func TestInjectHostDirMountsSetsHostPathOnVolumeMount(t *testing.T) {
 	}
 }
 
+func TestInjectHostDirMountsIsIdempotentForSnapshotRestore(t *testing.T) {
+	req := &types.CreateCubeSandboxReq{
+		Annotations: map[string]string{
+			AnnotationHostDirMount: `[
+				{"hostPath":"/data/shared/rw","mountPath":"/mnt/rw"},
+				{"hostPath":"/data/shared/ro","mountPath":"/mnt/ro","readOnly":true}
+			]`,
+		},
+		Containers: []*types.Container{{Name: "work"}},
+	}
+
+	if err := injectHostDirMounts(context.Background(), req); err != nil {
+		t.Fatalf("first injectHostDirMounts() error=%v", err)
+	}
+	if err := injectHostDirMounts(context.Background(), req); err != nil {
+		t.Fatalf("second injectHostDirMounts() error=%v", err)
+	}
+	if len(req.Volumes) != 2 {
+		t.Fatalf("volume count=%d want 2", len(req.Volumes))
+	}
+	if len(req.Containers[0].VolumeMounts) != 2 {
+		t.Fatalf("volume mount count=%d want 2", len(req.Containers[0].VolumeMounts))
+	}
+}
+
 func TestCreateRequestHasHostMount(t *testing.T) {
 	t.Parallel()
 	if createRequestHasHostMount(nil) {

--- a/Cubelet/pkg/container/virtiofs/virtiofs.go
+++ b/Cubelet/pkg/container/virtiofs/virtiofs.go
@@ -36,6 +36,9 @@ type VirtioBackendFsConfig struct {
 	AllowedDirs []string `json:"allowed_dirs"`
 	ReadOnly    bool     `json:"read_only"`
 	Cache       int      `json:"cache"`
+	// RemapFilter makes restore-time allowed_dirs authoritative for serialized
+	// filter roots. It is enabled only when restoring guest mount state.
+	RemapFilter bool `json:"remap_filter,omitempty"`
 }
 
 type ErofsImagePath struct {

--- a/Cubelet/plugins/cbri/cubeboxcbri/virtiofs.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/virtiofs.go
@@ -60,6 +60,7 @@ func generateSandboxVirtiofsOpt(ctx context.Context, flowOpts *workflow.CreateCo
 				AllowedDirs: v.bindPaths,
 				ReadOnly:    k.readOnly,
 				Cache:       constants.VirtiofsCacheNone,
+				RemapFilter: flowOpts.IsGuestMountRestore(),
 			},
 		}
 		if k.readOnly {

--- a/Cubelet/plugins/cbri/cubeboxcbri/virtiofs_test.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/virtiofs_test.go
@@ -355,6 +355,7 @@ func TestGenerateRestoreVirtiofsOptSkipsGuestMountRestore(t *testing.T) {
 			require.NoError(t, err)
 			spec := applySpecOpts(t, context.Background(), sandboxOpts)
 			require.NotEmpty(t, spec.Annotations[constants.AnnotationVirtiofs])
+			require.Contains(t, spec.Annotations[constants.AnnotationVirtiofs], `"remap_filter":true`)
 		})
 	}
 }

--- a/Cubelet/services/cubebox/service_test.go
+++ b/Cubelet/services/cubebox/service_test.go
@@ -281,9 +281,20 @@ func TestValidateCommitSandboxTarget(t *testing.T) {
 	assert.Equal(t, "root", rootVolume)
 }
 
-func TestValidateCommitSandboxTargetRejectsHostPath(t *testing.T) {
+func TestValidateCommitSandboxTargetAllowsDeclaredRawHostPath(t *testing.T) {
 	cb := &cubeboxstore.CubeBox{
-		Metadata: cubeboxstore.Metadata{ID: "sandbox"},
+		Metadata: cubeboxstore.Metadata{
+			ID: "sandbox",
+			Annotations: map[string]string{
+				"host-mount": `[{"hostPath":"/var/lib/data","mountPath":"/data"}]`,
+			},
+		},
+		Volumes: []*cubeboxv1.Volume{{
+			Name: "hostdir-0",
+			VolumeSource: &cubeboxv1.VolumeSource{HostDirVolumes: &cubeboxv1.HostDirVolumeSources{
+				VolumeSources: []*cubeboxv1.HostDirSource{{Name: "hostdir-0", HostPath: "/var/lib/data"}},
+			}},
+		}},
 	}
 	cb.AddContainer(&cubeboxstore.Container{
 		Metadata: cubeboxstore.Metadata{
@@ -293,8 +304,9 @@ func TestValidateCommitSandboxTargetRejectsHostPath(t *testing.T) {
 					Name:          "root",
 					ContainerPath: "/",
 				}, {
-					Name:     "host",
-					HostPath: "/var/lib/data",
+					Name:          "hostdir-0",
+					HostPath:      "/var/lib/data",
+					ContainerPath: "/data",
 				}},
 			},
 		},
@@ -302,9 +314,151 @@ func TestValidateCommitSandboxTargetRejectsHostPath(t *testing.T) {
 		IsPod:  true,
 	})
 
+	root, err := validateCommitSandboxTarget(cb)
+	require.NoError(t, err)
+	assert.Equal(t, "root", root)
+}
+
+func TestValidateCommitSandboxTargetRejectsUndeclaredHostPath(t *testing.T) {
+	cb := newRunningCommitSandboxForTest(nil, []*cubeboxv1.VolumeMounts{{
+		Name: "root", ContainerPath: "/",
+	}, {
+		Name: "host", HostPath: "/var/lib/data", ContainerPath: "/data",
+	}})
+
 	_, err := validateCommitSandboxTarget(cb)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "hostPath")
+	assert.Contains(t, err.Error(), "not declared")
+}
+
+func TestValidateCommitSandboxTargetRejectsMismatchedRawHostDirBackingVolume(t *testing.T) {
+	cb := newRunningCommitSandboxForTest([]*cubeboxv1.Volume{{
+		Name: "hostdir-0",
+		VolumeSource: &cubeboxv1.VolumeSource{HostDirVolumes: &cubeboxv1.HostDirVolumeSources{
+			VolumeSources: []*cubeboxv1.HostDirSource{{Name: "hostdir-0", HostPath: "/var/lib/other"}},
+		}},
+	}}, []*cubeboxv1.VolumeMounts{{Name: "root", ContainerPath: "/"}, {
+		Name: "hostdir-0", ContainerPath: "/data", HostPath: "/var/lib/data",
+	}})
+	cb.Annotations = map[string]string{
+		"host-mount": `[{"hostPath":"/var/lib/data","mountPath":"/data"}]`,
+	}
+
+	_, err := validateCommitSandboxTarget(cb)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+}
+
+func TestValidateCommitSandboxTargetRejectsMissingRawHostDirBackingVolume(t *testing.T) {
+	cb := newRunningCommitSandboxForTest(nil, []*cubeboxv1.VolumeMounts{{
+		Name: "root", ContainerPath: "/",
+	}, {
+		Name: "hostdir-0", ContainerPath: "/data", HostPath: "/var/lib/data",
+	}})
+	cb.Annotations = map[string]string{
+		"host-mount": `[{"hostPath":"/var/lib/data","mountPath":"/data"}]`,
+	}
+
+	_, err := validateCommitSandboxTarget(cb)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "volume hostdir-0 is missing")
+}
+
+func TestValidateCommitSandboxTargetRejectsMissingMountInOneContainer(t *testing.T) {
+	cb := newRunningCommitSandboxForTest([]*cubeboxv1.Volume{{
+		Name: "hostdir-0",
+		VolumeSource: &cubeboxv1.VolumeSource{HostDirVolumes: &cubeboxv1.HostDirVolumeSources{
+			VolumeSources: []*cubeboxv1.HostDirSource{{Name: "hostdir-0", HostPath: "/var/lib/data"}},
+		}},
+	}}, []*cubeboxv1.VolumeMounts{{Name: "root", ContainerPath: "/"}, {
+		Name: "hostdir-0", ContainerPath: "/data", HostPath: "/var/lib/data",
+	}})
+	cb.Annotations = map[string]string{
+		"host-mount": `[{"hostPath":"/var/lib/data","mountPath":"/data"}]`,
+	}
+	cb.AddContainer(&cubeboxstore.Container{
+		Metadata: cubeboxstore.Metadata{
+			ID: "second",
+			Config: &cubeboxv1.ContainerConfig{VolumeMounts: []*cubeboxv1.VolumeMounts{{
+				Name: "root", ContainerPath: "/",
+			}}},
+		},
+		Status: cubeboxstore.StoreStatus(cubeboxstore.Status{StartedAt: time.Now().UnixNano()}),
+		IsPod:  true,
+	})
+
+	_, err := validateCommitSandboxTarget(cb)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "volume mount hostdir-0 is missing")
+}
+
+func TestValidateCommitSandboxTargetAllowsAuxiliaryContainerWithoutRawHostMount(t *testing.T) {
+	cb := newRunningCommitSandboxForTest([]*cubeboxv1.Volume{{
+		Name: "hostdir-0",
+		VolumeSource: &cubeboxv1.VolumeSource{HostDirVolumes: &cubeboxv1.HostDirVolumeSources{
+			VolumeSources: []*cubeboxv1.HostDirSource{{Name: "hostdir-0", HostPath: "/var/lib/data"}},
+		}},
+	}}, []*cubeboxv1.VolumeMounts{{Name: "root", ContainerPath: "/"}, {
+		Name: "hostdir-0", ContainerPath: "/data", HostPath: "/var/lib/data",
+	}})
+	cb.Annotations = map[string]string{
+		"host-mount": `[{"hostPath":"/var/lib/data","mountPath":"/data"}]`,
+	}
+	cb.AddContainer(&cubeboxstore.Container{
+		Metadata: cubeboxstore.Metadata{
+			ID: "auxiliary",
+			Config: &cubeboxv1.ContainerConfig{VolumeMounts: []*cubeboxv1.VolumeMounts{{
+				Name: "root", ContainerPath: "/",
+			}}},
+		},
+		Status: cubeboxstore.StoreStatus(cubeboxstore.Status{StartedAt: time.Now().UnixNano()}),
+	})
+
+	root, err := validateCommitSandboxTarget(cb)
+	require.NoError(t, err)
+	assert.Equal(t, "root", root)
+}
+
+func TestValidateCommitSandboxTargetRejectsUndeclaredHostPathInAuxiliaryContainer(t *testing.T) {
+	cb := newRunningCommitSandboxForTest(nil, []*cubeboxv1.VolumeMounts{{
+		Name: "root", ContainerPath: "/",
+	}})
+	cb.AddContainer(&cubeboxstore.Container{
+		Metadata: cubeboxstore.Metadata{
+			ID: "auxiliary",
+			Config: &cubeboxv1.ContainerConfig{VolumeMounts: []*cubeboxv1.VolumeMounts{{
+				Name: "root", ContainerPath: "/",
+			}, {
+				Name: "host", HostPath: "/var/lib/data", ContainerPath: "/data",
+			}}},
+		},
+		Status: cubeboxstore.StoreStatus(cubeboxstore.Status{StartedAt: time.Now().UnixNano()}),
+	})
+
+	_, err := validateCommitSandboxTarget(cb)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not declared")
+}
+
+func TestValidateCommitSandboxTargetRejectsDuplicateRawHostDirBackingVolume(t *testing.T) {
+	volume := &cubeboxv1.Volume{
+		Name: "hostdir-0",
+		VolumeSource: &cubeboxv1.VolumeSource{HostDirVolumes: &cubeboxv1.HostDirVolumeSources{
+			VolumeSources: []*cubeboxv1.HostDirSource{{Name: "hostdir-0", HostPath: "/var/lib/data"}},
+		}},
+	}
+	cb := newRunningCommitSandboxForTest([]*cubeboxv1.Volume{volume, volume}, []*cubeboxv1.VolumeMounts{{
+		Name: "root", ContainerPath: "/",
+	}, {
+		Name: "hostdir-0", ContainerPath: "/data", HostPath: "/var/lib/data",
+	}})
+	cb.Annotations = map[string]string{
+		"host-mount": `[{"hostPath":"/var/lib/data","mountPath":"/data"}]`,
+	}
+
+	_, err := validateCommitSandboxTarget(cb)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "volume hostdir-0 is duplicated")
 }
 
 func TestValidatePauseSandboxTargetAllowsHostPath(t *testing.T) {

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -309,33 +309,41 @@ func (s *service) CommitSandbox(ctx context.Context, req *cubebox.CommitSandboxR
 }
 
 func validateCommitSandboxTarget(cb *cubeboxstore.CubeBox) (string, error) {
-	return validateSnapshotSandboxTarget(cb, true /* rejectHostDeps */)
+	return validateSnapshotSandboxTarget(cb, true /* validateHostDeps */)
 }
 
 // validatePauseSandboxTarget is the Pause/CoW gate: running + writable rootfs.
 // Unlike CommitSandbox, host-mount / host_dir / sandbox_path / plugin_volume
 // binds are allowed — Cubelet re-binds the same host path on Resume (same sandboxID).
 func validatePauseSandboxTarget(cb *cubeboxstore.CubeBox) (string, error) {
-	return validateSnapshotSandboxTarget(cb, false /* rejectHostDeps */)
+	return validateSnapshotSandboxTarget(cb, false /* validateHostDeps */)
 }
 
-func validateSnapshotSandboxTarget(cb *cubeboxstore.CubeBox, rejectHostDeps bool) (string, error) {
+func validateSnapshotSandboxTarget(cb *cubeboxstore.CubeBox, validateHostDeps bool) (string, error) {
 	if cb == nil {
 		return "", errors.New("sandbox is not found")
 	}
 	if cb.GetStatus() == nil || cb.GetStatus().Get().State() != cubebox.ContainerState_CONTAINER_RUNNING {
 		return "", fmt.Errorf("sandbox %s is not running", cb.ID)
 	}
-	if rejectHostDeps {
+	if validateHostDeps {
+		rawHostMounts, err := declaredRawHostMounts(cb.Annotations)
+		if err != nil {
+			return "", err
+		}
+		// The main container is created from the sandbox request and must carry
+		// every declared host mount. Runtime-created auxiliary containers may
+		// omit them, but any host mounts they do carry are still validated below.
+		mainContainer := cb.FirstContainer()
 		for _, container := range cb.AllContainers() {
-			if container == nil || container.Config == nil {
+			if container == nil {
 				continue
 			}
-			if err := validateNoHostPathVolumes(container.Config); err != nil {
+			if err := validateRawHostPathVolumes(container.Config, rawHostMounts, container == mainContainer); err != nil {
 				return "", err
 			}
 		}
-		if err := validateCommitVolumeSources(cb); err != nil {
+		if err := validateCommitVolumeSources(cb, rawHostMounts); err != nil {
 			return "", err
 		}
 	}
@@ -360,9 +368,12 @@ func validateSnapshotSandboxTarget(cb *cubeboxstore.CubeBox, rejectHostDeps bool
 	return rootVolumeName, nil
 }
 
-func validateCommitVolumeSources(cb *cubeboxstore.CubeBox) error {
+func validateCommitVolumeSources(cb *cubeboxstore.CubeBox, rawHostMounts map[string]rawHostMountDeclaration) error {
 	if cb == nil {
 		return nil
+	}
+	if err := validateDeclaredRawHostDirVolumes(cb.Volumes, rawHostMounts); err != nil {
+		return err
 	}
 	if len(cb.Volumes) == 0 {
 		for _, container := range cb.AllContainers() {
@@ -404,6 +415,9 @@ func validateCommitVolumeSources(cb *cubeboxstore.CubeBox) error {
 			return fmt.Errorf("plugin_volume %s is not supported by CommitSandbox", volume.GetName())
 		}
 		if hostDirs := source.GetHostDirVolumes(); hostDirs != nil {
+			if _, ok := rawHostMounts[volume.GetName()]; ok {
+				continue
+			}
 			for _, hostDir := range hostDirs.GetVolumeSources() {
 				if hostDir != nil && hostDir.GetHostPath() != "" {
 					return fmt.Errorf("host_dir volume %s is not supported by CommitSandbox", volume.GetName())
@@ -420,6 +434,36 @@ func validateCommitVolumeSources(cb *cubeboxstore.CubeBox) error {
 	for name := range usedVolumes {
 		if commitPluginVolumeListed(cb.Annotations, name) {
 			return fmt.Errorf("plugin_volume %s is not supported by CommitSandbox", name)
+		}
+	}
+	return nil
+}
+
+func validateDeclaredRawHostDirVolumes(volumes []*cubebox.Volume, declarations map[string]rawHostMountDeclaration) error {
+	counts := make(map[string]int, len(declarations))
+	for _, volume := range volumes {
+		if volume == nil {
+			continue
+		}
+		declaration, ok := declarations[volume.GetName()]
+		if !ok {
+			continue
+		}
+		counts[volume.GetName()]++
+		if counts[volume.GetName()] > 1 {
+			return fmt.Errorf("raw host-mount volume %s is duplicated", volume.GetName())
+		}
+		hostDirs := volume.GetVolumeSource().GetHostDirVolumes()
+		sources := hostDirs.GetVolumeSources()
+		if len(sources) != 1 || sources[0] == nil ||
+			sources[0].GetName() != volume.GetName() ||
+			filepath.Clean(sources[0].GetHostPath()) != declaration.HostPath {
+			return fmt.Errorf("host_dir volume %s does not match raw host-mount metadata", volume.GetName())
+		}
+	}
+	for name := range declarations {
+		if counts[name] != 1 {
+			return fmt.Errorf("raw host-mount volume %s is missing", name)
 		}
 	}
 	return nil
@@ -450,13 +494,72 @@ func commitPluginVolumeListed(annotations map[string]string, volumeName string) 
 	return false
 }
 
-func validateNoHostPathVolumes(config *cubebox.ContainerConfig) error {
+type rawHostMountDeclaration struct {
+	HostPath  string `json:"hostPath"`
+	MountPath string `json:"mountPath"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
+}
+
+func declaredRawHostMounts(annotations map[string]string) (map[string]rawHostMountDeclaration, error) {
+	result := make(map[string]rawHostMountDeclaration)
+	raw := strings.TrimSpace(annotations["host-mount"])
+	if raw == "" || raw == "[]" || strings.EqualFold(raw, "null") {
+		return result, nil
+	}
+	var declarations []rawHostMountDeclaration
+	if err := json.Unmarshal([]byte(raw), &declarations); err != nil {
+		return nil, fmt.Errorf("invalid host-mount annotation: %w", err)
+	}
+	for i, declaration := range declarations {
+		declaration.HostPath = filepath.Clean(declaration.HostPath)
+		declaration.MountPath = filepath.Clean(declaration.MountPath)
+		if !filepath.IsAbs(declaration.HostPath) || !filepath.IsAbs(declaration.MountPath) {
+			return nil, fmt.Errorf("host-mount entry %d must use absolute hostPath and mountPath", i)
+		}
+		result[fmt.Sprintf("hostdir-%d", i)] = declaration
+	}
+	return result, nil
+}
+
+func validateRawHostPathVolumes(config *cubebox.ContainerConfig, declarations map[string]rawHostMountDeclaration, requireDeclared bool) error {
 	if config == nil {
+		if requireDeclared && len(declarations) != 0 {
+			return errors.New("container config is missing declared raw host-mount volume mounts")
+		}
 		return nil
 	}
+	counts := make(map[string]int, len(declarations))
 	for _, mount := range config.GetVolumeMounts() {
-		if mount != nil && mount.GetHostPath() != "" {
-			return fmt.Errorf("hostPath volume mount %s is not supported by CommitSandbox", mount.GetName())
+		if mount == nil {
+			continue
+		}
+		declaration, ok := declarations[mount.GetName()]
+		if !ok {
+			if mount.GetHostPath() != "" {
+				return fmt.Errorf("hostPath volume mount %s is not declared by raw host-mount metadata", mount.GetName())
+			}
+			continue
+		}
+		counts[mount.GetName()]++
+		if counts[mount.GetName()] > 1 {
+			return fmt.Errorf("raw host-mount volume mount %s is duplicated", mount.GetName())
+		}
+		if mount.GetHostPath() == "" {
+			return fmt.Errorf("raw host-mount volume mount %s has no hostPath", mount.GetName())
+		}
+		if filepath.Clean(mount.GetHostPath()) != declaration.HostPath ||
+			filepath.Clean(mount.GetContainerPath()) != declaration.MountPath ||
+			mount.GetReadonly() != declaration.ReadOnly {
+			return fmt.Errorf("hostPath volume mount %s does not match raw host-mount metadata", mount.GetName())
+		}
+	}
+	// Only the main container must contain every declaration. Auxiliary
+	// containers are allowed to use none or a subset of the sandbox mounts.
+	if requireDeclared {
+		for name := range declarations {
+			if counts[name] != 1 {
+				return fmt.Errorf("raw host-mount volume mount %s is missing", name)
+			}
 		}
 	}
 	return nil

--- a/hypervisor/virtio-devices/src/fs.rs
+++ b/hypervisor/virtio-devices/src/fs.rs
@@ -642,6 +642,8 @@ pub struct BackendFsConfig {
     pub security_label: bool,
     #[serde(default)]
     pub allowed_dirs: Option<Vec<String>>,
+    #[serde(default)]
+    pub remap_filter: bool,
 }
 
 impl Default for BackendFsConfig {
@@ -662,6 +664,7 @@ impl Default for BackendFsConfig {
             killpriv_v2: false,
             security_label: false,
             allowed_dirs: None,
+            remap_filter: false,
         }
     }
 }
@@ -953,20 +956,20 @@ impl Fs {
                     "Failed to create internal ro filesystem representation: {e:?}",
                 )))
             })?;
-            Ok(Arc::new(ServerType::PassthroughFsRo(
-                Server::new(fs, &self.backendfs_config.allowed_dirs)
-                    .map_err(ActivateError::InvalidServerConfig)?,
-            )))
+            let server = Server::new(fs, &self.backendfs_config.allowed_dirs)
+                .map_err(ActivateError::InvalidServerConfig)?;
+            server.set_remap_filter_enabled(self.backendfs_config.remap_filter);
+            Ok(Arc::new(ServerType::PassthroughFsRo(server)))
         } else {
             let fs = PassthroughFs::new(fs_cfg).map_err(|e| {
                 ActivateError::ActivateVirtioFs(io::Error::other(format!(
                     "Failed to create internal filesystem representation: {e:?}",
                 )))
             })?;
-            Ok(Arc::new(ServerType::PassthroughFs(
-                Server::new(fs, &self.backendfs_config.allowed_dirs)
-                    .map_err(ActivateError::InvalidServerConfig)?,
-            )))
+            let server = Server::new(fs, &self.backendfs_config.allowed_dirs)
+                .map_err(ActivateError::InvalidServerConfig)?;
+            server.set_remap_filter_enabled(self.backendfs_config.remap_filter);
+            Ok(Arc::new(ServerType::PassthroughFs(server)))
         }
     }
 

--- a/hypervisor/virtiofsd/src/filesystem.rs
+++ b/hypervisor/virtiofsd/src/filesystem.rs
@@ -1296,4 +1296,11 @@ pub trait SerializableFileSystem {
             "State deserialization data not supported",
         ))
     }
+
+    /// Destination-only: map filter inode basename → host path to open at restore.
+    ///
+    /// `Server` fills this from the current `FilterList` before applying a
+    /// migration blob. Default is a no-op so backends that do not implement
+    /// filter restore ignore the table.
+    fn set_filter_path_remap(&self, _remap: std::collections::HashMap<String, String>) {}
 }

--- a/hypervisor/virtiofsd/src/passthrough/device_state/deserialization.rs
+++ b/hypervisor/virtiofsd/src/passthrough/device_state/deserialization.rs
@@ -200,7 +200,7 @@ impl serialized::Inode {
                 // walking via parent fd and are not remapped here.
                 let (filename, is_filter) =
                     if !fullname.is_empty() && std::path::Path::new(fullname).is_absolute() {
-                        (fs.remap_filter_fullname(self.id, filename, fullname), true)
+                        (fs.remap_filter_fullname(self.id, fullname), true)
                     } else {
                         (filename.as_str(), false)
                     };
@@ -580,6 +580,25 @@ mod tests {
         );
         assert_eq!(host_path(&fs, FILTER_ID), new_mnt);
         assert_eq!(host_path(&fs, CHILD_ID), new_mnt.join("file"));
+    }
+
+    #[test]
+    fn remap_uses_fullname_basename_after_restore() {
+        let shared = TestDir::new("restored-shared");
+        let old = TestDir::new("restored-old");
+        let new = TestDir::new("restored-new");
+        let old_mnt = old.mkdir("mnt");
+        let new_mnt = new.mkdir("mnt");
+
+        let fs = mk_fs(shared.path());
+        let mut remap = HashMap::new();
+        remap.insert("mnt".into(), new_mnt.to_str().unwrap().to_string());
+        fs.set_filter_path_remap(remap);
+
+        assert_eq!(
+            fs.remap_filter_fullname(FILTER_ID, old_mnt.to_str().unwrap()),
+            new_mnt.to_str().unwrap()
+        );
     }
 
     #[test]

--- a/hypervisor/virtiofsd/src/passthrough/device_state/deserialization.rs
+++ b/hypervisor/virtiofsd/src/passthrough/device_state/deserialization.rs
@@ -195,11 +195,14 @@ impl serialized::Inode {
                     }
                 };
 
+                // Restore-time FilterList is authoritative for filter roots: same
+                // guest basename opens at the current allow_dir path. Children keep
+                // walking via parent fd and are not remapped here.
                 let (filename, is_filter) =
                     if !fullname.is_empty() && std::path::Path::new(fullname).is_absolute() {
-                        (fullname, true)
+                        (fs.remap_filter_fullname(self.id, filename, fullname), true)
                     } else {
-                        (filename, false)
+                        (filename.as_str(), false)
                     };
 
                 let inode_data = self
@@ -217,10 +220,12 @@ impl serialized::Inode {
                         "deserialization filter inode, id:{:?}, name:{:?}, fullname:{:?}",
                         self.id, filename, fullname
                     );
+                    // Write the remapped open path so the data plane follows
+                    // the restore-time allow_dir, not the blob's stale fullname.
                     fs.filter
                         .write()
                         .unwrap()
-                        .insert(self.id, (filename.to_string(), fullname.to_string()));
+                        .insert(self.id, (filename.to_string(), filename.to_string()));
                 }
 
                 Ok(true)
@@ -416,5 +421,256 @@ impl serialized::Handle {
             .unwrap()
             .insert(self.id, Arc::new(handle_data));
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filesystem::SerializableFileSystem;
+    use crate::fuse;
+    use crate::passthrough::device_state::serialized;
+    use crate::passthrough::Config;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const FILTER_ID: u64 = 2;
+    const CHILD_ID: u64 = 3;
+
+    static FIXTURE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(test_name: &str) -> Self {
+            let pid = std::process::id();
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let seq = FIXTURE_SEQ.fetch_add(1, Ordering::Relaxed);
+            let base = std::env::temp_dir()
+                .join(format!("virtiofsd-remap-{pid}-{nanos}-{seq}-{test_name}"));
+            fs::create_dir_all(&base).unwrap();
+            TestDir {
+                path: fs::canonicalize(&base).unwrap(),
+            }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn mkdir(&self, rel: &str) -> PathBuf {
+            let full = self.path.join(rel);
+            fs::create_dir_all(&full).unwrap();
+            fs::canonicalize(&full).unwrap()
+        }
+
+        fn touch(&self, rel: &str) {
+            let full = self.path.join(rel);
+            if let Some(parent) = full.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::File::create(&full).unwrap();
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn mk_fs(root: &Path) -> PassthroughFs {
+        let mut cfg = Config::default();
+        cfg.root_dir = root.to_str().unwrap().to_string();
+        cfg.migration_verify_handles = false;
+        cfg.migration_on_error = MigrationOnError::Abort;
+        PassthroughFs::new(cfg).unwrap()
+    }
+
+    fn apply_mnt_tree(fs: &PassthroughFs, mnt_fullname: &str) {
+        serialized::PassthroughFsV1 {
+            inodes: vec![
+                serialized::Inode {
+                    id: fuse::ROOT_ID,
+                    // +1 for the filter inode's Path.parent strong ref
+                    refcount: 2,
+                    location: serialized::InodeLocation::RootNode,
+                    file_handle: None,
+                },
+                serialized::Inode {
+                    id: FILTER_ID,
+                    // +1 for the child inode's Path.parent strong ref
+                    refcount: 2,
+                    location: serialized::InodeLocation::Path {
+                        parent: fuse::ROOT_ID,
+                        filename: "mnt".into(),
+                        fullname: mnt_fullname.to_string(),
+                    },
+                    file_handle: None,
+                },
+                serialized::Inode {
+                    id: CHILD_ID,
+                    refcount: 1,
+                    location: serialized::InodeLocation::Path {
+                        parent: FILTER_ID,
+                        filename: "file".into(),
+                        fullname: String::new(),
+                    },
+                    file_handle: None,
+                },
+            ],
+            next_inode: 4,
+            handles: Vec::new(),
+            next_handle: 0,
+            negotiated_opts: serialized::NegotiatedOpts {
+                writeback: false,
+                announce_submounts: false,
+                posix_acl: false,
+                sup_group_extension: false,
+            },
+        }
+        .apply(fs)
+        .expect("apply failed");
+    }
+
+    fn host_path(fs: &PassthroughFs, inode: u64) -> PathBuf {
+        let data = fs.inodes.get(inode).expect("inode missing");
+        let cpath = data.get_path(&fs.proc_self_fd).expect("get_path failed");
+        PathBuf::from(cpath.to_str().unwrap())
+    }
+
+    fn filter_original_path(fs: &PassthroughFs, inode: u64) -> String {
+        fs.filter
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(|(_, original)| original.clone())
+            .expect("filter entry missing")
+    }
+
+    #[test]
+    fn remap_hit_opens_new_tree() {
+        let shared = TestDir::new("hit-shared");
+        let old = TestDir::new("hit-old");
+        let new = TestDir::new("hit-new");
+        old.mkdir("mnt");
+        old.touch("mnt/file");
+        let new_mnt = new.mkdir("mnt");
+        new.touch("mnt/file");
+
+        let fs = mk_fs(shared.path());
+        let mut remap = HashMap::new();
+        remap.insert("mnt".into(), new_mnt.to_str().unwrap().to_string());
+        fs.set_filter_path_remap(remap);
+
+        let old_mnt = old.path().join("mnt");
+        apply_mnt_tree(&fs, old_mnt.to_str().unwrap());
+
+        assert_eq!(
+            filter_original_path(&fs, FILTER_ID),
+            new_mnt.to_str().unwrap()
+        );
+        assert_eq!(host_path(&fs, FILTER_ID), new_mnt);
+        assert_eq!(host_path(&fs, CHILD_ID), new_mnt.join("file"));
+    }
+
+    #[test]
+    fn remap_miss_keeps_blob_fullname() {
+        let shared = TestDir::new("miss-shared");
+        let old = TestDir::new("miss-old");
+        old.mkdir("mnt");
+        old.touch("mnt/file");
+        let old_mnt = old.path().join("mnt");
+
+        let fs = mk_fs(shared.path());
+        apply_mnt_tree(&fs, old_mnt.to_str().unwrap());
+
+        let old_mnt = fs::canonicalize(&old_mnt).unwrap();
+        assert_eq!(
+            filter_original_path(&fs, FILTER_ID),
+            old_mnt.to_str().unwrap()
+        );
+        assert_eq!(host_path(&fs, FILTER_ID), old_mnt);
+        assert_eq!(host_path(&fs, CHILD_ID), old_mnt.join("file"));
+    }
+
+    #[test]
+    fn remap_identity_is_noop() {
+        let shared = TestDir::new("id-shared");
+        let old = TestDir::new("id-old");
+        old.mkdir("mnt");
+        old.touch("mnt/file");
+        let old_mnt = fs::canonicalize(old.path().join("mnt")).unwrap();
+
+        let fs = mk_fs(shared.path());
+        let mut remap = HashMap::new();
+        remap.insert("mnt".into(), old_mnt.to_str().unwrap().to_string());
+        fs.set_filter_path_remap(remap);
+        apply_mnt_tree(&fs, old_mnt.to_str().unwrap());
+
+        assert_eq!(
+            filter_original_path(&fs, FILTER_ID),
+            old_mnt.to_str().unwrap()
+        );
+        assert_eq!(host_path(&fs, FILTER_ID), old_mnt);
+    }
+
+    #[test]
+    fn remap_ignores_non_filter_child() {
+        let shared = TestDir::new("child-shared");
+        shared.touch("file");
+        let decoy = TestDir::new("child-decoy");
+        decoy.touch("file");
+
+        let fs = mk_fs(shared.path());
+        let mut remap = HashMap::new();
+        remap.insert(
+            "file".into(),
+            decoy.path().join("file").to_str().unwrap().to_string(),
+        );
+        fs.set_filter_path_remap(remap);
+
+        serialized::PassthroughFsV1 {
+            inodes: vec![
+                serialized::Inode {
+                    id: fuse::ROOT_ID,
+                    refcount: 2,
+                    location: serialized::InodeLocation::RootNode,
+                    file_handle: None,
+                },
+                serialized::Inode {
+                    id: CHILD_ID,
+                    refcount: 1,
+                    location: serialized::InodeLocation::Path {
+                        parent: fuse::ROOT_ID,
+                        filename: "file".into(),
+                        fullname: String::new(),
+                    },
+                    file_handle: None,
+                },
+            ],
+            next_inode: 4,
+            handles: Vec::new(),
+            next_handle: 0,
+            negotiated_opts: serialized::NegotiatedOpts {
+                writeback: false,
+                announce_submounts: false,
+                posix_acl: false,
+                sup_group_extension: false,
+            },
+        }
+        .apply(&fs)
+        .unwrap();
+
+        assert_eq!(host_path(&fs, CHILD_ID), shared.path().join("file"));
+        assert!(fs.filter.read().unwrap().is_empty());
     }
 }

--- a/hypervisor/virtiofsd/src/passthrough/device_state/mod.rs
+++ b/hypervisor/virtiofsd/src/passthrough/device_state/mod.rs
@@ -80,6 +80,10 @@ impl SerializableFileSystem for PassthroughFs {
         state_pipe.read_to_end(&mut serialized)?;
         self.deserialize_and_apply_data(&serialized)
     }
+
+    fn set_filter_path_remap(&self, remap: std::collections::HashMap<String, String>) {
+        let _ = self.restore_filter_remap.set(remap);
+    }
 }
 
 #[cfg(test)]

--- a/hypervisor/virtiofsd/src/passthrough/mod.rs
+++ b/hypervisor/virtiofsd/src/passthrough/mod.rs
@@ -31,7 +31,7 @@ use file_handle::{FileHandle, FileOrHandle, OpenableFileHandle};
 use mount_fd::{MPRError, MountFds};
 use stat::{statx, StatExt};
 use std::borrow::Cow;
-use std::collections::{btree_map, BTreeMap};
+use std::collections::{btree_map, BTreeMap, HashMap};
 use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
@@ -40,7 +40,7 @@ use std::mem::MaybeUninit;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use std::time::Duration;
 use xattrmap::{AppliedRule, XattrMap};
 
@@ -471,6 +471,11 @@ pub struct PassthroughFs {
     // serialization each subtree of filter entries.
     filter: RwLock<BTreeMap<Inode, (String, String)>>,
 
+    // basename → destination absolute path, used only while applying a
+    // migration blob so filter inodes open at the restore-time allow_dir.
+    // OnceLock so remap_filter_fullname can return &str borrowed from self.
+    restore_filter_remap: OnceLock<HashMap<String, String>>,
+
     cfg: Config,
 }
 
@@ -525,6 +530,7 @@ impl PassthroughFs {
             os_facts: oslib::OsFacts::new(),
             track_migration_info: AtomicBool::new(false),
             filter: RwLock::new(BTreeMap::new()),
+            restore_filter_remap: OnceLock::new(),
             cfg,
         };
 
@@ -575,6 +581,31 @@ impl PassthroughFs {
             .filter(|hd| hd.inode == inode)
             .cloned()
             .ok_or_else(ebadf)
+    }
+
+    /// If restore remapped this filter basename to a new host path, return that
+    /// path; otherwise keep `fullname` from the migration blob.
+    fn remap_filter_fullname<'a>(
+        &'a self,
+        inode: Inode,
+        filename: &str,
+        fullname: &'a str,
+    ) -> &'a str {
+        match self
+            .restore_filter_remap
+            .get()
+            .and_then(|remap| remap.get(filename))
+            .map(String::as_str)
+        {
+            Some(new_path) if new_path != fullname => {
+                info!(
+                    "remap filter inode {}: {:?} -> {:?}",
+                    inode, fullname, new_path
+                );
+                new_path
+            }
+            _ => fullname,
+        }
     }
 
     fn open_inode(&self, inode: Inode, mut flags: i32) -> io::Result<File> {

--- a/hypervisor/virtiofsd/src/passthrough/mod.rs
+++ b/hypervisor/virtiofsd/src/passthrough/mod.rs
@@ -585,16 +585,16 @@ impl PassthroughFs {
 
     /// If restore remapped this filter basename to a new host path, return that
     /// path; otherwise keep `fullname` from the migration blob.
-    fn remap_filter_fullname<'a>(
-        &'a self,
-        inode: Inode,
-        filename: &str,
-        fullname: &'a str,
-    ) -> &'a str {
+    fn remap_filter_fullname<'a>(&'a self, inode: Inode, fullname: &'a str) -> &'a str {
         match self
             .restore_filter_remap
             .get()
-            .and_then(|remap| remap.get(filename))
+            .and_then(|remap| {
+                std::path::Path::new(fullname)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .and_then(|name| remap.get(name))
+            })
             .map(String::as_str)
         {
             Some(new_path) if new_path != fullname => {

--- a/hypervisor/virtiofsd/src/passthrough/read_only.rs
+++ b/hypervisor/virtiofsd/src/passthrough/read_only.rs
@@ -17,6 +17,7 @@ use crate::filesystem::{
 };
 use crate::passthrough::stat::{statx, StatExt};
 
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::ffi::CStr;
 use std::fs::File;
@@ -448,6 +449,10 @@ impl FileSystem for PassthroughFsRo {
 }
 
 impl SerializableFileSystem for PassthroughFsRo {
+    fn set_filter_path_remap(&self, remap: HashMap<String, String>) {
+        self.0.set_filter_path_remap(remap)
+    }
+
     fn prepare_serialization(&self, cancel: Arc<AtomicBool>) -> io::Result<()> {
         self.0.prepare_serialization(cancel)
     }

--- a/hypervisor/virtiofsd/src/server.rs
+++ b/hypervisor/virtiofsd/src/server.rs
@@ -171,6 +171,13 @@ impl FilterList {
         self.allowed_dirs.is_empty()
     }
 
+    fn basename_paths(&self) -> HashMap<String, String> {
+        self.allowed_dirs
+            .iter()
+            .map(|(name, (path, _))| (name.clone(), path.clone()))
+            .collect()
+    }
+
     // return allow dire entry.
     pub fn get_allow_dir(&self, key: String) -> Result<(String, stat::StatExt)> {
         if !self.allowed_dirs.contains_key(&key) {
@@ -190,6 +197,7 @@ pub struct Server<F: FileSystem + Sync> {
     fs: F,
     options: AtomicU64,
     root_filter: Arc<Mutex<FilterList>>,
+    remap_filter_enabled: AtomicBool,
 }
 
 impl<F: FileSystem + Sync> Server<F> {
@@ -201,7 +209,20 @@ impl<F: FileSystem + Sync> Server<F> {
             fs,
             options: AtomicU64::new(FsOptions::empty().bits()),
             root_filter: Arc::new(Mutex::new(filter)),
+            remap_filter_enabled: AtomicBool::new(false),
         })
+    }
+
+    /// Enable or disable the filter-path remap feature used during migration
+    /// restore. When disabled (the default), the backend will keep the
+    /// legacy behaviour and skip populating the remap map before deserializing
+    /// device state.
+    pub fn set_remap_filter_enabled(&self, enabled: bool) {
+        self.remap_filter_enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn is_remap_filter_enabled(&self) -> bool {
+        self.remap_filter_enabled.load(Ordering::Relaxed)
     }
 
     pub fn update_filter(&self, whitelist: &Option<Vec<String>>) -> Result<()> {
@@ -1879,6 +1900,7 @@ impl<F: FileSystem + SerializableFileSystem + Sync> SerializableFileSystem for S
     }
 
     fn deserialize_and_apply(&self, state_pipe: File) -> io::Result<()> {
+        self.inject_filter_path_remap();
         self.fs.deserialize_and_apply(state_pipe)
     }
 
@@ -1887,7 +1909,20 @@ impl<F: FileSystem + SerializableFileSystem + Sync> SerializableFileSystem for S
     }
 
     fn deserialize_and_apply_data(&self, serialized: &Vec<u8>) -> io::Result<()> {
+        self.inject_filter_path_remap();
         self.fs.deserialize_and_apply_data(serialized)
+    }
+}
+
+impl<F: FileSystem + SerializableFileSystem + Sync> Server<F> {
+    fn inject_filter_path_remap(&self) {
+        if !self.is_remap_filter_enabled() {
+            return;
+        }
+        let remap = self.root_filter.lock().unwrap().basename_paths();
+        if !remap.is_empty() {
+            self.fs.set_filter_path_remap(remap);
+        }
     }
 }
 

--- a/hypervisor/vmm/src/config.rs
+++ b/hypervisor/vmm/src/config.rs
@@ -1396,7 +1396,7 @@ impl FsConfig {
     thread_pool_size=<thread_pool_size>,ops_size=<ops_size>,\
     ops_one_time_burst=<ops_one_time_burst>,ops_refill_time=<ops_refill_time>,\
     bw_size=<bw_size>,bw_one_time_burst=<bw_one_time_burst>,bw_refill_time=<bw_refill_time>,\
-    allowed_dirs=<dir_list>\"";
+    allowed_dirs=<dir_list>,remap_filter=<remap_filter>\"";
 
     fn add_frontend_args(parser: &mut OptionParser) {
         parser
@@ -1425,7 +1425,8 @@ impl FsConfig {
             .add("rlimit_nofile")
             .add("killpriv_v2")
             .add("security_label")
-            .add("allowed_dirs");
+            .add("allowed_dirs")
+            .add("remap_filter");
     }
 
     fn add_ratelimiter_args(parser: &mut OptionParser) {
@@ -1523,6 +1524,11 @@ impl FsConfig {
             .convert::<StringList>("allowed_dirs")
             .map_err(Error::ParseFileSystem)?
             .map(|v| v.0);
+        let remap_filter = parser
+            .convert::<Toggle>("remap_filter")
+            .map_err(Error::ParseFileSystem)?
+            .unwrap_or(Toggle(false))
+            .0;
 
         Ok(BackendFsConfig {
             shared_dir,
@@ -1540,6 +1546,7 @@ impl FsConfig {
             killpriv_v2,
             security_label,
             allowed_dirs,
+            remap_filter,
         })
     }
 

--- a/hypervisor/vmm/src/config.rs
+++ b/hypervisor/vmm/src/config.rs
@@ -32,6 +32,7 @@ const MAX_NUM_PCI_SEGMENTS: u16 = 16;
 const UPDATE_FS_SHARED_DIR_FIELD: &str = "shared_dir";
 const UPDATE_FS_ALLOWED_DIRS_FIELD: &str = "allowed_dirs";
 const UPDATE_FS_CACHE_FIELD: &str = "cache";
+const UPDATE_FS_REMAP_FILTER_FIELD: &str = "remap_filter";
 
 /// Errors associated with VM configuration parameters.
 #[derive(Debug, Error)]
@@ -2236,6 +2237,7 @@ enum DeviceValue {
     Str(String),
     Arr(Vec<String>),
     Value(u64),
+    Bool(bool),
 }
 
 impl VmConfig {
@@ -2369,6 +2371,10 @@ impl VmConfig {
                         UPDATE_FS_CACHE_FIELD,
                         DeviceValue::Value(backend.cache as u64),
                     );
+                    device.insert(
+                        UPDATE_FS_REMAP_FILTER_FIELD,
+                        DeviceValue::Bool(backend.remap_filter),
+                    );
                     devices.insert(fs_cfg.id.as_ref().unwrap().clone(), device);
                 }
                 if fs_cfg.rate_limiter_config.is_some() {
@@ -2397,6 +2403,11 @@ impl VmConfig {
                                 device.get(UPDATE_FS_CACHE_FIELD)
                             {
                                 backend.cache = *cache as u8;
+                            }
+                            if let Some(DeviceValue::Bool(remap_filter)) =
+                                device.get(UPDATE_FS_REMAP_FILTER_FIELD)
+                            {
+                                backend.remap_filter = *remap_filter;
                             }
                         }
                     }
@@ -2868,6 +2879,36 @@ impl VmConfig {
 mod tests {
     use super::*;
     use net_util::MacAddr;
+
+    #[test]
+    fn update_fses_preserves_restore_remap_filter() {
+        let mut config = VmConfig {
+            fs: Some(vec![FsConfig {
+                id: Some("virtio_rw".to_string()),
+                backendfs_config: Some(BackendFsConfig::default()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let restore_fses = vec![FsConfig {
+            id: Some("virtio_rw".to_string()),
+            backendfs_config: Some(BackendFsConfig {
+                remap_filter: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }];
+
+        config.update_fses(&restore_fses);
+
+        assert!(
+            config.fs.unwrap()[0]
+                .backendfs_config
+                .as_ref()
+                .unwrap()
+                .remap_filter
+        );
+    }
 
     #[test]
     fn test_cpu_parsing() -> Result<()> {

--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -483,7 +483,8 @@ Current capability domains:
   already-established connections (`test_policy_update.py`, CubeSandbox only).
 - `cases/concurrency/`: simultaneous multi-sandbox isolation.
 - `cases/host-mount/`: host-directory mount extension — happy path plus create-time
-  validation, runtime bind-mount failures, and cross-sandbox sharing boundary cases.
+  validation, runtime bind-mount failures, cross-sandbox sharing boundaries, and
+  multi-generation snapshot restore, rollback, and clone external-reference semantics.
 - `cases/volume/`: Volume Plugin CRUD plus sandbox `volumeMounts` bind/unbind and per-sandbox read-only attachment enforcement (CubeSandbox only; default driver `s3`). Runs with `--run-e2e` unless `SDK_E2E_VOLUME_PLUGIN=false`. Requires the default-install S3 plugin + MinIO and `cubesandbox` >= 0.6.0.
 - `cases/auth/`: `CUBE_API_KEY` simple-key authentication against the CubeAPI
   control plane — `X-API-Key`/`Bearer` accept, wrong/missing 401, `/health`

--- a/tests/e2e/sdk_compat/cases/host-mount/test_snapshot_clone_rollback.py
+++ b/tests/e2e/sdk_compat/cases/host-mount/test_snapshot_clone_rollback.py
@@ -1,0 +1,578 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Snapshot, rollback, and clone contracts for raw host mounts.
+
+Raw host mounts are external references: VM memory and rootfs participate in a
+snapshot, but files below the host mount do not. Rollback therefore restores
+guest state while retaining the host directory's latest contents. Clones have
+isolated guest state but deliberately share a writable raw host mount.
+
+The allowed-prefix root is mounted read-write, and a provisioned child is
+mounted read-only as a second virtiofs device. Each case operates in
+UUID-named children and removes them before teardown, so concurrent runs do
+not collide or leave payload files on the host.
+"""
+
+from __future__ import annotations
+
+import shlex
+import time
+import uuid
+from dataclasses import dataclass, replace
+
+import pytest
+
+from adapters import create_adapter_with_capacity_retry
+from framework.assertions import assert_command_ok
+from framework.capabilities import HOST_MOUNT, ROLLBACK_CLONE
+from framework.cleanup import safe_kill
+from framework.host_mount import (
+    host_mount_metadata,
+    mount_option,
+    provision_host_dirs,
+    skip_if_host_mount_unavailable,
+    under_prefix,
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.host_mount,
+    pytest.mark.lifecycle,
+    pytest.mark.p1,
+    pytest.mark.requires_capability(HOST_MOUNT),
+    pytest.mark.requires_capability(ROLLBACK_CLONE),
+    pytest.mark.sandbox_create_options(
+        metadata=host_mount_metadata(
+            [
+                mount_option(under_prefix(), "/mnt/sdk-host-rw", read_only=False),
+                mount_option(
+                    under_prefix("snapshot-ro"),
+                    "/mnt/sdk-host-ro",
+                    read_only=True,
+                ),
+            ]
+        )
+    ),
+]
+
+_RW_HOST_MOUNT = "/mnt/sdk-host-rw"
+_RO_HOST_MOUNT = "/mnt/sdk-host-ro"
+_provisioned_backends: set[str] = set()
+
+
+@pytest.fixture(autouse=True)
+def _provision_ro_host_dir(sdk_backend, sdk_e2e_config):
+    skip_if_host_mount_unavailable(sdk_backend, sdk_e2e_config)
+    if sdk_backend in _provisioned_backends:
+        return
+    provision_host_dirs(sdk_backend, sdk_e2e_config, ["snapshot-ro"])
+    _provisioned_backends.add(sdk_backend)
+
+
+@dataclass(frozen=True)
+class _TestPaths:
+    rw_dir: str
+    rw_file: str
+    ro_dir_via_rw: str
+    ro_dir: str
+    ro_file_via_rw: str
+    ro_file: str
+    guest_file: str
+
+
+def _run_ok(sandbox, command: str, *, timeout: int) -> str:
+    result = sandbox.run_command(command, timeout=timeout)
+    assert_command_ok(result)
+    return result.stdout.strip()
+
+
+def _paths() -> _TestPaths:
+    token = uuid.uuid4().hex
+    rw_dir = f"{_RW_HOST_MOUNT}/sdk-e2e-snapshot/{token}"
+    ro_dir_via_rw = f"{_RW_HOST_MOUNT}/snapshot-ro/sdk-e2e-snapshot/{token}"
+    ro_dir = f"{_RO_HOST_MOUNT}/sdk-e2e-snapshot/{token}"
+    return _TestPaths(
+        rw_dir=rw_dir,
+        rw_file=f"{rw_dir}/external.txt",
+        ro_dir_via_rw=ro_dir_via_rw,
+        ro_dir=ro_dir,
+        ro_file_via_rw=f"{ro_dir_via_rw}/external-ro.txt",
+        ro_file=f"{ro_dir}/external-ro.txt",
+        guest_file=f"/tmp/sdk-e2e-guest-{token}.txt",
+    )
+
+
+def _remove_host_dirs(sandbox, paths: _TestPaths, *, timeout: int) -> None:
+    result = sandbox.run_command(
+        f"rm -rf -- {shlex.quote(paths.rw_dir)} "
+        f"{shlex.quote(paths.ro_dir_via_rw)}",
+        timeout=timeout,
+    )
+    assert_command_ok(result)
+
+
+def _assert_ro_mount_rejects_write(sandbox, path: str, *, timeout: int) -> None:
+    result = sandbox.run_command(
+        f"printf denied > {shlex.quote(path)}",
+        timeout=timeout,
+    )
+    assert result.exit_code != 0, (
+        f"read-only host mount unexpectedly accepted a write to {path!r}"
+    )
+    assert "read-only" in result.stderr.lower() or "read only" in result.stderr.lower(), (
+        f"expected a read-only filesystem error, got stderr={result.stderr!r}"
+    )
+
+
+def _delete_snapshot_after_runtime_release(
+    sandbox,
+    snapshot_id: str,
+    *,
+    timeout: float,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            sandbox.delete_snapshot(snapshot_id)
+            return
+        except Exception as exc:  # noqa: BLE001 - normalize asynchronous ref release
+            message = str(exc).lower()
+            retryable = (
+                "active runtime ref" in message
+                or "attempt is already in progress" in message
+            )
+            if not retryable or time.monotonic() >= deadline:
+                raise
+            time.sleep(0.5)
+
+
+def test_snapshot_restore_reverts_guest_and_keeps_external_mounts_current(
+    sdk_sandbox,
+    sdk_backend,
+    sdk_e2e_config,
+):
+    """Creating from an exact snapshot restores guest state and remaps both mounts."""
+    paths = _paths()
+    snapshot_ids = []
+    target_snapshot_id = None
+    restored = None
+    cleanup_errors = []
+    try:
+        _run_ok(
+            sdk_sandbox,
+            f"mkdir -p {shlex.quote(paths.rw_dir)} "
+            f"{shlex.quote(paths.ro_dir_via_rw)} && "
+            f"printf external-before > {shlex.quote(paths.rw_file)} && "
+            f"printf external-ro-before > {shlex.quote(paths.ro_file_via_rw)} && "
+            f"printf guest-before > {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+
+        target_snapshot_id = sdk_sandbox.create_snapshot()
+        snapshot_ids.append(target_snapshot_id)
+        assert target_snapshot_id.startswith("snap-"), (
+            f"unexpected snapshot ID: {target_snapshot_id!r}"
+        )
+        _run_ok(
+            sdk_sandbox,
+            f"printf guest-decoy > {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        snapshot_ids.append(sdk_sandbox.create_snapshot())
+        _run_ok(
+            sdk_sandbox,
+            f"printf external-after > {shlex.quote(paths.rw_file)} && "
+            f"printf external-ro-after > {shlex.quote(paths.ro_file_via_rw)} && "
+            f"printf guest-after > {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+
+        restored = create_adapter_with_capacity_retry(
+            sdk_backend,
+            replace(sdk_e2e_config, cube_template_id=target_snapshot_id),
+            metadata={
+                "test_suite": "sdk_compat",
+                "test_role": "host_mount_snapshot_restore",
+            },
+        )
+        assert _run_ok(
+            restored,
+            f"cat {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "guest-before"
+        assert _run_ok(
+            restored,
+            f"cat {shlex.quote(paths.rw_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "external-after"
+        assert _run_ok(
+            restored,
+            f"cat {shlex.quote(paths.ro_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "external-ro-after"
+        _assert_ro_mount_rejects_write(
+            restored,
+            f"{paths.ro_dir}/denied.txt",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+
+        _run_ok(
+            restored,
+            f"printf restored-rw > {shlex.quote(paths.rw_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert _run_ok(
+            sdk_sandbox,
+            f"cat {shlex.quote(paths.rw_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "restored-rw"
+    finally:
+        try:
+            _remove_host_dirs(
+                sdk_sandbox,
+                paths,
+                timeout=sdk_e2e_config.command_timeout,
+            )
+        except Exception as exc:  # noqa: BLE001 - preserve cleanup diagnostics
+            cleanup_errors.append(exc)
+        if restored is not None:
+            cleanup_errors.extend(safe_kill(restored, sdk_e2e_config))
+        for snapshot_id in reversed(snapshot_ids):
+            try:
+                _delete_snapshot_after_runtime_release(
+                    sdk_sandbox,
+                    snapshot_id,
+                    timeout=sdk_e2e_config.default_timeout,
+                )
+            except Exception as exc:  # noqa: BLE001 - preserve cleanup diagnostics
+                cleanup_errors.append(exc)
+    assert not cleanup_errors, f"snapshot restore cleanup failed: {cleanup_errors!r}"
+
+
+def test_snapshot_restore_chain_remaps_host_mounts_each_generation(
+    sdk_sandbox,
+    sdk_backend,
+    sdk_e2e_config,
+):
+    """A snapshot made after restore must remap mounts on the next restore."""
+    paths = _paths()
+    snapshot_ids = []
+    first_restore = None
+    second_restore = None
+    cleanup_errors = []
+    try:
+        _run_ok(
+            sdk_sandbox,
+            f"mkdir -p {shlex.quote(paths.rw_dir)} "
+            f"{shlex.quote(paths.ro_dir_via_rw)} && "
+            f"printf external-a > {shlex.quote(paths.rw_file)} && "
+            f"printf external-ro-a > {shlex.quote(paths.ro_file_via_rw)} && "
+            f"printf guest-a > {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        snapshot_a = sdk_sandbox.create_snapshot()
+        snapshot_ids.append(snapshot_a)
+
+        first_restore = create_adapter_with_capacity_retry(
+            sdk_backend,
+            replace(sdk_e2e_config, cube_template_id=snapshot_a),
+            metadata={
+                "test_suite": "sdk_compat",
+                "test_role": "host_mount_snapshot_chain_first_restore",
+            },
+        )
+        assert _run_ok(
+            first_restore,
+            f"cat {shlex.quote(paths.rw_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "external-a"
+        assert _run_ok(
+            first_restore,
+            f"cat {shlex.quote(paths.ro_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "external-ro-a"
+        _run_ok(
+            first_restore,
+            f"printf external-b > {shlex.quote(paths.rw_file)} && "
+            f"printf guest-b > {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        snapshot_b = first_restore.create_snapshot()
+        snapshot_ids.append(snapshot_b)
+
+        # Snapshot B contains filter state produced by a restored instance.
+        # Destroy that instance so its per-sandbox bind path cannot mask a
+        # failed remap when snapshot B is restored again.
+        first_restore_cleanup = safe_kill(first_restore, sdk_e2e_config)
+        first_restore = None
+        assert not first_restore_cleanup, (
+            f"first restored sandbox cleanup failed: {first_restore_cleanup!r}"
+        )
+
+        second_restore = create_adapter_with_capacity_retry(
+            sdk_backend,
+            replace(sdk_e2e_config, cube_template_id=snapshot_b),
+            metadata={
+                "test_suite": "sdk_compat",
+                "test_role": "host_mount_snapshot_chain_second_restore",
+            },
+        )
+        assert _run_ok(
+            second_restore,
+            f"cat {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "guest-b"
+        assert _run_ok(
+            second_restore,
+            f"cat {shlex.quote(paths.rw_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "external-b"
+        assert _run_ok(
+            second_restore,
+            f"cat {shlex.quote(paths.ro_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "external-ro-a"
+        _assert_ro_mount_rejects_write(
+            second_restore,
+            f"{paths.ro_dir}/denied-after-second-restore.txt",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+    finally:
+        host_cleanup_error = None
+        for cleanup_sandbox in (second_restore, first_restore, sdk_sandbox):
+            if cleanup_sandbox is None:
+                continue
+            try:
+                _remove_host_dirs(
+                    cleanup_sandbox,
+                    paths,
+                    timeout=sdk_e2e_config.command_timeout,
+                )
+                host_cleanup_error = None
+                break
+            except Exception as exc:  # noqa: BLE001 - try another live mount
+                host_cleanup_error = exc
+        if host_cleanup_error is not None:
+            cleanup_errors.append(host_cleanup_error)
+        if second_restore is not None:
+            cleanup_errors.extend(safe_kill(second_restore, sdk_e2e_config))
+        if first_restore is not None:
+            cleanup_errors.extend(safe_kill(first_restore, sdk_e2e_config))
+        for snapshot_id in reversed(snapshot_ids):
+            try:
+                _delete_snapshot_after_runtime_release(
+                    sdk_sandbox,
+                    snapshot_id,
+                    timeout=sdk_e2e_config.default_timeout,
+                )
+            except Exception as exc:  # noqa: BLE001 - preserve cleanup diagnostics
+                cleanup_errors.append(exc)
+    assert not cleanup_errors, f"snapshot chain cleanup failed: {cleanup_errors!r}"
+
+
+def test_rollback_restores_guest_state_but_not_host_mount_data(
+    sdk_sandbox,
+    sdk_e2e_config,
+):
+    """Rollback restores guest state while preserving external data and access."""
+    paths = _paths()
+    host_created_after = f"{paths.rw_dir}/created-after-snapshot.txt"
+    host_deleted_after = f"{paths.rw_dir}/deleted-after-snapshot.txt"
+    snapshot_ids = []
+    target_snapshot_id = None
+    cleanup_errors = []
+    try:
+        _run_ok(
+            sdk_sandbox,
+            f"mkdir -p {shlex.quote(paths.rw_dir)} "
+            f"{shlex.quote(paths.ro_dir_via_rw)} && "
+            f"printf external-before > {shlex.quote(paths.rw_file)} && "
+            f"printf external-ro-before > {shlex.quote(paths.ro_file_via_rw)} && "
+            f"printf delete-me > {shlex.quote(host_deleted_after)} && "
+            f"printf guest-before > {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        target_snapshot_id = sdk_sandbox.create_snapshot()
+        snapshot_ids.append(target_snapshot_id)
+        _run_ok(
+            sdk_sandbox,
+            f"printf guest-decoy > {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        snapshot_ids.append(sdk_sandbox.create_snapshot())
+        _run_ok(
+            sdk_sandbox,
+            f"printf external-after > {shlex.quote(paths.rw_file)} && "
+            f"printf external-ro-after > {shlex.quote(paths.ro_file_via_rw)} && "
+            f"printf created-after > {shlex.quote(host_created_after)} && "
+            f"rm -- {shlex.quote(host_deleted_after)} && "
+            f"printf guest-after > {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+
+        response = sdk_sandbox.rollback(target_snapshot_id)
+
+        assert response.get("sandboxID") == sdk_sandbox.sandbox_id, response
+        assert response.get("snapshotID") == target_snapshot_id, response
+        assert _run_ok(
+            sdk_sandbox,
+            f"cat {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "guest-before"
+        assert _run_ok(
+            sdk_sandbox,
+            f"cat {shlex.quote(paths.rw_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "external-after"
+        assert _run_ok(
+            sdk_sandbox,
+            f"cat {shlex.quote(paths.ro_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "external-ro-after"
+        assert _run_ok(
+            sdk_sandbox,
+            f"cat {shlex.quote(host_created_after)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "created-after"
+        _run_ok(
+            sdk_sandbox,
+            f"test ! -e {shlex.quote(host_deleted_after)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        _assert_ro_mount_rejects_write(
+            sdk_sandbox,
+            f"{paths.ro_dir}/denied-after-rollback.txt",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+
+        # Prove the restored virtiofs channel remains writable, not merely readable.
+        assert _run_ok(
+            sdk_sandbox,
+            f"printf external-after-rollback > {shlex.quote(paths.rw_file)} && "
+            f"cat {shlex.quote(paths.rw_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        ) == "external-after-rollback"
+    finally:
+        try:
+            _remove_host_dirs(
+                sdk_sandbox,
+                paths,
+                timeout=sdk_e2e_config.command_timeout,
+            )
+        except Exception as exc:  # noqa: BLE001 - preserve cleanup diagnostics
+            cleanup_errors.append(exc)
+        cleanup_errors.extend(safe_kill(sdk_sandbox, sdk_e2e_config))
+        for snapshot_id in reversed(snapshot_ids):
+            try:
+                _delete_snapshot_after_runtime_release(
+                    sdk_sandbox,
+                    snapshot_id,
+                    timeout=sdk_e2e_config.default_timeout,
+                )
+            except Exception as exc:  # noqa: BLE001 - preserve cleanup diagnostics
+                cleanup_errors.append(exc)
+    assert not cleanup_errors, f"sandbox cleanup failed: {cleanup_errors!r}"
+
+
+def test_clone_isolates_guest_state_and_shares_rw_host_mount(
+    sdk_sandbox,
+    sdk_e2e_config,
+):
+    """Fork-style clones isolate VM state and preserve both external mounts."""
+    paths = _paths()
+    clone_guest_file = f"{paths.guest_file}.clone-only"
+    clones = []
+    cleanup_errors = []
+    try:
+        _run_ok(
+            sdk_sandbox,
+            f"mkdir -p {shlex.quote(paths.rw_dir)} "
+            f"{shlex.quote(paths.ro_dir_via_rw)} && "
+            f"printf external-source > {shlex.quote(paths.rw_file)} && "
+            f"printf external-ro-source > {shlex.quote(paths.ro_file_via_rw)} && "
+            f"printf guest-source > {shlex.quote(paths.guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+
+        clones = sdk_sandbox.clone(n=2, concurrency=2)
+        assert len(clones) == 2, f"expected two clones, got {len(clones)}"
+        left, right = clones
+
+        for clone in clones:
+            assert _run_ok(
+                clone,
+                f"cat {shlex.quote(paths.guest_file)}",
+                timeout=sdk_e2e_config.command_timeout,
+            ) == "guest-source"
+            assert _run_ok(
+                clone,
+                f"cat {shlex.quote(paths.rw_file)}",
+                timeout=sdk_e2e_config.command_timeout,
+            ) == "external-source"
+            assert _run_ok(
+                clone,
+                f"cat {shlex.quote(paths.ro_file)}",
+                timeout=sdk_e2e_config.command_timeout,
+            ) == "external-ro-source"
+            _assert_ro_mount_rejects_write(
+                clone,
+                f"{paths.ro_dir}/denied-from-{clone.sandbox_id}.txt",
+                timeout=sdk_e2e_config.command_timeout,
+            )
+
+        _run_ok(
+            left,
+            f"printf clone-overwrite > {shlex.quote(paths.guest_file)} && "
+            f"printf clone-private > {shlex.quote(clone_guest_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        for sandbox in (right, sdk_sandbox):
+            assert _run_ok(
+                sandbox,
+                f"cat {shlex.quote(paths.guest_file)}",
+                timeout=sdk_e2e_config.command_timeout,
+            ) == "guest-source"
+            _run_ok(
+                sandbox,
+                f"test ! -e {shlex.quote(clone_guest_file)}",
+                timeout=sdk_e2e_config.command_timeout,
+            )
+
+        _run_ok(
+            left,
+            f"printf external-from-left > {shlex.quote(paths.rw_file)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        for sandbox in (right, sdk_sandbox):
+            assert _run_ok(
+                sandbox,
+                f"cat {shlex.quote(paths.rw_file)}",
+                timeout=sdk_e2e_config.command_timeout,
+            ) == "external-from-left"
+
+        _run_ok(
+            left,
+            f"printf external-ro-from-left > {shlex.quote(paths.ro_file_via_rw)}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        for sandbox in (left, right, sdk_sandbox):
+            assert _run_ok(
+                sandbox,
+                f"cat {shlex.quote(paths.ro_file)}",
+                timeout=sdk_e2e_config.command_timeout,
+            ) == "external-ro-from-left"
+
+    finally:
+        try:
+            _remove_host_dirs(
+                sdk_sandbox,
+                paths,
+                timeout=sdk_e2e_config.command_timeout,
+            )
+        except Exception as exc:  # noqa: BLE001 - preserve cleanup diagnostics
+            cleanup_errors.append(exc)
+        for clone in clones:
+            cleanup_errors.extend(safe_kill(clone, sdk_e2e_config))
+    assert not cleanup_errors, f"clone cleanup failed: {cleanup_errors!r}"

--- a/tests/e2e/sdk_compat/docs/test-coverage.md
+++ b/tests/e2e/sdk_compat/docs/test-coverage.md
@@ -181,6 +181,27 @@ resource contention test or multi-worker safety validation.
 
 `cases/volume/` covers Volume Plugin CRUD, sandbox bind/unbind and delete-while-bound behavior. It also verifies that one Volume can remain writable in one sandbox while a concurrent attachment is read-only in another sandbox, including read access and rejected create, write, rename and delete operations. These cases are CubeSandbox-only, default to the S3 driver, and run with `--run-e2e` unless `SDK_E2E_VOLUME_PLUGIN=false`.
 
+### 2.9 Host Mount
+
+`cases/host-mount/` covers raw host-directory mount validation, runtime bind
+failures, read-only enforcement, nested mounts, public mount metadata, and
+cross-sandbox sharing. `test_snapshot_clone_rollback.py` additionally verifies:
+
+- creating a new sandbox from an exact snapshot restores guest rootfs state
+  while retaining current external data, remapping both RW and RO mounts, and
+  preserving their access modes;
+- snapshots created from a restored sandbox can be restored again after the
+  intermediate sandbox is destroyed, remapping both mounts on every generation;
+- rollback restores guest rootfs state while retaining external file content,
+  creations, deletions, mount access modes, and the writable channel;
+- fork-style concurrent clones inherit and isolate guest state while sharing
+  the writable raw host mount and preserving the read-only mount.
+
+These cases require both the CubeSandbox-only `host_mount` and
+`rollback_clone` capabilities. They mount the configured allowed-prefix root
+read-write and a provisioned child read-only, then isolate payloads in
+UUID-named directories so parallel runs do not collide.
+
 ## 3. Coverage Boundaries
 
 The current suite mainly validates synchronous Python SDK paths and the


### PR DESCRIPTION
Ref #1599

- preserve origin-node affinity for snapshots with host mounts
- make host-dir volume injection idempotent during restore
- propagate virtiofs remap_filter into restored VMM configs
- validate host-mount volumes and mounts before committing snapshots
- add unit and E2E coverage for restore, rollback, clone, and RW/RO mounts