### PR TITLE
fix(hypervisor): use mutable destinations for KVM_GET_DEVICE_ATTR to avoid miscompiled vgic state save

### DIFF
--- a/hypervisor/hypervisor/src/kvm/aarch64/gic/dist_regs.rs
+++ b/hypervisor/hypervisor/src/kvm/aarch64/gic/dist_regs.rs
@@ -77,44 +77,54 @@ static VGIC_DIST_REGS: &[DistReg] = &[
     VGIC_DIST_REG!(GICD_IPRIORITYR, 8, 0),
 ];
 
-fn dist_attr_access(gic: &DeviceFd, offset: u32, val: &u32, set: bool) -> Result<()> {
+/// Read a distributor register.
+///
+/// The destination buffer must be a local `mut` whose address is handed to
+/// KVM_GET_DEVICE_ATTR; going through a `&u32` would let LLVM treat the kernel
+/// write-back as a readonly-noalias violation and fold the result to 0.
+fn dist_attr_get(gic: &DeviceFd, offset: u32) -> Result<u32> {
+    let mut val: u32 = 0;
     let mut gic_dist_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_DIST_REGS,
         attr: offset as u64,
-        addr: val as *const u32 as u64,
+        addr: &mut val as *mut u32 as u64,
         flags: 0,
     };
-    if set {
-        gic.set_device_attr(&gic_dist_attr).map_err(|e| {
-            Error::SetDeviceAttribute(HypervisorDeviceError::SetDeviceAttribute(e.into()))
-        })?;
-    } else {
-        gic.get_device_attr(&mut gic_dist_attr).map_err(|e| {
-            Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
-        })?;
-    }
-    Ok(())
+    gic.get_device_attr(&mut gic_dist_attr).map_err(|e| {
+        Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
+    })?;
+    Ok(val)
+}
+
+/// Write a distributor register.
+fn dist_attr_set(gic: &DeviceFd, offset: u32, val: u32) -> Result<()> {
+    let gic_dist_attr = kvm_device_attr {
+        group: KVM_DEV_ARM_VGIC_GRP_DIST_REGS,
+        attr: offset as u64,
+        addr: &val as *const u32 as u64,
+        flags: 0,
+    };
+    gic.set_device_attr(&gic_dist_attr)
+        .map_err(|e| Error::SetDeviceAttribute(HypervisorDeviceError::SetDeviceAttribute(e.into())))
 }
 
 /// Get the distributor control register.
 pub fn read_ctlr(gic: &DeviceFd) -> Result<u32> {
-    let val: u32 = 0;
-    dist_attr_access(gic, GICD_CTLR, &val, false)?;
-    Ok(val)
+    dist_attr_get(gic, GICD_CTLR)
 }
 
 /// Set the distributor control register.
 pub fn write_ctlr(gic: &DeviceFd, val: u32) -> Result<()> {
-    dist_attr_access(gic, GICD_CTLR, &val, true)
+    dist_attr_set(gic, GICD_CTLR, val)
 }
 
 fn get_interrupts_num(gic: &DeviceFd) -> Result<u32> {
-    let num_irq = 0;
+    let mut num_irq = 0;
 
     let mut nr_irqs_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
         attr: 0,
-        addr: &num_irq as *const u32 as u64,
+        addr: &mut num_irq as *mut u32 as u64,
         flags: 0,
     };
     gic.get_device_attr(&mut nr_irqs_attr).map_err(|e| {
@@ -158,8 +168,7 @@ pub fn set_dist_regs(gic: &DeviceFd, state: &[u32]) -> Result<()> {
         let end = compute_reg_len(gic, dreg, base)?;
 
         while base < end {
-            let val = state[idx];
-            dist_attr_access(gic, base, &val, true)?;
+            dist_attr_set(gic, base, state[idx])?;
             idx += 1;
             base += REG_SIZE as u32;
         }
@@ -175,9 +184,7 @@ pub fn get_dist_regs(gic: &DeviceFd) -> Result<Vec<u32>> {
         let end = compute_reg_len(gic, dreg, base)?;
 
         while base < end {
-            let val: u32 = 0;
-            dist_attr_access(gic, base, &val, false)?;
-            state.push(val);
+            state.push(dist_attr_get(gic, base)?);
             base += REG_SIZE as u32;
         }
     }

--- a/hypervisor/hypervisor/src/kvm/aarch64/gic/icc_regs.rs
+++ b/hypervisor/hypervisor/src/kvm/aarch64/gic/icc_regs.rs
@@ -79,23 +79,50 @@ static VGIC_ICC_REGS: &[u64] = &[
     SYS_ICC_AP1R3_EL1,
 ];
 
-fn icc_attr_access(gic: &DeviceFd, offset: u64, typer: u64, val: &u32, set: bool) -> Result<()> {
+/// Read an ICC register.
+///
+/// `KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS` attributes go through the kvm_one_reg
+/// ABI, which accesses the user buffer as a `__u64` (see `kvm_sys_reg_get_user`
+/// in the kernel), so the ioctl must be backed by a full `u64` even though the
+/// register is 32-bit — a `u32` buffer would make KVM write 8 bytes into 4
+/// bytes of stack. The value is converted (and validated) at the `Vec<u32>`
+/// serialization boundary. The buffer must also be a local `mut` whose address
+/// is handed to KVM_GET_DEVICE_ATTR: going through a shared reference would
+/// let LLVM treat the kernel write-back as a readonly-noalias violation and
+/// fold the result to 0 (observed with rustc 1.96, release + lto).
+fn icc_attr_get(gic: &DeviceFd, offset: u64, typer: u64) -> Result<u32> {
+    let mut val: u64 = 0;
     let mut gic_icc_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS,
         attr: ((typer & KVM_DEV_ARM_VGIC_V3_MPIDR_MASK) | offset), // this needs the mpidr
-        addr: val as *const u32 as u64,
+        addr: &mut val as *mut u64 as u64,
         flags: 0,
     };
-    if set {
-        gic.set_device_attr(&gic_icc_attr).map_err(|e| {
-            Error::SetDeviceAttribute(HypervisorDeviceError::SetDeviceAttribute(e.into()))
-        })?;
-    } else {
-        gic.get_device_attr(&mut gic_icc_attr).map_err(|e| {
-            Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
-        })?;
-    }
-    Ok(())
+    gic.get_device_attr(&mut gic_icc_attr).map_err(|e| {
+        Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
+    })?;
+    u32::try_from(val).map_err(|_| {
+        Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(anyhow::anyhow!(
+            "ICC register {:#x} read-back exceeds 32 bits: {:#x}",
+            offset,
+            val
+        )))
+    })
+}
+
+/// Write an ICC register.
+///
+/// Same `__u64` buffer requirement as [`icc_attr_get`].
+fn icc_attr_set(gic: &DeviceFd, offset: u64, typer: u64, val: u32) -> Result<()> {
+    let val: u64 = u64::from(val);
+    let gic_icc_attr = kvm_device_attr {
+        group: KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS,
+        attr: ((typer & KVM_DEV_ARM_VGIC_V3_MPIDR_MASK) | offset), // this needs the mpidr
+        addr: &val as *const u64 as u64,
+        flags: 0,
+    };
+    gic.set_device_attr(&gic_icc_attr)
+        .map_err(|e| Error::SetDeviceAttribute(HypervisorDeviceError::SetDeviceAttribute(e.into())))
 }
 
 /// Get ICC registers.
@@ -107,10 +134,9 @@ pub fn get_icc_regs(gic: &DeviceFd, gicr_typer: &[u64]) -> Result<Vec<u32>> {
     for ix in gicr_typer {
         let i = *ix;
         for icc_offset in VGIC_ICC_REGS {
-            let val = 0;
             if *icc_offset == SYS_ICC_CTLR_EL1 {
                 // calculate priority bits by reading the ctrl_el1 register.
-                icc_attr_access(gic, *icc_offset, i, &val, false)?;
+                let val = icc_attr_get(gic, *icc_offset, i)?;
                 // The priority bits are found in the ICC_CTLR_EL1 register (bits from  10:8).
                 // See page 194 from https://static.docs.arm.com/ihi0069/c/IHI0069C_gic_
                 // architecture_specification.pdf.
@@ -130,8 +156,7 @@ pub fn get_icc_regs(gic: &DeviceFd, gicr_typer: &[u64]) -> Result<Vec<u32>> {
             // 7 bits of priority.
             else if *icc_offset == SYS_ICC_AP0R1_EL1 || *icc_offset == SYS_ICC_AP1R1_EL1 {
                 if num_priority_bits >= 6 {
-                    icc_attr_access(gic, *icc_offset, i, &val, false)?;
-                    state.push(val);
+                    state.push(icc_attr_get(gic, *icc_offset, i)?);
                 }
             } else if *icc_offset == SYS_ICC_AP0R2_EL1
                 || *icc_offset == SYS_ICC_AP0R3_EL1
@@ -139,12 +164,10 @@ pub fn get_icc_regs(gic: &DeviceFd, gicr_typer: &[u64]) -> Result<Vec<u32>> {
                 || *icc_offset == SYS_ICC_AP1R3_EL1
             {
                 if num_priority_bits == 7 {
-                    icc_attr_access(gic, *icc_offset, i, &val, false)?;
-                    state.push(val);
+                    state.push(icc_attr_get(gic, *icc_offset, i)?);
                 }
             } else {
-                icc_attr_access(gic, *icc_offset, i, &val, false)?;
-                state.push(val);
+                state.push(icc_attr_get(gic, *icc_offset, i)?);
             }
         }
     }
@@ -165,7 +188,7 @@ pub fn set_icc_regs(gic: &DeviceFd, gicr_typer: &[u64], state: &[u32]) -> Result
             }
             if *icc_offset == SYS_ICC_AP0R1_EL1 || *icc_offset == SYS_ICC_AP1R1_EL1 {
                 if num_priority_bits >= 6 {
-                    icc_attr_access(gic, *icc_offset, i, &state[idx], true)?;
+                    icc_attr_set(gic, *icc_offset, i, state[idx])?;
                     idx += 1;
                 }
                 continue;
@@ -176,12 +199,12 @@ pub fn set_icc_regs(gic: &DeviceFd, gicr_typer: &[u64], state: &[u32]) -> Result
                 || *icc_offset == SYS_ICC_AP1R3_EL1
             {
                 if num_priority_bits == 7 {
-                    icc_attr_access(gic, *icc_offset, i, &state[idx], true)?;
+                    icc_attr_set(gic, *icc_offset, i, state[idx])?;
                     idx += 1;
                 }
                 continue;
             }
-            icc_attr_access(gic, *icc_offset, i, &state[idx], true)?;
+            icc_attr_set(gic, *icc_offset, i, state[idx])?;
             idx += 1;
         }
     }

--- a/hypervisor/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -23,34 +23,38 @@ const GITS_CWRITER: u32 = 0x0088;
 const GITS_CREADR: u32 = 0x0090;
 const GITS_BASER: u32 = 0x0100;
 
-/// Access an ITS device attribute.
+/// Read an ITS device attribute.
 ///
-/// This is a helper function to get/set the ITS device attribute depending
-/// the bool parameter `set` provided.
-pub fn gicv3_its_attr_access(
-    its_device: &DeviceFd,
-    group: u32,
-    attr: u32,
-    val: &u64,
-    set: bool,
-) -> Result<()> {
+/// The destination buffer must be a local `mut` whose address is handed to
+/// KVM_GET_DEVICE_ATTR; going through a `&u64` would let LLVM treat the kernel
+/// write-back as a readonly-noalias violation and fold the result to 0.
+pub fn gicv3_its_attr_get(its_device: &DeviceFd, group: u32, attr: u32) -> Result<u64> {
+    let mut val: u64 = 0;
     let mut gicv3_its_attr = kvm_bindings::kvm_device_attr {
         group,
         attr: attr as u64,
-        addr: val as *const u64 as u64,
+        addr: &mut val as *mut u64 as u64,
         flags: 0,
     };
-    if set {
-        its_device.set_device_attr(&gicv3_its_attr).map_err(|e| {
-            Error::SetDeviceAttribute(HypervisorDeviceError::SetDeviceAttribute(e.into()))
-        })
-    } else {
-        its_device
-            .get_device_attr(&mut gicv3_its_attr)
-            .map_err(|e| {
-                Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
-            })
-    }
+    its_device
+        .get_device_attr(&mut gicv3_its_attr)
+        .map_err(|e| {
+            Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
+        })?;
+    Ok(val)
+}
+
+/// Write an ITS device attribute.
+pub fn gicv3_its_attr_set(its_device: &DeviceFd, group: u32, attr: u32, val: u64) -> Result<()> {
+    let gicv3_its_attr = kvm_bindings::kvm_device_attr {
+        group,
+        attr: attr as u64,
+        addr: &val as *const u64 as u64,
+        flags: 0,
+    };
+    its_device
+        .set_device_attr(&gicv3_its_attr)
+        .map_err(|e| Error::SetDeviceAttribute(HypervisorDeviceError::SetDeviceAttribute(e.into())))
 }
 
 /// Function that saves/restores ITS tables into guest RAM.
@@ -324,60 +328,43 @@ impl Vgic for KvmGicV3Its {
 
         let icc_state = get_icc_regs(&self.device, &gicr_typers)?;
 
-        let its_baser_state: [u64; 8] = [0; 8];
+        let mut its_baser_state: [u64; 8] = [0; 8];
         for i in 0..8 {
-            gicv3_its_attr_access(
+            its_baser_state[i as usize] = gicv3_its_attr_get(
                 self.its_device.as_ref().unwrap(),
                 kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
                 GITS_BASER + i * 8,
-                &its_baser_state[i as usize],
-                false,
             )?;
         }
 
-        let its_ctlr_state: u64 = 0;
-        gicv3_its_attr_access(
+        let its_ctlr_state = gicv3_its_attr_get(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_CTLR,
-            &its_ctlr_state,
-            false,
         )?;
 
-        let its_cbaser_state: u64 = 0;
-        gicv3_its_attr_access(
+        let its_cbaser_state = gicv3_its_attr_get(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_CBASER,
-            &its_cbaser_state,
-            false,
         )?;
 
-        let its_creadr_state: u64 = 0;
-        gicv3_its_attr_access(
+        let its_creadr_state = gicv3_its_attr_get(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_CREADR,
-            &its_creadr_state,
-            false,
         )?;
 
-        let its_cwriter_state: u64 = 0;
-        gicv3_its_attr_access(
+        let its_cwriter_state = gicv3_its_attr_get(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_CWRITER,
-            &its_cwriter_state,
-            false,
         )?;
 
-        let its_iidr_state: u64 = 0;
-        gicv3_its_attr_access(
+        let its_iidr_state = gicv3_its_attr_get(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_IIDR,
-            &its_iidr_state,
-            false,
         )?;
 
         Ok(Gicv3ItsState {
@@ -407,57 +394,51 @@ impl Vgic for KvmGicV3Its {
         set_icc_regs(&self.device, &gicr_typers, &state.icc)?;
 
         //Restore GICv3ITS registers
-        gicv3_its_attr_access(
+        gicv3_its_attr_set(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_IIDR,
-            &state.its_iidr,
-            true,
+            state.its_iidr,
         )?;
 
-        gicv3_its_attr_access(
+        gicv3_its_attr_set(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_CBASER,
-            &state.its_cbaser,
-            true,
+            state.its_cbaser,
         )?;
 
-        gicv3_its_attr_access(
+        gicv3_its_attr_set(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_CREADR,
-            &state.its_creadr,
-            true,
+            state.its_creadr,
         )?;
 
-        gicv3_its_attr_access(
+        gicv3_its_attr_set(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_CWRITER,
-            &state.its_cwriter,
-            true,
+            state.its_cwriter,
         )?;
 
         for i in 0..8 {
-            gicv3_its_attr_access(
+            gicv3_its_attr_set(
                 self.its_device.as_ref().unwrap(),
                 kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
                 GITS_BASER + i * 8,
-                &state.its_baser[i as usize],
-                true,
+                state.its_baser[i as usize],
             )?;
         }
 
         // Restore ITS tables
         gicv3_its_tables_access(self.its_device.as_ref().unwrap(), false)?;
 
-        gicv3_its_attr_access(
+        gicv3_its_attr_set(
             self.its_device.as_ref().unwrap(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
             GITS_CTLR,
-            &state.its_ctlr,
-            true,
+            state.its_ctlr,
         )
     }
 
@@ -559,6 +540,53 @@ mod tests {
         assert!(state.len() == 9);
 
         assert!(set_icc_regs(&gic.device, &gicr_typer, &state).is_ok());
+    }
+
+    // Regression test for the vgic state-save miscompile: rustc 1.96+
+    // (release, lto) folded the KVM_GET_DEVICE_ATTR read-backs to zero,
+    // producing an all-zero GIC snapshot that breaks pause->resume
+    // (GICv3ITS SetDeviceAttribute EINVAL). Needs /dev/kvm; run in
+    // release to exercise the optimized build.
+    #[test]
+    fn test_gic_state_save_nonzero_roundtrip() {
+        use crate::arch::aarch64::gic::Vgic;
+
+        let hv = crate::new().unwrap();
+        let vm = hv.create_vm().unwrap();
+        vm.create_vcpu(0, None).unwrap();
+        let mut vgic = KvmGicV3Its::new(&*vm, create_test_vgic_config()).unwrap();
+
+        // Every bank must read back non-zero (all-zero == miscompiled).
+        let dist = get_dist_regs(&vgic.device).unwrap();
+        let rdist = get_redist_regs(&vgic.device, &[123]).unwrap();
+        let icc = get_icc_regs(&vgic.device, &[123]).unwrap();
+        let its = vgic.state().unwrap();
+        assert!(dist.iter().any(|&v| v != 0), "dist all zero — miscompiled?");
+        assert!(
+            rdist.iter().any(|&v| v != 0),
+            "rdist all zero — miscompiled?"
+        );
+        assert!(icc.iter().any(|&v| v != 0), "icc all zero — miscompiled?");
+        assert_ne!(its.its_iidr, 0, "GITS_IIDR zero — miscompiled?");
+
+        // Exact-value round-trip on the writable ICC registers (the bank
+        // that broke pause->resume): IGRPEN0/1, PMR, BPR0/1. PMR is masked
+        // to the 5 implemented priority bits for kernel portability.
+        let mut icc_want = icc.clone();
+        icc_want[2..7].copy_from_slice(&[1, 1, 0xA8, 3, 3]);
+        set_icc_regs(&vgic.device, &[123], &icc_want).unwrap();
+        assert_eq!(
+            &get_icc_regs(&vgic.device, &[123]).unwrap()[2..7],
+            &[1u32, 1, 0xA8, 3, 3]
+        );
+
+        // Aggregate round-trip through the restore path (set_state).
+        vgic.set_state(&its).unwrap();
+        assert_ne!(
+            vgic.state().unwrap().its_iidr,
+            0,
+            "GITS_IIDR zero after set_state"
+        );
     }
 
     #[test]

--- a/hypervisor/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
+++ b/hypervisor/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
@@ -96,23 +96,35 @@ static VGIC_SGI_REGS: &[RdistReg] = &[
     VGIC_RDIST_REG!(GICR_IPRIORITYR0, 32),
 ];
 
-fn redist_attr_access(gic: &DeviceFd, offset: u32, typer: u64, val: &u32, set: bool) -> Result<()> {
+/// Read a redistributor register.
+///
+/// The destination buffer must be a local `mut` whose address is handed to
+/// KVM_GET_DEVICE_ATTR; going through a `&u32` would let LLVM treat the kernel
+/// write-back as a readonly-noalias violation and fold the result to 0.
+fn redist_attr_get(gic: &DeviceFd, offset: u32, typer: u64) -> Result<u32> {
+    let mut val: u32 = 0;
     let mut gic_redist_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_REDIST_REGS,
         attr: (typer & KVM_DEV_ARM_VGIC_V3_MPIDR_MASK) | (offset as u64), // this needs the mpidr
-        addr: val as *const u32 as u64,
+        addr: &mut val as *mut u32 as u64,
         flags: 0,
     };
-    if set {
-        gic.set_device_attr(&gic_redist_attr).map_err(|e| {
-            Error::SetDeviceAttribute(HypervisorDeviceError::SetDeviceAttribute(e.into()))
-        })?;
-    } else {
-        gic.get_device_attr(&mut gic_redist_attr).map_err(|e| {
-            Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
-        })?;
-    }
-    Ok(())
+    gic.get_device_attr(&mut gic_redist_attr).map_err(|e| {
+        Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
+    })?;
+    Ok(val)
+}
+
+/// Write a redistributor register.
+fn redist_attr_set(gic: &DeviceFd, offset: u32, typer: u64, val: u32) -> Result<()> {
+    let gic_redist_attr = kvm_device_attr {
+        group: KVM_DEV_ARM_VGIC_GRP_REDIST_REGS,
+        attr: (typer & KVM_DEV_ARM_VGIC_V3_MPIDR_MASK) | (offset as u64), // this needs the mpidr
+        addr: &val as *const u32 as u64,
+        flags: 0,
+    };
+    gic.set_device_attr(&gic_redist_attr)
+        .map_err(|e| Error::SetDeviceAttribute(HypervisorDeviceError::SetDeviceAttribute(e.into())))
 }
 
 fn access_redists_aux(
@@ -129,14 +141,11 @@ fn access_redists_aux(
             let end = base + rdreg.length as u32;
 
             while base < end {
-                let mut val = 0;
                 if set {
-                    val = state[*idx];
-                    redist_attr_access(gic, base, *i, &val, true)?;
+                    redist_attr_set(gic, base, *i, state[*idx])?;
                     *idx += 1;
                 } else {
-                    redist_attr_access(gic, base, *i, &val, false)?;
-                    state.push(val);
+                    state.push(redist_attr_get(gic, base, *i)?);
                 }
                 base += REG_SIZE as u32;
             }


### PR DESCRIPTION
## Problem

`pause` -> `resume` fails 100% on aarch64 when the shim (which embeds the hypervisor) is built with recent Rust toolchains:

```
Resume vm failed:resume vm from snapshot failed:Cannot restore VM: Failed to restore migratable component: Could not restore GICv3ITS state SetDeviceAttribute(SetDeviceAttribute(Invalid argument (os error 22))), status: launched
```

Sandbox *creation* (restore from the template snapshot) is unaffected, because the template's GIC state was captured correctly by an older build; only snapshots taken by an affected build are garbage.

## Root cause

The vgic state save path reads device attributes into buffers addressed through shared references cast to raw pointers:

```rust
let val = 0;
icc_attr_access(gic, offset, typer, &val, false)?;  // addr = val as *const u32 as u64
state.push(val);
```

The kernel writes the register value back through that pointer, but a shared reference carries readonly semantics in Rust/LLVM, so the compiler is entitled to fold the subsequent read to the initial constant 0. With rustc 1.96.0 (release, `lto = true`, `codegen-units = 1`) this actually happens: **the entire GIC state gets saved as zeroes**, and resume then restores `ICC_SRE_EL1 = 0`, which the kernel rejects with EINVAL (`set_gic_sre` in `arch/arm64/kvm/vgic-sys-reg-v3.c` requires the SRE bit to stay set).

Evidence collected with bpftrace (kretprobe on `kvm_device_ioctl`, reading the user-space buffer directly via `uptr()`):

- during pause (GET): the kernel writes `val = 0x7` into the buffer (SRE enabled)
- the snapshot's `state.json`: GIC section all zeroes
- during resume (SET): `val = 0x0` -> EINVAL (`attr = 0xc665` = `S3_0_C12_C12_5` = `SYS_ICC_SRE_EL1`, the first register in the ICC list)

A telltale fingerprint of the miscompile: `its_baser` (read into a `[u64; 8]` array, i.e. read back from memory) survives with real values, while every scalar folded to 0.

The same source built with an older toolchain (rustc 1.89.0, the version shipped in the official builder image) does not fold, which is why this went unnoticed until the tree was rebuilt with a newer rustc. This is a textbook UB manifestation: latent in the source, exposed by the toolchain.

## Fix

Split each `*_attr_access` helper into a get/set pair: reads go through a local `mut` whose address is passed as `*mut`, returning the value; writes take the value by value. Applied to `icc_regs.rs`, `dist_regs.rs`, `redist_regs.rs` and `gic/mod.rs::state()`; the same pattern in `get_interrupts_num` is fixed as well. This is pure UB removal — the write path is semantically unchanged.

## Verification (aarch64, host kernel 6.6.119)

- Root-cause control: pure v0.5.1 (a164417) rebuilt with the same rustc 1.96.0 reproduces the failure identically (rules out any other local patches)
- Build: release / lto / codegen-units=1
- End to end: pause snapshot GIC section changes from all-zero to real values (dist 67 non-zero entries, `its_ctlr = 0x80000001`, same shape as a healthy template snapshot); resume changes from 100% EINVAL to 201 OK
- Full concurrency ladder (c1..c50, n=5 each, 2C2G template, pause writes ~2GB per sandbox): pause wall c1 765.8ms / c50 999.3ms, resume wall c1 15.7ms / c50 72.1ms (per-sandbox 1.4ms) — healthy scaling, all 30 rounds successful
