### PR TITLE
fix(cubemastercli): align version command output

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/version/version.go
+++ b/CubeMaster/cmd/cubemastercli/commands/version/version.go
@@ -14,15 +14,15 @@ import (
 
 var Command = cli.Command{
 	Name:  "version",
-	Usage: "print the client and server versions",
+	Usage: "print the client version",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "versiononly,v",
-			Usage: "print server version only",
+			Usage: "print semantic version only",
 		},
 		&cli.BoolFlag{
 			Name:  "withclient,c",
-			Usage: "print client version",
+			Usage: "deprecated: client version is printed by default",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -30,10 +30,7 @@ var Command = cli.Command{
 			fmt.Println(version.Version)
 			return nil
 		}
-		if context.Bool("withclient") {
-			fmt.Println(version.VersionString("cubemastercli"))
-			fmt.Println("  Go version: " + version.GoVersion)
-		}
+		fmt.Println(version.VersionString("cubemastercli"))
 		return nil
 	},
 }

--- a/CubeMaster/cmd/cubemastercli/commands/version/version_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/version/version_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	pkgversion "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version"
+	"github.com/urfave/cli"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = old })
+
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func runVersion(args ...string) error {
+	app := cli.NewApp()
+	app.Name = "cubemastercli"
+	app.Commands = []cli.Command{Command}
+	return app.Run(append([]string{"cubemastercli"}, args...))
+}
+
+func TestVersionCommandDefault(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := runVersion("version"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	want := pkgversion.VersionString("cubemastercli") + "\n"
+	if out != want {
+		t.Fatalf("output = %q, want %q", out, want)
+	}
+}
+
+func TestVersionCommandVersionOnly(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := runVersion("version", "--versiononly"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	want := pkgversion.Version + "\n"
+	if out != want {
+		t.Fatalf("output = %q, want %q", out, want)
+	}
+}
+
+func TestVersionCommandWithClient(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := runVersion("version", "--withclient"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	want := pkgversion.VersionString("cubemastercli") + "\n"
+	if out != want {
+		t.Fatalf("output = %q, want %q", out, want)
+	}
+}


### PR DESCRIPTION
## Motivation

`cubemastercli` registers a `version` command, but invoking `cubemastercli version` previously returned successfully without printing anything unless an optional flag was provided. This made the command behavior inconsistent with its own advertised purpose and made the registered command appear broken to users who discover it through `cubemastercli --help`.

The command's usage also claimed to print client and server versions even though it only had local client-version data and no server-version query path. The global `--version` flag remains useful for standard CLI version discovery, but a registered `version` command should not silently do nothing. `cubeopscli version` already prints the client version by default, so `cubemastercli version` should provide the same predictable behavior and describe that behavior accurately.

## Example

Before:

```text
$ cubemastercli version
$ cubeopscli version
cubeopscli <version> (<commit>) built at <timestamp>
```

After this change:

```text
$ cubemastercli version
cubemastercli <version> (<commit>) built at <timestamp>
$ cubeopscli version
cubeopscli <version> (<commit>) built at <timestamp>
```

## What Changed

* Make `cubemastercli version` print the complete client version by default.
* Keep `version --versiononly` for callers that need only the semantic version.
* Preserve the existing `--withclient` flag for command-line compatibility and mark it deprecated because the client version is now printed by default.
* Add regression tests covering the default, semantic-version-only, and compatibility flag paths.
* Update the command and flag usage text to describe the actual output behavior.

## Validation

* `go test ./cmd/cubemastercli/commands/version -count=1` passed.
* Built `cubemastercli`.
* Verified `cubemastercli version`, `cubemastercli version --versiononly`, `cubemastercli version --withclient`, and `cubemastercli --version`.

## Scope

This PR only changes `cubemastercli version` output behavior.

It does not change version metadata, build-time version injection, global `--version` handling, server/API behavior, or `cubeopscli`.
