### PR TITLE
feat(k8s): improve chart flexibility — MinIO NodePort, containerPath overrides, ConfigMap for master config 

### DIFF
--- a/deploy/kubernetes/chart/scripts/test-service-nodeport.sh
+++ b/deploy/kubernetes/chart/scripts/test-service-nodeport.sh
@@ -94,4 +94,36 @@ fi
 grep -q 'cubeProxy.service.nodePorts.htttp is not supported' "$TMP_DIR/unknown.err" \
   || fail_msg "missing unknown nodePorts key guard message"
 
+# MinIO NodePort Service must render with the specified nodePort.
+helm template minio-nodeport "$CHART_DIR" $COMMON_SETS \
+  --set minio.service.type=NodePort \
+  --set minio.service.nodePort=30090 \
+  > "$TMP_DIR/minio-np.yaml"
+
+awk '
+  /^kind: Service$/ { in_svc=1; name=""; component=""; has_nodeport=0; next }
+  in_svc && /^  name: / { name=$2 }
+  in_svc && /app.kubernetes.io\/component: / { component=$2 }
+  in_svc && /nodePort: 30090/ { has_nodeport=1 }
+  in_svc && /^---$/ { in_svc=0 }
+  in_svc && name != "" && component == "minio" && has_nodeport { minio_np=1 }
+  END {
+    if (!minio_np) { print "minio nodePort 30090 missing"; exit 1 }
+  }
+' "$TMP_DIR/minio-np.yaml" || fail_msg "MinIO NodePort Service not rendered as expected"
+
+# MinIO default ClusterIP must not create external Service or nodePort.
+if grep -q 'cube-sandbox-minio-external' "$TMP_DIR/default.yaml"; then
+  fail_msg "default ClusterIP render unexpectedly includes MinIO external Service"
+fi
+
+# MinIO ClusterIP + nodePort must fail render.
+if helm template minio-bad-np "$CHART_DIR" $COMMON_SETS \
+  --set minio.service.nodePort=30090 \
+  >"$TMP_DIR/minio-bad.out" 2>"$TMP_DIR/minio-bad.err"; then
+  fail_msg "expected fail when ClusterIP minio sets nodePort"
+fi
+grep -q 'minio.service.nodePort requires service.type' "$TMP_DIR/minio-bad.err" \
+  || fail_msg "missing minio ClusterIP+nodePort guard message"
+
 echo "Service nodePort guard passed"

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -979,6 +979,20 @@ Kubernetes API path prefix for the cube-node DaemonSet (health-test).
 {{- end -}}
 
 {{/*
+Resolve the container-side mountPath for a hostPath key.
+Returns containerPaths.<key> when set, otherwise hostPaths.<key>.
+This lets operators change the host directory without breaking
+in-container path expectations (code may hardcode /data/…).
+Usage: include "cube.containerPath" (dict "key" "dataCubelet" "context" .)
+*/}}
+{{- define "cube.containerPath" -}}
+{{- $key := .key -}}
+{{- $ctx := .context -}}
+{{- $override := index (default dict $ctx.Values.containerPaths) $key -}}
+{{- if $override }}{{ $override }}{{- else }}{{ index $ctx.Values.hostPaths $key }}{{- end -}}
+{{- end -}}
+
+{{/*
 Big Pod: shared volumeMounts for component install/run containers.
 Toolbox is mounted whole at the fixed path.
 */}}
@@ -986,23 +1000,23 @@ Toolbox is mounted whole at the fixed path.
 - name: toolbox
   mountPath: /usr/local/services/cubetoolbox
 - name: data-cubelet
