### PR TITLE
fix(cube-egress): raise transparent proxy timeouts to 2h

### DIFF
--- a/CubeEgress/nginx.conf
+++ b/CubeEgress/nginx.conf
@@ -124,8 +124,8 @@ http {
 
             proxy_pass http://$server_addr:$server_port;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
+            proxy_send_timeout 2h;
+            proxy_read_timeout 2h;
 
             header_filter_by_lua_block {
                 require("debug_dump").dump_response_headers()
@@ -193,8 +193,8 @@ http {
             proxy_ssl_name $cube_original_sni;
             proxy_pass https://$server_addr:$server_port;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
+            proxy_send_timeout 2h;
+            proxy_read_timeout 2h;
 
             header_filter_by_lua_block {
                 require("debug_dump").dump_response_headers()

--- a/docs/guide/security-proxy.md
+++ b/docs/guide/security-proxy.md
@@ -18,6 +18,9 @@ rule list attached at sandbox-creation time:
 - **Access auditing** — every decision (allow / deny / inject /
   TLS handshake outcome) is written to a per-host JSONL audit log.
 
+Upstream `proxy_read_timeout` / `proxy_send_timeout` are 2h (same
+order as CubeProxy). `proxy_connect_timeout` stays 10s.
+
 ## How it intercepts
 
 CubeEgress runs as a host-network container and binds two TPROXY

--- a/docs/zh/guide/security-proxy.md
+++ b/docs/zh/guide/security-proxy.md
@@ -13,6 +13,9 @@ Cube Sandbox 在每台宿主机上部署一个透明出网代理 —— **CubeEg
 - **访问审计** —— 每一次决策（放行 / 拒绝 / 注入 / TLS 握手结果）
   都落到主机本地的 JSONL 审计日志
 
+上游 `proxy_read_timeout` / `proxy_send_timeout` 为 2h（与 CubeProxy
+同量级）。`proxy_connect_timeout` 仍是 10s。
+
 ## 拦截链路
 
 CubeEgress 是一个 host-network 容器，在面向沙箱的 IP 上 bind 两个


### PR DESCRIPTION
LLM prefill TTFB often exceeds the baked-in 60s proxy_read_timeout and gets a 504. Default both read/send to 2h.