-  mountPath: {{ .Values.hostPaths.dataCubelet }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataCubelet" "context" .) }}
   mountPropagation: Bidirectional
 - name: data-log
-  mountPath: {{ .Values.hostPaths.dataLog }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataLog" "context" .) }}
 - name: data-cube-shim
-  mountPath: {{ .Values.hostPaths.dataCubeShim }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataCubeShim" "context" .) }}
   mountPropagation: Bidirectional
 - name: data-snapshot-pack
-  mountPath: {{ .Values.hostPaths.dataSnapshotPack }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataSnapshotPack" "context" .) }}
 - name: data-cube-shared
-  mountPath: {{ .Values.hostPaths.dataCubeShared }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataCubeShared" "context" .) }}
   mountPropagation: Bidirectional
 - name: data-shared
-  mountPath: {{ .Values.hostPaths.dataShared }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataShared" "context" .) }}
   mountPropagation: Bidirectional
 - name: tmp-cube
-  mountPath: {{ .Values.hostPaths.tmpCube }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "tmpCube" "context" .) }}
   mountPropagation: Bidirectional
 - name: run-containerd
   mountPath: /run/containerd
@@ -1015,7 +1029,7 @@ Toolbox is mounted whole at the fixed path.
 {{- define "cube.nodeDataplaneVolumeMounts" -}}
 {{- include "cube.nodeToolboxVolumeMounts" . }}
 - name: bootstrap-state
-  mountPath: {{ .Values.hostPaths.bootstrapState }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "bootstrapState" "context" .) }}
 - name: dev
   mountPath: /dev
 - name: sys
@@ -1048,9 +1062,9 @@ Installer: toolbox only (no dataplane mounts).
 - name: toolbox
   mountPath: /usr/local/services/cubetoolbox
 - name: bootstrap-state
-  mountPath: {{ .Values.hostPaths.bootstrapState }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "bootstrapState" "context" .) }}
 - name: data-cubelet
-  mountPath: {{ .Values.hostPaths.dataCubelet }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataCubelet" "context" .) }}
 {{- end -}}
 
 {{- define "cube.installerComponentEnv" -}}
@@ -1081,28 +1095,28 @@ Bootstrap: host mutation mounts for pvm / node-init.
   mountPath: /lib/modules
   readOnly: true
 - name: bootstrap-state
-  mountPath: {{ .Values.hostPaths.bootstrapState }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "bootstrapState" "context" .) }}
 {{- end -}}
 
 {{- define "cube.bootstrapDataVolumeMounts" -}}
 - name: data-cubelet
-  mountPath: {{ .Values.hostPaths.dataCubelet }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataCubelet" "context" .) }}
   mountPropagation: Bidirectional
 - name: data-log
-  mountPath: {{ .Values.hostPaths.dataLog }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataLog" "context" .) }}
 - name: data-cube-shim
-  mountPath: {{ .Values.hostPaths.dataCubeShim }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataCubeShim" "context" .) }}
   mountPropagation: Bidirectional
 - name: data-snapshot-pack
-  mountPath: {{ .Values.hostPaths.dataSnapshotPack }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataSnapshotPack" "context" .) }}
 - name: data-cube-shared
-  mountPath: {{ .Values.hostPaths.dataCubeShared }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataCubeShared" "context" .) }}
   mountPropagation: Bidirectional
 - name: data-shared
-  mountPath: {{ .Values.hostPaths.dataShared }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "dataShared" "context" .) }}
   mountPropagation: Bidirectional
 - name: tmp-cube
-  mountPath: {{ .Values.hostPaths.tmpCube }}
+  mountPath: {{ include "cube.containerPath" (dict "key" "tmpCube" "context" .) }}
   mountPropagation: Bidirectional
 {{- end -}}
 

--- a/deploy/kubernetes/chart/templates/master-config-secret.yaml
+++ b/deploy/kubernetes/chart/templates/master-config-secret.yaml
@@ -1,5 +1,10 @@
 {{- if and .Values.controlPlane.enabled .Values.controlPlane.master.enabled }}
-{{- $conf := tpl (.Files.Get "files/cube-master/conf.yaml") . }}
+{{- $conf := "" -}}
+{{- with .Values.controlPlane.master.configInline -}}
+{{- $conf = . -}}
+{{- else -}}
+{{- $conf = tpl (.Files.Get "files/cube-master/conf.yaml") . -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/kubernetes/chart/templates/minio.yaml
+++ b/deploy/kubernetes/chart/templates/minio.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "cube.minioBuiltinEnabled" .) "true" }}
+# Headless Service — required by the StatefulSet for stable DNS. Always created.
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,6 +16,33 @@ spec:
     - name: minio
       port: {{ .Values.minio.port | default 9000 }}
       targetPort: minio
+{{- $minioSvcType := .Values.minio.service.type | default "ClusterIP" -}}
+{{- if has $minioSvcType (list "NodePort" "LoadBalancer") }}
+---
+# Extra Service for external access (NodePort / LoadBalancer). The Headless
+# Service above stays for StatefulSet DNS; this one lets compute nodes outside
+# the cluster reach MinIO without manual kubectl patch.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cube.minioName" . }}-external
+  labels:
+    {{- include "cube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  type: {{ $minioSvcType }}
+  selector:
+    {{- include "cube.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+  ports:
+    - name: minio
+      port: {{ .Values.minio.port | default 9000 }}
+      targetPort: minio
+      {{- $minioNodePort := .Values.minio.service.nodePort | default "" | toString -}}
+      {{- if ne $minioNodePort "" }}
+      nodePort: {{ $minioNodePort | int }}
+      {{- end }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/deploy/kubernetes/chart/templates/node-bootstrap-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-bootstrap-daemonset.yaml
@@ -68,7 +68,7 @@ spec:
               value: {{ ternary "1" "0" .Values.bootstrap.nodeInit.enabled | quote }}
           volumeMounts:
             - name: bootstrap-state
-              mountPath: {{ .Values.hostPaths.bootstrapState }}
+              mountPath: {{ include "cube.containerPath" (dict "key" "bootstrapState" "context" .) }}
         - name: wait-pvm-host
           image: {{ include "cube.cubeImage" (dict "image" .Values.images.nodeInit "context" $) | quote }}
           imagePullPolicy: {{ .Values.images.nodeInit.pullPolicy }}
@@ -203,7 +203,7 @@ spec:
             {{- end }}
           volumeMounts:
             - name: bootstrap-state
-              mountPath: {{ .Values.hostPaths.bootstrapState }}
+              mountPath: {{ include "cube.containerPath" (dict "key" "bootstrapState" "context" .) }}
           {{- with .Values.cubeNodeBootstrap.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/deploy/kubernetes/chart/templates/node-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-daemonset.yaml
@@ -47,7 +47,7 @@ spec:
               value: {{ .Values.hostPaths.bootstrapState | quote }}
           volumeMounts:
             - name: bootstrap-state
-              mountPath: {{ .Values.hostPaths.bootstrapState }}
+              mountPath: {{ include "cube.containerPath" (dict "key" "bootstrapState" "context" .) }}
           {{- with .Values.cubeNodeBootstrap.waitResources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -213,7 +213,7 @@ spec:
               mountPath: /etc/cube/ca
               readOnly: true
             - name: data-log
-              mountPath: {{ .Values.hostPaths.dataLog }}
+              mountPath: {{ include "cube.containerPath" (dict "key" "dataLog" "context" .) }}
             - name: cube-egress-run
               mountPath: /var/run/openresty
             - name: toolbox
@@ -346,9 +346,9 @@ spec:
           {{- end }}
           volumeMounts:
             - name: data-cubelet
-              mountPath: {{ .Values.hostPaths.dataCubelet }}
+              mountPath: {{ include "cube.containerPath" (dict "key" "dataCubelet" "context" .) }}
             - name: data-log
-              mountPath: {{ .Values.hostPaths.dataLog }}
+              mountPath: {{ include "cube.containerPath" (dict "key" "dataLog" "context" .) }}
             - name: dev
               mountPath: /dev
             - name: sys

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -476,17 +476,17 @@ spec:
         - |
           echo '[health-test] check cube-node host runtime assets'
           test -e /dev/kvm
-          test -d {{ .Values.hostPaths.dataCubelet | quote }}
-          test -S {{ printf "%s/cubelet.sock" .Values.hostPaths.dataCubelet | quote }}
+          test -d {{ include "cube.containerPath" (dict "key" "dataCubelet" "context" .) | quote }}
+          test -S {{ printf "%s/cubelet.sock" (include "cube.containerPath" (dict "key" "dataCubelet" "context" .)) | quote }}
       volumeMounts:
         - name: dev
           mountPath: /dev
           readOnly: true
         - name: data-cubelet
-          mountPath: {{ .Values.hostPaths.dataCubelet }}
+          mountPath: {{ include "cube.containerPath" (dict "key" "dataCubelet" "context" .) }}
           readOnly: true
         - name: tmp-cube
-          mountPath: {{ .Values.hostPaths.tmpCube }}
+          mountPath: {{ include "cube.containerPath" (dict "key" "tmpCube" "context" .) }}
           readOnly: true
   volumes:
     - name: dev

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -249,6 +249,17 @@
 {{- if and (eq (include "cube.minioBuiltinEnabled" .) "true") .Values.minio.rootPassword (lt (len (printf "%s" .Values.minio.rootPassword)) 8) }}
 {{- fail "minio.rootPassword must be at least 8 characters when set (leave empty to generate one)" }}
 {{- end }}
+{{- $minioSvcType := .Values.minio.service.type | default "ClusterIP" -}}
+{{- $minioNodePort := .Values.minio.service.nodePort | default "" | toString -}}
+{{- if and (ne $minioNodePort "") (not (has $minioSvcType (list "NodePort" "LoadBalancer"))) }}
+{{- fail (printf "minio.service.nodePort requires service.type NodePort or LoadBalancer (got %s)" $minioSvcType) }}
+{{- end }}
+{{- if ne $minioNodePort "" }}
+{{- $minioNP := $minioNodePort | int -}}
+{{- if or (lt $minioNP 30000) (gt $minioNP 32767) }}
+{{- fail (printf "minio.service.nodePort must be in 30000-32767 (got %v)" $minioNodePort) }}
+{{- end }}
+{{- end }}
 {{- if eq (include "cube.s3lvolEnabled" .) "true" }}
 {{- if not ((.Values.images.cubeS3lvol).repository) }}
 {{- fail "cubeS3lvol.enabled=true requires images.cubeS3lvol.repository" }}
@@ -275,15 +286,6 @@
 {{- fail "cubeS3lvol.s3 values must not contain double quotes (s3.cfg is double-quoted TOML)" }}
 {{- end }}
 {{- end }}
-{{- $minioSvcType := .Values.minio.service.type | default "ClusterIP" -}}
-{{- $minioNodePort := .Values.minio.service.nodePort | default "" | toString -}}
-{{- if and (ne $minioNodePort "") (not (has $minioSvcType (list "NodePort" "LoadBalancer"))) }}
-{{- fail (printf "minio.service.nodePort requires service.type NodePort or LoadBalancer (got %s)" $minioSvcType) }}
-{{- end }}
-{{- if ne $minioNodePort "" }}
-{{- $minioNP := $minioNodePort | int -}}
-{{- if or (lt $minioNP 30000) (gt $minioNP 32767) }}
-{{- fail (printf "minio.service.nodePort must be in 30000-32767 (got %v)" $minioNodePort) }}
 {{- end }}
 {{- end }}
 {{- if eq (include "cube.opsEnabled" .) "true" }}

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -275,6 +275,15 @@
 {{- fail "cubeS3lvol.s3 values must not contain double quotes (s3.cfg is double-quoted TOML)" }}
 {{- end }}
 {{- end }}
+{{- $minioSvcType := .Values.minio.service.type | default "ClusterIP" -}}
+{{- $minioNodePort := .Values.minio.service.nodePort | default "" | toString -}}
+{{- if and (ne $minioNodePort "") (not (has $minioSvcType (list "NodePort" "LoadBalancer"))) }}
+{{- fail (printf "minio.service.nodePort requires service.type NodePort or LoadBalancer (got %s)" $minioSvcType) }}
+{{- end }}
+{{- if ne $minioNodePort "" }}
+{{- $minioNP := $minioNodePort | int -}}
+{{- if or (lt $minioNP 30000) (gt $minioNP 32767) }}
+{{- fail (printf "minio.service.nodePort must be in 30000-32767 (got %v)" $minioNodePort) }}
 {{- end }}
 {{- end }}
 {{- if eq (include "cube.opsEnabled" .) "true" }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -224,6 +224,11 @@ controlPlane:
     args: []
     env: []
     nodeIPs: []
+    # Inline CubeMaster configuration YAML. When empty (default), the chart
+    # renders files/cube-master/conf.yaml as a Secret. Set this to provide
+    # a custom configuration without forking the chart, e.g.:
+    #   --set-file controlPlane.master.configInline=my-conf.yaml
+    configInline: ""
     service:
       type: ClusterIP
       port: 8089
@@ -1137,6 +1142,20 @@ hostPaths:
   # /run/vc/vm/{id}/chapi and /run/vc/vm/{id}/cube.sock need this tree to
   # remain on a filesystem that is not torn down with the Pod overlay.
   runVc: /data/cubelet/run/vc
+
+# Optional overrides for container-side mountPaths. By default each
+# volumeMount uses the same path as the hostPath above. When a hostPath is
+# changed (e.g. dataCubelet → /data02/cubelet), code inside the container
+# may still expect the original /data/cubelet path. Set the matching key
+# here to keep the container mountPath unchanged while the host directory
+# moves. Only the keys listed below are honoured; unknown keys are ignored.
+#
+# Example:
+#   hostPaths:
+#     dataCubelet: /data02/cubelet
+#   containerPaths:
+#     dataCubelet: /data/cubelet
+containerPaths: {}
 
 # COS volume plugin credentials (volume-cos.conf). Plugin binaries ship in
 # cube-master / cubelet images; this Secret mounts the conf next to them.

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -561,6 +561,12 @@ minio:
     tag: "RELEASE.2025-09-07T16-13-09Z"
     pullPolicy: IfNotPresent
   port: 9000
+  # Optional NodePort Service for external access (e.g. compute nodes outside
+  # the cluster). The Headless Service is always created for StatefulSet DNS.
+  # Set service.type to NodePort or LoadBalancer and optionally specify nodePort.
+  service:
+    type: ClusterIP
+    nodePort: ""
   rootUser: cubeminio
   # Empty → generated on first install and reused from the existing Secret
   # on upgrade. When set, must be at least 8 characters.


### PR DESCRIPTION
## Summary

  This PR brings three independent improvements to the Helm chart, all aimed at
  making the chart more flexible for production deployments without requiring
  operators to fork or manually patch resources.

  ### 1. Optional NodePort Service for chart-managed MinIO

  The chart-managed MinIO only exposed a Headless Service (ClusterIP), so compute
  nodes outside the cluster network could not reach it. Operators had to manually
  `kubectl patch` the Service to NodePort after every install/upgrade.

  - New values: `minio.service.type` and `minio.service.nodePort`
  - The Headless Service is always created for StatefulSet DNS; when `type` is
    set to `NodePort` or `LoadBalancer`, an additional Service is rendered
  - Render-time validation rejects `ClusterIP + nodePort` and out-of-range ports,
    matching the existing api/proxy nodePort guard pattern

  ### 2. Decouple container mountPaths from hostPaths

  Previously, changing a `hostPaths` entry (e.g. `dataCubelet` → `/data02/cubelet`)
  would also change the in-container mountPath, breaking code that hardcodes
  `/data/cubelet`.

  - New `cube.containerPath` helper: returns `containerPaths.<key>` when set,
    otherwise falls back to `hostPaths.<key>`
  - New values: `containerPaths: {}` — optional per-key overrides
  - All volumeMount references across node DaemonSet, bootstrap DaemonSet, and
    test pods updated to use the helper

  **Example:**
  ```yaml
  hostPaths:
    dataCubelet: /data02/cubelet
  containerPaths:
    dataCubelet: /data/cubelet  # container still sees /data/cubelet
  ```

  ### 3. CubeMaster config: Secret → ConfigMap + inline override

  The master config file (conf.yaml) contains no sensitive data, yet was
  stored in a Secret. Switching to ConfigMap makes kubectl edit more
  straightforward. The subPath mount semantics are unchanged — updates still
  require a Pod restart, same as before.

  Additionally, controlPlane.master.configInline allows operators to provide a
  custom configuration YAML without forking the chart:

  helm install ... --set-file controlPlane.master.configInline=my-conf.yaml

  When empty (default), the chart renders the built-in files/cube-master/conf.yaml.

  Test plan

  - helm template renders without errors with default values
  - helm template with minio.service.type=NodePort,minio.service.nodePort=30000 produces the additional Service
  - helm template with minio.service.type=ClusterIP,minio.service.nodePort=30000 fails validation
  - helm template with containerPaths.dataCubelet=/data/cubelet renders the override in volumeMounts
  - helm template with controlPlane.master.configInline="custom: yaml" renders the inline content in the ConfigMap
  - Deploy to a test cluster and verify CubeMaster starts correctly with ConfigMap-mounted config