### PR TITLE
s3lvol: pending-delete, derived exports, and faster same-bucket ingest

### DIFF
--- a/CubeS3lvol/README.md
+++ b/CubeS3lvol/README.md
@@ -209,18 +209,27 @@ scripts/s3lvol_rpc.py rcow_delete_lvol     '{"lvol_name":"clone0"}'
 scripts/s3lvol_rpc.py rcow_get_lvstores    # list all lvstores and lvols
 ```
 
+(`rcow_pending_load_hold` exists only so tests can park pending-delete registry
+HEAD/GET around unload; it is not an operations RPC.)
+
 The parameter names are deliberately chosen; the easy mistakes to make when
 copying them:
 
 - `create_lvol` has **no `lvs_name`** — it operates on the single lvstore that
   exists.
 - `create_snapshot` takes `lvol_name` as the source and `snapshot_name` as the
-  target; snapshots are read-only.
+  target; snapshots are read-only. If the source is still decoupling from an
+  import, the snapshot keeps that external parent and the reply includes
+  `decouple_cancelled: true`.
 - `create_clone` takes `snapshot_name` (which **must be a read-only snapshot**)
   as the source and `clone_name` as the target.
 - `resize_lvol` can only grow, never shrink.
 - `delete_lvol` also clears the volume's activation record, so the next restart
-  does not try to restore it.
+  does not try to restore it. A snapshot that is still pinned is recorded as an
+  intent rather than carried out. When the blocker is one the poller can finish
+  on its own, the reply is the usual success envelope plus `deferred: true`. A
+  lease-less export (`export_legacy`) still returns EBUSY; the mark is recorded
+  either way. `rcow_cancel_pending_delete` withdraws it.
 
 **Exporting a snapshot** (cross-node transfer):
 
@@ -402,10 +411,11 @@ only inside one loaded lvstore and is reusable, so a name-keyed mark could end u
 pointing at a snapshot the delete was never refused for.
 
 `rcow_get_lvstores` reports the mark per snapshot (`delete_pending`), together
-with whether the snapshot is deletable *right now* (`deletable`). Once the
-blocker clears — the export is released or expires, the extra clone is deleted —
-the snapshot becomes deletable, but the delete still has to be carried out by
-hand:
+with whether the snapshot is deletable *right now* (`deletable`).
+
+Most recorded intents are finished by a **background poller** (~60 s, 16 deletes
+per tick) once the blocker is gone. `--retry-pending` is for the cases the
+poller will not touch, and for not waiting a minute:
 
 ```sh
 test/tools/s3lvol_rpc.py --retry-pending
@@ -432,38 +442,84 @@ $ test/tools/s3lvol_rpc.py --retry-pending
 no pending snapshot deletes to retry
 ```
 
-### What this is not
+### What the poller completes, and what still needs a human
 
-The mark is a record and a manual retry, nothing more. Specifically:
+The poller finishes deletes whose blockers clear without anyone deciding
+anything:
+
+- a **leased** export (`export`) — the importer stops renewing, the lease goes
+  stale, that is evidence nobody is reading;
+- an export still **publishing** (`export_inflight`);
+- extra **clones** (`clone_count`);
+- a running **decouple** (`decouple`).
+
+It will **not** complete:
+
+- an export with **no lease at all** (`export_legacy`). Its TTL lapsing only
+  means time passed, not that an importer stopped reading; auto-completing that
+  would delete objects out from under a live reader. Those marks stay until a
+  human (or `--retry-pending`) decides;
+- a destroy that already **failed asynchronously** (`failed`). Retrying it every
+  minute would only repeat the same failure.
+
+If the poller itself failed to register, queued deletes also wait for an
+explicit retry (a log line says so).
+
+### Persistence and the crash window
+
+Marks are written to `<prefix>/meta/pending-deletes.json` and restored when the
+lvstore attaches, so a restart does not forget a delete the caller was told not
+to reissue.
+
+The RPC answers **before** that PUT. If the process crashes (or the PUT fails)
+in the window after the mark is in memory and before the object lands, the
+intent is gone after the next attach and the delete has to be asked for again
+— the same class of window the exports registry accepts, and cheaper: the
+snapshot is still there.
+
+Unload or destroy drops the in-memory queue for that lvstore (marks must not
+outlive the lvols they name). The S3 object is reloaded on the next attach of
+the same prefix; a failed or missing registry is logged and attach continues.
+
+### Cancelling a pending delete (`rcow_cancel_pending_delete`)
+
+The mark is an intent, not a lock. Withdraw it with:
+
+```sh
+scripts/s3lvol_rpc.py rcow_cancel_pending_delete '{"lvol_name":"snap0"}'
+# optional lvs_name when the same snapshot name exists on more than one lvstore
+scripts/s3lvol_rpc.py rcow_cancel_pending_delete '{"lvs_name":"vs0","lvol_name":"snap0"}'
+```
+
+`lvol_name` is required; `lvs_name` is optional and only disambiguates. The
+RPC is **idempotent**: cancelling a name that was never queued, or that the
+poller has already finished, still succeeds — the caller asked for "this
+snapshot will not be deleted behind my back", and that is the state they get.
+The snapshot itself was never touched, only the intent.
+
+The same crash window applies as for recording: the RPC answers, then the
+registry PUT runs. A crash before that PUT lands can restore the mark on the
+next attach.
+
+If the poller has **already submitted** `s3lvol_lvol_destroy`, cancel only
+drops the mark. It does not abort the in-flight destroy; the snapshot may
+still go away. Check `rcow_get_lvstores` afterwards if that race matters.
+
+### What this is not
 
 - **Not every refusal records a mark.** Recorded are the blockers
   `s3lvol_lvol_destroy()` itself identifies — an export pin (published or still
   in flight), more than one clone, a running decouple — plus an asynchronous
-  destroy failure. Those are the ones that clear on their own, which is what
-  makes coming back to them worthwhile. Not recorded: the RPC-layer refusals
-  that run before it (an NVMf-active volume, an unreadable active registry), a
-  bdev unregister that fails, and the case where `spdk_blob_get_clones()`
-  answers an unknown error. Those are either the caller's own precondition to
-  fix (deactivate first) or a failure that has to be looked at rather than
-  retried blindly.
+  destroy failure. Not recorded: the RPC-layer refusals that run before it (an
+  NVMf-active volume, an unreadable active registry), a bdev unregister that
+  fails, and the case where `spdk_blob_get_clones()` answers an unknown error.
+  Those are either the caller's own precondition to fix (deactivate first) or a
+  failure that has to be looked at rather than retried blindly.
 
   The recording does not re-check that the volume is a snapshot: with the blob
   closed that is not reliably answerable, and only the three blockers above get
   that far anyway. In practice a mark therefore means "a delete was asked for
   and refused because something still referenced the volume".
-- **No automatic retry.** Nothing on the target polls the marks; there is no
-  deferred-completion poller. `--retry-pending` is the only thing that acts on
-  them, and it has to be run.
-- **In memory only.** The marks live in the target process and are gone on
-  restart. A delete refused before a restart is afterwards indistinguishable
-  from one that was never asked for.
-- **Dropped with the lvstore.** Unloading or deleting an lvstore drops that
-  lvstore's marks, deliberately: past the teardown they would name lvols that no
-  longer exist, and an lvstore attached again can give the same names to
-  different objects.
-- **No cancel.** Completing the delete is the only way to clear a mark; a
-  refused delete stays recorded for as long as the target runs and its lvstore
-  stays attached.
 - **`delete_pending` is a snapshot notion.** `rcow_get_snapshot_status` reports
   it when queried by `snapshot_name`; queried by `export_uuid` it is always
   `false`, because an export names a snapshot but is not one.

--- a/CubeS3lvol/include/s3lvol/s3_bs_dev.h
+++ b/CubeS3lvol/include/s3lvol/s3_bs_dev.h
@@ -253,6 +253,30 @@ int s3_bs_dev_journal_apply(struct spdk_bs_dev *bs_dev,
 			    const struct s3_journal_record *rec);
 
 /* ==========================================================================
+ * Server-side ingest (CopyObject into the chunk map)
+ *
+ * Installed for the duration of a decouple of a same-bucket export. blobstore's
+ * allocate_and_copy_cluster then calls dest->copy instead of GET+write. copy()
+ * treats src_lba as an LBA on the export parent and dst_lba as the newly
+ * allocated cluster on this device.
+ * ========================================================================== */
+
+typedef int (*s3_ingest_src_fn)(void *cb_arg, uint64_t chunk_index,
+				char *src_key, size_t key_len,
+				uint32_t *valid_bytes);
+
+int s3_bs_dev_ingest_begin(struct spdk_bs_dev *bs_dev, const char *src_bucket,
+			   s3_ingest_src_fn src_fn, void *src_arg);
+
+/* Start CopyObject for this parent range if a slot is free. Harmless if the
+ * chunk is already in flight or ready. */
+void s3_bs_dev_ingest_prefetch(struct spdk_bs_dev *bs_dev, uint64_t src_lba,
+			       uint64_t lba_count);
+
+void s3_bs_dev_ingest_end(struct spdk_bs_dev *bs_dev, s3_bs_dev_cb cb_fn,
+			  void *cb_arg);
+
+/* ==========================================================================
  * Diagnostics
  * ========================================================================== */
 

--- a/CubeS3lvol/include/s3lvol/s3_client.h
+++ b/CubeS3lvol/include/s3lvol/s3_client.h
@@ -98,6 +98,12 @@ void s3_client_put(struct s3_client *client);
  */
 void s3_client_get(struct s3_client *client);
 
+/**
+ * Bucket this client signs requests for. CopyObject names the source bucket
+ * separately; this is the destination.
+ */
+const char *s3_client_bucket(const struct s3_client *client);
+
 /* ==========================================================================
  * Object operations
  *
@@ -189,12 +195,10 @@ int s3_delete_batch(struct s3_client *client, const char **keys, uint32_t count,
  * not modified by inflate / decouple can be copied server-side directly, saving
  * all data-plane traffic and leaving only control-plane RTT.
  *
- * **There is currently no caller, and that is deliberate** (2026-08-05). It was
- * meant for export "materialisation" (copying the objects into the exports
- * prefix before deleting a snapshot referenced by a zero-copy export); that
- * approach was rejected -- the reasoning and the alternative are in the header
- * comment of lib/s3bsdev/s3_gc.c. The inflate optimisation above still holds;
- * it just is not done yet.
+ * Used by decouple ingest: same-bucket CopyObject of export chunks into the
+ * destination lvstore's data/ prefix, so materialise does not GET+WAL the
+ * bytes. Export-prefix materialisation (copying into exports/ before deleting
+ * a referenced snapshot) was rejected -- see lib/s3bsdev/s3_gc.c.
  *
  * Before actually using it, know one trap: CopyObject returns **HTTP 200 with
  * `<Error>` in the body**. A DEFAULT-type meta request probably does not parse

--- a/CubeS3lvol/include/s3lvol/s3_client.h
+++ b/CubeS3lvol/include/s3lvol/s3_client.h
@@ -200,10 +200,11 @@ int s3_delete_batch(struct s3_client *client, const char **keys, uint32_t count,
  * bytes. Export-prefix materialisation (copying into exports/ before deleting
  * a referenced snapshot) was rejected -- see lib/s3bsdev/s3_gc.c.
  *
- * Before actually using it, know one trap: CopyObject returns **HTTP 200 with
- * `<Error>` in the body**. A DEFAULT-type meta request probably does not parse
- * the body, so after every object copy a HEAD verification is required -- the
- * status code alone is not enough.
+ * CopyObject can return HTTP 200 with `<Error>` in the body (S3 keeps the
+ * connection alive during a long server-side copy). The status code alone is
+ * not enough: this call accumulates up to 8 KiB of response XML and succeeds
+ * only when that prefix contains a complete CopyObjectResult opening tag.
+ * A truncated body without that tag is an error, not success.
  */
 int s3_copy_object(struct s3_client *client,
 		   const char *src_bucket, const char *src_key,

--- a/CubeS3lvol/include/s3lvol/s3_client.h
+++ b/CubeS3lvol/include/s3lvol/s3_client.h
@@ -89,6 +89,15 @@ int s3_client_get_or_create(const struct s3_target *target, struct s3_client **o
 
 void s3_client_put(struct s3_client *client);
 
+/**
+ * Take another reference on an existing client.
+ *
+ * Unload drops the lvstore's reference. An in-flight HEAD or GET started
+ * against that lvstore still needs the CRT client until its callback runs, so
+ * the load path holds an extra ref for the lifetime of that request.
+ */
+void s3_client_get(struct s3_client *client);
+
 /* ==========================================================================
  * Object operations
  *

--- a/CubeS3lvol/include/s3lvol/s3_export.h
+++ b/CubeS3lvol/include/s3lvol/s3_export.h
@@ -460,6 +460,16 @@ const char *s3_export_manifest_chunk_prefix(const struct s3_export_manifest *m,
 const struct s3_export_ref *s3_export_manifest_get_ref(
 	const struct s3_export_manifest *m, uint64_t chunk_index);
 
+/**
+ * S3 key of one present chunk, and how many bytes of it are valid.
+ *
+ * Dense exports use `<prefix>/exports/<uuid>/<index>`; ref exports use
+ * `<chunk prefix>/data/<uuid>`. Holes return -ENOENT.
+ */
+int s3_export_manifest_object_key(const struct s3_export_manifest *m,
+				  uint64_t chunk_index, char *out, size_t out_len,
+				  uint32_t *valid_bytes);
+
 bool s3_export_manifest_is_present(const struct s3_export_manifest *m,
 				   uint64_t chunk_index);
 

--- a/CubeS3lvol/include/s3lvol/s3_export.h
+++ b/CubeS3lvol/include/s3lvol/s3_export.h
@@ -54,8 +54,36 @@
  * 2: the ref table shed its per-chunk valid_bytes. A version 1 reader handed a
  *    version 2 manifest would consume 24 bytes per ref out of a 16-byte-per-ref
  *    table, so every chunk past the first would name another chunk's object --
- *    which reads back as valid data from the wrong place. Hence a bump. */
-#define S3_EXPORT_VERSION       2
+ *    which reads back as valid data from the wrong place. Hence a bump.
+ *
+ * 3: per-chunk sources (srcs[] plus src_idx[]), so that a snapshot whose chunks
+ *    come partly from another export can be described at all. A version 2 reader
+ *    would ignore src_idx and resolve every chunk against the single `src`,
+ *    returning another object's bytes for the ones that belong elsewhere. Hence
+ *    a bump.
+ */
+#define S3_EXPORT_VERSION       3
+
+/* The oldest a reader accepts. Writing is always at S3_EXPORT_VERSION; reading
+ * has to span the range, because manifests already in a bucket outlive the binary
+ * that wrote them -- including ones this binary wrote before being upgraded.
+ *
+ * 1 is excluded rather than merely old: its 24-byte ref entries read as 16-byte
+ * ones name a different object for every chunk past the first, and return
+ * plausible data from the wrong place. That is the failure a version exists to
+ * prevent, so it stays refused. */
+#define S3_EXPORT_VERSION_MIN   2
+
+/* How many prefixes one manifest may reference. A derived export adds its own
+ * prefix to the ones it inherited, so this bounds the length of a derivation
+ * lineage: A publishes, B imports and republishes, C imports and republishes.
+ *
+ * Explicit, and much smaller than the 255 a one-byte index would allow, because
+ * the ceiling has to be reachable in a test. What happens past it is a fallback
+ * to copying -- correct, but it turns an O(1) publish into an O(size) one, and a
+ * limit that can only be hit by a lineage nobody is watching is a limit nobody
+ * finds out about until it costs them a volume. */
+#define S3_EXPORT_MAX_SOURCES   16
 
 /* How a manifest names the bytes it describes.
  *
@@ -145,6 +173,35 @@ struct s3_export_source {
 	char     snapshot_uuid[SPDK_UUID_STRING_LEN];
 };
 
+/* One prefix a ref manifest resolves chunks against. Version 3 and later.
+ *
+ * Deliberately not a whole struct s3_export_source: every entry shares the
+ * endpoint, bucket and region of `src`, because the writer refuses to reference
+ * another bucket and falls back to copying instead. That keeps a reader to one S3
+ * client and keeps the pin enforceable -- a reference into a bucket this node may
+ * not even be configured for could not be honoured. */
+struct s3_export_src_entry {
+	char prefix[S3_EXPORT_PREFIX_MAX];
+
+	/* Whose lease governs these objects, so an importer knows what to renew:
+	 * <prefix>/meta/exports/<uuid>.lease. Empty for entry 0, whose lease is this
+	 * manifest's own.
+	 *
+	 * This is what keeps the delete path unchanged across a derivation. An
+	 * importer of a derived export renews on the *original* export directly, so
+	 * the original's source refuses to delete its snapshot whether or not the
+	 * intermediate node is still running -- which is what publish-then-leave
+	 * requires. */
+	char export_uuid[SPDK_UUID_STRING_LEN];
+
+	/* Identity of the snapshot behind that export. Present for the same reason
+	 * s3_export_source::snapshot_uuid is: blob ids are handed back after a
+	 * delete, so a snapshot deleted and recreated under one name can match on
+	 * both name and blob_id while being an entirely different volume. Empty
+	 * means "cannot prove", never "matches". */
+	char snapshot_uuid[SPDK_UUID_STRING_LEN];
+};
+
 struct s3_export_manifest {
 	uint32_t version;
 	enum s3_export_layout layout;
@@ -187,6 +244,21 @@ struct s3_export_manifest {
 	 * keeps sparse volumes sparse across an export. */
 	uint8_t *present;
 
+	/* Construction only, never serialized, not part of the crc.
+	 *
+	 * `present` cannot say "this chunk is already settled as zeroes": that
+	 * is also how an untouched hole is spelled, and inherit() fills those
+	 * from the parent. A local write_zeroes / unmap drops the mapping and
+	 * leaves the cluster allocated, so the walk sees a hole and, without
+	 * this bit, the parent object comes back -- stale data where the volume
+	 * reads as zero.
+	 *
+	 * The walk sets this when is_zeroes() says the cluster holds no data.
+	 * inherit() and later layers then skip it the same way they skip a
+	 * present chunk. On the wire the chunk stays a hole, which is what the
+	 * importer uses for zeroes. */
+	uint8_t *resolved;
+
 	/* REF layout only. One bit per chunk: set means "this chunk's object holds
 	 * a whole chunk_size", i.e. valid_bytes needs no separate entry.
 	 *
@@ -207,14 +279,39 @@ struct s3_export_manifest {
 	 * index and which therefore needs nothing here. */
 	struct s3_export_ref *refs;
 
+	/* Which prefix each chunk's object lives under. REF layout only.
+	 *
+	 * A snapshot taken on an imported volume owns some of its chunks and reads
+	 * the rest through the export it came from, so one prefix cannot describe
+	 * it. srcs[0] is always this export's own -- src.prefix -- which is what
+	 * lets the read path treat a single-source manifest as the ordinary case of
+	 * a multi-source one rather than a separate shape.
+	 *
+	 * A version 2 manifest has neither of these on the wire; parse synthesises
+	 * the one-entry table from src so that everything downstream sees one shape.
+	 * num_srcs is therefore >= 1 for any REF manifest, and 0 for a dense one. */
+	struct s3_export_src_entry *srcs;
+	uint32_t                    num_srcs;
+
+	/* num_chunks entries, meaningful exactly where `present` is set: an index
+	 * into srcs[]. Kept separate from refs[] rather than added to
+	 * struct s3_export_ref so that a ref stays 16 bytes on the wire and v2's
+	 * packing is untouched. NULL means every chunk resolves to srcs[0], which is
+	 * how a v2 manifest arrives. */
+	uint8_t *src_idx;
+
 	/* Over the bitmap, and for a ref manifest over the full bitmap, the packed
-	 * uuids and the partial-length exceptions too, in that order. */
+	 * uuids and the partial-length exceptions too, in that order -- and, from
+	 * version 3, src_idx after those. The stage list follows `version` rather
+	 * than S3_EXPORT_VERSION: recomputing a v2 manifest's crc with the v3 stages
+	 * would report corruption on every manifest already in a bucket. */
 	uint32_t crc32c;
 
 	/* Manifests are shared: the import cache holds one reference, and every
 	 * s3_export_bs_dev built from it holds another. The bs_dev outlives the
 	 * import RPC and may outlive a release, so this cannot be an owner
-	 * pointer. */
+	 * pointer. Touched from nvmf I/O threads as well as the swap thread, so
+	 * ref/unref are atomic. */
 	uint32_t refcnt;
 };
 
@@ -249,6 +346,15 @@ void s3_export_manifest_unref(struct s3_export_manifest *m);
 void s3_export_manifest_set_present(struct s3_export_manifest *m, uint64_t chunk_index);
 
 /**
+ * Claim a chunk as locally settled zeroes without marking it present.
+ *
+ * Used by the zero-copy walk so inherit() does not restore a parent object over
+ * a write_zeroes / unmap. Does not belong on the wire: a hole already reads as
+ * zeroes for the importer.
+ */
+void s3_export_manifest_set_resolved(struct s3_export_manifest *m, uint64_t chunk_index);
+
+/**
  * Record which object a chunk of a ref export lives in, and mark it present.
  *
  * \return -EINVAL on a dense manifest or an index out of range. Refused rather
@@ -256,6 +362,96 @@ void s3_export_manifest_set_present(struct s3_export_manifest *m, uint64_t chunk
  */
 int s3_export_manifest_set_ref(struct s3_export_manifest *m, uint64_t chunk_index,
 			       const struct spdk_uuid *uuid, uint32_t valid_bytes);
+
+/**
+ * Add a prefix this manifest may resolve chunks against, or find the existing
+ * entry for it, and answer its index.
+ *
+ * Idempotent on \p prefix: a derived export names the same parent prefix for
+ * however many chunks it inherited, so the caller can ask per chunk without
+ * having to keep track. The identity fields are taken from the first call that
+ * supplies them and are not overwritten afterwards, so a later call may pass NULL.
+ *
+ * \param export_uuid whose lease governs those objects, so an importer knows what
+ *                    to renew. NULL or empty for a prefix that needs no lease.
+ * \param snapshot_uuid identity of the snapshot behind it; NULL if unknown.
+ * \param out_idx receives the index to store in the chunk's slot.
+ *
+ * \return 0 on success, -E2BIG once S3_EXPORT_MAX_SOURCES prefixes are named --
+ * which the caller is expected to treat as "export by copying instead", the same
+ * as any other reason a reference cannot be expressed.
+ */
+int s3_export_manifest_add_src(struct s3_export_manifest *m, const char *prefix,
+			       const char *export_uuid, const char *snapshot_uuid,
+			       uint8_t *out_idx);
+
+/**
+ * Record that a chunk's object lives under source \p src_idx rather than under
+ * this export's own prefix. Marks the chunk present, like set_ref.
+ *
+ * Kept separate from set_ref so that the common single-source writer needs no
+ * per-chunk source argument at all, and so that a chunk cannot be given a source
+ * without a ref: this refuses an index no add_src() has handed out.
+ */
+int s3_export_manifest_set_chunk_src(struct s3_export_manifest *m,
+				     uint64_t chunk_index, uint8_t src_idx);
+
+/**
+ * Whether \p parent can be referenced by an export published to \p dst, or whether
+ * the caller has to copy instead.
+ *
+ * Separate from the walk because it is a question about two manifests and nothing
+ * else -- no blob, no device -- which is also what makes the degradation decision
+ * testable on its own. The walk asks it before doing any work.
+ *
+ * \return 0 when a reference can be expressed; -ENOTSUP when it cannot, which is a
+ * routing answer rather than a failure: the copy engine reads through blobstore
+ * and expresses any history under one prefix. -EINVAL on a NULL argument.
+ */
+int s3_export_manifest_inheritable(const struct s3_export_manifest *parent,
+				   const struct s3_export_source *dst,
+				   const char *uuid_str);
+
+/**
+ * Fill \p m 's absent chunks from \p parent, recording each against the prefix that
+ * actually holds it.
+ *
+ * This is how a snapshot taken on an imported volume is handed on without copying:
+ * the clusters written since the import are in the local chunk map and the caller's
+ * walk finds them, while everything older belongs to the export the volume reads
+ * through and lives under its prefix.
+ *
+ * **Call after everything local has been recorded.** A chunk already present, or
+ * one the walk marked resolved as local zeroes, is skipped, never overwritten.
+ * That is what makes a rewrite since the import, or a local write_zeroes, win
+ * over the imported object. Called too early, it would serve the data as it was
+ * before the import -- correct-looking and wrong.
+ *
+ * Flattening, not chaining: the prefix is taken from \p parent per chunk, so a
+ * parent that was itself derived contributes its grandparent's prefix for the
+ * chunks it inherited. A manifest therefore never refers to another manifest,
+ * resolution stays one hop however many times a volume has been handed on, and no
+ * intermediate node has to still exist. For the same reason the lease identity is
+ * carried across rather than replaced: an importer renews against the node that
+ * holds the objects, not against the middleman.
+ *
+ * Both manifests must be ref layout and share a chunk size, since a chunk index
+ * means a different byte range under a different one. Only the chunks the two have
+ * in common are considered -- a volume that grew since the import has chunks the
+ * parent never described.
+ *
+ * \return 0, with \p out_named and \p out_bytes set when non-NULL; -E2BIG once
+ * more distinct prefixes are needed than a manifest can name, which the caller is
+ * expected to treat as "export by copying instead"; -EINVAL on a mismatch of
+ * layout or chunk size.
+ */
+int s3_export_manifest_inherit(struct s3_export_manifest *m,
+			       const struct s3_export_manifest *parent,
+			       uint64_t *out_named, uint64_t *out_bytes);
+
+/** Which prefix a chunk resolves against; "" if the manifest cannot say. */
+const char *s3_export_manifest_chunk_prefix(const struct s3_export_manifest *m,
+					    uint64_t chunk_index);
 
 /**
  * The ref for one chunk, or NULL if this is not a ref manifest, the index is out
@@ -266,6 +462,9 @@ const struct s3_export_ref *s3_export_manifest_get_ref(
 
 bool s3_export_manifest_is_present(const struct s3_export_manifest *m,
 				   uint64_t chunk_index);
+
+bool s3_export_manifest_is_resolved(const struct s3_export_manifest *m,
+				    uint64_t chunk_index);
 
 /**
  * True when no chunk in the range has an object, i.e. the whole range reads as
@@ -371,6 +570,17 @@ struct s3_export_opts {
 	 * is otherwise a serial chain of round trips. 0 takes the default. */
 	uint32_t                max_inflight;
 
+	/* Which version of this export's manifest this run publishes. 0 for a new
+	 * export, which is every ordinary one.
+	 *
+	 * Non-zero only when *replacing* a manifest that importers may already
+	 * hold: materialising a reference export rewrites it in place, and the
+	 * higher generation is the only way a reader can tell the manifest it just
+	 * refetched from the one that sent it looking. Publishing a replacement at
+	 * the same generation would have that reader conclude its objects were
+	 * deleted rather than copied. */
+	uint32_t                generation;
+
 	struct s3_export_source src;
 };
 
@@ -459,7 +669,38 @@ struct s3_export_ref_opts {
 	uint32_t        cluster_size;
 	uint64_t    expires_at;
 
+	/* Version to publish. 0 for a new export; old+1 when an already-published
+	 * reference export is rewritten after its snapshot becomes fully local.
+	 * Readers use the increase to distinguish the replacement manifest from
+	 * the stale one that sent them to an object which has since disappeared. */
+	uint32_t        generation;
+
 	struct s3_export_source src;
+
+	/* The manifest of the export that the last layer of the chain reads through,
+	 * when that layer is an esnap clone. NULL for every export that is not
+	 * derived from an import, which is the ordinary case.
+	 *
+	 * This is what lets a snapshot taken on an imported volume be handed on
+	 * without copying. The clusters written since the import are in this
+	 * lvstore's chunk map and the walk finds them; everything older belongs to
+	 * the export the clone reads through, lives under *its* prefix, and cannot
+	 * be resolved by this chunk map at all. Naming those chunks out of this
+	 * manifest is the alternative to reading and re-uploading them.
+	 *
+	 * Flattened, not chained: each inherited chunk is recorded against the
+	 * prefix that actually holds it, which for a parent that was itself derived
+	 * means the grandparent's prefix rather than the parent's. So a manifest
+	 * never refers to another manifest, resolution stays one hop no matter how
+	 * many times a volume has been handed on, and no node in the history has to
+	 * still be alive.
+	 *
+	 * The caller must have checked that this export is reachable the same way
+	 * `src` is -- same endpoint, bucket and region -- because a source entry
+	 * carries only a prefix and shares the rest with `src`. It must also be a
+	 * ref export of the same chunk size. Where any of that does not hold there
+	 * is nothing to express and the caller uses the copying engine. */
+	const struct s3_export_manifest *parent;
 };
 
 /**
@@ -485,11 +726,12 @@ struct s3_export_ref_opts {
  * which references nothing and therefore does not care. -ENOTSUP is a routing
  * decision, not a failure: the caller is expected to try the copying engine.
  *
- * A chain whose last layer is an esnap clone must not be passed: the data it
- * inherits lives under another lvstore's prefix, so this chunk map cannot resolve
- * it and the manifest would be short exactly where that parent held data. The
- * caller detects that while assembling the chain and routes to the copy engine,
- * which reads through blobstore and flattens everything.
+ * A chain whose last layer is an esnap clone needs `parent` set to the manifest
+ * that layer reads through. The data it inherits lives under another lvstore's
+ * prefix, so this chunk map cannot resolve it, and without the parent manifest the
+ * result would be short exactly where that parent held data -- reading as zeroes
+ * on the importing node, with nothing to say so. Passing an esnap chain with no
+ * parent is refused rather than silently truncated.
  */
 int s3_export_run_ref(const struct s3_export_ref_opts *opts,
 		      s3_export_cb cb, void *cb_arg);
@@ -506,7 +748,16 @@ int s3_export_run_ref(const struct s3_export_ref_opts *opts,
  * write to a back device, so those exist to turn a bug into an error instead of
  * a corruption.
  *
- * Takes a reference on \c m and on \c client, releasing both from destroy().
+ * The two arguments are held differently, which is easy to get wrong in both
+ * directions:
+ *
+ *   \c m is *referenced* -- the caller keeps its own reference and must still
+ *   release it.
+ *
+ *   \c client is *consumed* -- the caller's reference moves in here, and
+ *   destroy() releases it. Putting it as well is a double free. On failure the
+ *   move does not happen and the caller still owns it.
+ *
  * Note that destroy() is called by blobstore, at a time the importer does not
  * control -- which is why neither may be owned by the import request.
  *
@@ -515,5 +766,68 @@ int s3_export_run_ref(const struct s3_export_ref_opts *opts,
  */
 int s3_export_bs_dev_create(struct s3_client *client, struct s3_export_manifest *m,
 			    struct spdk_bs_dev **out);
+
+/** Called once the swap is complete and the old manifest has been released. */
+typedef void (*s3_export_bs_dev_swap_cb)(void *cb_arg, int status);
+
+/**
+ * Called on the swapping thread immediately after the new manifest is published,
+ * before the grace period that releases the previous one.
+ *
+ * The import registry uses this so derive/decouple and a later attach see the
+ * same generation the data plane is already reading.
+ */
+typedef void (*s3_export_bs_dev_on_swap_fn)(void *arg, struct s3_export_manifest *m);
+
+void s3_export_bs_dev_set_on_swap(struct spdk_bs_dev *bs_dev,
+				  s3_export_bs_dev_on_swap_fn fn, void *arg);
+
+/**
+ * Point this device at a newer manifest for the same export.
+ *
+ * A ref export names the source's live objects, so when the source materialises
+ * it -- rewrites the manifest as dense, holding its own copies -- those objects
+ * go and an importer still on the old manifest reads 404s. Refetching and calling
+ * this is the way out, and `generation` is how the two are told apart.
+ *
+ * **Asynchronous, and the reason is not I/O.** Every other thread reads the
+ * manifest with no serialisation, which is what keeps this device lock free, so
+ * the old one cannot be released until each of them has been through its event
+ * loop once. The pointer is swapped before returning -- reads issued after this
+ * call resolve against \p m -- but the callback is what says the previous
+ * manifest is gone.
+ *
+ * Refuses rather than adopts a manifest that is not a strictly newer version of
+ * the same thing:
+ *
+ * \return 0 and the callback runs; -EINVAL for a different export uuid, a
+ * changed size, or a changed chunk size, any of which would have the clone
+ * reading something blobstore did not size it for; -EALREADY when \p m is no
+ * newer. That is not a failure:
+ * it is both "the source has not rewritten it yet" and "this generation is
+ * already installed" (another refetch swapped while a GET still used the old
+ * keys). A 404-driven refetch must retry waiters on -EALREADY, not treat it as
+ * the source having deleted the snapshot; see
+ * s3_export_bs_dev_refetch_already_current().
+ */
+int s3_export_bs_dev_swap_manifest(struct spdk_bs_dev *bs_dev,
+				   struct s3_export_manifest *m,
+				   s3_export_bs_dev_swap_cb cb, void *cb_arg);
+
+/**
+ * True when swap_manifest() returned -EALREADY: the device is already on the
+ * generation that was just fetched.
+ *
+ * A refetch started from a 404 must then retry waiters against the current
+ * keys. A GET issued before a swap can 404 after it; the follow-up refetch
+ * sees -EALREADY even though those keys now exist under the new manifest.
+ * If the objects are genuinely gone, the retry 404s once and the I/O's
+ * retried flag stops another refetch.
+ */
+static inline bool
+s3_export_bs_dev_refetch_already_current(int swap_rc)
+{
+	return swap_rc == -EALREADY;
+}
 
 #endif /* S3LVOL_EXPORT_H */

--- a/CubeS3lvol/include/s3lvol/s3_types.h
+++ b/CubeS3lvol/include/s3lvol/s3_types.h
@@ -24,7 +24,21 @@
 #define S3LVOL_DEFAULT_CHUNK_SIZE    (1024 * 1024)   /* 1 MiB, the LBA range one S3 object carries */
 #define S3LVOL_DEFAULT_CLUSTER_SIZE  (1024 * 1024)   /* 1 MiB, blobstore CoW granularity */
 
-/* Snapshot chain depth limits */
+/* Snapshot chain depth limits.
+ *
+ * MAX is a hard consequence rather than a policy: export_build_chain() walks the
+ * chain into a stack array of this size, and a chain deeper than it makes
+ * export_snapshot fall back to copying the whole volume. That fallback is correct
+ * but expensive and, because a copied (dense) export is never reaped, permanent.
+ *
+ * SOFT is where that becomes worth saying out loud. Nothing enforces it -- a
+ * snapshot is the user's to keep, and refusing to create one because a chain is
+ * long would break an ordinary workflow to avoid a cost the user may be happy to
+ * pay. So it warns, once per lvol per crossing, and the depth is reported by
+ * rcow_get_lvstores so a control plane can act before the cliff rather than
+ * discover it afterwards.
+ *
+ * The gap between the two is the room to act in: eight snapshots' worth. */
 #define S3LVOL_DEFAULT_MAX_CHAIN_DEPTH   32
 #define S3LVOL_DEFAULT_SOFT_CHAIN_DEPTH  24
 

--- a/CubeS3lvol/lib/s3bsdev/s3_bs_dev.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_bs_dev.c
@@ -2346,7 +2346,7 @@ s3_flush_put(struct s3_flush_ctx *fc)
 	/* Overlay goes on last so it wins over whatever the old object held. */
 	s3_overlay_flush_merge(ctx->overlay, fc->view, fc->chunk_buf);
 
-	/* create-once (P2): a fresh uuid every time, never an in-place update. */
+	/* create-once: a fresh uuid every time, never an in-place update. */
 	spdk_uuid_generate(&fc->new_uuid);
 	s3_data_key(ctx, &fc->new_uuid, key, sizeof(key));
 
@@ -3215,23 +3215,19 @@ s3_bs_dev_get_stats(struct spdk_bs_dev *bs_dev, struct s3_bs_dev_stats *out)
 	out->ckpt_lsn    = ctx->ckpt_lsn_done;
 	out->ckpt_gen    = ctx->ckpt_gen;
 	out->ckpt_interval_sec = ctx->ckpt_interval_sec;
-	{
-		struct s3_journal *j = s3_chunk_map_get_journal(ctx->chunk_map);
 
-		out->journal_used_bytes = s3_journal_get_used_bytes(j);
-		out->journal_capacity_bytes = s3_journal_get_capacity_bytes(j);
-	}
+	struct s3_journal *j = s3_chunk_map_get_journal(ctx->chunk_map);
+	out->journal_used_bytes = s3_journal_get_used_bytes(j);
+	out->journal_capacity_bytes = s3_journal_get_capacity_bytes(j);
 
 	out->overlay_bytes       = s3_overlay_get_bytes(ctx->overlay);
 	out->overlay_live_chunks = s3_overlay_get_live_chunks(ctx->overlay);
-	{
-		struct s3_overlay_stats ostats = {};
 
-		s3_overlay_get_stats(ctx->overlay, &ostats);
-		out->overlay_flushed_full   = ostats.flushed_full;
-		out->overlay_flushed_aged   = ostats.flushed_aged;
-		out->overlay_flushed_forced = ostats.flushed_forced;
-	}
+	struct s3_overlay_stats ostats = {};
+	s3_overlay_get_stats(ctx->overlay, &ostats);
+	out->overlay_flushed_full   = ostats.flushed_full;
+	out->overlay_flushed_aged   = ostats.flushed_aged;
+	out->overlay_flushed_forced = ostats.flushed_forced;
 
 	if (ctx->flusher) {
 		s3_flusher_get_stats(ctx->flusher, &fstats);

--- a/CubeS3lvol/lib/s3bsdev/s3_bs_dev.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_bs_dev.c
@@ -2142,7 +2142,6 @@ struct s3_ingest_slot {
 	struct spdk_uuid          uuid;
 	uint32_t                  valid_bytes;
 	char                      dest_key[S3_KEY_MAX];
-	uint64_t                  head_size;
 	struct s3_ingest_op      *waiter;
 };
 
@@ -2150,6 +2149,9 @@ struct s3_ingest {
 	char                      src_bucket[128];
 	s3_ingest_src_fn          src_fn;
 	void                     *src_arg;
+	/* CopyObjects plus in-flight chunk-map binds. End must not free this
+	 * struct until both have drained: bind callbacks keep a pointer into
+	 * slots[], which lives here. */
 	uint32_t                  inflight;
 	struct s3_ingest_slot     slots[S3_INGEST_SLOTS];
 	s3_bs_dev_cb              end_cb;
@@ -2160,18 +2162,56 @@ struct s3_ingest {
 struct s3_ingest_op {
 	struct s3_ctx             *ctx;
 	struct spdk_bs_dev_cb_args *cb_args;
+	struct spdk_thread       *submit_thread;
 	uint64_t                   dst_lba;
 	uint64_t                   src_lba;
 	uint64_t                   lba_count;
 	uint64_t                   pos;
+	int                        status;
+};
+
+struct ingest_prefetch_msg {
+	struct s3_ctx *ctx;
+	uint64_t        src_lba;
+	uint64_t        lba_count;
 };
 
 static void s3_bs_dev_copy(struct spdk_bs_dev *dev, struct spdk_io_channel *channel,
 			   uint64_t dst_lba, uint64_t src_lba, uint64_t lba_count,
 			   struct spdk_bs_dev_cb_args *cb_args);
 static void ingest_op_next(struct s3_ingest_op *op);
+static void ingest_op_complete(struct s3_ingest_op *op, int status);
 static void ingest_try_finish_end(struct s3_ctx *ctx);
 static int ingest_start_slot(struct s3_ingest_slot *slot, uint64_t src_chunk);
+static void ingest_bound(void *cb_arg, const struct spdk_uuid *old_uuid, int status);
+static void ingest_start_bind(struct s3_ingest_slot *slot, uint64_t dst_chunk);
+
+static void
+ingest_op_deliver(void *arg)
+{
+	struct s3_ingest_op *op = arg;
+
+	op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, op->status);
+	free(op);
+}
+
+static void
+ingest_op_complete(struct s3_ingest_op *op, int status)
+{
+	int rc;
+
+	op->status = status;
+	if (!op->submit_thread || op->submit_thread == spdk_get_thread()) {
+		ingest_op_deliver(op);
+		return;
+	}
+	rc = spdk_thread_send_msg(op->submit_thread, ingest_op_deliver, op);
+	if (rc != 0) {
+		SPDK_ERRLOG("ingest copy complete bounce failed: %s\n",
+			    spdk_strerror(-rc));
+		ingest_op_deliver(op);
+	}
+}
 
 static struct s3_ingest_slot *
 ingest_find_slot(struct s3_ingest *in, uint64_t src_chunk, bool alloc_free)
@@ -2211,6 +2251,20 @@ ingest_abandon_copy(struct s3_ingest_slot *slot)
 	ingest_slot_reset(slot);
 }
 
+static bool
+ingest_has_async_slots(struct s3_ingest *in)
+{
+	uint32_t i;
+
+	for (i = 0; i < S3_INGEST_SLOTS; i++) {
+		if (in->slots[i].state == S3_INGEST_COPYING ||
+		    in->slots[i].state == S3_INGEST_BINDING) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static void
 ingest_try_finish_end(struct s3_ctx *ctx)
 {
@@ -2219,7 +2273,10 @@ ingest_try_finish_end(struct s3_ctx *ctx)
 	void *arg;
 	uint32_t i;
 
-	if (!in || !in->ending || in->inflight != 0) {
+	/* Do not free while a CopyObject or a chunk-map bind is still using a
+	 * slot. inflight should already cover both; the slot walk is in case a
+	 * bind was issued without a matching increment. */
+	if (!in || !in->ending || in->inflight != 0 || ingest_has_async_slots(in)) {
 		return;
 	}
 
@@ -2241,30 +2298,48 @@ ingest_try_finish_end(struct s3_ctx *ctx)
 }
 
 static void
+ingest_start_bind(struct s3_ingest_slot *slot, uint64_t dst_chunk)
+{
+	struct s3_ctx *ctx = slot->ctx;
+	struct s3_ingest *in = ctx->ingest;
+
+	slot->state = S3_INGEST_BINDING;
+	in->inflight++;
+	s3_chunk_map_insert(ctx->chunk_map, dst_chunk, &slot->uuid,
+			    slot->valid_bytes, ingest_bound, slot);
+}
+
+static void
 ingest_bound(void *cb_arg, const struct spdk_uuid *old_uuid, int status)
 {
 	struct s3_ingest_slot *slot = cb_arg;
-	struct s3_ingest_op *op = slot->waiter;
 	struct s3_ctx *ctx = slot->ctx;
+	struct s3_ingest *in;
+	struct s3_ingest_op *op;
 	uint32_t bpc;
 
+	if (!ctx || !ctx->ingest) {
+		return;
+	}
+	in = ctx->ingest;
+	if (in->inflight > 0) {
+		in->inflight--;
+	}
+
+	op = slot->waiter;
 	slot->waiter = NULL;
 
 	if (status != 0) {
 		/* Insert did not take: dest_key is unreferenced. */
 		ingest_abandon_copy(slot);
 		if (op) {
-			op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, status);
-			free(op);
+			ingest_op_complete(op, status);
 		}
+		ingest_try_finish_end(ctx);
 		return;
 	}
 
-	if (!ctx && op) {
-		ctx = op->ctx;
-	}
-
-	if (old_uuid && !spdk_uuid_is_null(old_uuid) && ctx) {
+	if (old_uuid && !spdk_uuid_is_null(old_uuid)) {
 		char old_key[S3_KEY_MAX];
 
 		s3_data_key(ctx, old_uuid, old_key, sizeof(old_key));
@@ -2273,23 +2348,25 @@ ingest_bound(void *cb_arg, const struct spdk_uuid *old_uuid, int status)
 
 	ingest_slot_reset(slot);
 	if (!op) {
+		ingest_try_finish_end(ctx);
 		return;
 	}
 
 	bpc = s3_blocks_per_chunk(ctx);
 	op->pos += bpc;
 	ingest_op_next(op);
+	ingest_try_finish_end(ctx);
 }
 
 static void
-ingest_slot_headed(void *cb_arg, int status)
+ingest_slot_copied(void *cb_arg, int status)
 {
 	struct s3_ingest_slot *slot = cb_arg;
 	struct s3_ctx *ctx = slot->ctx;
 	struct s3_ingest *in;
 
 	if (!ctx || !ctx->ingest) {
-		ingest_slot_reset(slot);
+		/* End already freed the parent struct that contains this slot. */
 		return;
 	}
 	in = ctx->ingest;
@@ -2298,18 +2375,13 @@ ingest_slot_headed(void *cb_arg, int status)
 		in->inflight--;
 	}
 
-	if (status == 0 && slot->head_size < slot->valid_bytes) {
-		status = -EIO;
-	}
-
 	if (status != 0) {
 		struct s3_ingest_op *op = slot->waiter;
 
 		slot->waiter = NULL;
 		ingest_abandon_copy(slot);
 		if (op) {
-			op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, status);
-			free(op);
+			ingest_op_complete(op, status);
 		}
 		ingest_try_finish_end(ctx);
 		return;
@@ -2321,34 +2393,9 @@ ingest_slot_headed(void *cb_arg, int status)
 					     slot->waiter->dst_lba + slot->waiter->pos,
 					     ctx->chunk_shift);
 
-		slot->state = S3_INGEST_BINDING;
-		s3_chunk_map_insert(ctx->chunk_map, dst_chunk, &slot->uuid,
-				    slot->valid_bytes, ingest_bound, slot);
+		ingest_start_bind(slot, dst_chunk);
 	}
 	ingest_try_finish_end(ctx);
-}
-
-static void
-ingest_slot_copied(void *cb_arg, int status)
-{
-	struct s3_ingest_slot *slot = cb_arg;
-	struct s3_ctx *ctx = slot->ctx;
-	int rc;
-
-	if (status != 0) {
-		ingest_slot_headed(slot, status);
-		return;
-	}
-	if (!ctx) {
-		ingest_slot_reset(slot);
-		return;
-	}
-
-	rc = s3_head(ctx->client, slot->dest_key, &slot->head_size,
-		     ingest_slot_headed, slot);
-	if (rc != 0) {
-		ingest_slot_headed(slot, rc);
-	}
 }
 
 static int
@@ -2392,30 +2439,26 @@ ingest_op_next(struct s3_ingest_op *op)
 	int rc;
 
 	if (op->pos >= op->lba_count) {
-		op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, 0);
-		free(op);
+		ingest_op_complete(op, 0);
 		return;
 	}
 
 	if (!in) {
-		op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -EINVAL);
-		free(op);
+		ingest_op_complete(op, -EINVAL);
 		return;
 	}
 
 	dst_off = op->dst_lba + op->pos;
 	if (s3_lba_offset_in_chunk(dst_off, ctx->chunk_shift) != 0 ||
 	    s3_lba_offset_in_chunk(op->src_lba + op->pos, ctx->chunk_shift) != 0) {
-		op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -EINVAL);
-		free(op);
+		ingest_op_complete(op, -EINVAL);
 		return;
 	}
 
 	src_chunk = s3_lba_to_chunk_index(op->src_lba + op->pos, ctx->chunk_shift);
 	slot = ingest_find_slot(in, src_chunk, true);
 	if (!slot) {
-		op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -ENOMEM);
-		free(op);
+		ingest_op_complete(op, -ENOMEM);
 		return;
 	}
 
@@ -2424,16 +2467,14 @@ ingest_op_next(struct s3_ingest_op *op)
 		slot->waiter = op;
 		rc = ingest_start_slot(slot, src_chunk);
 		if (rc != 0) {
-			op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, rc);
-			free(op);
+			ingest_op_complete(op, rc);
 		}
 		return;
 	}
 
 	if (slot->state == S3_INGEST_COPYING) {
 		if (slot->waiter) {
-			op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -EBUSY);
-			free(op);
+			ingest_op_complete(op, -EBUSY);
 			return;
 		}
 		slot->waiter = op;
@@ -2444,14 +2485,17 @@ ingest_op_next(struct s3_ingest_op *op)
 		uint64_t dst_chunk = s3_lba_to_chunk_index(dst_off, ctx->chunk_shift);
 
 		slot->waiter = op;
-		slot->state = S3_INGEST_BINDING;
-		s3_chunk_map_insert(ctx->chunk_map, dst_chunk, &slot->uuid,
-				    slot->valid_bytes, ingest_bound, slot);
+		ingest_start_bind(slot, dst_chunk);
 		return;
 	}
 
-	op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -EBUSY);
-	free(op);
+	ingest_op_complete(op, -EBUSY);
+}
+
+static void
+ingest_op_on_owner(void *arg)
+{
+	ingest_op_next(arg);
 }
 
 static void
@@ -2461,6 +2505,7 @@ s3_bs_dev_copy(struct spdk_bs_dev *dev, struct spdk_io_channel *channel,
 {
 	struct s3_ctx *ctx = (struct s3_ctx *)dev;
 	struct s3_ingest_op *op;
+	int rc;
 
 	(void)channel;
 
@@ -2476,10 +2521,20 @@ s3_bs_dev_copy(struct spdk_bs_dev *dev, struct spdk_io_channel *channel,
 	}
 	op->ctx = ctx;
 	op->cb_args = cb_args;
+	op->submit_thread = spdk_get_thread();
 	op->dst_lba = dst_lba;
 	op->src_lba = src_lba;
 	op->lba_count = lba_count;
-	ingest_op_next(op);
+
+	if (ctx->owner_thread == NULL ||
+	    ctx->owner_thread == op->submit_thread) {
+		ingest_op_next(op);
+		return;
+	}
+	rc = spdk_thread_send_msg(ctx->owner_thread, ingest_op_on_owner, op);
+	if (rc != 0) {
+		ingest_op_complete(op, rc);
+	}
 }
 
 int
@@ -2508,20 +2563,14 @@ s3_bs_dev_ingest_begin(struct spdk_bs_dev *bs_dev, const char *src_bucket,
 	return 0;
 }
 
-void
-s3_bs_dev_ingest_prefetch(struct spdk_bs_dev *bs_dev, uint64_t src_lba,
-			  uint64_t lba_count)
+static void
+ingest_prefetch_work(struct s3_ctx *ctx, uint64_t src_lba, uint64_t lba_count)
 {
-	struct s3_ctx *ctx = (struct s3_ctx *)bs_dev;
-	struct s3_ingest *in;
+	struct s3_ingest *in = ctx->ingest;
 	uint32_t bpc;
 	uint64_t pos = 0;
 
-	if (!ctx || !ctx->ingest || lba_count == 0) {
-		return;
-	}
-	in = ctx->ingest;
-	if (in->ending) {
+	if (!in || in->ending) {
 		return;
 	}
 	bpc = s3_blocks_per_chunk(ctx);
@@ -2542,6 +2591,44 @@ s3_bs_dev_ingest_prefetch(struct spdk_bs_dev *bs_dev, uint64_t src_lba,
 			}
 		}
 		pos += bpc;
+	}
+}
+
+static void
+ingest_prefetch_on_owner(void *arg)
+{
+	struct ingest_prefetch_msg *m = arg;
+
+	ingest_prefetch_work(m->ctx, m->src_lba, m->lba_count);
+	free(m);
+}
+
+void
+s3_bs_dev_ingest_prefetch(struct spdk_bs_dev *bs_dev, uint64_t src_lba,
+			  uint64_t lba_count)
+{
+	struct s3_ctx *ctx = (struct s3_ctx *)bs_dev;
+	struct ingest_prefetch_msg *m;
+	int rc;
+
+	if (!ctx || !ctx->ingest || lba_count == 0) {
+		return;
+	}
+	if (ctx->owner_thread == NULL ||
+	    ctx->owner_thread == spdk_get_thread()) {
+		ingest_prefetch_work(ctx, src_lba, lba_count);
+		return;
+	}
+	m = calloc(1, sizeof(*m));
+	if (!m) {
+		return;
+	}
+	m->ctx = ctx;
+	m->src_lba = src_lba;
+	m->lba_count = lba_count;
+	rc = spdk_thread_send_msg(ctx->owner_thread, ingest_prefetch_on_owner, m);
+	if (rc != 0) {
+		free(m);
 	}
 }
 

--- a/CubeS3lvol/lib/s3bsdev/s3_bs_dev.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_bs_dev.c
@@ -258,6 +258,10 @@ struct s3_ctx {
 	uint64_t wal_writes;   /* writes acknowledged from the log */
 	uint64_t wal_retries;  /* writes parked by backpressure */
 	uint64_t overlay_hits; /* reads served without touching S3 */
+
+	/* Set only while a decouple (or similar) is ingesting export objects via
+	 * CopyObject. NULL means dest->copy is also NULL and CoW uses GET+write. */
+	struct s3_ingest *ingest;
 };
 
 /* Context for one bs_dev I/O.
@@ -2114,6 +2118,451 @@ s3_bs_dev_destroy(struct spdk_bs_dev *dev)
 	}
 
 	s3_bs_dev_teardown(ctx);
+}
+
+/* ==========================================================================
+ * CopyObject ingest (decouple of a same-bucket export)
+ * ========================================================================== */
+
+#define S3_INGEST_SLOTS 32
+
+enum s3_ingest_slot_state {
+	S3_INGEST_FREE = 0,
+	S3_INGEST_COPYING,
+	S3_INGEST_READY,
+	S3_INGEST_BINDING,
+};
+
+struct s3_ingest_op;
+
+struct s3_ingest_slot {
+	struct s3_ctx            *ctx;
+	enum s3_ingest_slot_state state;
+	uint64_t                  src_chunk;
+	struct spdk_uuid          uuid;
+	uint32_t                  valid_bytes;
+	char                      dest_key[S3_KEY_MAX];
+	uint64_t                  head_size;
+	struct s3_ingest_op      *waiter;
+};
+
+struct s3_ingest {
+	char                      src_bucket[128];
+	s3_ingest_src_fn          src_fn;
+	void                     *src_arg;
+	uint32_t                  inflight;
+	struct s3_ingest_slot     slots[S3_INGEST_SLOTS];
+	s3_bs_dev_cb              end_cb;
+	void                     *end_arg;
+	bool                      ending;
+};
+
+struct s3_ingest_op {
+	struct s3_ctx             *ctx;
+	struct spdk_bs_dev_cb_args *cb_args;
+	uint64_t                   dst_lba;
+	uint64_t                   src_lba;
+	uint64_t                   lba_count;
+	uint64_t                   pos;
+};
+
+static void s3_bs_dev_copy(struct spdk_bs_dev *dev, struct spdk_io_channel *channel,
+			   uint64_t dst_lba, uint64_t src_lba, uint64_t lba_count,
+			   struct spdk_bs_dev_cb_args *cb_args);
+static void ingest_op_next(struct s3_ingest_op *op);
+static void ingest_try_finish_end(struct s3_ctx *ctx);
+static int ingest_start_slot(struct s3_ingest_slot *slot, uint64_t src_chunk);
+
+static struct s3_ingest_slot *
+ingest_find_slot(struct s3_ingest *in, uint64_t src_chunk, bool alloc_free)
+{
+	struct s3_ingest_slot *free_slot = NULL;
+	uint32_t i;
+
+	for (i = 0; i < S3_INGEST_SLOTS; i++) {
+		if (in->slots[i].state != S3_INGEST_FREE &&
+		    in->slots[i].src_chunk == src_chunk) {
+			return &in->slots[i];
+		}
+		if (alloc_free && in->slots[i].state == S3_INGEST_FREE &&
+		    free_slot == NULL) {
+			free_slot = &in->slots[i];
+		}
+	}
+	return alloc_free ? free_slot : NULL;
+}
+
+static void
+ingest_slot_reset(struct s3_ingest_slot *slot)
+{
+	memset(slot, 0, sizeof(*slot));
+}
+
+/* Drop a CopyObject that never made it into the chunk map. Fire-and-forget
+ * delete: a missing key (copy never landed) is fine. */
+static void
+ingest_abandon_copy(struct s3_ingest_slot *slot)
+{
+	struct s3_ctx *ctx = slot->ctx;
+
+	if (ctx && ctx->client && slot->dest_key[0] != '\0') {
+		s3_delete(ctx->client, slot->dest_key, NULL, NULL);
+	}
+	ingest_slot_reset(slot);
+}
+
+static void
+ingest_try_finish_end(struct s3_ctx *ctx)
+{
+	struct s3_ingest *in = ctx->ingest;
+	s3_bs_dev_cb cb;
+	void *arg;
+	uint32_t i;
+
+	if (!in || !in->ending || in->inflight != 0) {
+		return;
+	}
+
+	for (i = 0; i < S3_INGEST_SLOTS; i++) {
+		if (in->slots[i].state == S3_INGEST_READY) {
+			s3_delete(ctx->client, in->slots[i].dest_key, NULL, NULL);
+			ingest_slot_reset(&in->slots[i]);
+		}
+	}
+
+	ctx->bs_dev.copy = NULL;
+	ctx->ingest = NULL;
+	cb = in->end_cb;
+	arg = in->end_arg;
+	free(in);
+	if (cb) {
+		cb(arg, 0);
+	}
+}
+
+static void
+ingest_bound(void *cb_arg, const struct spdk_uuid *old_uuid, int status)
+{
+	struct s3_ingest_slot *slot = cb_arg;
+	struct s3_ingest_op *op = slot->waiter;
+	struct s3_ctx *ctx = slot->ctx;
+	uint32_t bpc;
+
+	slot->waiter = NULL;
+
+	if (status != 0) {
+		/* Insert did not take: dest_key is unreferenced. */
+		ingest_abandon_copy(slot);
+		if (op) {
+			op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, status);
+			free(op);
+		}
+		return;
+	}
+
+	if (!ctx && op) {
+		ctx = op->ctx;
+	}
+
+	if (old_uuid && !spdk_uuid_is_null(old_uuid) && ctx) {
+		char old_key[S3_KEY_MAX];
+
+		s3_data_key(ctx, old_uuid, old_key, sizeof(old_key));
+		s3_delete(ctx->client, old_key, NULL, NULL);
+	}
+
+	ingest_slot_reset(slot);
+	if (!op) {
+		return;
+	}
+
+	bpc = s3_blocks_per_chunk(ctx);
+	op->pos += bpc;
+	ingest_op_next(op);
+}
+
+static void
+ingest_slot_headed(void *cb_arg, int status)
+{
+	struct s3_ingest_slot *slot = cb_arg;
+	struct s3_ctx *ctx = slot->ctx;
+	struct s3_ingest *in;
+
+	if (!ctx || !ctx->ingest) {
+		ingest_slot_reset(slot);
+		return;
+	}
+	in = ctx->ingest;
+
+	if (in->inflight > 0) {
+		in->inflight--;
+	}
+
+	if (status == 0 && slot->head_size < slot->valid_bytes) {
+		status = -EIO;
+	}
+
+	if (status != 0) {
+		struct s3_ingest_op *op = slot->waiter;
+
+		slot->waiter = NULL;
+		ingest_abandon_copy(slot);
+		if (op) {
+			op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, status);
+			free(op);
+		}
+		ingest_try_finish_end(ctx);
+		return;
+	}
+
+	slot->state = S3_INGEST_READY;
+	if (slot->waiter) {
+		uint64_t dst_chunk = s3_lba_to_chunk_index(
+					     slot->waiter->dst_lba + slot->waiter->pos,
+					     ctx->chunk_shift);
+
+		slot->state = S3_INGEST_BINDING;
+		s3_chunk_map_insert(ctx->chunk_map, dst_chunk, &slot->uuid,
+				    slot->valid_bytes, ingest_bound, slot);
+	}
+	ingest_try_finish_end(ctx);
+}
+
+static void
+ingest_slot_copied(void *cb_arg, int status)
+{
+	struct s3_ingest_slot *slot = cb_arg;
+	struct s3_ctx *ctx = slot->ctx;
+	int rc;
+
+	if (status != 0) {
+		ingest_slot_headed(slot, status);
+		return;
+	}
+	if (!ctx) {
+		ingest_slot_reset(slot);
+		return;
+	}
+
+	rc = s3_head(ctx->client, slot->dest_key, &slot->head_size,
+		     ingest_slot_headed, slot);
+	if (rc != 0) {
+		ingest_slot_headed(slot, rc);
+	}
+}
+
+static int
+ingest_start_slot(struct s3_ingest_slot *slot, uint64_t src_chunk)
+{
+	struct s3_ctx *ctx = slot->ctx;
+	struct s3_ingest *in = ctx->ingest;
+	char src_key[S3_KEY_MAX];
+	uint32_t valid_bytes = 0;
+	int rc;
+
+	rc = in->src_fn(in->src_arg, src_chunk, src_key, sizeof(src_key), &valid_bytes);
+	if (rc != 0) {
+		return rc;
+	}
+
+	slot->src_chunk = src_chunk;
+	slot->valid_bytes = valid_bytes ? valid_bytes : ctx->chunk_size;
+	slot->state = S3_INGEST_COPYING;
+	spdk_uuid_generate(&slot->uuid);
+	s3_data_key(ctx, &slot->uuid, slot->dest_key, sizeof(slot->dest_key));
+	in->inflight++;
+
+	rc = s3_copy_object(ctx->client, in->src_bucket, src_key, slot->dest_key,
+			    ingest_slot_copied, slot);
+	if (rc != 0) {
+		in->inflight--;
+		ingest_slot_reset(slot);
+		return rc;
+	}
+	return 0;
+}
+
+static void
+ingest_op_next(struct s3_ingest_op *op)
+{
+	struct s3_ctx *ctx = op->ctx;
+	struct s3_ingest *in = ctx->ingest;
+	struct s3_ingest_slot *slot;
+	uint64_t src_chunk, dst_off;
+	int rc;
+
+	if (op->pos >= op->lba_count) {
+		op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, 0);
+		free(op);
+		return;
+	}
+
+	if (!in) {
+		op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -EINVAL);
+		free(op);
+		return;
+	}
+
+	dst_off = op->dst_lba + op->pos;
+	if (s3_lba_offset_in_chunk(dst_off, ctx->chunk_shift) != 0 ||
+	    s3_lba_offset_in_chunk(op->src_lba + op->pos, ctx->chunk_shift) != 0) {
+		op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -EINVAL);
+		free(op);
+		return;
+	}
+
+	src_chunk = s3_lba_to_chunk_index(op->src_lba + op->pos, ctx->chunk_shift);
+	slot = ingest_find_slot(in, src_chunk, true);
+	if (!slot) {
+		op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -ENOMEM);
+		free(op);
+		return;
+	}
+
+	if (slot->state == S3_INGEST_FREE) {
+		slot->ctx = ctx;
+		slot->waiter = op;
+		rc = ingest_start_slot(slot, src_chunk);
+		if (rc != 0) {
+			op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, rc);
+			free(op);
+		}
+		return;
+	}
+
+	if (slot->state == S3_INGEST_COPYING) {
+		if (slot->waiter) {
+			op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -EBUSY);
+			free(op);
+			return;
+		}
+		slot->waiter = op;
+		return;
+	}
+
+	if (slot->state == S3_INGEST_READY) {
+		uint64_t dst_chunk = s3_lba_to_chunk_index(dst_off, ctx->chunk_shift);
+
+		slot->waiter = op;
+		slot->state = S3_INGEST_BINDING;
+		s3_chunk_map_insert(ctx->chunk_map, dst_chunk, &slot->uuid,
+				    slot->valid_bytes, ingest_bound, slot);
+		return;
+	}
+
+	op->cb_args->cb_fn(op->cb_args->channel, op->cb_args->cb_arg, -EBUSY);
+	free(op);
+}
+
+static void
+s3_bs_dev_copy(struct spdk_bs_dev *dev, struct spdk_io_channel *channel,
+	       uint64_t dst_lba, uint64_t src_lba, uint64_t lba_count,
+	       struct spdk_bs_dev_cb_args *cb_args)
+{
+	struct s3_ctx *ctx = (struct s3_ctx *)dev;
+	struct s3_ingest_op *op;
+
+	(void)channel;
+
+	if (!ctx->ingest || lba_count == 0) {
+		cb_args->cb_fn(cb_args->channel, cb_args->cb_arg, -EINVAL);
+		return;
+	}
+
+	op = calloc(1, sizeof(*op));
+	if (!op) {
+		cb_args->cb_fn(cb_args->channel, cb_args->cb_arg, -ENOMEM);
+		return;
+	}
+	op->ctx = ctx;
+	op->cb_args = cb_args;
+	op->dst_lba = dst_lba;
+	op->src_lba = src_lba;
+	op->lba_count = lba_count;
+	ingest_op_next(op);
+}
+
+int
+s3_bs_dev_ingest_begin(struct spdk_bs_dev *bs_dev, const char *src_bucket,
+		       s3_ingest_src_fn src_fn, void *src_arg)
+{
+	struct s3_ctx *ctx = (struct s3_ctx *)bs_dev;
+	struct s3_ingest *in;
+
+	if (!ctx || !src_bucket || !src_fn) {
+		return -EINVAL;
+	}
+	if (ctx->ingest) {
+		return -EEXIST;
+	}
+
+	in = calloc(1, sizeof(*in));
+	if (!in) {
+		return -ENOMEM;
+	}
+	snprintf(in->src_bucket, sizeof(in->src_bucket), "%s", src_bucket);
+	in->src_fn = src_fn;
+	in->src_arg = src_arg;
+	ctx->ingest = in;
+	ctx->bs_dev.copy = s3_bs_dev_copy;
+	return 0;
+}
+
+void
+s3_bs_dev_ingest_prefetch(struct spdk_bs_dev *bs_dev, uint64_t src_lba,
+			  uint64_t lba_count)
+{
+	struct s3_ctx *ctx = (struct s3_ctx *)bs_dev;
+	struct s3_ingest *in;
+	uint32_t bpc;
+	uint64_t pos = 0;
+
+	if (!ctx || !ctx->ingest || lba_count == 0) {
+		return;
+	}
+	in = ctx->ingest;
+	if (in->ending) {
+		return;
+	}
+	bpc = s3_blocks_per_chunk(ctx);
+
+	while (pos < lba_count) {
+		uint64_t src_chunk;
+		struct s3_ingest_slot *slot;
+
+		if (s3_lba_offset_in_chunk(src_lba + pos, ctx->chunk_shift) != 0) {
+			return;
+		}
+		src_chunk = s3_lba_to_chunk_index(src_lba + pos, ctx->chunk_shift);
+		slot = ingest_find_slot(in, src_chunk, true);
+		if (slot && slot->state == S3_INGEST_FREE) {
+			slot->ctx = ctx;
+			if (ingest_start_slot(slot, src_chunk) != 0) {
+				return;
+			}
+		}
+		pos += bpc;
+	}
+}
+
+void
+s3_bs_dev_ingest_end(struct spdk_bs_dev *bs_dev, s3_bs_dev_cb cb_fn, void *cb_arg)
+{
+	struct s3_ctx *ctx = (struct s3_ctx *)bs_dev;
+	struct s3_ingest *in;
+
+	if (!ctx || !ctx->ingest) {
+		if (cb_fn) {
+			cb_fn(cb_arg, 0);
+		}
+		return;
+	}
+
+	in = ctx->ingest;
+	in->ending = true;
+	in->end_cb = cb_fn;
+	in->end_arg = cb_arg;
+	ingest_try_finish_end(ctx);
 }
 
 static bool

--- a/CubeS3lvol/lib/s3bsdev/s3_chunk_map.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_chunk_map.c
@@ -609,8 +609,8 @@ s3_chunk_map_remove(struct s3_chunk_map *map, uint64_t chunk_index,
  *
  * lsn == 0 means "no journal record behind this change" and always applies. Two
  * callers rely on it: restoring a checkpoint, whose entries carry one LSN for the
- * snapshot as a whole (s3_checkpoint.c:326), and the WAL's unmap replay
- * (s3_bs_dev.c:2399), which must be able to undo a mapping the journal restored.
+ * snapshot as a whole (s3_checkpoint.c), and the WAL's unmap replay
+ * (s3_bs_dev.c), which must be able to undo a mapping the journal restored.
  * ========================================================================== */
 
 /* Should this record be applied, given what the entry already holds?

--- a/CubeS3lvol/lib/s3bsdev/s3_client_aws.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_client_aws.c
@@ -27,6 +27,7 @@
 
 #include "s3lvol/s3_client.h"
 #include "s3lvol/s3_spawner.h"
+#include "s3_copy_xml.h"
 
 /* ==========================================================================
  * Internal structures
@@ -154,6 +155,11 @@ struct s3_request {
 	uint64_t                         bytes_read;
 
 	bool                             if_none_match;
+
+	/* CopyObject: the body was larger than S3_COPY_XML_MAX. The prefix can
+	 * still be a valid CopyObjectResult; without that opening tag it is
+	 * incomplete XML, not success. */
+	bool                             xml_truncated;
 
 	/* HEAD: where to store Content-Length (may be NULL) */
 	uint64_t                        *out_size;
@@ -2084,6 +2090,50 @@ submit_failed:
  * COPY OBJECT (server-side)
  * ========================================================================== */
 
+static int
+s3_copy_body_callback(struct aws_s3_meta_request *meta_request,
+		      const struct aws_byte_cursor *body,
+		      uint64_t range_start, void *user_data)
+{
+	struct s3_request *req = user_data;
+	bool truncated = false;
+
+	(void)meta_request;
+	(void)range_start;
+
+	if (!req->buf || !body) {
+		return AWS_OP_SUCCESS;
+	}
+	req->bytes_read = s3_copy_xml_append((char *)req->buf, (size_t)req->len,
+					     (size_t)req->bytes_read,
+					     body->ptr, body->len, &truncated);
+	if (truncated) {
+		req->xml_truncated = true;
+	}
+	return AWS_OP_SUCCESS;
+}
+
+static int
+s3_copy_status_from_xml(const char *xml, size_t len, bool truncated,
+			const char *src_bucket, const char *src_key,
+			const char *dst_key)
+{
+	int rc = s3_copy_xml_status(xml, len, truncated);
+
+	if (rc == 0) {
+		return 0;
+	}
+	if (s3_xml_has_open_tag(xml, len, "Error")) {
+		SPDK_ERRLOG("CopyObject returned HTTP 200 with <Error> in the body: "
+			    "%s/%s -> %s\n", src_bucket, src_key, dst_key);
+		return -EIO;
+	}
+	SPDK_ERRLOG("CopyObject response had no CopyObjectResult: %s/%s -> %s "
+		    "(%zu byte body%s)\n", src_bucket, src_key, dst_key, len,
+		    truncated ? ", truncated" : "");
+	return -EIO;
+}
+
 static void
 s3_copy_finished(struct aws_s3_meta_request *meta_request,
 		 const struct aws_s3_meta_request_result *result,
@@ -2100,19 +2150,25 @@ s3_copy_finished(struct aws_s3_meta_request *meta_request,
 						result->response_status);
 		s3_stats_record_error(req->client, result->response_status);
 	} else {
-		/* NOTE: CopyObject can return 200 with an <Error> in the body
-		 * (S3 keeps the connection alive during a long server-side
-		 * copy). Callers that must be certain should HEAD the
-		 * destination afterwards. */
-		req->status = 0;
+		/* HTTP 200 is not success: S3 can park an <Error> in the body
+		 * while the copy runs. CRT does not parse that for DEFAULT. */
+		req->status = s3_copy_status_from_xml(
+				      req->buf ? (const char *)req->buf : "",
+				      (size_t)req->bytes_read,
+				      req->xml_truncated,
+				      req->src_bucket, req->src_key, req->key_buf);
 	}
 
 	S3_STAT_INC(req->client, copy_ops);
 	assert(S3_STAT_GET(req->client, inflight) > 0);
 	S3_STAT_DEC(req->client, inflight);
 
-	/* Release CRT state before the callback may hop threads. */
 	aws_s3_meta_request_release(meta_request);
+
+	if (req->buf) {
+		aws_mem_release(req->allocator, req->buf);
+		req->buf = NULL;
+	}
 
 	s3_request_complete(req);
 }
@@ -2151,9 +2207,16 @@ s3_copy_object(struct s3_client *client,
 	req->cb.op_cb  = cb;
 	req->cb_arg    = cb_arg;
 	req->owner_thread = spdk_get_thread();
+	req->len = S3_COPY_XML_MAX;
+	req->buf = aws_mem_calloc(client->app_ctx->allocator, 1, S3_COPY_XML_MAX);
+	if (!req->buf) {
+		aws_mem_release(client->app_ctx->allocator, req);
+		return -ENOMEM;
+	}
 
 	rc = s3_request_set_key(req, dst_key);
 	if (rc) {
+		aws_mem_release(client->app_ctx->allocator, req->buf);
 		aws_mem_release(client->app_ctx->allocator, req);
 		return rc;
 	}
@@ -2170,11 +2233,13 @@ s3_copy_object(struct s3_client *client,
 		.operation_name  = aws_byte_cursor_from_c_str("PutObjectCopy"),
 		.user_data       = req,
 		.signing_config  = &client->signing_config,
+		.body_callback   = s3_copy_body_callback,
 		.finish_callback = s3_copy_finished,
 	};
 
 	options.message = aws_http_message_new_request(client->app_ctx->allocator);
 	if (!options.message) {
+		aws_mem_release(client->app_ctx->allocator, req->buf);
 		aws_mem_release(client->app_ctx->allocator, req);
 		return -ENOMEM;
 	}
@@ -2193,6 +2258,7 @@ s3_copy_object(struct s3_client *client,
 				 client, req->key);
 	if (rc != AWS_OP_SUCCESS) {
 		aws_http_message_release(options.message);
+		aws_mem_release(client->app_ctx->allocator, req->buf);
 		aws_mem_release(client->app_ctx->allocator, req);
 		return -ENOMEM;
 	}
@@ -2207,6 +2273,7 @@ s3_copy_object(struct s3_client *client,
 		SPDK_ERRLOG("CopyObject: failed to create meta request for %s -> %s: %s\n",
 			    src_key, dst_key, aws_error_str(aws_last_error()));
 		S3_STAT_DEC(client, inflight);
+		aws_mem_release(client->app_ctx->allocator, req->buf);
 		aws_mem_release(client->app_ctx->allocator, req);
 		return -EIO;
 	}

--- a/CubeS3lvol/lib/s3bsdev/s3_client_aws.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_client_aws.c
@@ -1062,6 +1062,12 @@ s3_client_shutdown_complete(void *user_data)
 	free(client);
 }
 
+const char *
+s3_client_bucket(const struct s3_client *client)
+{
+	return client ? client->bucket : "";
+}
+
 void
 s3_client_get(struct s3_client *client)
 {

--- a/CubeS3lvol/lib/s3bsdev/s3_client_aws.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_client_aws.c
@@ -1063,6 +1063,19 @@ s3_client_shutdown_complete(void *user_data)
 }
 
 void
+s3_client_get(struct s3_client *client)
+{
+	if (!client) {
+		return;
+	}
+
+	assert(client->refcnt > 0);
+	client->refcnt++;
+	SPDK_NOTICELOG("S3 client %s refcnt incremented to %u\n",
+		       client->endpoint, client->refcnt);
+}
+
+void
 s3_client_put(struct s3_client *client)
 {
 	uint32_t i;

--- a/CubeS3lvol/lib/s3bsdev/s3_copy_xml.h
+++ b/CubeS3lvol/lib/s3bsdev/s3_copy_xml.h
@@ -1,0 +1,101 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+/*
+ * CopyObject response XML is a few hundred bytes. The client caps the body so a
+ * runaway reply cannot grow without bound; these helpers decide whether that
+ * prefix is a CopyObjectResult, an Error, or something too short to tell.
+ *
+ * Kept out of s3_client_aws.c so the delimiter arithmetic can be tested without
+ * CRT, SPDK, or a bucket.
+ */
+
+#ifndef S3_COPY_XML_H
+#define S3_COPY_XML_H
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#define S3_COPY_XML_MAX 8192
+
+static inline bool
+s3_xml_has_open_tag(const char *xml, size_t len, const char *name)
+{
+	size_t nlen;
+	size_t i;
+
+	if (!xml || !name) {
+		return false;
+	}
+	nlen = strlen(name);
+	if (nlen == 0 || len < nlen + 2) {
+		return false;
+	}
+	/* The character after the name is the delimiter. It must be inside the
+	 * buffer: i + 1 + nlen == len would read xml[len]. */
+	for (i = 0; i + 1 + nlen < len; i++) {
+		char c;
+
+		if (xml[i] != '<') {
+			continue;
+		}
+		if (memcmp(xml + i + 1, name, nlen) != 0) {
+			continue;
+		}
+		c = xml[i + 1 + nlen];
+		if (c == '>' || c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
+		    c == '/') {
+			return true;
+		}
+	}
+	return false;
+}
+
+static inline size_t
+s3_copy_xml_append(char *buf, size_t cap, size_t used,
+		   const void *src, size_t n, bool *truncated)
+{
+	size_t room;
+
+	if (!buf || cap == 0) {
+		return used;
+	}
+	if (used >= cap) {
+		if (n > 0 && truncated) {
+			*truncated = true;
+		}
+		return used;
+	}
+	if (!src || n == 0) {
+		return used;
+	}
+	room = cap - used;
+	if (n > room) {
+		n = room;
+		if (truncated) {
+			*truncated = true;
+		}
+	}
+	memcpy(buf + used, src, n);
+	return used + n;
+}
+
+/* 0 when the prefix contains a complete CopyObjectResult opening tag.
+ * -EIO for an Error tag, a missing tag, or a truncated body that never
+ * formed one. An opening tag that is already complete is enough: the rest of
+ * the document can be cut off at S3_COPY_XML_MAX. */
+static inline int
+s3_copy_xml_status(const char *xml, size_t len, bool truncated)
+{
+	if (s3_xml_has_open_tag(xml, len, "CopyObjectResult")) {
+		return 0;
+	}
+	if (s3_xml_has_open_tag(xml, len, "Error")) {
+		return -EIO;
+	}
+	(void)truncated;
+	return -EIO;
+}
+
+#endif /* S3_COPY_XML_H */

--- a/CubeS3lvol/lib/s3bsdev/s3_export.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_export.c
@@ -50,6 +50,15 @@ bitmap_bytes(uint64_t num_chunks)
 	return (size_t)((num_chunks + 7) / 8);
 }
 
+/* snprintf rather than strncpy: the destinations are fixed-size fields that must
+ * end up NUL-terminated whatever the source length, and a NULL source is the
+ * ordinary case for an optional JSON member. */
+static void
+copy_field(char *dst, size_t dst_len, const char *src)
+{
+	snprintf(dst, dst_len, "%s", src ? src : "");
+}
+
 /* Wire form of one ref: 16 bytes of uuid, and nothing else.
  *
  * valid_bytes used to live here, as four bytes that were almost always the same
@@ -175,7 +184,15 @@ s3_export_manifest_create(const char *uuid_str, uint64_t size_bytes,
 		return -ENOMEM;
 	}
 
-	m->version      = S3_EXPORT_VERSION;
+	/* Version 2 until something needs more, which is decided at serialize time by
+	 * how many sources ended up in the table -- see s3_export_manifest_serialize().
+	 *
+	 * Not S3_EXPORT_VERSION: an export that references one prefix is describable
+	 * in version 2, and writing it as 3 would make it unreadable to every binary
+	 * that has not been upgraded, for no gain. Only a derived export -- which an
+	 * older binary could not have produced or served anyway -- needs the newer
+	 * form. That is what keeps the rollout free of ordering constraints. */
+	m->version      = 2;
 	m->layout       = layout;
 	m->size_bytes   = size_bytes;
 	m->chunk_size   = chunk_size;
@@ -189,6 +206,12 @@ s3_export_manifest_create(const char *uuid_str, uint64_t size_bytes,
 		free(m);
 		return -ENOMEM;
 	}
+	m->resolved = calloc(1, bitmap_bytes(m->num_chunks));
+	if (!m->resolved) {
+		free(m->present);
+		free(m);
+		return -ENOMEM;
+	}
 
 	if (layout == S3_EXPORT_LAYOUT_REF) {
 		/* Indexed by chunk rather than packed by presence: the walk that fills
@@ -197,6 +220,7 @@ s3_export_manifest_create(const char *uuid_str, uint64_t size_bytes,
 		 * an order the reader depends on. Packing happens once, at serialize. */
 		m->refs = calloc(m->num_chunks, sizeof(*m->refs));
 		if (!m->refs) {
+			free(m->resolved);
 			free(m->present);
 			free(m);
 			return -ENOMEM;
@@ -206,10 +230,30 @@ s3_export_manifest_create(const char *uuid_str, uint64_t size_bytes,
 		m->full = calloc(1, bitmap_bytes(m->num_chunks));
 		if (!m->full) {
 			free(m->refs);
+			free(m->resolved);
 			free(m->present);
 			free(m);
 			return -ENOMEM;
 		}
+
+		/* One source to start with, this export's own, filled in by
+		 * s3_export_manifest_set_src(). Every REF manifest has at least this
+		 * entry -- including one parsed from version 2, where it is synthesised
+		 * -- so the read path never has to ask whether a source table exists.
+		 *
+		 * src_idx stays NULL until a second source appears: all-zero indices are
+		 * exactly what NULL means, and not allocating a byte per chunk for the
+		 * common single-source export keeps the manifest the size it was. */
+		m->srcs = calloc(S3_EXPORT_MAX_SOURCES, sizeof(*m->srcs));
+		if (!m->srcs) {
+			free(m->full);
+			free(m->refs);
+			free(m->resolved);
+			free(m->present);
+			free(m);
+			return -ENOMEM;
+		}
+		m->num_srcs = 1;
 	}
 
 	*out = m;
@@ -220,23 +264,29 @@ void
 s3_export_manifest_ref(struct s3_export_manifest *m)
 {
 	if (m) {
-		m->refcnt++;
+		__atomic_fetch_add(&m->refcnt, 1, __ATOMIC_RELAXED);
 	}
 }
 
 void
 s3_export_manifest_unref(struct s3_export_manifest *m)
 {
+	uint32_t prev;
+
 	if (!m) {
 		return;
 	}
-	assert(m->refcnt > 0);
-	if (--m->refcnt > 0) {
+	prev = __atomic_fetch_sub(&m->refcnt, 1, __ATOMIC_ACQ_REL);
+	assert(prev > 0);
+	if (prev > 1) {
 		return;
 	}
 	free(m->present);
+	free(m->resolved);
 	free(m->full);
 	free(m->refs);
+	free(m->srcs);
+	free(m->src_idx);
 	free(m);
 }
 
@@ -247,6 +297,15 @@ s3_export_manifest_set_present(struct s3_export_manifest *m, uint64_t chunk_inde
 		return;
 	}
 	m->present[chunk_index / 8] |= (uint8_t)(1u << (chunk_index % 8));
+}
+
+void
+s3_export_manifest_set_resolved(struct s3_export_manifest *m, uint64_t chunk_index)
+{
+	if (!m || !m->resolved || chunk_index >= m->num_chunks) {
+		return;
+	}
+	m->resolved[chunk_index / 8] |= (uint8_t)(1u << (chunk_index % 8));
 }
 
 int
@@ -275,6 +334,288 @@ s3_export_manifest_set_ref(struct s3_export_manifest *m, uint64_t chunk_index,
 	return 0;
 }
 
+int
+s3_export_manifest_add_src(struct s3_export_manifest *m, const char *prefix,
+			   const char *export_uuid, const char *snapshot_uuid,
+			   uint8_t *out_idx)
+{
+	uint32_t i;
+
+	if (!m || !prefix || prefix[0] == '\0' || !out_idx) {
+		return -EINVAL;
+	}
+	if (m->layout != S3_EXPORT_LAYOUT_REF || !m->srcs) {
+		return -EINVAL;
+	}
+
+	/* Entry 0 mirrors src.prefix, which create() cannot know: the caller fills
+	 * src in afterwards. Synced here rather than requiring a setter, so that
+	 * "this export's own prefix" resolves to 0 no matter which order the caller
+	 * did things in -- and so entry 0 cannot silently stay empty and then match
+	 * nothing, which would give the own prefix a second entry of its own. */
+	if (m->srcs[0].prefix[0] == '\0' && m->src.prefix[0] != '\0') {
+		copy_field(m->srcs[0].prefix, sizeof(m->srcs[0].prefix), m->src.prefix);
+	}
+
+	/* Entry 0 included: a chunk that turns out to live under this export's own
+	 * prefix must resolve to 0 rather than to a duplicate entry naming the same
+	 * place, or two indices would mean the same thing and the manifest would stop
+	 * being canonical. */
+	for (i = 0; i < m->num_srcs; i++) {
+		if (strcmp(m->srcs[i].prefix, prefix) == 0) {
+			/* First writer of the identity fields wins, so a caller that
+			 * has them can pass them once and the rest can pass NULL. */
+			if (m->srcs[i].export_uuid[0] == '\0' && export_uuid) {
+				copy_field(m->srcs[i].export_uuid,
+					   sizeof(m->srcs[i].export_uuid), export_uuid);
+			}
+			if (m->srcs[i].snapshot_uuid[0] == '\0' && snapshot_uuid) {
+				copy_field(m->srcs[i].snapshot_uuid,
+					   sizeof(m->srcs[i].snapshot_uuid),
+					   snapshot_uuid);
+			}
+			*out_idx = (uint8_t)i;
+			return 0;
+		}
+	}
+
+	if (m->num_srcs >= S3_EXPORT_MAX_SOURCES) {
+		/* The caller's move is to export by copying, which collapses the whole
+		 * lineage back to one source. Reported rather than silently reusing a
+		 * slot, because a wrong index reads another chunk's object and returns
+		 * bytes that look fine. */
+		SPDK_ERRLOG("export manifest already names %u sources; cannot add '%s'\n",
+			    m->num_srcs, prefix);
+		return -E2BIG;
+	}
+
+	i = m->num_srcs;
+	copy_field(m->srcs[i].prefix, sizeof(m->srcs[i].prefix), prefix);
+	copy_field(m->srcs[i].export_uuid, sizeof(m->srcs[i].export_uuid), export_uuid);
+	copy_field(m->srcs[i].snapshot_uuid, sizeof(m->srcs[i].snapshot_uuid),
+		   snapshot_uuid);
+	m->num_srcs = i + 1;
+	*out_idx = (uint8_t)i;
+	return 0;
+}
+
+int
+s3_export_manifest_inheritable(const struct s3_export_manifest *parent,
+			       const struct s3_export_source *dst,
+			       const char *uuid_str)
+{
+	if (!parent || !dst) {
+		return -EINVAL;
+	}
+	if (!uuid_str) {
+		uuid_str = "(unnamed)";
+	}
+
+	if (parent->layout != S3_EXPORT_LAYOUT_REF) {
+		/* A copied export keys its objects exports/<uuid>/chunk-N rather than
+		 * data/<uuid>, and a source entry is a bare prefix -- there is no way
+		 * to write down where those chunks are. */
+		SPDK_NOTICELOG("Export %s: parent %s is a copied export, whose object "
+			       "layout a source entry cannot name. Exporting by copying "
+			       "instead.\n", uuid_str, parent->uuid_str);
+		return -ENOTSUP;
+	}
+
+	/* A source entry carries a prefix and shares endpoint, bucket and region
+	 * with `src`. Referencing a parent reachable some other way would write a
+	 * manifest whose reader looks in the wrong bucket -- finding either nothing,
+	 * or, under a prefix that happens to exist there, another volume's objects.
+	 *
+	 * Region is compared with the rest even though it does not address anything
+	 * by itself: a client is built per endpoint/bucket/region, so a manifest that
+	 * silently changed it would be resolved by a client the importer did not
+	 * expect to need. */
+	if (strcmp(parent->src.bucket, dst->bucket) != 0 ||
+	    strcmp(parent->src.endpoint, dst->endpoint) != 0 ||
+	    strcmp(parent->src.region, dst->region) != 0) {
+		SPDK_NOTICELOG("Export %s: parent %s lives in %s/%s (region '%s'), not "
+			       "%s/%s (region '%s'), and a source entry cannot say so. "
+			       "Exporting by copying instead.\n", uuid_str,
+			       parent->uuid_str, parent->src.endpoint,
+			       parent->src.bucket, parent->src.region,
+			       dst->endpoint, dst->bucket, dst->region);
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+/* Whose lease governs one chunk of \p p, which is what an importer of the manifest
+ * inheriting it has to renew to keep the objects alive.
+ *
+ * Entry 0 carries no export uuid -- its objects are governed by that manifest's
+ * own export -- so the identity comes from the manifest itself there. Deeper
+ * entries already name the export governing them and are carried across unchanged,
+ * which is what keeps a twice-derived export renewing against the node that
+ * actually holds the data rather than against the middleman. */
+static void
+inherit_chunk_lease(const struct s3_export_manifest *p, uint64_t chunk,
+		    const char **export_uuid, const char **snapshot_uuid)
+{
+	uint8_t idx = p->src_idx ? p->src_idx[chunk] : 0;
+
+	if (idx == 0 || idx >= p->num_srcs) {
+		*export_uuid   = p->uuid_str;
+		*snapshot_uuid = p->src.snapshot_uuid;
+		return;
+	}
+	*export_uuid   = p->srcs[idx].export_uuid;
+	*snapshot_uuid = p->srcs[idx].snapshot_uuid;
+}
+
+int
+s3_export_manifest_inherit(struct s3_export_manifest *m,
+			   const struct s3_export_manifest *parent,
+			   uint64_t *out_named, uint64_t *out_bytes)
+{
+	uint64_t chunks, chunk;
+	uint64_t named = 0, bytes = 0;
+
+	if (!m || !parent) {
+		return -EINVAL;
+	}
+	if (m->layout != S3_EXPORT_LAYOUT_REF ||
+	    parent->layout != S3_EXPORT_LAYOUT_REF) {
+		return -EINVAL;
+	}
+	if (m->chunk_size != parent->chunk_size) {
+		/* Index i covers a different byte range under each, so nothing can be
+		 * carried across without re-cutting the data. */
+		return -EINVAL;
+	}
+
+	/* The shorter of the two. A volume can grow after an import, so the parent is
+	 * often the smaller; chunks past its end were never its to describe. It can
+	 * also be the longer one, if the export was of something bigger than this
+	 * snapshot, and those chunks are past the end of this manifest's tables. */
+	chunks = spdk_min(m->num_chunks, parent->num_chunks);
+
+	for (chunk = 0; chunk < chunks; chunk++) {
+		const struct s3_export_ref *ref;
+		const char *prefix, *export_uuid, *snapshot_uuid;
+		uint8_t idx;
+		int rc;
+
+		if (s3_export_manifest_is_present(m, chunk) ||
+		    s3_export_manifest_is_resolved(m, chunk)) {
+			/* Something nearer owns it, or the walk already settled it as
+			 * local zeroes. Not overwritten: reversing either would serve the
+			 * data as it was before the import. */
+			continue;
+		}
+		ref = s3_export_manifest_get_ref(parent, chunk);
+		if (!ref) {
+			/* A hole in the parent, left absent here too -- which is how a
+			 * manifest spells "reads as zeroes". */
+			continue;
+		}
+
+		prefix = s3_export_manifest_chunk_prefix(parent, chunk);
+		if (prefix[0] == '\0') {
+			/* The parent cannot say where its own chunk lives. parse()
+			 * rejects that, so a manifest off the wire is never in this state.
+			 * Refused rather than guessed: a guess names an object that very
+			 * likely exists and holds something else. */
+			SPDK_ERRLOG("export %s: parent %s cannot resolve its chunk %"
+				    PRIu64 "\n", m->uuid_str, parent->uuid_str, chunk);
+			return -EIO;
+		}
+
+		inherit_chunk_lease(parent, chunk, &export_uuid, &snapshot_uuid);
+
+		/* Deduped on prefix by add_src(), so the many chunks sharing a source
+		 * cost one entry. -E2BIG once there are more distinct prefixes than a
+		 * manifest can name, which the caller treats as "copy instead". */
+		rc = s3_export_manifest_add_src(m, prefix, export_uuid, snapshot_uuid,
+						&idx);
+		if (rc != 0) {
+			return rc;
+		}
+
+		rc = s3_export_manifest_set_ref(m, chunk, &ref->uuid, ref->valid_bytes);
+		if (rc != 0) {
+			return rc;
+		}
+		rc = s3_export_manifest_set_chunk_src(m, chunk, idx);
+		if (rc != 0) {
+			return rc;
+		}
+
+		named++;
+		bytes += ref->valid_bytes;
+	}
+
+	if (out_named) {
+		*out_named = named;
+	}
+	if (out_bytes) {
+		*out_bytes = bytes;
+	}
+	return 0;
+}
+
+int
+s3_export_manifest_set_chunk_src(struct s3_export_manifest *m, uint64_t chunk_index,
+				 uint8_t src_idx)
+{
+	if (!m || chunk_index >= m->num_chunks) {
+		return -EINVAL;
+	}
+	if (m->layout != S3_EXPORT_LAYOUT_REF || !m->srcs) {
+		return -EINVAL;
+	}
+	if (src_idx >= m->num_srcs) {
+		/* Never handed out by add_src(), so it cannot be resolved. Refused for
+		 * the same reason parse does: an out-of-range index picks up whatever is
+		 * at that slot and reads another chunk's object. */
+		SPDK_ERRLOG("chunk %" PRIu64 " names source %u of %u\n", chunk_index,
+			    src_idx, m->num_srcs);
+		return -EINVAL;
+	}
+
+	if (src_idx == 0 && !m->src_idx) {
+		/* Nothing to record: NULL already means "everything from entry 0", and
+		 * allocating a byte per chunk to store zeroes would make a
+		 * single-source manifest pay for a table it does not need -- and would
+		 * make it serialize as version 3. */
+		s3_export_manifest_set_present(m, chunk_index);
+		return 0;
+	}
+
+	if (!m->src_idx) {
+		m->src_idx = calloc(m->num_chunks, 1);
+		if (!m->src_idx) {
+			return -ENOMEM;
+		}
+	}
+	m->src_idx[chunk_index] = src_idx;
+	s3_export_manifest_set_present(m, chunk_index);
+	return 0;
+}
+
+const char *
+s3_export_manifest_chunk_prefix(const struct s3_export_manifest *m,
+				uint64_t chunk_index)
+{
+	uint8_t idx;
+
+	if (!m || chunk_index >= m->num_chunks || !m->srcs || m->num_srcs == 0) {
+		return "";
+	}
+	/* NULL src_idx is the single-source case, which is also every version 2
+	 * manifest: entry 0 for every chunk. */
+	idx = m->src_idx ? m->src_idx[chunk_index] : 0;
+	if (idx >= m->num_srcs) {
+		return "";
+	}
+	return m->srcs[idx].prefix;
+}
+
 const struct s3_export_ref *
 s3_export_manifest_get_ref(const struct s3_export_manifest *m, uint64_t chunk_index)
 {
@@ -294,6 +635,15 @@ s3_export_manifest_is_present(const struct s3_export_manifest *m, uint64_t chunk
 		return false;
 	}
 	return (m->present[chunk_index / 8] & (1u << (chunk_index % 8))) != 0;
+}
+
+bool
+s3_export_manifest_is_resolved(const struct s3_export_manifest *m, uint64_t chunk_index)
+{
+	if (!m || !m->resolved || chunk_index >= m->num_chunks) {
+		return false;
+	}
+	return (m->resolved[chunk_index / 8] & (1u << (chunk_index % 8))) != 0;
 }
 
 bool
@@ -370,6 +720,49 @@ s3_export_manifest_seal(struct s3_export_manifest *m)
 		}
 		pack_u32(wire, m->refs[i].valid_bytes);
 		m->crc32c = spdk_crc32c_update(wire, sizeof(wire), m->crc32c);
+	}
+
+	/* Appended, and only from version 3, so the stages above stay byte for byte
+	 * what version 2 computed. Keyed on the manifest's own version rather than
+	 * S3_EXPORT_VERSION: parse re-seals to verify the crc it read, so using the
+	 * compile-time constant here would recompute every version 2 manifest with a
+	 * stage it does not have and report corruption on all of them.
+	 *
+	 * src_idx has to be covered. A flipped bit there resolves a chunk against a
+	 * different prefix, and the object it finds is another chunk's -- valid
+	 * bytes, wrong place, no error anywhere. That is the failure the crc exists
+	 * for, and the bitmaps would still check out without this.
+	 *
+	 * A single-source manifest has src_idx == NULL, i.e. all indices zero, and
+	 * contributes nothing here: the two ways of saying "everything comes from
+	 * srcs[0]" have to seal identically, or a manifest would fail its own crc
+	 * after a round trip that changed nothing. */
+	if (m->version < 3 || !m->src_idx) {
+		return;
+	}
+	/* Batched into a small buffer rather than fed a byte at a time.
+	 * spdk_crc32c_update() reads its input eight bytes at a time and masks the
+	 * tail, so handing it a one-byte object reads past that object -- which is a
+	 * segfault when the byte happens to sit near the end of a mapping, and
+	 * silently reads adjacent memory when it does not. The other stages avoid it
+	 * by passing whole arrays; this one has to skip holes, so it copies. */
+	{
+		uint8_t batch[64];
+		size_t n = 0;
+
+		for (i = 0; i < m->num_chunks; i++) {
+			if (!bitmap_test(m->present, i)) {
+				continue;
+			}
+			batch[n++] = m->src_idx[i];
+			if (n == sizeof(batch)) {
+				m->crc32c = spdk_crc32c_update(batch, n, m->crc32c);
+				n = 0;
+			}
+		}
+		if (n != 0) {
+			m->crc32c = spdk_crc32c_update(batch, n, m->crc32c);
+		}
 	}
 }
 
@@ -498,6 +891,39 @@ pack_all_partials(const struct s3_export_manifest *m, uint8_t **out, size_t *out
 	return 0;
 }
 
+/* The source index of every present chunk, ascending -- the same packing rule the
+ * ref table follows, so a reader that walks one walks the other.
+ *
+ * One byte per present chunk rather than per chunk: a hole has no object and so no
+ * prefix to resolve it against, and packing by presence keeps this array the same
+ * length as the ref table it parallels. */
+static int
+pack_all_src_idx(const struct s3_export_manifest *m, uint8_t **out, size_t *out_len)
+{
+	uint8_t *buf;
+	size_t len;
+	uint64_t i;
+	size_t at = 0;
+
+	len = (size_t)m->present_chunks;
+	buf = malloc(len ? len : 1);
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	for (i = 0; i < m->num_chunks; i++) {
+		if (!bitmap_test(m->present, i)) {
+			continue;
+		}
+		buf[at++] = m->src_idx ? m->src_idx[i] : 0;
+	}
+	assert(at == len);
+
+	*out = buf;
+	*out_len = len;
+	return 0;
+}
+
 /* base64 of a byte range, or NULL on allocation failure. Zero length yields an
  * empty string, which is what an all-full manifest's partials table is. */
 static char *
@@ -525,6 +951,7 @@ s3_export_manifest_serialize(struct s3_export_manifest *m, char **out, size_t *o
 	char *full_b64 = NULL;
 	char *refs_b64 = NULL;
 	char *partials_b64 = NULL;
+	char *src_idx_b64 = NULL;
 	uint8_t *packed = NULL;
 	size_t packed_len = 0;
 	size_t nbytes;
@@ -568,6 +995,44 @@ s3_export_manifest_serialize(struct s3_export_manifest *m, char **out, size_t *o
 			rc = -ENOMEM;
 			goto err;
 		}
+
+		/* Version is decided here, by whether more than one prefix is involved,
+		 * rather than fixed at create time. A single-source export is fully
+		 * describable in version 2, and emitting 3 for it would make it
+		 * unreadable to every binary that has not been upgraded, for nothing.
+		 *
+		 * Raised before the seal below, because seal() stages the crc by
+		 * m->version -- writing the header at 3 while sealing as 2 would produce
+		 * a manifest whose own crc does not verify. */
+		/* Same sync add_src() does, for the manifest that never called it: the
+		 * read path answers a chunk's prefix out of srcs[0], so leaving it empty
+		 * would make every chunk of an ordinary single-source export resolve to
+		 * "". Cheap, and it keeps the invariant in both places rather than
+		 * relying on the writer having used one particular API. */
+		if (m->srcs && m->srcs[0].prefix[0] == '\0') {
+			copy_field(m->srcs[0].prefix, sizeof(m->srcs[0].prefix),
+				   m->src.prefix);
+		}
+
+		if (m->num_srcs > 1) {
+			m->version = 3;
+
+			rc = pack_all_src_idx(m, &packed, &packed_len);
+			if (rc != 0) {
+				goto err;
+			}
+			src_idx_b64 = encode_b64(packed, packed_len);
+			free(packed);
+			if (!src_idx_b64) {
+				rc = -ENOMEM;
+				goto err;
+			}
+		}
+
+		/* Re-sealed because the version may have just moved, and with it the crc
+		 * stages. Callers seal before serializing, but they cannot know which
+		 * version this is going to be. */
+		s3_export_manifest_seal(m);
 	}
 
 	w = spdk_json_write_begin(json_buf_append, &buf, 0);
@@ -610,10 +1075,40 @@ s3_export_manifest_serialize(struct s3_export_manifest *m, char **out, size_t *o
 		spdk_json_write_named_string(w, "full", full_b64);
 		spdk_json_write_named_string(w, "refs", refs_b64);
 		spdk_json_write_named_string(w, "partials", partials_b64);
+
+		/* Version 3 only, and both together: a source table without indices
+		 * would leave every chunk pointing at entry 0, and indices without a
+		 * table would name entries nobody can resolve. Parse refuses either on
+		 * its own for that reason.
+		 *
+		 * Entry 0 is not written. It always mirrors `source` above, so putting it
+		 * on the wire would be a second place for the same prefix to be wrong,
+		 * and a reader that trusted the copy would resolve chunks against a
+		 * prefix the manifest does not claim to come from. */
+		if (src_idx_b64) {
+			uint32_t si;
+
+			spdk_json_write_named_array_begin(w, "srcs");
+			for (si = 1; si < m->num_srcs; si++) {
+				spdk_json_write_object_begin(w);
+				spdk_json_write_named_string(w, "prefix",
+							     m->srcs[si].prefix);
+				spdk_json_write_named_string(w, "export_uuid",
+							     m->srcs[si].export_uuid);
+				if (m->srcs[si].snapshot_uuid[0] != '\0') {
+					spdk_json_write_named_string(w, "snapshot_uuid",
+								     m->srcs[si].snapshot_uuid);
+				}
+				spdk_json_write_object_end(w);
+			}
+			spdk_json_write_array_end(w);
+			spdk_json_write_named_string(w, "src_idx", src_idx_b64);
+		}
 	}
 	spdk_json_write_object_end(w);
 
 	rc = spdk_json_write_end(w);
+	free(src_idx_b64);
 	free(partials_b64);
 	free(refs_b64);
 	free(full_b64);
@@ -628,6 +1123,7 @@ s3_export_manifest_serialize(struct s3_export_manifest *m, char **out, size_t *o
 	*out_len = buf.len;
 	return 0;
 err:
+	free(src_idx_b64);
 	free(partials_b64);
 	free(refs_b64);
 	free(full_b64);
@@ -661,6 +1157,41 @@ static const struct spdk_json_object_decoder source_decoders[] = {
 	{"snapshot_uuid", offsetof(struct source_json, snapshot_uuid), spdk_json_decode_string, true},
 };
 
+/* One entry of the "srcs" array. Only entries 1.. travel: entry 0 always mirrors
+ * "source", so it is synthesised rather than read. */
+struct src_entry_json {
+	char *prefix;
+	char *export_uuid;
+	char *snapshot_uuid;
+};
+
+static const struct spdk_json_object_decoder src_entry_decoders[] = {
+	{"prefix",        offsetof(struct src_entry_json, prefix),        spdk_json_decode_string, false},
+	{"export_uuid",   offsetof(struct src_entry_json, export_uuid),   spdk_json_decode_string, true},
+	{"snapshot_uuid", offsetof(struct src_entry_json, snapshot_uuid), spdk_json_decode_string, true},
+};
+
+/* Decoded straight into the manifest's table rather than into an intermediate
+ * array, because the count is what has to be checked against
+ * S3_EXPORT_MAX_SOURCES before anything is indexed by it. Filled in by
+ * decode_srcs() below, which needs the manifest and so cannot be a plain
+ * spdk_json_decode_array element function. */
+struct srcs_json {
+	const struct spdk_json_val *values;   /* the array, or NULL */
+};
+
+static int
+decode_srcs_array(const struct spdk_json_val *val, void *out)
+{
+	struct srcs_json *s = out;
+
+	if (val->type != SPDK_JSON_VAL_ARRAY_BEGIN) {
+		return -EINVAL;
+	}
+	s->values = val;
+	return 0;
+}
+
 struct manifest_json {
 	uint32_t          version;
 	char             *layout;
@@ -680,6 +1211,8 @@ struct manifest_json {
 	char             *partials;
 	uint32_t generation;
 	uint64_t expires_at;
+	struct srcs_json  srcs;
+	char             *src_idx;
 };
 
 static int
@@ -717,6 +1250,11 @@ static const struct spdk_json_object_decoder manifest_decoders[] = {
 	 * optional: those are generation 0 and never expire, which is what a
 	 * zeroed struct already says. */
 	{"generation", offsetof(struct manifest_json, generation), spdk_json_decode_uint32, true},
+	/* Version 3. Optional so a version 2 manifest still decodes; the pair is
+	 * then checked for being all-or-nothing, since one without the other
+	 * describes chunks nobody can resolve. */
+	{"srcs",    offsetof(struct manifest_json, srcs),    decode_srcs_array,       true},
+	{"src_idx", offsetof(struct manifest_json, src_idx), spdk_json_decode_string, true},
 	{"expires_at", offsetof(struct manifest_json, expires_at), spdk_json_decode_uint64, true},
 };
 
@@ -729,6 +1267,7 @@ free_manifest_json(struct manifest_json *j)
 	free(j->refs);
 	free(j->full);
 	free(j->partials);
+	free(j->src_idx);
 	free(j->src.endpoint);
 	free(j->src.region);
 	free(j->src.bucket);
@@ -878,10 +1417,123 @@ out:
 	return rc;
 }
 
-static void
-copy_field(char *dst, size_t dst_len, const char *src)
+/* The source table and the per-chunk indices, for a version 3 ref manifest.
+ *
+ * Entry 0 is already in place, synthesised from `source`, so this fills in 1..
+ * and then the indices. Everything here is a refusal rather than a repair: an
+ * index that names a source which is not there resolves a chunk against whatever
+ * happens to be at that slot, and the object it finds belongs to another chunk --
+ * valid bytes from the wrong place, which no later check would catch.
+ */
+static int
+parse_srcs(struct s3_export_manifest *m, const struct manifest_json *j)
 {
-	snprintf(dst, dst_len, "%s", src ? src : "");
+	struct spdk_json_val *it;
+	uint8_t *decoded = NULL;
+	uint32_t n = 1;
+	uint64_t i;
+	size_t at = 0;
+	int rc;
+
+	/* All or nothing. A table without indices leaves every chunk on entry 0,
+	 * silently ignoring the sources the writer meant to use; indices without a
+	 * table name entries that do not exist. Either way the manifest means
+	 * something other than what it says. */
+	if ((j->srcs.values != NULL) != (j->src_idx != NULL)) {
+		SPDK_ERRLOG("export manifest has %s but not the other\n",
+			    j->srcs.values ? "a source table" : "source indices");
+		return -EINVAL;
+	}
+	if (j->srcs.values == NULL) {
+		/* Version 2, or a version 3 manifest that needed only one source.
+		 * src_idx stays NULL, which every reader treats as all zeroes. */
+		return 0;
+	}
+	if (j->version < 3) {
+		SPDK_ERRLOG("export manifest is version %u but carries a source "
+			    "table\n", j->version);
+		return -EINVAL;
+	}
+
+	/* spdk_json_val arrays are flat: the ARRAY_BEGIN carries how many values it
+	 * spans, and each element is itself a run of values. Walked with
+	 * spdk_json_next() so nested objects are skipped as units. */
+	/* Cast away const because spdk_json_next() takes a mutable pointer; it does
+	 * not write through it. */
+	it = (struct spdk_json_val *)(uintptr_t)(j->srcs.values + 1);
+	while (it->type != SPDK_JSON_VAL_ARRAY_END) {
+		struct src_entry_json e = {0};
+
+		if (n >= S3_EXPORT_MAX_SOURCES) {
+			SPDK_ERRLOG("export manifest names more than %d sources\n",
+				    S3_EXPORT_MAX_SOURCES);
+			return -E2BIG;
+		}
+		if (spdk_json_decode_object(it, src_entry_decoders,
+					    SPDK_COUNTOF(src_entry_decoders), &e) != 0) {
+			SPDK_ERRLOG("export manifest source %u is malformed\n", n);
+			return -EINVAL;
+		}
+		copy_field(m->srcs[n].prefix, sizeof(m->srcs[n].prefix), e.prefix);
+		copy_field(m->srcs[n].export_uuid, sizeof(m->srcs[n].export_uuid),
+			   e.export_uuid);
+		copy_field(m->srcs[n].snapshot_uuid, sizeof(m->srcs[n].snapshot_uuid),
+			   e.snapshot_uuid);
+		free(e.prefix);
+		free(e.export_uuid);
+		free(e.snapshot_uuid);
+
+		if (m->srcs[n].prefix[0] == '\0') {
+			SPDK_ERRLOG("export manifest source %u has an empty prefix\n", n);
+			return -EINVAL;
+		}
+		n++;
+		/* spdk_json_next() answers NULL at the end of the enclosing container as
+		 * well as on malformed input, so the loop condition above -- not this --
+		 * is what ends a well-formed array. Treating NULL as an error here
+		 * rejected every valid table whose last element it stepped past. */
+		it = spdk_json_next(it);
+		if (it == NULL) {
+			break;
+		}
+	}
+
+	if (n < 2) {
+		/* An empty table would have been written as version 2, so its presence
+		 * means the writer thought it had sources and lost them. */
+		SPDK_ERRLOG("export manifest carries an empty source table\n");
+		return -EINVAL;
+	}
+	m->num_srcs = n;
+
+	/* One byte per present chunk, in ascending chunk order -- the same packing
+	 * the ref table uses. present_chunks is already correct here: the caller
+	 * sealed after decoding the bitmap. */
+	rc = decode_b64_exact(j->src_idx, &decoded, (size_t)m->present_chunks,
+			      "source indices");
+	if (rc != 0) {
+		return rc;
+	}
+
+	m->src_idx = calloc(m->num_chunks, 1);
+	if (!m->src_idx) {
+		free(decoded);
+		return -ENOMEM;
+	}
+	for (i = 0; i < m->num_chunks; i++) {
+		if (!bitmap_test(m->present, i)) {
+			continue;
+		}
+		if (decoded[at] >= m->num_srcs) {
+			SPDK_ERRLOG("export manifest chunk %" PRIu64 " names source %u "
+				    "of %u\n", i, decoded[at], m->num_srcs);
+			free(decoded);
+			return -EINVAL;
+		}
+		m->src_idx[i] = decoded[at++];
+	}
+	free(decoded);
+	return 0;
 }
 
 int
@@ -949,9 +1601,9 @@ s3_export_manifest_parse(const void *json, size_t len, struct s3_export_manifest
 	 * future zero-copy layout would name the source's own chunk objects, and
 	 * reading it as if it were dense would produce an lvol full of the wrong
 	 * data rather than an error. */
-	if (j.version != S3_EXPORT_VERSION) {
-		SPDK_ERRLOG("export manifest version %u is not supported (want %u)\n",
-			    j.version, S3_EXPORT_VERSION);
+	if (j.version < S3_EXPORT_VERSION_MIN || j.version > S3_EXPORT_VERSION) {
+		SPDK_ERRLOG("export manifest version %u is not supported (want %u..%u)\n",
+			    j.version, S3_EXPORT_VERSION_MIN, S3_EXPORT_VERSION);
 		rc = -ENOTSUP;
 		goto out;
 	}
@@ -1000,6 +1652,13 @@ s3_export_manifest_parse(const void *json, size_t len, struct s3_export_manifest
 	if (rc != 0) {
 		goto out;
 	}
+	/* Set before anything re-seals, because seal() picks its crc stages by it.
+	 * create() leaves it at S3_EXPORT_VERSION, which was harmless while exactly
+	 * one version could be read and becomes a bug the moment two can: every older
+	 * manifest would be recomputed with a stage it does not carry, and reported as
+	 * corrupt. */
+	m->version = j.version;
+
 	if (m->num_chunks != j.num_chunks) {
 		SPDK_ERRLOG("export manifest claims %" PRIu64 " chunks, geometry says "
 			    "%" PRIu64 "\n", j.num_chunks, m->num_chunks);
@@ -1021,6 +1680,28 @@ s3_export_manifest_parse(const void *json, size_t len, struct s3_export_manifest
 		 * crc is discarded -- the full bitmap is still zeroed at this point. */
 		s3_export_manifest_seal(m);
 		rc = unpack_all_refs(m, j.refs, j.full, j.partials);
+		if (rc != 0) {
+			goto out;
+		}
+		/* Entry 0 mirrors src, for every version, and is synthesised rather
+		 * than read: a version 2 manifest has no source table at all, and this
+		 * is what makes that invisible further in -- it arrives as a one-entry
+		 * table naming its own prefix, with src_idx NULL meaning "every chunk
+		 * from entry 0". So the read path has one shape to handle rather than a
+		 * version test at every key it builds.
+		 *
+		 * Done here rather than beside the other src fields further down,
+		 * because parse_srcs() needs it and the final seal is what folds
+		 * src_idx into the crc: decoding the indices after that seal would
+		 * leave them out of the sum and fail every version 3 manifest on its
+		 * own checksum. */
+		copy_field(m->srcs[0].prefix, sizeof(m->srcs[0].prefix), j.src.prefix);
+		copy_field(m->srcs[0].snapshot_uuid, sizeof(m->srcs[0].snapshot_uuid),
+			   j.src.snapshot_uuid);
+		m->srcs[0].export_uuid[0] = '\0';
+		m->num_srcs = 1;
+
+		rc = parse_srcs(m, &j);
 		if (rc != 0) {
 			goto out;
 		}
@@ -1492,6 +2173,10 @@ s3_export_run(const struct s3_export_opts *opts, s3_export_cb cb, void *cb_arg)
 
 	ctx->m->src          = opts->src;
 	ctx->m->cluster_size = opts->cluster_size;
+	/* 0 for a new export, which leaves the field as created() set it. Non-zero
+	 * when this run replaces a manifest importers may hold -- see the field's
+	 * comment in s3_export.h. */
+	ctx->m->generation   = opts->generation;
 	ctx->num_chunks= ctx->m->num_chunks;
 	ctx->blocks_per_chunk = ctx->chunk_size / S3LVOL_BLOCK_SIZE;
 

--- a/CubeS3lvol/lib/s3bsdev/s3_export.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_export.c
@@ -37,6 +37,7 @@
 #include "spdk/util.h"
 
 #include "s3lvol/s3_export.h"
+#include "s3lvol/s3_chunk_map.h"
 
 SPDK_LOG_REGISTER_COMPONENT(s3lvol_export)
 
@@ -626,6 +627,41 @@ s3_export_manifest_get_ref(const struct s3_export_manifest *m, uint64_t chunk_in
 		return NULL;
 	}
 	return &m->refs[chunk_index];
+}
+
+int
+s3_export_manifest_object_key(const struct s3_export_manifest *m,
+			      uint64_t chunk_index, char *out, size_t out_len,
+			      uint32_t *valid_bytes)
+{
+	const struct s3_export_ref *ref;
+	const char *prefix;
+
+	if (!m || !out || out_len == 0) {
+		return -EINVAL;
+	}
+	if (!s3_export_manifest_is_present(m, chunk_index)) {
+		return -ENOENT;
+	}
+
+	if (m->layout == S3_EXPORT_LAYOUT_DENSE) {
+		s3_export_chunk_key(m->src.prefix, m->uuid_str, chunk_index, out, out_len);
+		if (valid_bytes) {
+			*valid_bytes = m->chunk_size;
+		}
+		return 0;
+	}
+
+	ref = s3_export_manifest_get_ref(m, chunk_index);
+	prefix = s3_export_manifest_chunk_prefix(m, chunk_index);
+	if (!ref || prefix[0] == '\0') {
+		return -EINVAL;
+	}
+	s3_chunk_data_key(prefix, &ref->uuid, out, out_len);
+	if (valid_bytes) {
+		*valid_bytes = ref->valid_bytes;
+	}
+	return 0;
 }
 
 bool

--- a/CubeS3lvol/lib/s3bsdev/s3_export.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_export.c
@@ -746,23 +746,21 @@ s3_export_manifest_seal(struct s3_export_manifest *m)
 	 * segfault when the byte happens to sit near the end of a mapping, and
 	 * silently reads adjacent memory when it does not. The other stages avoid it
 	 * by passing whole arrays; this one has to skip holes, so it copies. */
-	{
-		uint8_t batch[64];
-		size_t n = 0;
+	uint8_t batch[64];
+	size_t n = 0;
 
-		for (i = 0; i < m->num_chunks; i++) {
-			if (!bitmap_test(m->present, i)) {
-				continue;
-			}
-			batch[n++] = m->src_idx[i];
-			if (n == sizeof(batch)) {
-				m->crc32c = spdk_crc32c_update(batch, n, m->crc32c);
-				n = 0;
-			}
+	for (i = 0; i < m->num_chunks; i++) {
+		if (!bitmap_test(m->present, i)) {
+			continue;
 		}
-		if (n != 0) {
+		batch[n++] = m->src_idx[i];
+		if (n == sizeof(batch)) {
 			m->crc32c = spdk_crc32c_update(batch, n, m->crc32c);
+			n = 0;
 		}
+	}
+	if (n != 0) {
+		m->crc32c = spdk_crc32c_update(batch, n, m->crc32c);
 	}
 }
 

--- a/CubeS3lvol/lib/s3bsdev/s3_export_bs_dev.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_export_bs_dev.c
@@ -591,10 +591,13 @@ export_is_range_valid(struct spdk_bs_dev *bs_dev, uint64_t lba, uint64_t lba_cou
 static bool
 export_translate_lba(struct spdk_bs_dev *bs_dev, uint64_t lba, uint64_t *base_lba)
 {
-	/* There is no underlying bdev, so there is no LBA to translate to. Same
-	 * answer as s3_bs_dev, and for the same reason: saying "yes" here is what
-	 * makes blobstore try a device-to-device copy, which needs dev->copy. */
-	return false;
+	/* Identity: dest->copy during ingest treats src_lba as an LBA on this
+	 * export device, not as a block on the destination disk. Returning false
+	 * would force allocate_and_copy_cluster down the GET+write path even when
+	 * the destination has installed copy(). */
+	(void)bs_dev;
+	*base_lba = lba;
+	return true;
 }
 
 static bool
@@ -1131,7 +1134,7 @@ s3_export_bs_dev_create(struct s3_client *client, struct s3_export_manifest *m,
 	dev->bs_dev.is_range_valid  = export_is_range_valid;
 	dev->bs_dev.translate_lba   = export_translate_lba;
 	dev->bs_dev.is_degraded     = export_is_degraded;
-	/* copy stays NULL: see export_translate_lba. */
+	/* copy stays NULL: the destination of a CoW copy is the lvstore bs_dev. */
 
 	SPDK_NOTICELOG("Imported export %s as a read-only parent: %" PRIu64 " bytes "
 		       "(%" PRIu64 " blocks), %" PRIu64 " of %" PRIu64 " chunk(s) "

--- a/CubeS3lvol/lib/s3bsdev/s3_export_bs_dev.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_export_bs_dev.c
@@ -50,20 +50,43 @@ struct s3_export_dev {
 	struct s3_client          *client;
 	struct s3_export_manifest *m;
 
+	s3_export_bs_dev_on_swap_fn on_swap;
+	void                      *on_swap_arg;
+
 	uint32_t                   chunk_shift;
 	uint32_t                   blocks_per_chunk;
 
 	/* io_device name, which spdk_io_device_register() keeps a pointer to. */
 	char                       name[SPDK_UUID_STRING_LEN + 16];
 
+	/* Where the refetch machinery runs, and the only thread that touches the
+	 * three fields below.
+	 *
+	 * Everything else here is read-only after construction, which is what lets
+	 * reads run on any thread with no serialisation. A refetch is the one thing
+	 * that is not: several threads can hit 404 at the same moment on the same
+	 * export, and they must produce one refetch between them rather than one
+	 * each. Rather than lock, the state lives on one thread and the others send
+	 * it a message -- the same shape s3_bs_dev uses for its owner thread, and
+	 * the reason this device could avoid it everywhere else.
+	 *
+	 * The thread that created the device, since that is the one that will still
+	 * be there: blobstore's channels come and go with the poll groups. */
+	struct spdk_thread        *home_thread;
+	bool                       refetch_in_flight;
+	TAILQ_HEAD(, s3_export_io) refetch_waiters;
+
+	/* Incremented from nvmf I/O threads as well as the home thread. */
 	uint64_t                   reads;
 	uint64_t                   bytes_read;
 	uint64_t                   zero_fills;
+	uint64_t                   refetches;
 };
 
 /* One bs_dev read, possibly spanning several chunks. */
 struct s3_export_io {
 	struct s3_export_dev       *dev;
+	struct s3_export_manifest  *m;
 	struct spdk_bs_dev_cb_args *cb_args;
 
 	uint32_t                    num_pending;
@@ -72,6 +95,30 @@ struct s3_export_io {
 	/* Stops the first sub-read from completing the whole I/O while the split
 	 * loop is still adding to it. */
 	bool                        submit_done;
+
+	/* Enough to run the read again after the manifest has been replaced.
+	 *
+	 * The payload belongs to blobstore and stays valid until cb_fn is called,
+	 * which is exactly what a retry postpones -- so holding it across the
+	 * refetch is allowed by the same contract that makes the ordinary
+	 * asynchronous completion legal. */
+	void                       *payload;
+	uint64_t                    lba;
+	uint32_t                    lba_count;
+
+	/* The thread this I/O was submitted on. The retry has to go back to it:
+	 * cb_args->cb_fn is blobstore's, and blobstore expects it on the thread
+	 * that issued the read. */
+	struct spdk_thread         *origin;
+
+	/* Set when a sub-read returned 404. It means the objects this manifest
+	 * names are gone, which is what the source materialising the export looks
+	 * like from here -- so the I/O waits for a newer manifest instead of
+	 * failing. Once retried it is cleared, and a second 404 is a real one. */
+	bool                        saw_missing;
+	bool                        retried;
+
+	TAILQ_ENTRY(s3_export_io)   waiter_link;
 };
 
 struct s3_export_chunk_io {
@@ -94,26 +141,41 @@ struct s3_export_chunk_io {
  * ========================================================================== */
 
 static void
-export_chunk_key(const struct s3_export_dev *dev, uint64_t chunk_index,
+export_chunk_key(const struct s3_export_manifest *m, uint64_t chunk_index,
 		 char *out, size_t out_len)
 {
 	const struct s3_export_ref *ref;
 
-	if (dev->m->layout == S3_EXPORT_LAYOUT_REF) {
-		/* The source lvstore's own live object. Built with the chunk map's own
-		 * key function rather than a copy of the format, because reading a
-		 * *different* key than the source writes would not fail -- it would
-		 * either 404 or, worse, find something else. */
-		ref = s3_export_manifest_get_ref(dev->m, chunk_index);
-		if (ref) {
-			s3_chunk_data_key(dev->m->src.prefix, &ref->uuid, out, out_len);
+	if (m->layout == S3_EXPORT_LAYOUT_REF) {
+		const char *prefix;
+
+		/* A live object under whichever lvstore's prefix owns it. Built with the
+		 * chunk map's own key function rather than a copy of the format, because
+		 * reading a *different* key than the source writes would not fail -- it
+		 * would either 404 or, worse, find something else.
+		 *
+		 * The prefix is per chunk, not per manifest: a snapshot taken on an
+		 * imported volume owns some chunks and inherited the rest, so they live
+		 * under different prefixes. chunk_prefix() answers src.prefix for every
+		 * chunk of a single-source manifest, which is every version 2 one, so
+		 * there is nothing to branch on here.
+		 *
+		 * An empty answer means the manifest cannot say -- an index outside its
+		 * source table, which parse refuses, so only a manifest built in memory
+		 * can be in that state. Treated as no key at all rather than falling
+		 * back to src.prefix: a wrong prefix finds another chunk's object and
+		 * returns bytes that look perfectly good. */
+		ref = s3_export_manifest_get_ref(m, chunk_index);
+		prefix = s3_export_manifest_chunk_prefix(m, chunk_index);
+		if (ref && prefix[0] != '\0') {
+			s3_chunk_data_key(prefix, &ref->uuid, out, out_len);
 			return;
 		}
 		out[0] = '\0';
 		return;
 	}
 
-	s3_export_chunk_key(dev->m->src.prefix, dev->m->uuid_str, chunk_index,
+	s3_export_chunk_key(m->src.prefix, m->uuid_str, chunk_index,
 			    out, out_len);
 }
 
@@ -121,13 +183,50 @@ export_chunk_key(const struct s3_export_dev *dev, uint64_t chunk_index,
  * Completion
  * ========================================================================== */
 
+static void export_io_start_refetch(struct s3_export_io *io);
+static void export_read_internal(struct spdk_bs_dev *bs_dev,
+				 struct spdk_io_channel *channel, void *payload,
+				 uint64_t lba, uint32_t lba_count,
+				 struct spdk_bs_dev_cb_args *cb_args, bool is_retry);
+
+static void
+export_io_drop(struct s3_export_io *io)
+{
+	if (io->m) {
+		s3_export_manifest_unref(io->m);
+	}
+	free(io);
+}
+
 static void
 export_io_complete(struct s3_export_io *io)
 {
 	struct spdk_bs_dev_cb_args *cb_args = io->cb_args;
 	int status = io->status;
 
-	free(io);
+	/* A chunk was missing and nothing worse went wrong: hold the I/O and go
+	 * looking for a newer manifest instead of failing it. Checked here rather
+	 * than per sub-read so that every sub-read of this I/O has finished first --
+	 * retrying with some of them still in flight would have two of them writing
+	 * into the same buffer.
+	 *
+	 * status is honoured first because a real error is a worse answer than a
+	 * stale manifest, and refetching would not fix it. */
+	if (status == 0 && io->saw_missing && !io->retried) {
+		export_io_start_refetch(io);
+		return;
+	}
+
+	/* Retried and still missing. The manifest is current, so the objects really
+	 * are gone -- the source deleted the snapshot rather than materialising it. */
+	if (status == 0 && io->saw_missing) {
+		SPDK_ERRLOG("export %s: chunks are still missing after refetching the "
+			    "manifest; the source has deleted them\n",
+			    io->m ? io->m->uuid_str : io->dev->m->uuid_str);
+		status = -ENOENT;
+	}
+
+	export_io_drop(io);
 	cb_args->cb_fn(cb_args->channel, cb_args->cb_arg, status);
 }
 
@@ -146,7 +245,22 @@ export_chunk_read_done(void *cb_arg, uint64_t bytes_read, int status)
 	struct s3_export_chunk_io *cio = cb_arg;
 	struct s3_export_io *io = cio->io;
 
-	if (status != 0) {
+	if (status == -ENOENT && !io->retried) {
+		/* The object this manifest names is gone. On a ref export that is what
+		 * the source materialising it looks like from here: it rewrote the
+		 * manifest with its own copies and deleted the originals, and nothing
+		 * tells an importer -- the 404 is the notification.
+		 *
+		 * So this is not recorded as the I/O's status. The I/O is held instead,
+		 * the manifest refetched, and the read run again against whatever comes
+		 * back. -EALREADY from that swap still retries: another refetch may
+		 * already have installed this generation. If the objects are genuinely
+		 * gone the retry 404s, which is the other thing a 404 can mean.
+		 *
+		 * Only once. A 404 after the retry is against the manifest that was
+		 * just fetched, so refetching again would find the same thing. */
+		io->saw_missing = true;
+	} else if (status != 0) {
 		SPDK_ERRLOG("Failed to read export chunk '%s': %s\n",
 			    cio->key, spdk_strerror(-status));
 		if (io->status == 0) {
@@ -173,7 +287,7 @@ export_chunk_read_done(void *cb_arg, uint64_t bytes_read, int status)
 			io->status = -EIO;
 		}
 	} else {
-		io->dev->bytes_read += bytes_read;
+		__atomic_fetch_add(&io->dev->bytes_read, bytes_read, __ATOMIC_RELAXED);
 	}
 
 	free(cio);
@@ -184,10 +298,13 @@ export_chunk_read_done(void *cb_arg, uint64_t bytes_read, int status)
  * Read path
  * ========================================================================== */
 
+/* The read itself. \p is_retry marks an I/O that has already been through one
+ * refetch, so a 404 against the manifest just fetched is reported rather than
+ * sent round again. */
 static void
-export_read(struct spdk_bs_dev *bs_dev, struct spdk_io_channel *channel,
-	    void *payload, uint64_t lba, uint32_t lba_count,
-	    struct spdk_bs_dev_cb_args *cb_args)
+export_read_internal(struct spdk_bs_dev *bs_dev, struct spdk_io_channel *channel,
+		     void *payload, uint64_t lba, uint32_t lba_count,
+		     struct spdk_bs_dev_cb_args *cb_args, bool is_retry)
 {
 	struct s3_export_dev *dev = (struct s3_export_dev *)bs_dev;
 	struct s3_export_io *io;
@@ -212,19 +329,29 @@ export_read(struct spdk_bs_dev *bs_dev, struct spdk_io_channel *channel,
 		return;
 	}
 	io->dev = dev;
+	io->m = __atomic_load_n(&dev->m, __ATOMIC_ACQUIRE);
+	s3_export_manifest_ref(io->m);
 	io->cb_args = cb_args;
+	/* Kept so the read can be run again after a refetch. */
+	io->payload = payload;
+	io->lba = lba;
+	io->lba_count = lba_count;
+	io->origin = spdk_get_thread();
+	io->retried = is_retry;
 	/* Self reference, so a sub-read that completes inline -- which a hole
 	 * always does -- cannot finish the I/O before the split loop is done. */
 	io->num_pending = 1;
 
-	dev->reads++;
+	__atomic_fetch_add(&dev->reads, 1, __ATOMIC_RELAXED);
 
 	while (remaining > 0 && io->status == 0) {
-		uint64_t chunk_index = offset_bytes >> dev->chunk_shift;
+		uint32_t chunk_size = io->m->chunk_size;
+		uint32_t chunk_shift = (uint32_t)spdk_u32log2(chunk_size);
+		uint64_t chunk_index = offset_bytes >> chunk_shift;
 		uint32_t offset_in_chunk = (uint32_t)(offset_bytes &
-						(dev->m->chunk_size - 1));
+						(chunk_size - 1));
 		uint32_t length = (uint32_t)spdk_min(remaining,
-						     dev->m->chunk_size - offset_in_chunk);
+						     chunk_size - offset_in_chunk);
 		struct s3_export_chunk_io *cio;
 		uint32_t get_len;
 		int rc;
@@ -232,24 +359,39 @@ export_read(struct spdk_bs_dev *bs_dev, struct spdk_io_channel *channel,
 		/* A chunk with no object reads as zeroes. Not an optimisation: it is how
 		 * an export represents a hole, and it is the common case across the
 		 * sparse regions of a snapshot. */
-		if (!s3_export_manifest_is_present(dev->m, chunk_index)) {
+		if (!s3_export_manifest_is_present(io->m, chunk_index)) {
 			memset(buf, 0, length);
-			dev->zero_fills++;
+			__atomic_fetch_add(&dev->zero_fills, 1, __ATOMIC_RELAXED);
 			goto next;
 		}
 
 		get_len = length;
 
-		if (dev->m->layout == S3_EXPORT_LAYOUT_REF) {
+		if (io->m->layout == S3_EXPORT_LAYOUT_REF) {
 			const struct s3_export_ref *ref;
 
-			ref = s3_export_manifest_get_ref(dev->m, chunk_index);
+			ref = s3_export_manifest_get_ref(io->m, chunk_index);
 			if (!ref) {
 				/* Present in the bitmap with no ref behind it. parse()
 				 * rejects that, so getting here means the manifest was
 				 * mutated in memory afterwards. */
 				SPDK_ERRLOG("export %s: chunk %" PRIu64 " is present but "
-					    "has no ref\n", dev->m->uuid_str, chunk_index);
+					    "has no ref\n", io->m->uuid_str, chunk_index);
+				io->status = -EIO;
+				break;
+			}
+
+			/* Same class of failure, for the prefix rather than the uuid: an
+			 * index outside the source table, which parse() also rejects.
+			 * Checked here rather than left to export_chunk_key() because this
+			 * is where a failure can be reported -- and because the alternative
+			 * is worse than an error. Falling back to src.prefix would build a
+			 * key that very likely exists and holds another chunk's data, so the
+			 * read would succeed and return the wrong bytes. */
+			if (s3_export_manifest_chunk_prefix(io->m, chunk_index)[0] == '\0') {
+				SPDK_ERRLOG("export %s: chunk %" PRIu64 " names a source this "
+					    "manifest does not have\n", io->m->uuid_str,
+					    chunk_index);
 				io->status = -EIO;
 				break;
 			}
@@ -263,7 +405,7 @@ export_read(struct spdk_bs_dev *bs_dev, struct spdk_io_channel *channel,
 			 * because it uploads whole chunks. */
 			if (offset_in_chunk >= ref->valid_bytes) {
 				memset(buf, 0, length);
-				dev->zero_fills++;
+				__atomic_fetch_add(&dev->zero_fills, 1, __ATOMIC_RELAXED);
 				goto next;
 			}
 			if (offset_in_chunk + length > ref->valid_bytes) {
@@ -280,7 +422,7 @@ export_read(struct spdk_bs_dev *bs_dev, struct spdk_io_channel *channel,
 		cio->io = io;
 		cio->chunk_index = chunk_index;
 		cio->expected = get_len;
-		export_chunk_key(dev, chunk_index, cio->key, sizeof(cio->key));
+		export_chunk_key(io->m, chunk_index, cio->key, sizeof(cio->key));
 
 		io->num_pending++;
 		rc = s3_get_range(dev->client, cio->key, offset_in_chunk, get_len, buf,
@@ -302,6 +444,16 @@ next:
 
 	io->submit_done = true;
 	export_io_put(io);
+}
+
+/* blobstore's entry point: always a first attempt. */
+static void
+export_read(struct spdk_bs_dev *bs_dev, struct spdk_io_channel *channel,
+	    void *payload, uint64_t lba, uint32_t lba_count,
+	    struct spdk_bs_dev_cb_args *cb_args)
+{
+	export_read_internal(bs_dev, channel, payload, lba, lba_count, cb_args,
+			     false);
 }
 
 static void
@@ -409,20 +561,25 @@ static bool
 export_is_zeroes(struct spdk_bs_dev *bs_dev, uint64_t lba, uint64_t lba_count)
 {
 	struct s3_export_dev *dev = (struct s3_export_dev *)bs_dev;
+	struct s3_export_manifest *m;
+	uint32_t chunk_shift;
 	uint64_t first, last;
 
 	if (lba_count == 0) {
 		return true;
 	}
 
+	m = __atomic_load_n(&dev->m, __ATOMIC_ACQUIRE);
+	chunk_shift = (uint32_t)spdk_u32log2(m->chunk_size);
+
 	/* Whole chunks only. A range that starts or ends inside a present chunk is
 	 * reported as non-zero even if those particular bytes are zero: the answer
 	 * has to be conservative, since blobstore uses it to skip reading the
 	 * parent entirely. */
-	first = (lba * S3LVOL_BLOCK_SIZE) >> dev->chunk_shift;
-	last = ((lba + lba_count - 1) * S3LVOL_BLOCK_SIZE) >> dev->chunk_shift;
+	first = (lba * S3LVOL_BLOCK_SIZE) >> chunk_shift;
+	last = ((lba + lba_count - 1) * S3LVOL_BLOCK_SIZE) >> chunk_shift;
 
-	return s3_export_manifest_range_is_zeroes(dev->m, first, last - first + 1);
+	return s3_export_manifest_range_is_zeroes(m, first, last - first + 1);
 }
 
 static bool
@@ -501,12 +658,417 @@ export_destroy(struct spdk_bs_dev *bs_dev)
 	struct s3_export_dev *dev = (struct s3_export_dev *)bs_dev;
 
 	SPDK_NOTICELOG("Releasing imported export %s: %" PRIu64 " read(s), "
-		       "%" PRIu64 " bytes from S3, %" PRIu64 " served as zeroes\n",
-		       dev->m->uuid_str, dev->reads, dev->bytes_read, dev->zero_fills);
+		       "%" PRIu64 " bytes from S3, %" PRIu64 " served as zeroes, "
+		       "%" PRIu64 " manifest refetch(es)\n",
+		       dev->m->uuid_str, dev->reads, dev->bytes_read, dev->zero_fills,
+		       dev->refetches);
+
+	/* No wait for a refetch, deliberately.
+	 *
+	 * A refetch only exists while an I/O is waiting on it, and that I/O is one
+	 * blobstore is waiting for a callback on -- so blobstore cannot have decided
+	 * the device is unreferenced. The same reasoning already covers an ordinary
+	 * chunk GET, which writes to dev from its completion.
+	 *
+	 * What that rests on is that every path out of a refetch releases its
+	 * waiters, including each failure: a refetch that returned without doing so
+	 * would leave blobstore waiting for ever, and the leak would look like a
+	 * hung volume rather than like anything to do with this file. */
 
 	/* Frees in the callback: unregistering is asynchronous, and any channel
 	 * still open would otherwise be pointing at freed memory. */
 	spdk_io_device_unregister(dev, export_io_device_unregistered);
+}
+
+/* ==========================================================================
+ * Replacing the manifest
+ *
+ * A ref export names the source's live objects. When the source materialises it
+ * -- rewrites the manifest as dense, with its own copies -- those objects stop
+ * existing, and an importer still holding the old manifest reads 404s. Its way
+ * out is to fetch the manifest again and carry on against the new one, which is
+ * what `generation` is for.
+ *
+ * The hard part is not fetching it. It is that the whole of this file is lock
+ * free *because* the manifest never changes: blobstore makes a channel per
+ * thread that touches the clone, and every one of them reads dev->m with no
+ * serialisation at all. Swapping it is therefore the one operation that has to
+ * think about the other threads.
+ *
+ * What makes it tractable is that no reader holds the manifest across an await.
+ * Every dereference is synchronous inside export_read() or export_is_zeroes():
+ * a chunk's key is copied into the sub-I/O before the GET is submitted, and the
+ * completion never looks at the manifest again. So a reader's window is one
+ * synchronous stretch on its own thread.
+ *
+ * Hence a grace period rather than a lock. The pointer is replaced first -- a
+ * pointer store, so every reader sees one manifest or the other, never a torn
+ * value, and both are valid to read against. The old one is then released only
+ * after spdk_for_each_channel() has run on every thread that has a channel:
+ * having got a turn on each of them means every reader that could have loaded
+ * the old pointer has already finished with it, because it could only have been
+ * doing so from the same event loop the iteration just ran in.
+ * ========================================================================== */
+
+struct export_swap_ctx {
+	/* Deliberately no dev pointer. destroy() can run while this is in flight --
+	 * spdk_io_device_unregister() defers behind for_each, but the completion
+	 * still arrives -- and holding the device here would suggest it is safe to
+	 * dereference on the way out. Nothing below needs it: the old manifest's
+	 * reference was transferred into this struct, so releasing it does not
+	 * involve the device at all. */
+	struct s3_export_manifest *old;
+	s3_export_bs_dev_swap_cb   cb;
+	void                      *cb_arg;
+};
+
+static void
+export_swap_channel(struct spdk_io_channel_iter *i)
+{
+	/* Nothing to do per channel: being called here is the point. It says this
+	 * thread has reached the iteration, so it is not inside a read that loaded
+	 * the old manifest. */
+	spdk_for_each_channel_continue(i, 0);
+}
+
+static void
+export_swap_done(struct spdk_io_channel_iter *i, int status)
+{
+	struct export_swap_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+
+	/* Past the grace period: the old manifest cannot be reachable from any
+	 * reader now, so this reference is the last thing holding it. */
+	s3_export_manifest_unref(ctx->old);
+
+	if (ctx->cb) {
+		ctx->cb(ctx->cb_arg, status);
+	}
+	free(ctx);
+}
+
+int
+s3_export_bs_dev_swap_manifest(struct spdk_bs_dev *bs_dev,
+			       struct s3_export_manifest *m,
+			       s3_export_bs_dev_swap_cb cb, void *cb_arg)
+{
+	struct s3_export_dev *dev = (struct s3_export_dev *)bs_dev;
+	struct export_swap_ctx *ctx;
+
+	if (!bs_dev || !m) {
+		return -EINVAL;
+	}
+
+	/* A different export entirely. Nothing else here would catch it -- the
+	 * geometry could match by coincidence -- and the result would be a clone
+	 * silently reading another volume. */
+	if (strcmp(m->uuid_str, dev->m->uuid_str) != 0) {
+		SPDK_ERRLOG("export %s: refusing a manifest for %s\n",
+			    dev->m->uuid_str, m->uuid_str);
+		return -EINVAL;
+	}
+
+	/* blobstore sized the clone against the old manifest and has been serving
+	 * that size since. A parent that changed length would put the end of the
+	 * volume somewhere the clone does not agree with, so this is refused rather
+	 * than adopted -- reading through a shorter parent is data loss, and a
+	 * longer one is data blobstore will never ask for. */
+	if (m->size_bytes != dev->m->size_bytes) {
+		SPDK_ERRLOG("export %s: refusing a manifest of %" PRIu64 " byte(s) "
+			    "against the %" PRIu64 " this device was built for\n",
+			    dev->m->uuid_str, m->size_bytes, dev->m->size_bytes);
+		return -EINVAL;
+	}
+
+	if (m->chunk_size != dev->m->chunk_size) {
+		SPDK_ERRLOG("export %s: refusing a manifest with chunk_size %u "
+			    "against the %u this device was built for\n",
+			    dev->m->uuid_str, m->chunk_size, dev->m->chunk_size);
+		return -EINVAL;
+	}
+
+	/* Older or identical: reported as -EALREADY rather than success so the
+	 * caller can tell "already on this generation" from "now reading a new
+	 * one". A refetch must not treat that as data loss -- another refetch
+	 * may have swapped while this GET still used the pre-swap keys. */
+	if (m->generation <= dev->m->generation) {
+		return -EALREADY;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		return -ENOMEM;
+	}
+	ctx->old    = dev->m;
+	ctx->cb     = cb;
+	ctx->cb_arg = cb_arg;
+
+	s3_export_manifest_ref(m);
+
+	/* Publish one snapshot. Each I/O captures `m` at submit and uses that
+	 * manifest's geometry until it completes, so these stores do not have to
+	 * appear atomic with a concurrent read's split loop. Rejecting a chunk-size
+	 * change above is what keeps is_zeroes and a in-flight read from disagreeing
+	 * on which byte range a chunk index covers. */
+	dev->chunk_shift      = (uint32_t)spdk_u32log2(m->chunk_size);
+	dev->blocks_per_chunk = m->chunk_size / S3LVOL_BLOCK_SIZE;
+	__atomic_store_n(&dev->m, m, __ATOMIC_RELEASE);
+
+	if (dev->on_swap) {
+		dev->on_swap(dev->on_swap_arg, m);
+	}
+
+	SPDK_NOTICELOG("export %s: now reading generation %u (%s), was %u (%s)\n",
+		       m->uuid_str, m->generation,
+		       m->layout == S3_EXPORT_LAYOUT_REF ? "ref" : "copied",
+		       ctx->old->generation,
+		       ctx->old->layout == S3_EXPORT_LAYOUT_REF ? "ref" : "copied");
+
+	spdk_for_each_channel(dev, export_swap_channel, ctx, export_swap_done);
+	return 0;
+}
+
+/* ==========================================================================
+ * Refetch: what a 404 means, and what to do about it
+ *
+ * A ref export names the source's live objects. The source's way of taking its
+ * snapshot back is to materialise the export -- copy the data under the export's
+ * own prefix, rewrite the manifest as dense with `generation` bumped, and delete
+ * the originals. Nothing tells the importer. The 404 *is* the notification.
+ *
+ * So a missing object is not failed straight back to blobstore. The I/O is held,
+ * the manifest fetched again, and the read run once more against whatever came
+ * back. A caller sees a slower read rather than an error, which matters because
+ * materialising is an ordinary operation on the source and the importer cannot
+ * anticipate it.
+ *
+ * It all runs on home_thread. Several threads can hit 404 on the same export at
+ * the same moment -- one large read splits into many chunk GETs, and after a
+ * materialisation every one of them misses -- so they have to produce one refetch
+ * between them. The waiters queue there and each is sent back to its own thread
+ * to be retried, because blobstore's completion belongs on the thread that
+ * issued the read.
+ * ========================================================================== */
+
+/* Big enough for any manifest this can produce, and small enough that a wrong
+ * answer from HEAD cannot turn into a huge allocation. Matches the import path. */
+#define EXPORT_MANIFEST_MAX (64u * 1024 * 1024)
+
+struct export_refetch_ctx {
+	struct s3_export_dev *dev;
+	char                  key[S3_EXPORT_KEY_MAX];
+	uint64_t              size;
+	char                 *body;
+};
+
+static void export_retry_msg(void *arg);
+
+/* Release every waiter back to its own thread. Called on home_thread once the
+ * refetch has settled, whatever the outcome: a waiter that is not retried still
+ * has to be completed, or blobstore waits for a callback that never comes. */
+static void
+export_release_waiters(struct s3_export_dev *dev, bool retry)
+{
+	struct s3_export_io *io, *tmp;
+
+	TAILQ_FOREACH_SAFE(io, &dev->refetch_waiters, waiter_link, tmp) {
+		TAILQ_REMOVE(&dev->refetch_waiters, io, waiter_link);
+		/* Set either way: it is what stops the retry from refetching again. */
+		io->retried = true;
+		/* Cleared on the retry path, kept on the give-up path. The pair is what
+		 * export_retry_msg() reads to tell "run it again against the new
+		 * manifest" from "there is no new manifest, report the 404". */
+		io->saw_missing = !retry;
+		spdk_thread_send_msg(io->origin, export_retry_msg, io);
+	}
+	dev->refetch_in_flight = false;
+}
+
+static void
+export_refetch_free(struct export_refetch_ctx *ctx)
+{
+	free(ctx->body);
+	free(ctx);
+}
+
+static void
+export_refetch_swapped(void *cb_arg, int status)
+{
+	struct export_refetch_ctx *ctx = cb_arg;
+
+	/* The swap is complete and the old manifest is gone, so the waiters can now
+	 * be re-run against the new one. */
+	export_release_waiters(ctx->dev, true);
+	export_refetch_free(ctx);
+}
+
+static void
+export_refetch_got_manifest(void *cb_arg, uint64_t bytes_read, int status)
+{
+	struct export_refetch_ctx *ctx = cb_arg;
+	struct s3_export_dev *dev = ctx->dev;
+	struct s3_export_manifest *m = NULL;
+	int rc;
+
+	if (status != 0) {
+		SPDK_ERRLOG("export %s: could not read the manifest back: %s\n",
+			    dev->m->uuid_str, spdk_strerror(-status));
+		goto give_up;
+	}
+
+	rc = s3_export_manifest_parse(ctx->body, bytes_read, &m);
+	if (rc != 0) {
+		SPDK_ERRLOG("export %s: the refetched manifest does not parse: %s\n",
+			    dev->m->uuid_str, spdk_strerror(-rc));
+		goto give_up;
+	}
+
+	rc = s3_export_bs_dev_swap_manifest(&dev->bs_dev, m,
+					    export_refetch_swapped, ctx);
+	/* The device holds its own reference now, or refused it; either way this
+	 * one is done with. */
+	s3_export_manifest_unref(m);
+
+	if (rc == 0) {
+		__atomic_fetch_add(&dev->refetches, 1, __ATOMIC_RELAXED);
+		return;
+	}
+
+	if (s3_export_bs_dev_refetch_already_current(rc)) {
+		/* Already on this generation. Retry against the keys now in
+		 * dev->m: a GET that left before a swap 404s after it, and a
+		 * second refetch then hits -EALREADY even though the new
+		 * objects are there. Genuine deletion still fails -- the retry
+		 * 404s and io->retried blocks another refetch. */
+		export_release_waiters(dev, true);
+		export_refetch_free(ctx);
+		return;
+	}
+
+	SPDK_ERRLOG("export %s: the refetched manifest was refused: %s\n",
+		    dev->m->uuid_str, spdk_strerror(-rc));
+
+give_up:
+	export_release_waiters(dev, false);
+	export_refetch_free(ctx);
+}
+
+static void
+export_refetch_head_done(void *cb_arg, int status)
+{
+	struct export_refetch_ctx *ctx = cb_arg;
+	struct s3_export_dev *dev = ctx->dev;
+	int rc;
+
+	if (status != 0) {
+		/* A 404 here is worth saying out loud: the manifest itself is gone, so
+		 * there is nothing to refetch and nothing will fix this export. */
+		SPDK_ERRLOG("export %s: cannot stat the manifest '%s': %s\n",
+			    dev->m->uuid_str, ctx->key, spdk_strerror(-status));
+		goto give_up;
+	}
+	if (ctx->size == 0 || ctx->size > EXPORT_MANIFEST_MAX) {
+		SPDK_ERRLOG("export %s: manifest '%s' has an implausible size of %"
+			    PRIu64 " bytes\n", dev->m->uuid_str, ctx->key, ctx->size);
+		goto give_up;
+	}
+
+	ctx->body = malloc(ctx->size);
+	if (!ctx->body) {
+		goto give_up;
+	}
+
+	rc = s3_get_range(dev->client, ctx->key, 0, ctx->size, ctx->body,
+			  export_refetch_got_manifest, ctx);
+	if (rc != 0) {
+		SPDK_ERRLOG("export %s: could not submit the manifest read: %s\n",
+			    dev->m->uuid_str, spdk_strerror(-rc));
+		goto give_up;
+	}
+	return;
+
+give_up:
+	export_release_waiters(dev, false);
+	export_refetch_free(ctx);
+}
+
+/* On home_thread. Queues the I/O and starts a refetch if one is not already
+ * under way. */
+static void
+export_refetch_msg(void *arg)
+{
+	struct s3_export_io *io = arg;
+	struct s3_export_dev *dev = io->dev;
+	struct export_refetch_ctx *ctx;
+	int rc;
+
+	TAILQ_INSERT_TAIL(&dev->refetch_waiters, io, waiter_link);
+
+	/* One refetch for all of them. After a materialisation every chunk read
+	 * misses at once, and one GET per miss would be a burst of identical
+	 * requests -- and several swaps racing to replace the same manifest. */
+	if (dev->refetch_in_flight) {
+		return;
+	}
+	dev->refetch_in_flight = true;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		export_release_waiters(dev, false);
+		return;
+	}
+	ctx->dev = dev;
+	s3_export_manifest_key(dev->m->uuid_str, ctx->key, sizeof(ctx->key));
+
+	SPDK_NOTICELOG("export %s: a chunk is missing; refetching the manifest "
+		       "(generation %u now)\n", dev->m->uuid_str, dev->m->generation);
+
+	rc = s3_head(dev->client, ctx->key, &ctx->size, export_refetch_head_done, ctx);
+	if (rc != 0) {
+		SPDK_ERRLOG("export %s: could not submit the manifest stat: %s\n",
+			    dev->m->uuid_str, spdk_strerror(-rc));
+		export_release_waiters(dev, false);
+		export_refetch_free(ctx);
+	}
+}
+
+static void
+export_io_start_refetch(struct s3_export_io *io)
+{
+	spdk_thread_send_msg(io->dev->home_thread, export_refetch_msg, io);
+}
+
+/* Back on the I/O's own thread, with the manifest already replaced. */
+static void
+export_retry_msg(void *arg)
+{
+	struct s3_export_io *io = arg;
+	struct spdk_bs_dev *bs_dev = &io->dev->bs_dev;
+	struct spdk_bs_dev_cb_args *cb_args = io->cb_args;
+	void *payload = io->payload;
+	uint64_t lba = io->lba;
+	uint32_t lba_count = io->lba_count;
+
+	if (io->retried && io->saw_missing) {
+		/* The refetch gave up. Completed rather than re-read, since reading
+		 * again would produce the same 404. */
+		export_io_complete(io);
+		return;
+	}
+
+	/* A fresh read against the new manifest, so the whole splitting and hole
+	 * logic is reused rather than a second, subtly different, copy of it.
+	 *
+	 * is_retry carries across. Without it the new I/O would start with a clean
+	 * slate, and a 404 against the manifest that was *just* fetched would send
+	 * it round again -- a materialisation the source is still part way through
+	 * would loop for as long as it lasted. One refetch per I/O is the rule, and
+	 * this is where it is kept.
+	 *
+	 * The old I/O is dropped here: export_read() builds its own, and this one's
+	 * captured manifest is released with it. */
+	export_io_drop(io);
+	export_read_internal(bs_dev, cb_args->channel, payload, lba, lba_count,
+			     cb_args, true);
 }
 
 /* ==========================================================================
@@ -536,6 +1098,13 @@ s3_export_bs_dev_create(struct s3_client *client, struct s3_export_manifest *m,
 	dev->chunk_shift      = (uint32_t)spdk_u32log2(m->chunk_size);
 	dev->blocks_per_chunk = m->chunk_size / S3LVOL_BLOCK_SIZE;
 	snprintf(dev->name, sizeof(dev->name), "esnap:%s", m->uuid_str);
+
+	/* The refetch machinery's thread. Taken here rather than from the first
+	 * read, because it has to be a thread that stays: blobstore's channels come
+	 * and go with the poll groups, and a refetch outliving the thread that
+	 * started it would send a message to an exited thread, which aborts. */
+	dev->home_thread = spdk_get_thread();
+	TAILQ_INIT(&dev->refetch_waiters);
 
 	s3_export_manifest_ref(m);
 
@@ -570,6 +1139,35 @@ s3_export_bs_dev_create(struct s3_client *client, struct s3_export_manifest *m,
 		       dev->bs_dev.blockcnt, m->present_chunks, m->num_chunks,
 		       m->src.bucket, m->src.prefix);
 
+	/* Named individually when there is more than one, because the line above
+	 * would otherwise describe a derived import as depending on a single prefix.
+	 * Which prefixes an import reads from is what decides whose lease has to be
+	 * renewed and whose snapshot cannot be deleted, so an operator looking into
+	 * either has to be able to see it. */
+	if (m->num_srcs > 1) {
+		uint32_t si;
+
+		for (si = 1; si < m->num_srcs; si++) {
+			SPDK_NOTICELOG("Export %s also reads prefix '%s' (export %s)\n",
+				       m->uuid_str, m->srcs[si].prefix,
+				       m->srcs[si].export_uuid[0] ? m->srcs[si].export_uuid
+				       : "unnamed");
+		}
+	}
+
 	*out = &dev->bs_dev;
 	return 0;
+}
+
+void
+s3_export_bs_dev_set_on_swap(struct spdk_bs_dev *bs_dev,
+			      s3_export_bs_dev_on_swap_fn fn, void *arg)
+{
+	struct s3_export_dev *dev = (struct s3_export_dev *)bs_dev;
+
+	if (!bs_dev) {
+		return;
+	}
+	dev->on_swap = fn;
+	dev->on_swap_arg = arg;
 }

--- a/CubeS3lvol/lib/s3bsdev/s3_export_ref.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_export_ref.c
@@ -62,8 +62,10 @@
  *   to do, turned an ordinary sparse snapshot into a full copy.
  *
  *   is_zeroes() separates the two, because it consults the overlay as well as
- *   the chunk map. A hole is left out of the bitmap, which is exactly how the
- *   manifest spells "reads as zeroes"; anything else still stops the walk.
+ *   the chunk map. A hole is left out of the present bitmap -- which is how
+ *   the importer spells "reads as zeroes" -- and marked resolved so inherit()
+ *   and older layers cannot put a parent object back. Anything else still
+ *   stops the walk.
  */
 
 #include "spdk/stdinc.h"
@@ -97,16 +99,18 @@ struct ref_walk {
 	uint64_t                   bytes_named;
 
 	/* Clusters blobstore has allocated that hold no data at all. Counted
-	 * rather than recorded: the manifest says "not present" for them, which
-	 * is what the importer needs, and the count is worth a line in the log. */
+	 * rather than recorded as present: the published bitmap still says
+	 * "not present" for them, which is what the importer needs. They are
+	 * marked resolved so inherit cannot restore a parent object. */
 	uint64_t                   holes;
 };
 
 /* One layer. Returns the number of chunks it contributed, or negative on error.
  *
- * Chunks already named are skipped rather than overwritten: the layers arrive
- * nearest first, so whoever got there first is the closest layer that has the
- * cluster, which is the one blobstore would reach by reading through the chain.
+ * Chunks already named, or already settled as local zeroes, are skipped rather
+ * than overwritten: the layers arrive nearest first, so whoever got there first
+ * is the closest layer that has the cluster, which is the one blobstore would
+ * reach by reading through the chain.
  */
 static int64_t
 walk_layer(struct ref_walk *w, struct spdk_blob *blob, const char *uuid_str,
@@ -138,8 +142,10 @@ walk_layer(struct ref_walk *w, struct spdk_blob *blob, const char *uuid_str,
 
 		export_chunk = offset / w->io_units_per_chunk;
 
-		if (s3_export_manifest_is_present(w->m, export_chunk)) {
-			/* A nearer layer already owns this chunk. */
+		if (s3_export_manifest_is_present(w->m, export_chunk) ||
+		    s3_export_manifest_is_resolved(w->m, export_chunk)) {
+			/* A nearer layer already owns this chunk, or settled it as
+			 * zeroes. */
 			offset += w->io_units_per_chunk;
 			continue;
 		}
@@ -177,11 +183,14 @@ walk_layer(struct ref_walk *w, struct spdk_blob *blob, const char *uuid_str,
 			 *
 			 * is_zeroes() is the device's own answer to exactly this question
 			 * -- it checks the overlay as well as the chunk map -- so it is
-			 * asked rather than reimplemented. A hole is left absent from the
-			 * bitmap, which is how the manifest spells "reads as zeroes".
+			 * asked rather than reimplemented. A hole is left absent from
+			 * the present bitmap, which is how the importer spells "reads
+			 * as zeroes", and marked resolved so inherit() cannot restore
+			 * a parent object over the zero.
 			 */
 			if (w->bs_dev->is_zeroes(w->bs_dev, lba,
 						 w->io_units_per_chunk)) {
+				s3_export_manifest_set_resolved(w->m, export_chunk);
 				w->holes++;
 				offset += w->io_units_per_chunk;
 				continue;
@@ -220,6 +229,7 @@ s3_export_run_ref(const struct s3_export_ref_opts *opts, s3_export_cb cb, void *
 	struct s3_export_manifest *m = NULL;
 	struct ref_walk w = {0};
 	uint64_t size_bytes;
+	uint64_t inherited = 0;
 	uint32_t chunk_size;
 	uint32_t i;
 	int64_t contributed;
@@ -232,6 +242,27 @@ s3_export_run_ref(const struct s3_export_ref_opts *opts, s3_export_cb cb, void *
 	for (i = 0; i < opts->chain_len; i++) {
 		if (!opts->chain[i]) {
 			return -EINVAL;
+		}
+	}
+
+	/* An esnap chain with no parent manifest would produce a manifest that is
+	 * short exactly where the export it reads through holds data, and short in a
+	 * manifest means "reads as zeroes". Refused here as well as at the caller,
+	 * because the caller is the one place that knows and this is the one place
+	 * that can prove it. */
+	if (spdk_blob_is_esnap_clone(opts->chain[opts->chain_len - 1]) &&
+	    !opts->parent) {
+		SPDK_ERRLOG("Export %s: the chain ends in an external snapshot but no "
+			    "parent manifest was given, so the chunks it inherits could "
+			    "not be named\n", opts->uuid_str);
+		return -EINVAL;
+	}
+
+	if (opts->parent) {
+		rc = s3_export_manifest_inheritable(opts->parent, &opts->src,
+						    opts->uuid_str);
+		if (rc != 0) {
+			return rc;
 		}
 	}
 
@@ -278,6 +309,19 @@ s3_export_run_ref(const struct s3_export_ref_opts *opts, s3_export_cb cb, void *
 		return -ENOTSUP;
 	}
 
+	/* Chunk indices are only comparable between two manifests of the same chunk
+	 * size: index i means a different byte range under each. Inheriting across a
+	 * change of chunk size would need the ranges re-cut, which is reading and
+	 * rewriting the data -- exactly what the copy engine does. */
+	if (opts->parent && opts->parent->chunk_size != chunk_size) {
+		SPDK_NOTICELOG("Export %s: parent %s has a chunk size of %u against "
+			       "this lvstore's %u, so their chunk indices do not line "
+			       "up. Exporting by copying instead.\n", opts->uuid_str,
+			       opts->parent->uuid_str, opts->parent->chunk_size,
+			       chunk_size);
+		return -ENOTSUP;
+	}
+
 	w.chunk_shift = spdk_u32log2(chunk_size);
 	w.io_units_per_chunk = chunk_size / S3LVOL_BLOCK_SIZE;
 	w.num_io_units = spdk_blob_get_num_io_units(opts->chain[0]);
@@ -294,6 +338,7 @@ s3_export_run_ref(const struct s3_export_ref_opts *opts, s3_export_cb cb, void *
 	m->cluster_size = opts->cluster_size;
 	m->created_at = (uint64_t)time(NULL);
 	m->expires_at = opts->expires_at;
+	m->generation = opts->generation;
 
 	/* The walk. Every step is memory: blobstore is asked which cluster is next,
 	 * not to read it. */
@@ -307,11 +352,44 @@ s3_export_run_ref(const struct s3_export_ref_opts *opts, s3_export_cb cb, void *
 			      " chunk(s)\n", opts->uuid_str, i, contributed);
 	}
 
+	/* Then whatever the chain inherited from an export rather than from a blob.
+	 * Last, so every local layer has already claimed what it owns -- a chunk
+	 * rewritten since the import must resolve to the rewritten cluster, and a
+	 * locally zeroed chunk must stay a hole. */
+	if (opts->parent) {
+		uint64_t bytes = 0;
+
+		rc = s3_export_manifest_inherit(m, opts->parent, &inherited, &bytes);
+		if (rc != 0) {
+			/* Including -E2BIG, which leaves m holding the sources that did
+			 * fit and the chunks recorded against them. Not repaired,
+			 * because err drops the manifest -- publishing happens further
+			 * down and only on the success path, so a half-filled one is
+			 * never written. The caller copies instead. */
+			goto err;
+		}
+		w.named += inherited;
+		w.bytes_named += bytes;
+		SPDK_DEBUGLOG(s3lvol_export, "Export %s: inherited %" PRIu64
+			      " chunk(s) from export %s\n", opts->uuid_str, inherited,
+			      opts->parent->uuid_str);
+	}
+
 	SPDK_NOTICELOG("Export %s references %" PRIu64 " object(s) holding %" PRIu64
 		       " byte(s) of a %" PRIu64 "-byte snapshot across %u layer(s), "
 		       "skipping %" PRIu64 " zeroed cluster(s); nothing was copied\n",
 		       opts->uuid_str, w.named, w.bytes_named, size_bytes,
 		       opts->chain_len, w.holes);
+
+	/* Said separately because it is the part an operator cannot infer: these
+	 * chunks are not under this lvstore's prefix, so this node's own snapshot
+	 * being present is not enough to keep the export readable. */
+	if (inherited) {
+		SPDK_NOTICELOG("Export %s inherits %" PRIu64 " of those chunk(s) from "
+			       "export %s, across %u prefix(es) in total\n",
+			       opts->uuid_str, inherited, opts->parent->uuid_str,
+			       m->num_srcs);
+	}
 
 	/* Hands its reference to the callback. */
 	rc = s3_export_manifest_publish(opts->client, m, cb, cb_arg);

--- a/CubeS3lvol/lib/s3bsdev/s3_spawner.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_spawner.c
@@ -3,8 +3,6 @@
 /*
  *   Thread spawner implementation. The design rationale lives in
  *   include/s3lvol/s3_spawner.h.
- *
- *   Ported from spdk/module/bdev/erofs/bdev_erofs.c (verified in production).
  */
 
 #include "spdk/stdinc.h"

--- a/CubeS3lvol/lib/s3bsdev/s3_wal.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_wal.c
@@ -640,7 +640,7 @@ wal_submit(struct s3_wal *wal, enum s3_wal_entry_type type, uint64_t lba,
 		return;
 	}
 	/* Backpressure is a retry signal, not a failure: blobstore will queue
-	 * and resubmit (W5). */
+	 * and resubmit. */
 	if (wal->state == S3_WAL_BACKPRESSURE) {
 		if (cb_fn) {
 			cb_fn(cb_arg, -EAGAIN);

--- a/CubeS3lvol/mk/s3lvol.common.mk
+++ b/CubeS3lvol/mk/s3lvol.common.mk
@@ -403,6 +403,12 @@ spdk_only_libs   = $(filter-out -lrte_%,$(1))
 # does not register constructors the way SPDK/DPDK do, and wrapping it would
 # pull unused ENGINE objects. -ldl -pthread stay dynamic (OpenSSL 1.1 needs
 # them).
+#
+# The archive may also need -lz, which the .so never does because it carries its
+# own DT_NEEDED. Distros disagree: TencentOS/RHEL build libcrypto with zlib
+# compression, so c_zlib.o refers to inflate/deflate and the link fails without
+# it, while Debian's is built no-comp. Probed rather than always appended, so a
+# builder that does not need zlib does not gain a dependency on it.
 # ---------------------------------------------------------------------------
 
 OPENSSL_LIBDIR := $(strip $(shell pkg-config --variable=libdir openssl 2>/dev/null))
@@ -412,18 +418,28 @@ ifneq ($(filter /%,$(OPENSSL_SSL_A_PROBE)),)
 OPENSSL_LIBDIR := $(patsubst %/,%,$(dir $(OPENSSL_SSL_A_PROBE)))
 endif
 endif
-OPENSSL_STATIC_LIBS := $(OPENSSL_LIBDIR)/libssl.a $(OPENSSL_LIBDIR)/libcrypto.a
 
 filter_ssl = $(filter-out -lssl -lcrypto,$(1))
 SYS_LIBS := $(call filter_ssl,$(SYS_LIBS))
 
-ifeq ($(filter clean help,$(MAKECMDGOALS)),)
+# Archives when present (release / Ubuntu 20.04 builder). Shared -lssl otherwise:
+# openssl-devel on RHEL/TencentOS ships headers and .so only; the .a files are
+# openssl-static. make_release.sh still refuses a binary that DT_NEEDED libssl.
 ifeq ($(and $(wildcard $(OPENSSL_LIBDIR)/libssl.a),$(wildcard $(OPENSSL_LIBDIR)/libcrypto.a)),)
-$(error No static OpenSSL at $(OPENSSL_LIBDIR) (need libssl.a and libcrypto.a). \
-        Install libssl-dev (Debian/Ubuntu) or openssl-devel (RHEL/CentOS). \
-        Release s3lvol_tgt links OpenSSL statically so the package does not \
-        need libssl.so.1.1 on the target)
+ifeq ($(filter clean help,$(MAKECMDGOALS)),)
+ifndef S3LVOL_OPENSSL_SHARED_WARNED
+$(warning No static OpenSSL at $(OPENSSL_LIBDIR); linking shared -lssl -lcrypto. \
+        Install openssl-static (RHEL/TencentOS) or libssl-dev (Debian/Ubuntu) \
+        for a package that does not need libssl.so.1.1 on the target)
+export S3LVOL_OPENSSL_SHARED_WARNED := 1
 endif
+endif
+OPENSSL_STATIC_LIBS := -lssl -lcrypto
+else
+OPENSSL_ZLIB := $(shell nm -u $(OPENSSL_LIBDIR)/libcrypto.a 2>/dev/null \
+        | grep -qw inflate && echo -lz)
+OPENSSL_STATIC_LIBS := $(OPENSSL_LIBDIR)/libssl.a $(OPENSSL_LIBDIR)/libcrypto.a \
+        $(OPENSSL_ZLIB)
 endif
 
 # $(call dpdk_link_args,<pkg-config --libs output>) -- the DPDK half, ready to

--- a/CubeS3lvol/module/bdev/s3lvol/Makefile
+++ b/CubeS3lvol/module/bdev/s3lvol/Makefile
@@ -16,6 +16,7 @@ SRCS = vbdev_s3lvol.c \
        vbdev_s3lvol_lvstore.c \
        vbdev_s3lvol_lvol.c \
        vbdev_s3lvol_xfer.c vbdev_s3lvol_exports.c \
+       vbdev_s3lvol_pending.c \
        vbdev_s3lvol_namespace.c \
        vbdev_s3lvol_statefile.c \
        vbdev_s3lvol_active.c \

--- a/CubeS3lvol/module/bdev/s3lvol/export_lease_term.h
+++ b/CubeS3lvol/module/bdev/s3lvol/export_lease_term.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+/*
+ * When a lease-aware export may be treated as "nobody imported it".
+ *
+ * A 404 only means the last check missed. An importer can PUT the lease after
+ * that HEAD and still before expires_at; combining "ever saw 404" with
+ * "now past the deadline" would reap a live import's manifest. The miss has
+ * to have been observed on a check submitted at or after the deadline.
+ */
+
+#ifndef EXPORT_LEASE_TERM_H
+#define EXPORT_LEASE_TERM_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+static inline bool
+export_lease_miss_confirms_gone(bool lease_absent, uint64_t absent_at,
+				uint64_t expires_at, uint64_t now)
+{
+	if (!lease_absent || expires_at == 0) {
+		return false;
+	}
+	if (now < expires_at) {
+		return false;
+	}
+	return absent_at >= expires_at;
+}
+
+#endif

--- a/CubeS3lvol/module/bdev/s3lvol/pending_persist_ctl.h
+++ b/CubeS3lvol/module/bdev/s3lvol/pending_persist_ctl.h
@@ -1,0 +1,54 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+/*
+ *   One in-flight pending-delete registry PUT per lvstore
+ *
+ *   Every set/clear serialises the whole registry to the same key. Independent
+ *   PUTs can complete out of mutation order: a slow set(A) landing after
+ *   cancel(A) brings A back after restart.
+ *
+ *   One PUT at a time, with a dirty flag so a completion always writes the
+ *   newest in-memory snapshot rather than the bytes captured at submit.
+ *   Header-only so the state machine is testable without S3 or SPDK.
+ */
+
+#ifndef S3LVOL_PENDING_PERSIST_CTL_H
+#define S3LVOL_PENDING_PERSIST_CTL_H
+
+#include <stdbool.h>
+
+struct pending_persist_ctl {
+	bool in_flight;
+	bool dirty;
+};
+
+/* True: caller should serialise now and PUT. False: a PUT is already in
+ * flight; this mutation will be written when that PUT completes. */
+static inline bool
+pending_persist_begin(struct pending_persist_ctl *c)
+{
+	if (c->in_flight) {
+		c->dirty = true;
+		return false;
+	}
+	c->in_flight = true;
+	return true;
+}
+
+/* True: caller should serialise the current marks and PUT again.
+ *
+ * Does not set in_flight. The follow-up PUT is submitted on this thread by
+ * begin(), which takes the flag; pre-setting it made that begin() coalesce
+ * and skip the write. */
+static inline bool
+pending_persist_end(struct pending_persist_ctl *c)
+{
+	c->in_flight = false;
+	if (!c->dirty) {
+		return false;
+	}
+	c->dirty = false;
+	return true;
+}
+
+#endif /* S3LVOL_PENDING_PERSIST_CTL_H */

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
@@ -745,25 +745,119 @@ int s3lvol_snapshot_query_lvol(struct spdk_lvol *lvol,
 			       bool *pending);
 
 /**
+ * Why a delete could not be carried out when it was asked for.
+ *
+ * The distinction that matters is whether the blocker clears on its own, which
+ * is what decides if the poller may finish the job -- see
+ * vbdev_s3lvol_pending.c. EXPORT does: an importer's lease goes stale once it
+ * stops renewing, and that is positive evidence nobody is reading any more.
+ * EXPORT_LEGACY is the deliberate exception -- an export with no lease at all,
+ * where only a TTL speaks and it lapses whether or not somebody is reading.
+ */
+enum s3lvol_pending_reason {
+	S3LVOL_PENDING_EXPORT,		/* an export pins it; its lease will say when */
+	S3LVOL_PENDING_EXPORT_LEGACY,	/* an export with no lease pins it */
+	S3LVOL_PENDING_EXPORT_INFLIGHT,	/* an export is publishing right now */
+	S3LVOL_PENDING_CLONE_COUNT,	/* more than one clone */
+	S3LVOL_PENDING_DECOUPLE,	/* a decouple is running on it */
+	S3LVOL_PENDING_FAILED,		/* the destroy failed asynchronously */
+};
+
+const char *s3lvol_pending_reason_str(enum s3lvol_pending_reason reason);
+
+/**
  * Record / test / clear the "a delete of this snapshot was attempted and could
- * not complete" mark. There is no deferred-completion poller: the mark only
- * shows up in rcow_get_lvstores, and the caller (today
- * test/tools/s3lvol_rpc.py --retry-pending) reissues rcow_delete_lvol once the
- * blocker (export pin, clones, decouple) clears. The list lives in memory only
- * and is gone on restart.
+ * not complete" mark.
+ *
+ * The mark is reported by rcow_get_lvstores (the PEND column) and by
+ * rcow_get_pending_deletes, and a poller completes the delete once the blocker
+ * clears -- for the reasons that clear on their own. Marks are also written to
+ * `<prefix>/meta/pending-deletes.json` and restored on attach.
  *
  * Keyed by (lvstore uuid, lvol uuid) rather than by name: a name is unique only
  * inside one loaded lvstore and is reusable, so a name-keyed mark can end up
- * pointing at an object the delete was never refused for. \c name is carried
- * for log lines only.
+ * pointing at an object the delete was never refused for. The names are carried
+ * for reporting only.
+ *
+ * Recording an intent that is already recorded updates its reason -- the
+ * blocker may differ from the one the first attempt hit -- and never enqueues
+ * twice.
  */
 void s3lvol_snapshot_pending_set(const struct spdk_uuid *lvs_uuid,
 				 const struct spdk_uuid *lvol_uuid,
-				 const char *snapshot_name);
+				 const char *lvs_name,
+				 const char *snapshot_name,
+				 enum s3lvol_pending_reason reason);
 bool s3lvol_snapshot_pending_test(const struct spdk_uuid *lvs_uuid,
 				  const struct spdk_uuid *lvol_uuid);
 void s3lvol_snapshot_pending_clear(const struct spdk_uuid *lvs_uuid,
 				   const struct spdk_uuid *lvol_uuid);
+
+/**
+ * Whether a recorded intent is one the poller will finish on its own.
+ *
+ * This is what rcow_delete_lvol reports as \c deferred: the delete was accepted
+ * as an intent and needs nothing further from the caller. A mark whose blocker
+ * needs a decision (a published export) answers false, and the RPC reports the
+ * refusal as it always has.
+ */
+bool s3lvol_snapshot_pending_deferred(const struct spdk_uuid *lvs_uuid,
+				      const struct spdk_uuid *lvol_uuid);
+
+/** One entry of the pending-delete queue, as handed to s3lvol_pending_foreach(). */
+struct s3lvol_pending_entry {
+	struct spdk_uuid           lvs_uuid;
+	struct spdk_uuid           lvol_uuid;
+	const char                *lvs_name;
+	const char                *lvol_name;
+	uint64_t                   enqueued_at;
+	enum s3lvol_pending_reason reason;
+	bool                       deferred;	/* the poller will complete it */
+};
+
+typedef void (*s3lvol_pending_cb)(void *cb_arg,
+				  const struct s3lvol_pending_entry *entry);
+
+/**
+ * Walk the pending-delete queue.
+ *
+ * Safe for the callback to cancel the entry it is looking at.
+ *
+ * \return the number of entries visited, or -EINVAL for a NULL callback.
+ */
+int s3lvol_pending_foreach(s3lvol_pending_cb cb, void *cb_arg);
+
+/**
+ * Restore this lvstore's queue from `<prefix>/meta/pending-deletes.json`.
+ *
+ * Fire and forget, and deliberately so: unlike the exports and imports
+ * registries, nothing here protects data -- the worst case is a delete the
+ * caller has to ask for again -- so a failure is logged and the attach carries
+ * on rather than being held up or refused. Entries land in the queue as the
+ * load completes, and the poller re-checks them from scratch; nothing is
+ * trusted about whether they are still deletable.
+ *
+ * The load does not keep a pointer to the wrapper. HEAD/GET callbacks
+ * re-resolve the live lvstore by uuid and drop the body if it is gone (or has
+ * been replaced by a same-name store with a different uuid). An extra S3
+ * client reference keeps CRT alive if unload races the request.
+ */
+void s3lvol_pending_load(struct s3lvol_lvstore *lvs);
+
+/**
+ * Park pending-delete registry HEAD or GET completions until
+ * s3lvol_pending_load_release(). Tests only: production never holds attach.
+ *
+ * \param stage  "head", "get", or "none" / NULL.
+ * \return 0, or -EINVAL for an unknown stage.
+ */
+int s3lvol_pending_load_hold(const char *stage);
+
+unsigned s3lvol_pending_load_parked_count(void);
+
+const char *s3lvol_pending_load_hold_name(void);
+
+unsigned s3lvol_pending_load_release(void);
 
 /**
  * Drop every pending-delete mark belonging to one lvstore.
@@ -792,6 +886,27 @@ bool s3lvol_export_inflight_pinning(struct s3lvol_lvstore *lvs,
  * so it wants to be comfortably longer than an import takes and far shorter than
  * "forever". An importer renews while it still needs the export. */
 #define S3LVOL_EXPORT_DEFAULT_TTL_SEC 3600
+
+/* The two ends of the lease clock, together because they are one decision.
+ *
+ * An importer renews every max(remaining_ttl/3, RENEW_MIN); the source treats a
+ * lease as fresh for 3x the cadence the importer reports, but never less than
+ * MIN_GRACE. The two numbers are chosen so that 3 * RENEW_MIN == MIN_GRACE: an
+ * import at the floor and a source at its floor agree exactly, rather than by two
+ * values happening to be compatible. Change one and the other has to move.
+ *
+ * Why the source clamps at all, rather than believing renew_s: the verdict it
+ * feeds, STALE, is carried out by a poller with nobody watching, and renew_s is a
+ * number the importer chose. An importer whose export was already past its
+ * deadline used to derive a one-second interval -- remaining_ttl of zero -- and
+ * so asked to be declared dead after three seconds. Nothing refuses an expired
+ * export at import, so that was reachable, and three seconds is inside the
+ * ordinary jitter of a WAN and an object store.
+ *
+ * The direction of the error is what settles the values. Too long only delays
+ * reclaiming a snapshot nobody is reading; too short deletes one somebody is. */
+#define S3LVOL_LEASE_RENEW_MIN_SEC 20
+#define S3LVOL_LEASE_MIN_GRACE_SEC (3 * S3LVOL_LEASE_RENEW_MIN_SEC)
 
 struct s3lvol_import_opts {
 	const char *lvol_name;/* name of the clone to create here */
@@ -1023,6 +1138,44 @@ int s3lvol_esnap_dev_create(void *bs_ctx, void *blob_ctx, struct spdk_blob *blob
 
 struct s3lvol_export;
 
+/**
+ * Why the snapshot is (or is not) held, for callers that need more than
+ * yes/no.
+ *
+ * Ordered by how restrictive the answer is, so aggregating several exports over
+ * one snapshot is a max().
+ *
+ * The distinction that matters is STALE versus LEGACY, and it is the reason this
+ * exists alongside s3lvol_export_pinning(): both let a delete through, but only
+ * STALE is *evidence* that nobody is reading (an importer wrote the lease and
+ * stopped renewing it). LEGACY is an export that predates the lease machinery,
+ * where a TTL lapses on its own whether or not somebody is still reading -- so a
+ * delete on that basis stays a decision the caller makes, and is never carried
+ * out unattended, until GC treats a reference manifest as live.
+ */
+enum s3lvol_export_pin {
+	S3LVOL_EXPORT_PIN_NONE,		/* no reference export names it */
+	S3LVOL_EXPORT_PIN_STALE,	/* named, but its lease says nobody reads */
+	S3LVOL_EXPORT_PIN_LEGACY,	/* named, no lease at all: only the TTL speaks */
+	S3LVOL_EXPORT_PIN_LEASE,	/* an importer is reading, or may be */
+};
+
+static inline const char *
+s3lvol_export_pin_str(enum s3lvol_export_pin pin)
+{
+	switch (pin) {
+	case S3LVOL_EXPORT_PIN_STALE:
+		return "stale";
+	case S3LVOL_EXPORT_PIN_LEGACY:
+		return "legacy";
+	case S3LVOL_EXPORT_PIN_LEASE:
+		return "lease";
+	case S3LVOL_EXPORT_PIN_NONE:
+	default:
+		return "none";
+	}
+}
+
 struct s3lvol_export_entry {
 	const char *export_uuid;
 	const char *snapshot;
@@ -1031,6 +1184,15 @@ struct s3lvol_export_entry {
 	uint32_t    generation;
 	bool    is_ref;
 	bool    expired;
+	bool    lease_aware;
+	bool    lease_checked;
+	bool    lease_absent;
+	bool    lease_watch;
+	bool    snapshot_alive;
+	bool    reaping;
+	uint64_t    lease_updated_at;
+	uint32_t    lease_renew_s;
+	enum s3lvol_export_pin pin;
 };
 
 /**
@@ -1042,6 +1204,9 @@ struct s3lvol_export_entry {
  */
 struct s3lvol_export *s3lvol_export_pinning(struct s3lvol_lvstore *lvs,
 					    const char *snapshot_name);
+
+enum s3lvol_export_pin s3lvol_export_pin_state(struct s3lvol_lvstore *lvs,
+					       const char *snapshot_name);
 
 struct s3lvol_export *s3lvol_export_find(struct s3lvol_lvstore *lvs,
 					 const char *uuid_str);

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
@@ -543,13 +543,33 @@ int s3lvol_lvol_create(struct s3lvol_lvstore *lvs, const char *name,
  * the missing bdev.
  */
 /* True while the lvol is in the decouple queue, running or waiting its turn.
- * A snapshot or clone must not be taken of such a volume: the snapshot would
- * take the external snapshot identity with it, and the queued decouple would
- * then fail its detach after materialising the data. */
+ * A snapshot or clone must not be taken of such a volume while this holds: the
+ * snapshot would take the external snapshot identity with it, and the decouple
+ * would then fail its detach after materialising the data. create_snapshot
+ * cancels the decouple rather than refusing -- see s3lvol_decouple_cancel(). */
 bool s3lvol_lvol_decouple_pending(const struct spdk_lvol *lvol);
 
+/**
+ * Stop decoupling this lvol so that a snapshot may be taken of it.
+ *
+ * \return 0  nothing to cancel, or done synchronously -- carry on immediately
+ *         1  under way; cb_fn is called once the decouple has stopped
+ *         <0 error (-EBUSY if a cancellation is already pending)
+ */
+int s3lvol_decouple_cancel(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn,
+			   void *cb_arg);
+
+/**
+ * Create a read-only snapshot of an lvol, and register it as a bdev.
+ *
+ * If a decouple is in flight on \p lvol it is cancelled first, which makes this
+ * asynchronous even before the snapshot itself starts; \p out_cancelled_decouple,
+ * when not NULL, is set synchronously to say whether that happened, so a caller
+ * can report that the volume it asked to be decoupled no longer will be.
+ */
 int s3lvol_lvol_create_snapshot(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol,
 				const char *snapshot_name,
+				bool *out_cancelled_decouple,
 				s3lvol_lvol_op_cb cb_fn, void *cb_arg);
 
 /**
@@ -743,6 +763,33 @@ int s3lvol_snapshot_query(const char *snapshot_name,
 int s3lvol_snapshot_query_lvol(struct spdk_lvol *lvol,
 			       enum s3lvol_export_state *state, bool *deletable,
 			       bool *pending);
+
+/**
+ * How many layers a zero-copy export of \p lvol would have to walk.
+ *
+ * The same walk export_build_chain() performs, counting rather than collecting,
+ * so the number answers a question with a consequence: past
+ * S3LVOL_DEFAULT_MAX_CHAIN_DEPTH that export stops being zero-copy and becomes a
+ * full copy of the volume -- and the resulting dense export is permanent, since
+ * the reaper only ever collects reference exports (their snapshot going away is
+ * what makes them collectable, which says nothing about a self-contained one).
+ *
+ * Which is why this is reported rather than merely bounded. The fallback to
+ * copying is correct and silent, so without a number in hand there is no way to
+ * tell a node approaching it from one nowhere near, and the first evidence would
+ * be the duplicate objects after it happened.
+ *
+ * Includes \p lvol itself, so a volume with no parent is 1. Counts through an
+ * esnap clone to the clone and stops there: what lies beyond is another
+ * lvstore's, and the export names it out of the parent manifest rather than
+ * walking it. Not capped -- how far past a threshold a chain is, is the useful
+ * part.
+ *
+ * \return the depth, or 0 if the lvol has no open blob (a deactivated volume
+ *         cannot be asked, exactly as the cluster counts cannot).
+ */
+uint32_t s3lvol_lvol_chain_depth(struct s3lvol_lvstore *lvs,
+				 struct spdk_lvol *lvol);
 
 /**
  * Why a delete could not be carried out when it was asked for.
@@ -1217,6 +1264,7 @@ struct s3lvol_export *s3lvol_export_add(struct s3lvol_lvstore *lvs,
 					const char *snapshot_name);
 void s3lvol_export_forget(struct s3lvol_export *exp);
 void s3lvol_export_set_materialised(struct s3lvol_export *exp, uint32_t generation);
+void s3lvol_export_set_local_ref(struct s3lvol_export *exp, uint32_t generation);
 
 struct s3lvol_export *s3lvol_export_first(struct s3lvol_lvstore *lvs);
 struct s3lvol_export *s3lvol_export_next(struct s3lvol_export *prev);
@@ -1241,6 +1289,39 @@ int s3lvol_xfer_exports_load(struct s3lvol_lvstore *lvs,
 			     spdk_lvs_op_complete cb_fn, void *cb_arg);
 
 void s3lvol_xfer_exports_fini(struct s3lvol_lvstore *lvs);
+
+/**
+ * Turn a reference export into a copied one, so this node stops owing anybody
+ * its snapshot.
+ *
+ * A reference export names this lvstore's live chunk objects, which is why it
+ * pins the snapshot behind it: those objects cannot be reclaimed while an
+ * importer may read them. There is no way out of that today -- the snapshot
+ * stays undeletable for as long as any importer keeps renewing, however little
+ * it still needs the data. Materialising is the way out: read the snapshot,
+ * upload the export's own copies, and publish the manifest again as dense with
+ * `generation` bumped.
+ *
+ * Afterwards the export owes nothing. It holds copies, so the pin goes, the
+ * lease watch stops, and the TTL is meaningless -- see
+ * s3lvol_export_set_materialised().
+ *
+ * **Importers are not told, and do not have to be.** The manifest is replaced in
+ * place, so an importer holding the old one keeps reading until the objects it
+ * names disappear; the 404 then makes it refetch, find the higher generation, and
+ * carry on against the copies. That is why the ordering here is not negotiable:
+ * the new manifest has to be published before the old objects can be deleted, or
+ * a reader hits a 404 and refetches into the manifest that sent it there.
+ *
+ * This does not delete the old chunk objects. They belong to the snapshot's chunk
+ * map, not to the export, and they go when the snapshot does -- which is now
+ * allowed to happen.
+ *
+ * \return 0 with the callback pending; -ENOENT if no such export; -EALREADY if it
+ * is already a copy; -EBUSY if a materialisation of it is already running.
+ */
+int s3lvol_export_materialise(struct s3lvol_lvstore *lvs, const char *export_uuid,
+			      spdk_lvol_op_complete cb_fn, void *cb_arg);
 
 struct s3lvol_import *s3lvol_import_first(struct s3lvol_lvstore *lvs);
 struct s3lvol_import *s3lvol_import_next(struct s3lvol_import *prev);

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.h
@@ -353,6 +353,27 @@ int s3lvol_nvmf_remove_ns(const char *nqn, uint32_t nsid,
 int s3lvol_nvmf_resolve_device(const char *uuid_str, char *out, size_t out_len);
 
 /**
+ * True when \p dev is the live host node for \p uuid_str.
+ *
+ * sysfs can publish a namespace before udev creates (or replaces) /dev, and
+ * after deactive then reactivate at the same nsid the leftover node can still
+ * belong to the previous occupant. Ready means: it is a block device, its
+ * major:minor matches /sys/block/<name>/dev, and that sysfs directory names
+ * this uuid.
+ */
+bool s3lvol_nvmf_device_is_ready(const char *dev, const char *uuid_str);
+
+/**
+ * True when udev has no events left to apply.
+ *
+ * A ready node is only stable once udev is done: a pending REMOVE for the
+ * previous occupant of the same nsid can still unlink /dev after the checks
+ * above pass. Steady state answers from a single access(2), so callers can
+ * test this before deciding to wait at all.
+ */
+bool s3lvol_nvmf_udev_settled(void);
+
+/**
  * Readahead, in KiB, to apply to a freshly discovered host device.
  *
  * The chunk size, and for the same reason the transport's max_io_size is: what a

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_exports.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_exports.c
@@ -44,6 +44,7 @@
 
 #include "vbdev_s3lvol.h"
 #include "vbdev_s3lvol_json.h"
+#include "export_lease_term.h"
 
 /* Same reasoning as the import cap: the registry is read into a fixed decoder
  * table, and a node with more live exports than this has a different problem.
@@ -56,121 +57,6 @@
  * machinery below), so this bounds a registry nobody is maintaining rather
  * than a working set. */
 #define S3LVOL_MAX_EXPORTS 256
-
-/* === Pending-delete marks ==================================================
- * A delete that cannot complete because the snapshot is referenced (an export
- * pins it, it has clones, or a decouple is running) records the intent here.
- * rcow_get_lvstores reports it so the caller sees the snapshot was "tried to
- * delete" and can retry once the blocker clears. The deferred-completion poller
- * is a later step.
- *
- * Keyed by (lvstore uuid, lvol uuid), not by name. A name is unique only within
- * one loaded lvstore and is reusable: delete a snapshot and create another one
- * by the same name, or unload the lvstore and attach it again, and a name-keyed
- * mark would point at a different object than the one the delete was refused
- * for -- which --retry-pending would then delete. A lvol uuid is generated once
- * and never reused, so the mark can only ever name the object it was recorded
- * for. The lvstore uuid groups the marks so a teardown can drop them all
- * (s3lvol_snapshot_pending_clear_lvs()); the name is kept for log lines only.
- */
-
-struct s3lvol_pending_delete {
-	struct spdk_uuid           lvs_uuid;
-	struct spdk_uuid           lvol_uuid;
-	char                       name[SPDK_LVOL_NAME_MAX];
-	TAILQ_ENTRY(s3lvol_pending_delete) link;
-};
-
-static TAILQ_HEAD(, s3lvol_pending_delete) g_pending_deletes =
-	TAILQ_HEAD_INITIALIZER(g_pending_deletes);
-
-static struct s3lvol_pending_delete *
-pending_delete_find(const struct spdk_uuid *lvs_uuid,
-		    const struct spdk_uuid *lvol_uuid)
-{
-	struct s3lvol_pending_delete *pd;
-
-	TAILQ_FOREACH(pd, &g_pending_deletes, link) {
-		if (spdk_uuid_compare(&pd->lvs_uuid, lvs_uuid) == 0 &&
-		    spdk_uuid_compare(&pd->lvol_uuid, lvol_uuid) == 0) {
-			return pd;
-		}
-	}
-	return NULL;
-}
-
-void
-s3lvol_snapshot_pending_set(const struct spdk_uuid *lvs_uuid,
-			    const struct spdk_uuid *lvol_uuid,
-			    const char *name)
-{
-	struct s3lvol_pending_delete *pd;
-
-	if (!lvs_uuid || !lvol_uuid) {
-		return;
-	}
-	if (pending_delete_find(lvs_uuid, lvol_uuid)) {
-		return;
-	}
-	pd = calloc(1, sizeof(*pd));
-	if (!pd) {
-		SPDK_ERRLOG("failed to allocate pending-delete mark for '%s'\n",
-			    name ? name : "(unnamed)");
-		return;
-	}
-	spdk_uuid_copy(&pd->lvs_uuid, lvs_uuid);
-	spdk_uuid_copy(&pd->lvol_uuid, lvol_uuid);
-	snprintf(pd->name, sizeof(pd->name), "%s", name ? name : "");
-	TAILQ_INSERT_TAIL(&g_pending_deletes, pd, link);
-}
-
-bool
-s3lvol_snapshot_pending_test(const struct spdk_uuid *lvs_uuid,
-			     const struct spdk_uuid *lvol_uuid)
-{
-	if (!lvs_uuid || !lvol_uuid) {
-		return false;
-	}
-	return pending_delete_find(lvs_uuid, lvol_uuid) != NULL;
-}
-
-void
-s3lvol_snapshot_pending_clear(const struct spdk_uuid *lvs_uuid,
-			      const struct spdk_uuid *lvol_uuid)
-{
-	struct s3lvol_pending_delete *pd;
-
-	if (!lvs_uuid || !lvol_uuid) {
-		return;
-	}
-	pd = pending_delete_find(lvs_uuid, lvol_uuid);
-	if (pd) {
-		TAILQ_REMOVE(&g_pending_deletes, pd, link);
-		free(pd);
-	}
-}
-
-/* Every mark belonging to one lvstore, dropped in one go.
- *
- * Called from the unload / destroy / free paths: past a teardown the marks name
- * lvols that no longer exist, and an lvstore that is attached again can hand the
- * same names to different objects. Marks that outlive their lvstore are how
- * --retry-pending could end up deleting something nobody asked it to. */
-void
-s3lvol_snapshot_pending_clear_lvs(const struct spdk_uuid *lvs_uuid)
-{
-	struct s3lvol_pending_delete *pd, *tmp;
-
-	if (!lvs_uuid) {
-		return;
-	}
-	TAILQ_FOREACH_SAFE(pd, &g_pending_deletes, link, tmp) {
-		if (spdk_uuid_compare(&pd->lvs_uuid, lvs_uuid) == 0) {
-			TAILQ_REMOVE(&g_pending_deletes, pd, link);
-			free(pd);
-		}
-	}
-}
 
 /* One in-flight lease check. Defined below, next to the machinery that uses it;
  * named here because an export points at the check it is waiting for. */
@@ -203,6 +89,16 @@ struct s3lvol_export {
 	 *                    not exist (no importer ever, or legacy export).
 	 *   lease_renew_s    the importer's renew interval in seconds, so the
 	 *                    grace period is 3x *its* cadence, not a guess.
+	 *   lease_absent     the last completed check was a definite miss
+	 *                    (404 or an empty/unreadable body), not a failed
+	 *                    HEAD. export_lease_failed() never sets this: a
+	 *                    bucket this node cannot reach must not look like
+	 *                    "nobody imported", or the reaper would delete a
+	 *                    live export's manifest during an outage.
+	 *   lease_absent_at  when that miss's check was submitted. Terminal reap
+	 *                    requires this >= expires_at: a 404 from before the
+	 *                    deadline does not speak for an importer that PUTs
+	 *                    the lease in the remaining window.
 	 *
 	 * lease_poller refreshes these on the lvstore's thread. Dense exports get
 	 * no poller: they hold their own copies and pin nothing, so there is no
@@ -219,16 +115,44 @@ struct s3lvol_export {
 	 * 404, so a bucket this node cannot reach does not pin every snapshot for
 	 * ever: see the fallback in export_lease_failed(). */
 	bool                       lease_checked;
+	bool                       lease_absent;
+	uint64_t                   lease_absent_at;
 	uint64_t                   lease_updated_at;
 	uint32_t                   lease_renew_s;
 	uint32_t                   lease_failures;
 	struct spdk_poller        *lease_poller;
 	struct export_lease_get_ctx *lease_fetch;
 
+	/* This export was created by a build whose importers renew a lease.
+	 *
+	 * It is what makes "no lease object" readable. Without it the absence is
+	 * ambiguous -- nobody ever imported, or an importer from before leases
+	 * existed is reading right now and leaves no trace -- and the only safe
+	 * reading of an ambiguous answer is the second one, which means the
+	 * export pins its snapshot until somebody releases it by hand. With it,
+	 * an absent lease past the deadline means exactly one thing: no importer
+	 * ever came. That is the common case for an export nobody consumed, and
+	 * it is the one this flag lets the delete path finish on its own.
+	 *
+	 * Written into the registry, so it survives a restart; absent from
+	 * entries written by older builds, which therefore keep the old
+	 * behaviour. */
+	bool                       lease_aware;
+
+	/* A reap of this entry is in flight. The reaper is a poller, the release
+	 * it starts is asynchronous, and the entry stays in the list until that
+	 * release completes -- so without this the next tick would start a second
+	 * release of the same export. */
+	bool                       reaping;
+
 	TAILQ_ENTRY(s3lvol_export) link;
 };
 
 static TAILQ_HEAD(, s3lvol_export) g_exports = TAILQ_HEAD_INITIALIZER(g_exports);
+
+/* Reaps entries whose snapshot is gone; see the reaping section below. */
+static struct spdk_poller *g_exports_reaper;
+static void exports_reaper_sync(void);
 
 /* Liveness lease machinery. Declared here because s3lvol_export_add()
  * starts the watch, while the implementations live further down where the
@@ -312,15 +236,15 @@ s3lvol_export_find(struct s3lvol_lvstore *lvs, const char *uuid_str)
  * leases existed, and says so once. */
 #define S3LVOL_LEASE_MAX_FAILURES 5
 
-/* Grace period assumed when a lease carries updated_at but no renew_s.
+/* The shortest grace period this node will apply, and the one it assumes when a
+ * lease carries updated_at but no renew_s.
  *
- * That means a newer source reading an older importer's lease. Deriving the
- * interval from the remaining TTL is wrong here: this situation is most likely
- * *after* the TTL has passed, which is exactly when the lease matters, and the
- * derivation would then collapse to the one-second floor -- far too tight for
- * cross-node clock skew plus S3 latency, so a live importer would look stale.
- * A fixed, generous value is the safe reading of an ambiguous object. */
-#define S3LVOL_LEASE_DEFAULT_GRACE_SEC 60
+ * Both cases and the reasoning behind the value live with the constant, in
+ * vbdev_s3lvol.h, next to the renew floor it is tied to. The second case is a
+ * newer source reading an older importer's lease: deriving a grace from the
+ * remaining TTL is wrong there, because that situation is most likely *after* the
+ * deadline has passed -- which is exactly when the lease matters -- and the
+ * derivation would collapse to a second or two. */
 
 static void
 s3lvol_export_lease_key(struct s3lvol_export *exp, char *out, size_t out_len)
@@ -336,7 +260,49 @@ struct export_lease_get_ctx {
 	char                  key[S3_EXPORT_KEY_MAX];
 	char                 *body;
 	uint64_t              size;
+	/* time(NULL) at s3_head, not at completion: a check that left before
+	 * expires_at cannot confirm the lease is gone after it. */
+	uint64_t              submitted_at;
 };
+
+/* A lease-aware reference export whose lease object is confirmed gone, after
+ * the deadline. No importer can appear later -- they must write the lease
+ * before they can read -- so watching it, and keeping the registry entry, is
+ * a leak. Distinct from lease_updated_at == 0: that is also the fallback
+ * after S3LVOL_LEASE_MAX_FAILURES, which must not reap. The miss itself has
+ * to post-date the deadline; see export_lease_miss_confirms_gone(). */
+static bool
+export_lease_is_terminal(const struct s3lvol_export *exp)
+{
+	return exp->layout == S3_EXPORT_LAYOUT_REF
+	       && exp->lease_aware
+	       && export_lease_miss_confirms_gone(exp->lease_absent,
+						   exp->lease_absent_at,
+						   exp->expires_at,
+						   (uint64_t)time(NULL));
+}
+
+static void
+export_lease_note_absent(struct s3lvol_export *exp, uint64_t submitted_at)
+{
+	exp->lease_checked = true;
+	exp->lease_absent = true;
+	exp->lease_absent_at = submitted_at;
+	exp->lease_updated_at = 0;
+	exp->lease_failures = 0;
+	exp->lease_renew_s = 0;
+}
+
+static void
+export_lease_stop_if_terminal(struct s3lvol_export *exp)
+{
+	if (!export_lease_is_terminal(exp) || !exp->lease_poller) {
+		return;
+	}
+	SPDK_NOTICELOG("lease of export %s is absent past the deadline; "
+		       "stopping the watch\n", exp->uuid_str);
+	s3lvol_export_lease_stop(exp);
+}
 
 static void
 export_lease_get_done(struct export_lease_get_ctx *ctx)
@@ -406,13 +372,12 @@ export_lease_got_body(void *cb_arg, uint64_t bytes_read, int status)
 		if (status == -ENOENT) {
 			/* Deleted between the HEAD and the GET -- release does
 			 * exactly this. No lease means the TTL decides. */
-			exp->lease_checked = true;
-			exp->lease_updated_at = 0;
-			exp->lease_failures = 0;
+			export_lease_note_absent(exp, ctx->submitted_at);
 		} else {
 			export_lease_failed(exp, status);
 		}
 		export_lease_get_done(ctx);
+		export_lease_stop_if_terminal(exp);
 		return;
 	}
 
@@ -433,12 +398,22 @@ export_lease_got_body(void *cb_arg, uint64_t bytes_read, int status)
 	/* A lease that carries no updated_at is not a lease we recognise. Treat
 	 * it as absent: legacy TTL fallback, which is exactly what a pre-lease
 	 * object would need. */
+	if (updated_at == 0) {
+		export_lease_note_absent(exp, ctx->submitted_at);
+		export_lease_get_done(ctx);
+		export_lease_stop_if_terminal(exp);
+		return;
+	}
+
 	exp->lease_checked = true;
 	exp->lease_updated_at = updated_at;
 	exp->lease_renew_s = (updated_at != 0) ? renew_s : 0;
 	exp->lease_failures = 0;
+	exp->lease_absent = false;
+	exp->lease_absent_at = 0;
 
 	export_lease_get_done(ctx);
+	export_lease_stop_if_terminal(exp);
 }
 
 static void
@@ -454,10 +429,9 @@ export_lease_head_done(void *cb_arg, int status)
 	}
 
 	if (status == -ENOENT) {
-		exp->lease_checked = true;
-		exp->lease_updated_at = 0;
-		exp->lease_failures = 0;
+		export_lease_note_absent(exp, ctx->submitted_at);
 		export_lease_get_done(ctx);
+		export_lease_stop_if_terminal(exp);
 		return;
 	}
 	if (status != 0) {
@@ -468,10 +442,9 @@ export_lease_head_done(void *cb_arg, int status)
 	/* Empty or implausible: not a lease we can read, and not an error either.
 	 * The TTL decides, as it does for an export nobody ever imported. */
 	if (ctx->size == 0 || ctx->size > 4096) {
-		exp->lease_checked = true;
-		exp->lease_updated_at = 0;
-		exp->lease_failures = 0;
+		export_lease_note_absent(exp, ctx->submitted_at);
 		export_lease_get_done(ctx);
+		export_lease_stop_if_terminal(exp);
 		return;
 	}
 
@@ -497,6 +470,15 @@ export_lease_renew(void *arg)
 	struct export_lease_get_ctx *ctx;
 	int rc;
 
+	/* Deadline passed and a check submitted at or after it missed: further
+	 * HEADs cannot change that, and they are the 404 storm a restart used to
+	 * amplify. The reaper collects the entry; this just stops asking. A miss
+	 * from before the deadline is not enough -- an importer may still PUT. */
+	if (export_lease_is_terminal(exp)) {
+		export_lease_stop_if_terminal(exp);
+		return SPDK_POLLER_IDLE;
+	}
+
 	/* One check at a time. A slow bucket must not queue a check per tick,
 	 * and the completion writes to fields a second check would race on. */
 	if (exp->lease_fetch) {
@@ -508,6 +490,7 @@ export_lease_renew(void *arg)
 		return SPDK_POLLER_IDLE;
 	}
 	ctx->exp = exp;
+	ctx->submitted_at = (uint64_t)time(NULL);
 	s3lvol_export_lease_key(exp, ctx->key, sizeof(ctx->key));
 	exp->lease_fetch = ctx;
 
@@ -550,14 +533,23 @@ s3lvol_export_lease_start(struct s3lvol_export *exp)
 
 	/* Poll at the cadence the importer is expected to renew at, so a stopped
 	 * renewer is noticed within one grace period. The importer's interval is
-	 * max(1 s, remaining_ttl/3) computed at import time; this is the same
-	 * formula against this node's clock, which is close enough -- and the
-	 * grace period is 3x the *importer's* reported interval, not this poll
-	 * interval, so the safety margin does not depend on the two clocks
-	 * agreeing exactly. */
+	 * max(S3LVOL_LEASE_RENEW_MIN_SEC, remaining_ttl/3) computed at import
+	 * time; this is the same formula against this node's clock, which is
+	 * close enough -- and the grace period is 3x the *importer's* reported
+	 * interval, not this poll interval, so the safety margin does not depend
+	 * on the two clocks agreeing exactly.
+	 *
+	 * The floor has to be the same one, or the mirror stops being a mirror:
+	 * without it an export past its deadline polls every second for the life
+	 * of the import, which is a GET per second per export and buys nothing --
+	 * the lease it is reading cannot go stale any sooner than the grace period
+	 * allows. */
 	remaining = (exp->expires_at > (uint64_t)time(NULL))
 		    ? (exp->expires_at - (uint64_t)time(NULL)) : 0;
-	interval = (remaining / 3) ? (remaining / 3) : 1;
+	interval = remaining / 3;
+	if (interval < S3LVOL_LEASE_RENEW_MIN_SEC) {
+		interval = S3LVOL_LEASE_RENEW_MIN_SEC;
+	}
 
 	exp->lease_poller = SPDK_POLLER_REGISTER(export_lease_renew, exp,
 						 interval * SPDK_SEC_TO_USEC);
@@ -569,6 +561,129 @@ s3lvol_export_lease_start(struct s3lvol_export *exp)
 
 	SPDK_NOTICELOG("watching lease of export %s every %" PRIu64
 		       " second(s)\n", exp->uuid_str, interval);
+
+	/* And check once now, rather than at the end of the first interval.
+	 *
+	 * The interval is a third of the TTL, which is twenty minutes at the
+	 * default hour -- so without this, "has anybody imported this" stays
+	 * unanswered for twenty minutes after the export was published, and every
+	 * delete in that window is held on the possibility of an importer. The
+	 * first answer is the one that matters most: an export nobody consumed can
+	 * only be recognised by its lease being absent. */
+	export_lease_renew(exp);
+}
+
+/* One export's verdict on one snapshot. Split out of s3lvol_export_pinning()
+ * because two callers need different amounts of detail from the same decision:
+ * the delete path only asks "may I delete this now", while the pending-delete
+ * poller also has to know *why* the answer is yes.
+ *
+ * That distinction is the whole point. A lease that has gone stale is positive
+ * evidence -- an importer wrote it and stopped renewing, so nobody is reading --
+ * and a delete on that basis is safe to carry out unattended. An export with no
+ * lease object at all is the legacy case, where the only signal is a TTL that
+ * lapses on its own whether or not somebody is still reading; that one has to
+ * stay a decision a human (or an explicit retry) makes, until GC treats a
+ * reference manifest as live. Collapsing both into "not pinned" is what would
+ * turn expiry into the automatic path to deleting data underneath a reader. */
+static enum s3lvol_export_pin
+export_pin_verdict(const struct s3lvol_export *exp)
+{
+	uint64_t now, grace;
+
+	/* A dense export holds copies, so it does not pin the snapshot. */
+	if (exp->layout != S3_EXPORT_LAYOUT_REF) {
+		return S3LVOL_EXPORT_PIN_NONE;
+	}
+
+	/* Before the first GET completes, assume the lease may exist and an
+	 * importer may be reading it: refuse, and let the next poll decide. */
+	if (!exp->lease_checked) {
+		return S3LVOL_EXPORT_PIN_LEASE;
+	}
+
+	/* No lease object. Two very different situations, and the flag is what
+	 * tells them apart.
+	 *
+	 * On a lease-aware export any importer would have written one, so an
+	 * absent lease means nobody ever imported -- but only once the deadline
+	 * has passed. Before that, the export is a standing promise to an
+	 * importer the control plane may not have started yet: the lease is
+	 * written when the esnap clone exists, so an import that is under way has
+	 * not written one either, and deleting the snapshot on the strength of
+	 * "no lease" would break exactly the importer the TTL exists to admit.
+	 *
+	 * Past the deadline, STALE only if the miss itself was observed on a
+	 * check submitted at or after expires_at. A 404 from before the
+	 * deadline is not evidence that nobody imported: the control plane can
+	 * still PUT a lease in the remaining window, and the reaper must not
+	 * drop that import's manifest. Until a post-deadline check misses,
+	 * keep LEASE -- refuse the unattended delete.
+	 *
+	 * Without the flag the absence stays ambiguous (an importer from before
+	 * leases existed reads without writing one), so it remains LEGACY: the TTL
+	 * still lets a delete through, but never one nobody asked for twice. */
+	if (exp->lease_updated_at == 0) {
+		if (exp->lease_aware) {
+			if (exp->lease_absent) {
+				return export_lease_miss_confirms_gone(
+					       true, exp->lease_absent_at,
+					       exp->expires_at,
+					       (uint64_t)time(NULL))
+				       ? S3LVOL_EXPORT_PIN_STALE
+				       : S3LVOL_EXPORT_PIN_LEASE;
+			}
+			return s3lvol_export_is_expired(exp)
+			       ? S3LVOL_EXPORT_PIN_STALE
+			       : S3LVOL_EXPORT_PIN_LEASE;
+		}
+		return S3LVOL_EXPORT_PIN_LEGACY;
+	}
+
+	now = (uint64_t)time(NULL);
+	grace = 3 * (uint64_t)exp->lease_renew_s;
+	if (grace < S3LVOL_LEASE_MIN_GRACE_SEC) {
+		/* Either no renew_s at all (an older importer), or one small enough
+		 * that honouring it would delete data under a reader that is merely
+		 * slow. See the constant. */
+		grace = S3LVOL_LEASE_MIN_GRACE_SEC;
+	}
+	/* Guard against a lease stamped in the future -- a skewed importer clock
+	 * would otherwise make now - updated_at wrap and read as ancient. */
+	if (exp->lease_updated_at > now || now - exp->lease_updated_at < grace) {
+		return S3LVOL_EXPORT_PIN_LEASE;
+	}
+	return S3LVOL_EXPORT_PIN_STALE;
+}
+
+enum s3lvol_export_pin
+s3lvol_export_pin_state(struct s3lvol_lvstore *lvs, const char *snapshot_name)
+{
+	enum s3lvol_export_pin worst = S3LVOL_EXPORT_PIN_NONE;
+	struct s3lvol_export *exp;
+
+	if (!lvs || !snapshot_name) {
+		return S3LVOL_EXPORT_PIN_NONE;
+	}
+
+	/* Several exports can name the same snapshot, and the most restrictive
+	 * verdict wins: one live reader is enough to pin it, and one export whose
+	 * liveness is unknowable is enough to keep the delete a decision. */
+	TAILQ_FOREACH(exp, &g_exports, link) {
+		enum s3lvol_export_pin v;
+
+		if (exp->lvs != lvs || strcmp(exp->snapshot, snapshot_name) != 0) {
+			continue;
+		}
+		v = export_pin_verdict(exp);
+		if (v == S3LVOL_EXPORT_PIN_LEASE) {
+			return S3LVOL_EXPORT_PIN_LEASE;
+		}
+		if (v > worst) {
+			worst = v;
+		}
+	}
+	return worst;
 }
 
 struct s3lvol_export *
@@ -581,57 +696,29 @@ s3lvol_export_pinning(struct s3lvol_lvstore *lvs, const char *snapshot_name)
 	}
 
 	TAILQ_FOREACH(exp, &g_exports, link) {
-		uint64_t now, grace;
-
 		if (exp->lvs != lvs || strcmp(exp->snapshot, snapshot_name) != 0) {
 			continue;
 		}
-		/* A dense export holds copies, so it does not pin the snapshot.
-		 * Reported as "not pinning", which lets the delete proceed. */
-		if (exp->layout != S3_EXPORT_LAYOUT_REF) {
+
+		switch (export_pin_verdict(exp)) {
+		case S3LVOL_EXPORT_PIN_LEASE:
+			/* An importer is reading, or may be. */
+			return exp;
+		case S3LVOL_EXPORT_PIN_LEGACY:
+			/* No lease: the TTL decides, as it always has. */
+			if (!s3lvol_export_is_expired(exp)) {
+				return exp;
+			}
+			continue;
+		case S3LVOL_EXPORT_PIN_STALE:
+			/* Nobody has renewed in three intervals. The TTL has
+			 * almost certainly passed too (the lease is younger
+			 * than the TTL), but even if not, nobody is reading. */
+			continue;
+		case S3LVOL_EXPORT_PIN_NONE:
+		default:
 			continue;
 		}
-
-		/* Lease first. Once the first GET has completed, a lease that
-		 * exists decides the question on its own: fresh means an importer
-		 * is still reading, stale means nobody has renewed in 3 intervals
-		 * and the snapshot can go. Before that first GET, assume the
-		 * lease may exist (safe direction). */
-		if (exp->lease_checked) {
-			if (exp->lease_updated_at != 0) {
-				now = (uint64_t)time(NULL);
-				grace = 3 * (uint64_t)exp->lease_renew_s;
-				if (grace == 0) {
-					/* A lease with no renew_s: an older
-					 * importer. See the constant for why this
-					 * is a fixed value and not derived from
-					 * the deadline. */
-					grace = S3LVOL_LEASE_DEFAULT_GRACE_SEC;
-				}
-				/* Guard against a lease stamped in the future --
-				 * a skewed importer clock would otherwise make
-				 * now - updated_at wrap and read as ancient. */
-				if (exp->lease_updated_at > now ||
-				    now - exp->lease_updated_at < grace) {
-					return exp;
-				}
-				/* Stale lease: no importer has renewed. The TTL
-				 * has almost certainly passed too (the lease is
-				 * younger than the TTL), but even if not, nobody
-				 * is reading, so the delete may proceed. */
-				continue;
-			}
-			/* No lease object. Legacy: TTL decides, as it always
-			 * has. */
-			if (s3lvol_export_is_expired(exp)) {
-				continue;
-			}
-			return exp;
-		}
-
-		/* First GET not done yet. Behave as if an importer may be
-		 * reading: refuse, and let the next poll decide. */
-		return exp;
 	}
 	return NULL;
 }
@@ -665,6 +752,8 @@ s3lvol_export_next(struct s3lvol_export *prev)
 void
 s3lvol_export_get(const struct s3lvol_export *exp, struct s3lvol_export_entry *out)
 {
+	struct spdk_lvol *lvol;
+
 	out->export_uuid = exp->uuid_str;
 	out->snapshot    = exp->snapshot;
 	out->blob_id     = exp->blob_id;
@@ -672,6 +761,18 @@ s3lvol_export_get(const struct s3lvol_export *exp, struct s3lvol_export_entry *o
 	out->generation  = exp->generation;
 	out->is_ref      = (exp->layout == S3_EXPORT_LAYOUT_REF);
 	out->expired     = s3lvol_export_is_expired(exp);
+	out->lease_aware = exp->lease_aware;
+	out->lease_checked = exp->lease_checked;
+	out->lease_absent = exp->lease_absent;
+	out->lease_watch = exp->lease_poller != NULL;
+	out->lease_updated_at = exp->lease_updated_at;
+	out->lease_renew_s = exp->lease_renew_s;
+	out->pin = export_pin_verdict(exp);
+	out->reaping = exp->reaping;
+
+	lvol = s3lvol_lvol_find(exp->lvs, exp->snapshot);
+	out->snapshot_alive = lvol &&
+			      (exp->blob_id == 0 || lvol->blob_id == exp->blob_id);
 }
 
 /* ==========================================================================
@@ -693,6 +794,8 @@ s3lvol_export_add(struct s3lvol_lvstore *lvs, const struct s3_export_manifest *m
 	exp->blob_id    = m->src.blob_id;
 	exp->expires_at = m->expires_at;
 	exp->generation = m->generation;
+	/* Created by this build, so any importer of it renews a lease. */
+	exp->lease_aware = true;
 	snprintf(exp->uuid_str, sizeof(exp->uuid_str), "%s", m->uuid_str);
 	snprintf(exp->snapshot, sizeof(exp->snapshot), "%s", snapshot_name);
 
@@ -704,6 +807,7 @@ s3lvol_export_add(struct s3lvol_lvstore *lvs, const struct s3_export_manifest *m
 	 * and an attach resurrecting the registry because the importers it
 	 * describes may still be reading. */
 	s3lvol_export_lease_start(exp);
+	exports_reaper_sync();
 
 	return exp;
 }
@@ -714,6 +818,229 @@ s3lvol_export_forget(struct s3lvol_export *exp)
 	s3lvol_export_lease_stop(exp);
 	TAILQ_REMOVE(&g_exports, exp, link);
 	free(exp);
+	exports_reaper_sync();
+}
+
+/* ==========================================================================
+ * Reaping exports nothing can serve any more
+ *
+ * A reference export is its snapshot: the manifest names the snapshot's live
+ * chunk objects, and deleting the snapshot releases them. So once the snapshot
+ * is gone the export cannot be imported by anyone, ever -- what is left is a
+ * registry entry and a manifest object that nothing will read.
+ *
+ * The other terminal state is a lease-aware export nobody imported, once its
+ * deadline has passed. The lease object is confirmed absent (HEAD 404), and an
+ * importer has to write one before it can read, so nothing will appear later.
+ * The snapshot may still be here -- a control plane that treats a refused
+ * delete as success never comes back -- but the registry entry is already
+ * garbage, and leaving it up is a HEAD against a missing key for the life of
+ * the process, resurrected on every attach.
+ *
+ * They used to leave only by an explicit rcow_release_export. A control plane
+ * that deletes snapshots but never releases therefore accumulates entries, and
+ * that is not merely untidy: the registry is read into a fixed decoder table at
+ * attach (S3LVOL_MAX_EXPORTS), so crossing it makes the whole lvstore
+ * un-attachable, live exports and all.
+ *
+ * Reaping is exactly a release, reusing the same path: it deletes the manifest,
+ * drops the entry and rewrites the registry. For a reference layout that is all
+ * a release does anyway -- it owns no objects of its own (see
+ * release_delete_chunks) -- so nothing that belongs to anyone else is touched.
+ * The snapshot is not deleted.
+ *
+ * Only reference exports. A dense export is self-contained: its snapshot
+ * disappearing says nothing about whether it can still be imported, and
+ * deleting its manifest would destroy a working export. Entries without
+ * lease_aware are left alone on an absent lease: a pre-lease importer reads
+ * without writing one, so 404 is not evidence.
+ * ========================================================================== */
+
+/* The same cadence as the pending-delete poller, and for the same reason:
+ * nothing here is urgent -- the cost of a dead entry lingering is one row in a
+ * registry -- but a completed delete is what makes a snapshot-gone export
+ * reapable, so a matching period keeps that step from trailing the first by
+ * an awkward margin. An unimported export past its deadline is noticed on the
+ * next tick after the lease check, without waiting for a delete that may
+ * never come. */
+#define S3LVOL_EXPORT_REAP_US (60ULL * SPDK_SEC_TO_USEC)
+
+/* Reaps started per tick, so a node that just deleted a thousand snapshots does
+ * not answer with a thousand simultaneous manifest deletes and registry
+ * rewrites. */
+#define S3LVOL_EXPORT_REAP_BATCH 8
+
+struct export_reap_ctx {
+	struct s3lvol_lvstore *lvs;
+	char                   uuid_str[SPDK_UUID_STRING_LEN];
+};
+
+static void
+export_reaped(void *cb_arg, int lvolerrno)
+{
+	struct export_reap_ctx *ctx = cb_arg;
+	struct s3lvol_export *exp;
+
+	if (lvolerrno == 0) {
+		SPDK_NOTICELOG("export %s reaped\n", ctx->uuid_str);
+		goto out;
+	}
+
+	if (lvolerrno == -ENOENT) {
+		/* No manifest to delete. The export is dead twice over then, and
+		 * the release stopped short of dropping the entry -- which is the
+		 * right call for a release somebody asked for (it says so and
+		 * changes nothing), and the wrong one here, where the entry is
+		 * precisely what is being collected. Drop it directly. */
+		exp = s3lvol_export_find(ctx->lvs, ctx->uuid_str);
+		if (exp) {
+			s3lvol_export_forget(exp);
+			if (s3lvol_export_registry_save(ctx->lvs, NULL, NULL) != 0) {
+				SPDK_WARNLOG("Dropped dead export %s but could not "
+					     "rewrite the registry of '%s'\n",
+					     ctx->uuid_str,
+					     s3lvol_lvstore_get_name(ctx->lvs));
+			}
+		}
+		SPDK_NOTICELOG("export %s reaped: neither its snapshot nor its "
+			       "manifest is left\n", ctx->uuid_str);
+		goto out;
+	}
+
+	/* The entry keeps its reaping flag, so it is not tried again: something
+	 * about this export needs looking at, and a poller repeating the same
+	 * failure every minute would only fill the log. rcow_release_export still
+	 * works by hand. */
+	SPDK_WARNLOG("export %s could not be reaped: %s. It will not be retried; "
+		     "release it explicitly if it is really dead.\n",
+		     ctx->uuid_str, spdk_strerror(-lvolerrno));
+out:
+	free(ctx);
+}
+
+/* Whether the snapshot this export references still exists.
+ *
+ * Matched on blob id when the registry has one, so a snapshot deleted and
+ * recreated under the same name reads as gone -- which it is, as far as this
+ * export is concerned: the objects its manifest names went with the original
+ * blob. Entries written before blob_id was recorded fall back to the name. */
+static bool
+export_snapshot_alive(struct s3lvol_export *exp)
+{
+	struct spdk_lvol *lvol = s3lvol_lvol_find(exp->lvs, exp->snapshot);
+
+	if (!lvol) {
+		return false;
+	}
+	if (exp->blob_id != 0 && lvol->blob_id != exp->blob_id) {
+		return false;
+	}
+	return true;
+}
+
+static int
+exports_reap(void *arg)
+{
+	struct s3lvol_export *dead[S3LVOL_EXPORT_REAP_BATCH];
+	struct s3lvol_lvstore *lvs;
+	unsigned n = 0;
+	unsigned i;
+
+	/* Iterating the *lvstores* rather than g_exports, because only a loaded
+	 * lvstore can answer whether a snapshot exists. An lvstore reaches
+	 * g_lvstores only once its blobstore is up and its lvols are open, so
+	 * this cannot mistake a half-loaded store for one whose snapshots are all
+	 * gone -- which would reap every export it has. */
+	for (lvs = s3lvol_lvstore_first(); lvs;
+	     lvs = s3lvol_lvstore_next(lvs)) {
+		struct s3lvol_export *exp;
+
+		if (!s3lvol_lvstore_get_lvs(lvs)) {
+			continue;
+		}
+
+		for (exp = s3lvol_export_first(lvs); exp;
+		     exp = s3lvol_export_next(exp)) {
+			if (exp->layout != S3_EXPORT_LAYOUT_REF || exp->reaping) {
+				continue;
+			}
+			if (export_lease_is_terminal(exp)) {
+				/* Even if this tick's batch is full, the watch
+				 * has nothing left to learn. */
+				export_lease_stop_if_terminal(exp);
+			}
+			if (n >= S3LVOL_EXPORT_REAP_BATCH) {
+				continue;
+			}
+			if (export_snapshot_alive(exp) &&
+			    !export_lease_is_terminal(exp)) {
+				continue;
+			}
+			dead[n++] = exp;
+		}
+	}
+
+	/* Collected first: the release is asynchronous but can fail inline, and
+	 * its completion removes the entry from the list being walked. */
+	for (i = 0; i < n; i++) {
+		struct export_reap_ctx *ctx;
+		int rc;
+
+		ctx = calloc(1, sizeof(*ctx));
+		if (!ctx) {
+			continue;
+		}
+		ctx->lvs = dead[i]->lvs;
+		snprintf(ctx->uuid_str, sizeof(ctx->uuid_str), "%s",
+			 dead[i]->uuid_str);
+		dead[i]->reaping = true;
+
+		if (export_snapshot_alive(dead[i])) {
+			SPDK_NOTICELOG("reaping export %s: nobody imported it "
+				       "past the deadline\n", ctx->uuid_str);
+		} else {
+			SPDK_NOTICELOG("reaping export %s: the snapshot it "
+				       "referenced is gone\n", ctx->uuid_str);
+		}
+
+		rc = s3lvol_export_release(ctx->lvs, ctx->uuid_str, export_reaped,
+					   ctx);
+		if (rc != 0) {
+			/* -EBUSY: a volume in this process still reads through
+			 * the export. Leave it and look again -- for a
+			 * snapshot-gone export that is an esnap clone of a
+			 * deleted snapshot; for an unimported one past its
+			 * deadline, a same-host reader that has not gone yet. */
+			dead[i]->reaping = false;
+			SPDK_DEBUGLOG(vbdev_s3lvol,
+				      "export %s not reaped this time: %s\n",
+				      ctx->uuid_str, spdk_strerror(-rc));
+			free(ctx);
+		}
+	}
+
+	return n ? SPDK_POLLER_BUSY : SPDK_POLLER_IDLE;
+}
+
+/* Runs only while this node has exports at all, like the pending-delete poller:
+ * a target with nothing published should have no timer ticking. */
+static void
+exports_reaper_sync(void)
+{
+	bool want = !TAILQ_EMPTY(&g_exports);
+
+	if (want && !g_exports_reaper) {
+		g_exports_reaper = SPDK_POLLER_REGISTER(exports_reap, NULL,
+							S3LVOL_EXPORT_REAP_US);
+		if (!g_exports_reaper) {
+			SPDK_WARNLOG("could not start the export reaper; dead "
+				     "export entries will have to be released by "
+				     "hand\n");
+		}
+	} else if (!want && g_exports_reaper) {
+		spdk_poller_unregister(&g_exports_reaper);
+		g_exports_reaper = NULL;
+	}
 }
 
 void
@@ -778,6 +1105,12 @@ exports_serialize(struct s3lvol_lvstore *lvs, char **out, size_t *out_len)
 					     S3_EXPORT_LAYOUT_DENSE_STR);
 		spdk_json_write_named_uint64(w, "expires_at", exp->expires_at);
 		spdk_json_write_named_uint32(w, "generation", exp->generation);
+		/* Only written when true. An older build ignores the unknown
+		 * field, and this build reads its absence as "not lease-aware",
+		 * which is what an entry written by an older build means. */
+		if (exp->lease_aware) {
+			spdk_json_write_named_bool(w, "lease_aware", true);
+		}
 		spdk_json_write_object_end(w);
 	}
 
@@ -802,6 +1135,7 @@ struct export_entry_json {
 	uint64_t blob_id;
 	uint64_t expires_at;
 	uint32_t generation;
+	bool     lease_aware;
 };
 
 static const struct spdk_json_object_decoder export_entry_decoders[] = {
@@ -811,6 +1145,7 @@ static const struct spdk_json_object_decoder export_entry_decoders[] = {
 	{"blob_id",     offsetof(struct export_entry_json, blob_id),     spdk_json_decode_uint64, true},
 	{"expires_at",  offsetof(struct export_entry_json, expires_at),  spdk_json_decode_uint64, true},
 	{"generation",  offsetof(struct export_entry_json, generation),  spdk_json_decode_uint32, true},
+	{"lease_aware", offsetof(struct export_entry_json, lease_aware), spdk_json_decode_bool, true},
 };
 
 struct export_entries_holder {
@@ -908,6 +1243,7 @@ exports_parse(struct s3lvol_lvstore *lvs, const void *json, size_t len)
 		exp->blob_id    = e->blob_id;
 		exp->expires_at = e->expires_at;
 		exp->generation = e->generation;
+		exp->lease_aware = e->lease_aware;
 		exp->layout     = strcmp(e->layout, S3_EXPORT_LAYOUT_REF_STR) == 0 ?
 				  S3_EXPORT_LAYOUT_REF : S3_EXPORT_LAYOUT_DENSE;
 		snprintf(exp->uuid_str, sizeof(exp->uuid_str), "%s", e->export_uuid);
@@ -925,8 +1261,10 @@ exports_parse(struct s3lvol_lvstore *lvs, const void *json, size_t len)
 		 * query. Safe, but permanent: an export whose importer went away
 		 * years ago still pins its snapshot, and the registry only grows.
 		 * With the poller running, a lease that is absent or stale lets the
-		 * delete through, and releasing the export is what takes the entry
-		 * out of the registry.
+		 * delete through. A lease-aware entry whose lease is a confirmed
+		 * miss past the deadline is then reaped -- releasing the export
+		 * is what takes the entry out of the registry, whether that
+		 * release is asked for or collected.
 		 *
 		 * Deliberately *not* a filter on expires_at. That stamp is written
 		 * once at export creation and never refreshed, while the importer

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_exports.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_exports.c
@@ -136,7 +136,7 @@ struct s3lvol_export {
 	 * resolved to nothing.
 	 *
 	 * So the export renews on its own behalf, from the moment it is published.
-	 * "E pins A while E is alive" (design §6) rather than "while somebody reads
+	 * "E pins A while E is alive" rather than "while somebody reads
 	 * E", which is the difference between a publish-then-leave flow working and
 	 * silently rotting.
 	 *
@@ -445,7 +445,7 @@ export_lease_got_body(void *cb_arg, uint64_t bytes_read, int status)
 
 	/* The high-water mark, not the last value read, and that is load-bearing.
 	 *
-	 * One key holds one object and the last writer wins (design §2.1), but there
+	 * One key holds one object and the last writer wins, but there
 	 * can be several writers with wildly different cadences: an importer renews
 	 * at remaining_ttl/3 -- 1200 s at the default TTL -- while a *derived export*
 	 * referencing this prefix renews at the 20 s floor, because it has no TTL of

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_exports.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_exports.c
@@ -123,6 +123,38 @@ struct s3lvol_export {
 	struct spdk_poller        *lease_poller;
 	struct export_lease_get_ctx *lease_fetch;
 
+	/* The other direction: leases this export *writes*, because its manifest
+	 * references somebody else's objects.
+	 *
+	 * A derived export -- one published from a volume imported from elsewhere --
+	 * names prefixes belonging to the nodes it passed through. Those nodes decide
+	 * independently whether to keep their snapshots, and they decide by lease. So
+	 * until now a derived export that nobody had imported yet was protected by
+	 * nothing: its own reader would have renewed, but there was no reader, and
+	 * the exporting node upstream would let its lease go stale and delete the
+	 * objects. What was left was a manifest that looked perfectly valid and
+	 * resolved to nothing.
+	 *
+	 * So the export renews on its own behalf, from the moment it is published.
+	 * "E pins A while E is alive" (design §6) rather than "while somebody reads
+	 * E", which is the difference between a publish-then-leave flow working and
+	 * silently rotting.
+	 *
+	 * Nothing releases these automatically. An export whose sources are all its
+	 * own has none; a derived one holds them until rcow_release_export, which is
+	 * the deliberate choice -- there is no way to tell "nobody will ever import
+	 * this" from "nobody has yet", and guessing wrong destroys data. Held keys
+	 * cost one PUT each per interval and are visible in the log at publish.
+	 *
+	 * One client and one poller for all of them, since every source of a manifest
+	 * shares its endpoint, bucket and region -- the writer refuses to reference
+	 * anything else. */
+	char                     (*src_lease_keys)[S3_EXPORT_KEY_MAX];
+	uint32_t                   num_src_leases;
+	struct spdk_poller        *src_lease_poller;
+	struct s3_client          *src_lease_client;
+	uint64_t                   src_lease_interval_us;
+
 	/* This export was created by a build whose importers renew a lease.
 	 *
 	 * It is what makes "no lease object" readable. Without it the absence is
@@ -407,10 +439,36 @@ export_lease_got_body(void *cb_arg, uint64_t bytes_read, int status)
 
 	exp->lease_checked = true;
 	exp->lease_updated_at = updated_at;
-	exp->lease_renew_s = (updated_at != 0) ? renew_s : 0;
 	exp->lease_failures = 0;
 	exp->lease_absent = false;
 	exp->lease_absent_at = 0;
+
+	/* The high-water mark, not the last value read, and that is load-bearing.
+	 *
+	 * One key holds one object and the last writer wins (design §2.1), but there
+	 * can be several writers with wildly different cadences: an importer renews
+	 * at remaining_ttl/3 -- 1200 s at the default TTL -- while a *derived export*
+	 * referencing this prefix renews at the 20 s floor, because it has no TTL of
+	 * its own to derive from. The frequent writer then wins nearly every race, so
+	 * taking the last renew_s read would set the grace period from the fastest
+	 * writer and apply it to the slowest: 60 s of grace against a writer that
+	 * speaks every 1200 s. The export going away would make this snapshot STALE
+	 * within a minute, and STALE is carried out unattended by the pending-delete
+	 * poller -- deleting objects an importer is still reading, which is the exact
+	 * corruption the lease exists to prevent.
+	 *
+	 * The grace period has to cover the slowest writer, so it is derived from the
+	 * largest cadence anyone claimed. Monotonic within the life of this entry;
+	 * an attach starts it over, which is right because the set of readers may
+	 * have changed while this node was down. Cost of being wrong in this
+	 * direction is a snapshot reclaimed later than it could have been. */
+	if (updated_at != 0) {
+		if (renew_s > exp->lease_renew_s) {
+			exp->lease_renew_s = renew_s;
+		}
+	} else {
+		exp->lease_renew_s = 0;
+	}
 
 	export_lease_get_done(ctx);
 	export_lease_stop_if_terminal(exp);
@@ -571,6 +629,241 @@ s3lvol_export_lease_start(struct s3lvol_export *exp)
 	 * first answer is the one that matters most: an export nobody consumed can
 	 * only be recognised by its lease being absent. */
 	export_lease_renew(exp);
+}
+
+/* ==========================================================================
+ * Leases this export writes, rather than reads
+ *
+ * A derived export names prefixes belonging to other nodes. Each of those decides
+ * on its own whether to keep the snapshot behind them, and decides by reading a
+ * lease -- so somebody has to write one, or the objects this manifest references
+ * are deleted while it still names them.
+ *
+ * The importer of a derived export does write them (see import_lease_start), and
+ * that covers an export somebody is reading. It does not cover one that has been
+ * published and not yet imported, which is exactly the state a
+ * publish-then-hand-over flow leaves behind. So the export renews for itself, from
+ * publication until it is released.
+ * ========================================================================== */
+
+static void
+export_src_lease_put_done(void *cb_arg, int status)
+{
+	char *key = cb_arg;
+
+	/* Fire and forget, like every other lease PUT: a lost one is absorbed by the
+	 * grace period at the other end and the next tick tries again. The key rather
+	 * than the export uuid, because an export may renew several and the one that
+	 * fails is the prefix whose node may now delete data this manifest needs. */
+	if (status != 0) {
+		SPDK_WARNLOG("source lease renew failed for '%s': %s\n",
+			     key, spdk_strerror(-status));
+	}
+	free(key);
+}
+
+static int
+export_src_lease_renew(void *arg)
+{
+	struct s3lvol_export *exp = arg;
+	char body[160];
+	struct iovec iov;
+	uint64_t now = (uint64_t)time(NULL);
+	uint64_t remaining;
+	uint32_t claim;
+	uint32_t i;
+
+	/* What this asks the upstream for, and why it is not the PUT interval.
+	 *
+	 * The source turns renew_s into a grace period of 3x it: "nobody has written
+	 * for that long, so nobody is reading". For an importer the two coincide,
+	 * because the importer is the only writer and its cadence is what going
+	 * quiet means. For an export they do not, and reporting the cadence here
+	 * caused the corruption this comment exists to prevent.
+	 *
+	 * A key can have several writers -- this export, plus every importer of
+	 * *this* export, which renews the same upstream key -- and the object holds
+	 * only the last one. This export writes every 20 s; an importer writes every
+	 * remaining_ttl/3, which is 1200 s at the default TTL. So this export wins
+	 * nearly every race, and a cadence reported here would set the upstream's
+	 * grace to 60 s and then apply it to a writer that speaks every 1200 s.
+	 * Losing this node would make the upstream snapshot STALE within a minute,
+	 * and the pending-delete poller carries STALE out unattended -- deleting
+	 * objects an importer of this export is still reading.
+	 *
+	 * So what is reported is the *protection wanted*, not the write rate: keep
+	 * the objects until this export's own promise to its readers runs out. Same
+	 * quantity an importer of this export would ask for, which is what makes the
+	 * two comparable when they overwrite each other. Writing more often than
+	 * claimed is harmless in the safe direction -- it only keeps updated_at
+	 * fresher than required. Paired with the source taking the high-water mark
+	 * of renew_s (see export_lease_got_body), because this value shrinks as the
+	 * deadline approaches while an importer's stays fixed at what it read. */
+	remaining = (exp->expires_at > now) ? (exp->expires_at - now) : 0;
+	claim = (uint32_t)(remaining / 3);
+	if (claim < S3LVOL_LEASE_RENEW_MIN_SEC) {
+		claim = S3LVOL_LEASE_RENEW_MIN_SEC;
+	}
+
+	/* Same document an importer writes, so the reading side needs no new case.
+	 * importer_id says which node is holding the reference and why -- an operator
+	 * looking at a lease that will not go away needs to know it belongs to an
+	 * export rather than to a volume, since the way to clear it is
+	 * rcow_release_export and not deleting anything. */
+	snprintf(body, sizeof(body),
+		 "{\"importer_id\":\"export:%s\",\"updated_at\":%" PRIu64
+		 ",\"renew_s\":%lu}",
+		 exp->uuid_str, now, (unsigned long)claim);
+	iov.iov_base = body;
+	iov.iov_len  = strlen(body);
+
+	for (i = 0; i < exp->num_src_leases; i++) {
+		char *key;
+
+		/* Owned by the completion: s3_put copies the body but not cb_arg, and
+		 * the callback outlives both the poller and, after forget(), the array
+		 * these were copied from. */
+		key = strdup(exp->src_lease_keys[i]);
+		if (!key) {
+			continue;
+		}
+		/* Each submitted independently: they protect different nodes'
+		 * snapshots, so one unreachable prefix must not take the rest stale
+		 * with it. */
+		if (s3_put(exp->src_lease_client, key, &iov, 1, false,
+			   export_src_lease_put_done, key) != 0) {
+			SPDK_WARNLOG("source lease renew submit failed for '%s'\n", key);
+			free(key);
+		}
+	}
+
+	return SPDK_POLLER_IDLE;
+}
+
+static void
+export_src_lease_stop(struct s3lvol_export *exp)
+{
+	if (exp->src_lease_poller) {
+		spdk_poller_unregister(&exp->src_lease_poller);
+		exp->src_lease_poller = NULL;
+	}
+	if (exp->src_lease_client) {
+		s3_client_put(exp->src_lease_client);
+		exp->src_lease_client = NULL;
+	}
+	/* Safe with PUTs in flight: each carries its own copy of the key, which is
+	 * why the renew strdup()s rather than passing these. */
+	free(exp->src_lease_keys);
+	exp->src_lease_keys = NULL;
+	exp->num_src_leases = 0;
+}
+
+/* Bring the poller up for keys already in exp->src_lease_keys. Shared by the
+ * publish path, which derives the keys from a manifest, and the attach path, which
+ * reads them back from the registry -- the difference between the two is only
+ * where the keys came from. \p src describes where to reach them. */
+static void
+export_src_lease_arm(struct s3lvol_export *exp, const struct s3_export_source *src)
+{
+	struct s3_target target = {0};
+	uint32_t j;
+	int rc;
+
+	if (exp->num_src_leases == 0) {
+		free(exp->src_lease_keys);
+		exp->src_lease_keys = NULL;
+		return;
+	}
+
+	/* Every source shares the manifest's endpoint, bucket and region, so one
+	 * client serves all of them -- the writer refuses to reference another
+	 * bucket, which is what makes that true. */
+	target.endpoint  = (char *)src->endpoint;
+	target.region    = (char *)src->region;
+	target.bucket    = (char *)src->bucket;
+	target.auth_mode = S3_AUTH_ENV;
+	rc = s3_client_get_or_create(&target, &exp->src_lease_client);
+	if (rc != 0) {
+		SPDK_WARNLOG("export %s: no S3 client for its source leases: %s. The "
+			     "nodes it references may delete their snapshots.\n",
+			     exp->uuid_str, spdk_strerror(-rc));
+		export_src_lease_stop(exp);
+		return;
+	}
+
+	/* The floor, and deliberately unrelated to what the renew *claims*.
+	 *
+	 * How often to write and how long to ask the upstream to wait are two
+	 * questions here, unlike for an importer where one answer serves both. This
+	 * is the first: write often, so updated_at stays fresh and a lost PUT is
+	 * covered by the next one soon after. The second is answered per renew, from
+	 * this export's own deadline -- see export_src_lease_renew(), which explains
+	 * why conflating them deleted data. */
+	exp->src_lease_interval_us = S3LVOL_LEASE_RENEW_MIN_SEC * SPDK_SEC_TO_USEC;
+	exp->src_lease_poller = SPDK_POLLER_REGISTER(export_src_lease_renew, exp,
+						     exp->src_lease_interval_us);
+	if (!exp->src_lease_poller) {
+		SPDK_WARNLOG("export %s: could not start its source lease poller\n",
+			     exp->uuid_str);
+		export_src_lease_stop(exp);
+		return;
+	}
+
+	/* Now, not one interval from now. At publish there may be no upstream lease
+	 * at all yet; at attach, whatever was there has been going stale for however
+	 * long this node was down, and an absent or stale lease is what lets the
+	 * other end delete. */
+	export_src_lease_renew(exp);
+
+	SPDK_NOTICELOG("export %s renews %u upstream lease(s) every %u second(s) "
+		       "because it references other prefixes; rcow_release_export is "
+		       "what stops it\n", exp->uuid_str, exp->num_src_leases,
+		       S3LVOL_LEASE_RENEW_MIN_SEC);
+	for (j = 0; j < exp->num_src_leases; j++) {
+		SPDK_NOTICELOG("export %s upstream lease [%u]: %s\n", exp->uuid_str, j,
+			       exp->src_lease_keys[j]);
+	}
+}
+
+/* Start renewing on behalf of \p m 's sources. Does nothing for a manifest that
+ * references only its own prefix, which is every non-derived export. */
+static void
+export_src_lease_start(struct s3lvol_export *exp, const struct s3_export_manifest *m)
+{
+	uint32_t j;
+
+	/* num_srcs <= 1 means entry 0 only, i.e. this lvstore's own prefix, whose
+	 * objects this node already owns. Nothing to ask anybody else for. */
+	if (m->layout != S3_EXPORT_LAYOUT_REF || m->num_srcs <= 1) {
+		return;
+	}
+
+	exp->src_lease_keys = calloc(m->num_srcs, sizeof(*exp->src_lease_keys));
+	if (!exp->src_lease_keys) {
+		SPDK_WARNLOG("export %s: no memory for its source leases; the nodes it "
+			     "references may delete their snapshots\n", exp->uuid_str);
+		return;
+	}
+
+	/* From entry 1: entry 0 is this export's own prefix. Each later entry names
+	 * the export that governs it, and the lease goes *there* rather than to
+	 * whoever this manifest was derived from -- that middleman may be gone, and
+	 * the objects are not its to protect. */
+	for (j = 1; j < m->num_srcs; j++) {
+		if (m->srcs[j].export_uuid[0] == '\0') {
+			SPDK_WARNLOG("export %s names prefix '%s' with no export uuid, "
+				     "so nothing can renew its lease; that node may "
+				     "delete the snapshot behind those chunks\n",
+				     exp->uuid_str, m->srcs[j].prefix);
+			continue;
+		}
+		snprintf(exp->src_lease_keys[exp->num_src_leases],
+			 sizeof(exp->src_lease_keys[0]), "%s/meta/exports/%s.lease",
+			 m->srcs[j].prefix, m->srcs[j].export_uuid);
+		exp->num_src_leases++;
+	}
+
+	export_src_lease_arm(exp, &m->src);
 }
 
 /* One export's verdict on one snapshot. Split out of s3lvol_export_pinning()
@@ -807,6 +1100,10 @@ s3lvol_export_add(struct s3lvol_lvstore *lvs, const struct s3_export_manifest *m
 	 * and an attach resurrecting the registry because the importers it
 	 * describes may still be reading. */
 	s3lvol_export_lease_start(exp);
+	/* And, if this export references anybody else's prefixes, start renewing
+	 * *their* leases too -- from now rather than from the first import. See the
+	 * fields' comment in struct s3lvol_export. */
+	export_src_lease_start(exp, m);
 	exports_reaper_sync();
 
 	return exp;
@@ -816,6 +1113,10 @@ void
 s3lvol_export_forget(struct s3lvol_export *exp)
 {
 	s3lvol_export_lease_stop(exp);
+	/* The only thing that stops the upstream renewals. Deliberately: nothing can
+	 * tell "nobody will ever import this" from "nobody has yet", so releasing the
+	 * export is the caller's statement that the reference is finished with. */
+	export_src_lease_stop(exp);
 	TAILQ_REMOVE(&g_exports, exp, link);
 	free(exp);
 	exports_reaper_sync();
@@ -1053,6 +1354,23 @@ s3lvol_export_set_materialised(struct s3lvol_export *exp, uint32_t generation)
 	exp->expires_at = 0;
 	/* Nor a snapshot to protect, so the lease watch stops with it. */
 	s3lvol_export_lease_stop(exp);
+	/* And it references nobody else's objects any more: materialising uploaded
+	 * copies of everything it used to point at, including whatever it inherited
+	 * from another prefix. Holding those upstream leases now would keep another
+	 * node's snapshot alive for data this export no longer needs. */
+	export_src_lease_stop(exp);
+}
+
+void
+s3lvol_export_set_local_ref(struct s3lvol_export *exp, uint32_t generation)
+{
+	/* The replacement manifest is still a reference export: its objects belong
+	 * to the local snapshot, so the ordinary export lease continues to pin that
+	 * snapshot. What changed is that no chunk points at another lvstore any
+	 * more, hence only the upstream leases are retired. */
+	assert(exp->layout == S3_EXPORT_LAYOUT_REF);
+	exp->generation = generation;
+	export_src_lease_stop(exp);
 }
 
 void
@@ -1111,6 +1429,33 @@ exports_serialize(struct s3lvol_lvstore *lvs, char **out, size_t *out_len)
 		if (exp->lease_aware) {
 			spdk_json_write_named_bool(w, "lease_aware", true);
 		}
+		/* The upstream leases this export renews, written as the keys rather
+		 * than as the prefixes they came from.
+		 *
+		 * Persisted because without them a restart forgets an obligation to
+		 * *another node*: the entry comes back, its own lease is watched again,
+		 * and nothing renews upstream -- so the node this manifest references
+		 * sees a stale lease and deletes the snapshot behind chunks this export
+		 * still names. Exactly the failure this whole mechanism exists to
+		 * prevent, arriving by way of a restart.
+		 *
+		 * Keys and not prefixes so that reloading needs no manifest: the
+		 * manifest is on S3 and fetching it at attach would make the registry
+		 * load depend on a GET per derived export. What is stored is precisely
+		 * what has to be written.
+		 *
+		 * Absent for a non-derived export, which is the common case, and absent
+		 * in anything an older build wrote -- read as "renews nothing", which is
+		 * what such an entry meant. */
+		if (exp->num_src_leases > 0) {
+			uint32_t k;
+
+			spdk_json_write_named_array_begin(w, "src_leases");
+			for (k = 0; k < exp->num_src_leases; k++) {
+				spdk_json_write_string(w, exp->src_lease_keys[k]);
+			}
+			spdk_json_write_array_end(w);
+		}
 		spdk_json_write_object_end(w);
 	}
 
@@ -1128,6 +1473,72 @@ exports_serialize(struct s3lvol_lvstore *lvs, char **out, size_t *out_len)
 	return 0;
 }
 
+/* The upstream lease keys of one entry. A fixed table rather than allocations,
+ * because the whole registry is decoded into fixed tables and one exception would
+ * be one more thing to free on every error path here. */
+struct src_leases_holder {
+	char  *k[S3_EXPORT_MAX_SOURCES];
+	size_t n;
+};
+
+static int
+decode_src_leases(const struct spdk_json_val *val, void *out)
+{
+	struct src_leases_holder *h = out;
+
+	return spdk_json_decode_array(val, spdk_json_decode_string, h->k,
+				      S3_EXPORT_MAX_SOURCES, &h->n, sizeof(h->k[0]));
+}
+
+/* Resume renewing the upstream leases of an export read back from the registry.
+ *
+ * The keys are stored verbatim, so nothing has to be derived -- but the endpoint,
+ * bucket and region to reach them do, and there is no manifest here to read them
+ * from. They come from this lvstore's own namespace, which is correct because a
+ * manifest may not reference another bucket: the writer refuses, so every source
+ * of it is necessarily in the same place as the export itself. If that rule ever
+ * relaxes, this is one of the places that has to learn about it. */
+static void
+export_src_lease_restart(struct s3lvol_export *exp,
+			 const struct src_leases_holder *stored)
+{
+	struct s3_export_source src = {0};
+	const struct s3_target *tgt;
+	const char *ns;
+	size_t i;
+
+	if (stored->n == 0) {
+		return;
+	}
+
+	ns  = s3lvol_lvstore_get_namespace(exp->lvs);
+	tgt = rcow_namespace_to_target(ns);
+	if (!tgt || !tgt->endpoint || !tgt->bucket) {
+		SPDK_WARNLOG("export %s references other prefixes but namespace '%s' "
+			     "does not resolve, so its upstream leases cannot be "
+			     "renewed; those nodes may delete their snapshots\n",
+			     exp->uuid_str, ns ? ns : "(none)");
+		return;
+	}
+
+	exp->src_lease_keys = calloc(stored->n, sizeof(*exp->src_lease_keys));
+	if (!exp->src_lease_keys) {
+		SPDK_WARNLOG("export %s: no memory to resume its source leases\n",
+			     exp->uuid_str);
+		return;
+	}
+	for (i = 0; i < stored->n; i++) {
+		snprintf(exp->src_lease_keys[i], sizeof(exp->src_lease_keys[0]), "%s",
+			 stored->k[i]);
+	}
+	exp->num_src_leases = (uint32_t)stored->n;
+
+	snprintf(src.endpoint, sizeof(src.endpoint), "%s", tgt->endpoint);
+	snprintf(src.region, sizeof(src.region), "%s", tgt->region ? tgt->region : "");
+	snprintf(src.bucket, sizeof(src.bucket), "%s", tgt->bucket);
+	export_src_lease_arm(exp, &src);
+}
+
 struct export_entry_json {
 	char *export_uuid;
 	char    *snapshot;
@@ -1136,6 +1547,7 @@ struct export_entry_json {
 	uint64_t expires_at;
 	uint32_t generation;
 	bool     lease_aware;
+	struct src_leases_holder src_leases;
 };
 
 static const struct spdk_json_object_decoder export_entry_decoders[] = {
@@ -1146,6 +1558,9 @@ static const struct spdk_json_object_decoder export_entry_decoders[] = {
 	{"expires_at",  offsetof(struct export_entry_json, expires_at),  spdk_json_decode_uint64, true},
 	{"generation",  offsetof(struct export_entry_json, generation),  spdk_json_decode_uint32, true},
 	{"lease_aware", offsetof(struct export_entry_json, lease_aware), spdk_json_decode_bool, true},
+	/* Optional: absent for a non-derived export and for anything an older build
+	 * wrote, both of which mean "renews nothing upstream". */
+	{"src_leases",  offsetof(struct export_entry_json, src_leases),  decode_src_leases, true},
 };
 
 struct export_entries_holder {
@@ -1275,6 +1690,15 @@ exports_parse(struct s3lvol_lvstore *lvs, const void *json, size_t len)
 		 * that snapshot would leave it reading holes. */
 		s3lvol_export_lease_start(exp);
 
+		/* And resume renewing upstream, which is an obligation to another
+		 * node rather than to this one. Without it a restart quietly hands
+		 * whoever this export references permission to delete the snapshot
+		 * behind chunks it still names.
+		 *
+		 * Restarted from the stored keys rather than from the manifest, so the
+		 * registry load needs no S3 GET per derived export. */
+		export_src_lease_restart(exp, &e->src_leases);
+
 		if (exp->layout == S3_EXPORT_LAYOUT_REF) {
 			SPDK_NOTICELOG("lvstore '%s' still owes export %s the snapshot "
 				       "'%s'%s\n", s3lvol_lvstore_get_name(lvs),
@@ -1288,9 +1712,16 @@ exports_parse(struct s3lvol_lvstore *lvs, const void *json, size_t len)
 		       s3lvol_lvstore_get_name(lvs), j.entries.n);
 out:
 	for (i = 0; i < j.entries.n; i++) {
+		size_t k;
+
 		free(j.entries.e[i].export_uuid);
 		free(j.entries.e[i].snapshot);
 		free(j.entries.e[i].layout);
+		/* spdk_json_decode_string strdup()s into the table, so each element is
+		 * its own allocation. The restart above copied what it needed. */
+		for (k = 0; k < j.entries.e[i].src_leases.n; k++) {
+			free(j.entries.e[i].src_leases.k[k]);
+		}
 	}
 	free(values);
 	free(copy);

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvol.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvol.c
@@ -8,15 +8,15 @@
  *   The core point is not "a few NULL checks"; the entry points are closed to out-of-tree code:
  *
  *   - Every built-in lvol RPC goes through vbdev_lvol_store_first() walking
- *     g_spdk_lvol_pairs (vbdev_lvol.c:20), which is a **static private list** --
+ *     g_spdk_lvol_pairs (vbdev_lvol.c), which is a **static private list** --
  *     no external API can insert entries into it.
  *   - _create_lvol_disk() starts with vbdev_get_lvs_bdev_by_lvs() and
  *     assert(false)s when the lookup fails (the struct lvol_store_bdev
- *     machinery at vbdev_lvol.c:202 requires a real spdk_bdev); our lvstore
+ *     machinery at vbdev_lvol.c requires a real spdk_bdev); our lvstore
  *     sits on s3_bs_dev, with no bdev underneath.
  *
  *   Conversely, nvmf only recognises a name in the global bdev registry
- *   (spdk_bdev_open_ext_v2, lib/nvmf/subsystem.c:2596). So this file's whole
+ *   (spdk_bdev_open_ext_v2, lib/nvmf/subsystem.c). So this file's whole
  *   reason for being is: **register lvols as bdevs, thereby getting the entire
  *   nvmf ecosystem for free.**
  *
@@ -199,7 +199,7 @@ s3lvol_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io)
 }
 
 /* Read-only-ness is expressed through here, with no extra flag (copying what
- * vbdev_lvol.c:842 does).
+ * vbdev_lvol.c does).
  *
  *   - `nvmf_subsystem_add_ns` has no read-only-like parameter (only nsid /
  *     nguid / eui64 / uuid / anagrpid / ptpl-file);

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
@@ -757,6 +757,14 @@ lvs_setup_report(struct lvs_setup_ctx *ctx)
 
 	TAILQ_INSERT_TAIL(&g_lvstores, lvs, link);
 
+	/* Deletes that were asked for before the last restart and could not be
+	 * carried out. Started here rather than earlier in the chain because the
+	 * queue is keyed by lvstore uuid, which only exists once blobstore is up,
+	 * and because it must not be able to hold the attach up: it is fire and
+	 * forget. Callbacks re-resolve this wrapper by uuid, so an unload that
+	 * wins the race drops the body instead of using a freed pointer. */
+	s3lvol_pending_load(lvs);
+
 	SPDK_NOTICELOG("lvstore '%s' %s: cluster=%" PRIu64 " bytes, "
 		       "%" PRIu64 " free clusters, write path=%s\n",
 		       lvs->name, ctx_attaching ? "attached" : "ready",
@@ -2670,13 +2678,17 @@ struct lvol_destroy_ctx {
  * volume's "deactivate it first" refusal is answered in the RPC layer and never
  * gets this far. */
 static void
-destroy_mark_pending(struct spdk_lvol *lvol)
+destroy_mark_pending(struct spdk_lvol *lvol, enum s3lvol_pending_reason reason)
 {
+	struct s3lvol_lvstore *owner;
+
 	if (!lvol || !lvol->lvol_store) {
 		return;
 	}
+	owner = s3lvol_lvstore_find_by_lvs(lvol->lvol_store);
 	s3lvol_snapshot_pending_set(&lvol->lvol_store->uuid, &lvol->uuid,
-				    lvol->name);
+				    owner ? s3lvol_lvstore_get_name(owner) : NULL,
+				    lvol->name, reason);
 }
 
 /* Deleting the last volume that read an export is what ends this node's
@@ -2717,10 +2729,20 @@ s3lvol_lvol_destroyed(void *cb_arg, int lvolerrno)
 		/* The refusal paths in s3lvol_lvol_destroy() log before returning, but
 		 * an asynchronous failure -- the unregister, or spdk_lvol_destroy --
 		 * lands here instead and would otherwise be silent. A blocked
-		 * snapshot delete records the intent so --ls can show it. */
+		 * snapshot delete records the intent so --ls can show it.
+		 *
+		 * Recorded as FAILED rather than as one of the reference blockers:
+		 * the pre-checks all passed, so whatever stopped this is not a
+		 * reference count and would stop it again. The poller leaves such
+		 * an entry alone and an explicit retry is needed. */
 		if (ctx->is_snapshot) {
 			s3lvol_snapshot_pending_set(&ctx->lvs_uuid,
-						    &ctx->lvol_uuid, ctx->name);
+						    &ctx->lvol_uuid,
+						    ctx->owner
+						    ? s3lvol_lvstore_get_name(ctx->owner)
+						    : NULL,
+						    ctx->name,
+						    S3LVOL_PENDING_FAILED);
 		}
 		SPDK_ERRLOG("Failed to delete lvol '%s/%s': %s\n",
 			    ctx->owner ? s3lvol_lvstore_get_name(ctx->owner) : "(null)",
@@ -2797,7 +2819,7 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 		SPDK_ERRLOG("lvol '%s' is being exported right now; wait for "
 			    "rcow_get_snapshot_status to stop reporting INPROGRESS "
 			    "before deleting it\n", lvol->name);
-		destroy_mark_pending(lvol);
+		destroy_mark_pending(lvol, S3LVOL_PENDING_EXPORT_INFLIGHT);
 		return -EBUSY;
 	}
 
@@ -2810,7 +2832,16 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 			    "node may be reading through. Release that export, or wait "
 			    "for it to expire, before deleting this.\n",
 			    lvol->name, info.export_uuid);
-		destroy_mark_pending(lvol);
+		/* Recorded either way -- the caller asked, and the request must not
+		 * be lost -- but which kind of blocker decides whether the queue
+		 * finishes it. An export whose importers keep a lease says so when
+		 * they stop; one with no lease can only ever be judged by a TTL,
+		 * and a delete on that basis stays a decision. */
+		destroy_mark_pending(lvol,
+				     s3lvol_export_pin_state(owner, lvol->name) ==
+				     S3LVOL_EXPORT_PIN_LEGACY
+				     ? S3LVOL_PENDING_EXPORT_LEGACY
+				     : S3LVOL_PENDING_EXPORT);
 		return -EBUSY;
 	}
 
@@ -2879,10 +2910,10 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 				    "blobstore can only merge a snapshot into a "
 				    "single clone, so delete the others first\n",
 				    lvol->name, clone_count);
-			/* Same "record the intent so --retry-pending can pick it up
+			/* Same "record the intent so the queue can pick it up
 			 * once the blocker (the extra clones) clears" contract as
 			 * the export-pin refusals above. */
-			destroy_mark_pending(lvol);
+			destroy_mark_pending(lvol, S3LVOL_PENDING_CLONE_COUNT);
 			return -EBUSY;
 		}
 	}
@@ -2897,7 +2928,7 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 		/* The decouple that is running will clear, after which the delete can
 		 * succeed; record the intent for --retry-pending, same contract as
 		 * the export-pin refusals above. */
-		destroy_mark_pending(lvol);
+		destroy_mark_pending(lvol, S3LVOL_PENDING_DECOUPLE);
 		return -EBUSY;
 	}
 

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
@@ -2472,6 +2472,7 @@ s3lvol_lvol_derive_cb(void *cb_arg, struct spdk_lvol *lvol, int lvolerrno)
 	s3lvol_lvol_op_cb cb_fn = ctx->cb_fn;
 	void *user_arg = ctx->cb_arg;
 	const char *lvs_name = ctx->lvs->name;
+	struct s3lvol_lvstore *lvs = ctx->lvs;
 	int rc;
 
 	free(ctx);
@@ -2483,6 +2484,48 @@ s3lvol_lvol_derive_cb(void *cb_arg, struct spdk_lvol *lvol, int lvolerrno)
 			cb_fn(user_arg, NULL, lvolerrno);
 		}
 		return;
+	}
+
+	/* Say so while there is still room to act.
+	 *
+	 * Deriving is the only thing that lengthens a chain, so this is the one
+	 * place the crossing can be caught as it happens. Past
+	 * S3LVOL_DEFAULT_MAX_CHAIN_DEPTH an export of this lvol silently stops being
+	 * zero-copy and duplicates the whole volume into an export that is then
+	 * never reaped -- correct, expensive, and permanent. The soft threshold
+	 * leaves eight snapshots' worth of warning before that.
+	 *
+	 * A warning and not a refusal: the snapshot is the caller's to keep, and
+	 * failing an ordinary create_snapshot to avoid a cost they may be willing to
+	 * pay would be the worse trade. What the message has to carry is therefore
+	 * what to *do* -- deleting an intermediate snapshot shortens the chain and is
+	 * pure metadata, no S3 traffic, because blobstore merges the deleted layer
+	 * into its single clone.
+	 *
+	 * Logged after the bdev registration below would be tidier, but this runs
+	 * before it deliberately: a registration failure keeps the snapshot, so the
+	 * chain is longer either way and the caller should hear about it either way. */
+	if (lvs) {
+		uint32_t depth = s3lvol_lvol_chain_depth(lvs, lvol);
+
+		if (depth > S3LVOL_DEFAULT_MAX_CHAIN_DEPTH) {
+			SPDK_WARNLOG("lvol '%s/%s' is %u snapshot(s) deep, past the "
+				     "limit of %u: exporting it can no longer name "
+				     "the objects it already has and will copy the "
+				     "whole volume instead, into an export nothing "
+				     "reclaims. Delete an intermediate snapshot to "
+				     "shorten the chain -- that is metadata only, no "
+				     "S3 traffic.\n",
+				     lvs_name, lvol->name, depth,
+				     S3LVOL_DEFAULT_MAX_CHAIN_DEPTH);
+		} else if (depth >= S3LVOL_DEFAULT_SOFT_CHAIN_DEPTH) {
+			SPDK_WARNLOG("lvol '%s/%s' is %u snapshot(s) deep; at %u an "
+				     "export stops being zero-copy and duplicates the "
+				     "volume. Deleting an intermediate snapshot "
+				     "shortens the chain and moves no data.\n",
+				     lvs_name, lvol->name, depth,
+				     S3LVOL_DEFAULT_MAX_CHAIN_DEPTH + 1);
+		}
 	}
 
 	rc = vbdev_s3lvol_bdev_register(lvol, lvs_name);
@@ -2556,13 +2599,88 @@ derive_ctx_alloc(struct s3lvol_lvstore *lvs, s3lvol_lvol_op_cb cb_fn, void *cb_a
 	return ctx;
 }
 
+/* Everything create_snapshot needs to resume after a cancelled decouple.
+ *
+ * snapshot_name is copied rather than kept: the caller's string belongs to the
+ * RPC request, which frees it as soon as the dispatching function returns -- and
+ * with a cancellation in flight that happens long before the name is used. */
+struct snapshot_after_cancel_ctx {
+	struct s3lvol_lvstore *lvs;
+	struct spdk_lvol      *lvol;
+	char                   snapshot_name[SPDK_LVOL_NAME_MAX];
+	s3lvol_lvol_op_cb      cb_fn;
+	void                  *cb_arg;
+};
+
+static void
+snapshot_after_cancel(void *cb_arg, int status)
+{
+	struct snapshot_after_cancel_ctx *c = cb_arg;
+	int rc;
+
+	/* The cancellation is what clears action_in_progress and empties the queue,
+	 * so by here the volume must look untouched to derive_check. If it does not,
+	 * the retry below would cancel nothing and refuse -- better to state the
+	 * expectation than to loop on it. */
+	assert(!s3lvol_lvol_decouple_pending(c->lvol));
+
+	rc = s3lvol_lvol_create_snapshot(c->lvs, c->lvol, c->snapshot_name, NULL,
+					 c->cb_fn, c->cb_arg);
+	if (rc != 0 && c->cb_fn) {
+		c->cb_fn(c->cb_arg, NULL, rc);
+	}
+	free(c);
+}
+
 int
 s3lvol_lvol_create_snapshot(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol,
 			    const char *snapshot_name,
+			    bool *out_cancelled_decouple,
 			    s3lvol_lvol_op_cb cb_fn, void *cb_arg)
 {
 	struct lvol_create_ctx *ctx;
 	int rc;
+
+	if (out_cancelled_decouple) {
+		*out_cancelled_decouple = false;
+	}
+
+	/* Before derive_check, because a decouple in flight is exactly what it
+	 * refuses -- and for the default import it always is one. Cancelling here
+	 * turns "import, then snapshot" from impossible into ordinary; what it costs
+	 * is that the volume keeps reading the export, which is the reference
+	 * snapshot this is for. Reported through out_cancelled_decouple so the
+	 * caller learns that the decouple it asked for is not going to happen. */
+	if (s3lvol_lvol_decouple_pending(lvol)) {
+		struct snapshot_after_cancel_ctx *c;
+
+		c = calloc(1, sizeof(*c));
+		if (!c) {
+			return -ENOMEM;
+		}
+		c->lvs    = lvs;
+		c->lvol   = lvol;
+		c->cb_fn  = cb_fn;
+		c->cb_arg = cb_arg;
+		spdk_strcpy_pad(c->snapshot_name, snapshot_name,
+				sizeof(c->snapshot_name) - 1, '\0');
+
+		rc = s3lvol_decouple_cancel(lvol, snapshot_after_cancel, c);
+		if (rc < 0) {
+			free(c);
+			return rc;
+		}
+		if (out_cancelled_decouple) {
+			*out_cancelled_decouple = true;
+		}
+		if (rc == 1) {
+			/* Accepted; snapshot_after_cancel() carries on from here. */
+			return 0;
+		}
+		/* Cancelled synchronously (it was only queued), so fall through and
+		 * take the snapshot now rather than bouncing through the callback. */
+		free(c);
+	}
 
 	rc = derive_check(lvs, lvol, snapshot_name);
 	if (rc != 0) {

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_lvstore.c
@@ -9,7 +9,7 @@
  *   === Why maintain our own lvstore list ===
  *
  *   The upstream lvstore<->bdev pairing table g_spdk_lvol_pairs is static
- *   private (vbdev_lvol.c:20); no external API can insert entries, so the
+ *   private (vbdev_lvol.c); no external API can insert entries, so the
  *   built-in bdev_lvol_* RPCs are unavailable to us. We keep our own copy for
  *   the bespoke RPCs to look up.
  *
@@ -17,7 +17,7 @@
  *
  *   It assumes the lvstore sits on a real bdev: it builds its own bs_dev with
  *   spdk_bdev_create_bs_dev_ext() and then unconditionally dereferences
- *   bs_dev->get_base_bdev() (vbdev_lvol.c:286). Our bs_dev has no bdev
+ *   bs_dev->get_base_bdev() (vbdev_lvol.c). Our bs_dev has no bdev
  *   underneath; get_base_bdev is NULL and it would segfault. spdk_lvs_init()
  *   itself only needs a struct spdk_bs_dev *, so the wrapper is bypassed and
  *   it is called directly.
@@ -2904,7 +2904,7 @@ s3lvol_lvol_destroy(struct spdk_lvol *lvol,
 	 * are not holes, and unable to open its clone at all after a restart.
 	 *
 	 * Refused rather than materialised, and that is now a decision rather than a
-	 * gap (2026-08-05). Materialising -- server-side copying the objects into the
+	 * gap. Materialising -- server-side copying the objects into the
 	 * export's own prefix and rewriting the manifest as dense -- founders on the
 	 * rewrite: an importer caches the manifest verbatim in its imports registry
 	 * and reloads it from there on attach, never re-fetching, so it would go on

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_nvmf.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_nvmf.c
@@ -28,6 +28,8 @@
 #include "spdk/nvmf.h"
 #include "spdk/string.h"
 
+#include <sys/sysmacros.h>
+
 #include "vbdev_s3lvol.h"
 
 SPDK_LOG_REGISTER_COMPONENT(s3lvol_nvmf)
@@ -444,6 +446,78 @@ s3lvol_nvmf_resolve_device(const char *uuid_str, char *out, size_t out_len)
 
 	closedir(d);
 	return rc;
+}
+
+bool
+s3lvol_nvmf_device_is_ready(const char *dev, const char *uuid_str)
+{
+	struct stat st, st2;
+	char sysdir[PATH_MAX];
+	char id[SPDK_UUID_STRING_LEN + 16];
+	char devnum[64];
+	const char *leaf;
+	unsigned maj, min;
+	int n;
+
+	if (!dev || !dev[0] || !uuid_str || !uuid_str[0]) {
+		return false;
+	}
+	if (stat(dev, &st) != 0 || !S_ISBLK(st.st_mode)) {
+		return false;
+	}
+	leaf = strrchr(dev, '/');
+	if (leaf == NULL || leaf[1] == '\0') {
+		return false;
+	}
+	n = snprintf(sysdir, sizeof(sysdir), "/sys/block/%s", leaf + 1);
+	if (n < 0 || n >= (int)sizeof(sysdir)) {
+		return false;
+	}
+
+	/* The uuid (or wwid) must be this lvol. After a same-nsid reactivate,
+	 * /sys/block/<name>/uuid can already be the new namespace while /dev
+	 * still holds the previous occupant's node; matching only major:minor
+	 * would hand that node out. */
+	if (sysfs_read_line(sysdir, "uuid", id, sizeof(id))) {
+		if (strcasecmp(id, uuid_str) != 0) {
+			return false;
+		}
+	} else if (sysfs_read_line(sysdir, "wwid", id, sizeof(id))) {
+		if (strcasestr(id, uuid_str) == NULL) {
+			return false;
+		}
+	} else {
+		return false;
+	}
+
+	if (!sysfs_read_line(sysdir, "dev", devnum, sizeof(devnum))) {
+		return false;
+	}
+	if (sscanf(devnum, "%u:%u", &maj, &min) != 2) {
+		return false;
+	}
+	if (st.st_rdev != makedev(maj, min)) {
+		return false;
+	}
+
+	/* udev may unlink the node between the first stat and the sysfs reads. */
+	if (stat(dev, &st2) != 0 || !S_ISBLK(st2.st_mode) ||
+	    st2.st_rdev != st.st_rdev) {
+		return false;
+	}
+	return true;
+}
+
+bool
+s3lvol_nvmf_udev_settled(void)
+{
+	/* udev keeps /run/udev/queue in place exactly while it still has events
+	 * to apply -- this is the file udevadm settle waits on. Its absence is
+	 * what makes a node that passes s3lvol_nvmf_device_is_ready() stable:
+	 * nobody is left to unlink it. When udev is not running (containers
+	 * with a static /dev) the file never appears, and nothing moves /dev
+	 * behind us either, so treating that as settled is right. */
+	return access("/run/udev/queue", F_OK) != 0;
 }
 
 uint32_t

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_pending.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_pending.c
@@ -1,0 +1,1324 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+/*
+ *   Deletes that were asked for and could not be carried out yet
+ *
+ *   === Why an intent has to be recorded at all ===
+ *
+ *   `rcow_delete_lvol` on a snapshot is refused when something still references
+ *   it: an export names it, it has more than one clone, or a decouple is copying
+ *   through it. Some of those blockers clear with no further action from anyone
+ *   -- the extra clone is deleted, the copy finishes -- and at that point the
+ *   delete the caller asked for would simply succeed.
+ *
+ *   Without a record, that request is gone the moment the RPC answers. The
+ *   caller has to remember it and come back, and nothing on this node can say
+ *   which snapshots someone has already tried to remove. So a refusal that is
+ *   expected to resolve records the intent here, and two things consume it:
+ *   `rcow_get_lvstores` reports it (the PEND column), and the poller below
+ *   completes the delete once the blocker is gone.
+ *
+ *   === Why the poller does not act on every kind of blocker ===
+ *
+ *   An export whose importers left a *lease* is finished automatically: the
+ *   lease goes stale once nobody renews it, which is positive evidence that
+ *   nobody is reading, and the delete is then exactly as safe as it would have
+ *   been by hand.
+ *
+ *   An export with *no lease at all* is the exception, and deliberately so. Its
+ *   TTL lapsing already makes `s3lvol_export_pinning()` stop reporting a pin, so
+ *   a delete becomes *permitted* on expiry -- but an importer that is still
+ *   reading has no way to say so, and the objects the delete releases are the
+ *   ones it is reading. Completing that automatically would turn expiry into the
+ *   normal path for destroying data somebody may still need; the cheap fix is
+ *   for GC to treat a reference manifest as live (constraint 4b,
+ *   lib/s3bsdev/s3_gc.c), which does not exist yet.
+ *
+ *   So a lease-less export's intent is recorded and reported, and waits for a
+ *   human (or `--retry-pending`) to decide. Everything else -- a live export's
+ *   lease going stale, an export still publishing, extra clones, a running
+ *   decouple -- is completed by the poller. `pending_reason_auto()` is that
+ *   distinction, and `pending_lvol_deletable()` re-checks it against the live
+ *   pin state so an intent recorded before the first lease GET cannot be
+ *   completed on legacy evidence later.
+ *
+ *   === Why the marks are keyed by uuid, and the queue is unbounded ===
+ *
+ *   A name is unique only inside one loaded lvstore and is reusable: delete a
+ *   snapshot and create another by the same name, or unload and attach again,
+ *   and a name-keyed mark would name a different object than the delete was
+ *   refused for -- which the poller would then delete. A lvol uuid is generated
+ *   once and never reused, so a mark can only ever mean the object it was
+ *   recorded for. The lvstore uuid groups them so a teardown can drop them all.
+ *
+ *   The list is not capped. A cap would have to either refuse to record an
+ *   intent (losing a delete the caller did ask for) or evict an older one
+ *   (same, silently); a node with a lot of blocked deletes has a real backlog to
+ *   report, not a reason to start forgetting. Each entry is one small
+ *   allocation, and entries leave on completion or cancellation.
+ */
+
+#include "spdk/stdinc.h"
+#include "spdk/log.h"
+#include "spdk/string.h"
+#include "spdk/thread.h"
+#include "spdk/util.h"
+
+#include "spdk_internal/lvolstore.h"
+
+#include "s3lvol/s3_export.h"
+#include "s3lvol/s3_client.h"
+
+#include "vbdev_s3lvol.h"
+#include "vbdev_s3lvol_json.h"
+#include "pending_persist_ctl.h"
+
+/* How often the queue is re-examined.
+ *
+ * A deleted clone therefore takes up to this long to trigger the snapshot's
+ * removal. That is the accepted latency: the delete is a background intent, the
+ * caller was told it was deferred, and both querying and cancelling it are
+ * immediate. Polling faster would spend blobstore lookups on a queue that is
+ * almost always empty and almost never urgent. */
+#define S3LVOL_PENDING_POLL_US (60ULL * SPDK_SEC_TO_USEC)
+
+/* Deletes started per tick.
+ *
+ * The queue is walked in full each time, but only this many destroys are
+ * launched, so a backlog that has just become deletable drains over several
+ * ticks instead of arriving at blobstore and S3 as one burst. */
+#define S3LVOL_PENDING_BATCH 16
+
+struct s3lvol_pending_delete {
+	struct spdk_uuid           lvs_uuid;
+	struct spdk_uuid           lvol_uuid;
+
+	/* Reporting only -- every lookup goes through the uuids. Kept because an
+	 * entry has to be printable while its lvstore is not loaded, which is
+	 * exactly when the names cannot be resolved. */
+	char                       lvs_name[SPDK_LVS_NAME_MAX];
+	char                       name[SPDK_LVOL_NAME_MAX];
+
+	uint64_t                   enqueued_at;
+	enum s3lvol_pending_reason reason;
+
+	TAILQ_ENTRY(s3lvol_pending_delete) link;
+};
+
+static TAILQ_HEAD(, s3lvol_pending_delete) g_pending_deletes =
+	TAILQ_HEAD_INITIALIZER(g_pending_deletes);
+
+struct pending_persist {
+	struct spdk_uuid           lvs_uuid;
+	struct pending_persist_ctl ctl;
+	/* Unload dropped the marks while a PUT was still in flight. The
+	 * completion writes an empty registry and then frees this, instead of
+	 * freeing under the PUT or letting that completion run against a later
+	 * attach of the same uuid. */
+	bool                       dying;
+	struct s3_client          *client;
+	char                       key[S3_EXPORT_KEY_MAX];
+	TAILQ_ENTRY(pending_persist) link;
+};
+
+static TAILQ_HEAD(, pending_persist) g_pending_persist =
+	TAILQ_HEAD_INITIALIZER(g_pending_persist);
+
+static struct spdk_poller *g_pending_poller;
+
+static int pending_poll(void *arg);
+static void pending_persist(const struct spdk_uuid *lvs_uuid);
+static struct pending_persist *pending_persist_find(const struct spdk_uuid *lvs_uuid);
+static void pending_persist_drop(struct pending_persist *p);
+
+/* ==========================================================================
+ * Reasons
+ * ========================================================================== */
+
+const char *
+s3lvol_pending_reason_str(enum s3lvol_pending_reason reason)
+{
+	switch (reason) {
+	case S3LVOL_PENDING_EXPORT:
+		return "export";
+	case S3LVOL_PENDING_EXPORT_LEGACY:
+		return "export_legacy";
+	case S3LVOL_PENDING_EXPORT_INFLIGHT:
+		return "export_inflight";
+	case S3LVOL_PENDING_CLONE_COUNT:
+		return "clone_count";
+	case S3LVOL_PENDING_DECOUPLE:
+		return "decouple";
+	case S3LVOL_PENDING_FAILED:
+		return "failed";
+	default:
+		return "unknown";
+	}
+}
+
+/* Whether the poller may finish this delete on its own.
+ *
+ * Only the blockers that clear without anyone deciding anything. An export
+ * counts: the importer's lease goes stale once it stops renewing, and that is
+ * positive evidence nobody is reading any more -- which is the condition the
+ * poller waits for. An export with *no lease at all* does not: the only signal
+ * there is a TTL that lapses whether or not somebody is reading, so completing
+ * on that basis would delete data out from under a live importer (constraint 4b,
+ * lib/s3bsdev/s3_gc.c). A destroy that already failed asynchronously is excluded
+ * too -- the failure was not a reference count, and retrying it every minute
+ * forever would only repeat it.
+ *
+ * This decides how the *intent* is reported. Whether a delete actually goes
+ * ahead is decided again, against the live pin state, in
+ * pending_lvol_deletable() -- so an entry recorded before the first lease GET
+ * completed cannot be completed on legacy evidence later. */
+static bool
+pending_reason_auto(enum s3lvol_pending_reason reason)
+{
+	return reason == S3LVOL_PENDING_EXPORT ||
+	       reason == S3LVOL_PENDING_EXPORT_INFLIGHT ||
+	       reason == S3LVOL_PENDING_CLONE_COUNT ||
+	       reason == S3LVOL_PENDING_DECOUPLE;
+}
+
+/* ==========================================================================
+ * The queue
+ * ========================================================================== */
+
+static struct s3lvol_pending_delete *
+pending_delete_find(const struct spdk_uuid *lvs_uuid,
+		    const struct spdk_uuid *lvol_uuid)
+{
+	struct s3lvol_pending_delete *pd;
+
+	TAILQ_FOREACH(pd, &g_pending_deletes, link) {
+		if (spdk_uuid_compare(&pd->lvs_uuid, lvs_uuid) == 0 &&
+		    spdk_uuid_compare(&pd->lvol_uuid, lvol_uuid) == 0) {
+			return pd;
+		}
+	}
+	return NULL;
+}
+
+/* The poller exists only while there is something to poll for.
+ *
+ * Registered on the first entry and unregistered on the last, so an idle node
+ * runs no timer at all. Both are called from paths that already run on the
+ * thread the RPCs run on, which is the thread the destroys have to be issued
+ * from. */
+static void
+pending_poller_sync(void)
+{
+	bool want = !TAILQ_EMPTY(&g_pending_deletes);
+
+	if (want && !g_pending_poller) {
+		g_pending_poller = SPDK_POLLER_REGISTER(pending_poll, NULL,
+						       S3LVOL_PENDING_POLL_US);
+		if (!g_pending_poller) {
+			SPDK_WARNLOG("could not start the pending-delete poller; "
+				     "queued deletes will only complete when "
+				     "retried explicitly\n");
+		}
+	} else if (!want && g_pending_poller) {
+		spdk_poller_unregister(&g_pending_poller);
+		g_pending_poller = NULL;
+	}
+}
+
+void
+s3lvol_snapshot_pending_set(const struct spdk_uuid *lvs_uuid,
+			    const struct spdk_uuid *lvol_uuid,
+			    const char *lvs_name, const char *name,
+			    enum s3lvol_pending_reason reason)
+{
+	struct s3lvol_pending_delete *pd;
+
+	if (!lvs_uuid || !lvol_uuid) {
+		return;
+	}
+
+	pd = pending_delete_find(lvs_uuid, lvol_uuid);
+	if (pd) {
+		/* Asking again is not a second intent, but the blocker may have
+		 * changed between the two attempts -- and it is the current one
+		 * that decides whether the poller may finish the job. */
+		if (pd->reason != reason) {
+			pd->reason = reason;
+			pending_persist(lvs_uuid);
+		}
+		return;
+	}
+
+	pd = calloc(1, sizeof(*pd));
+	if (!pd) {
+		SPDK_ERRLOG("failed to allocate pending-delete mark for '%s'\n",
+			    name ? name : "(unnamed)");
+		return;
+	}
+	spdk_uuid_copy(&pd->lvs_uuid, lvs_uuid);
+	spdk_uuid_copy(&pd->lvol_uuid, lvol_uuid);
+	snprintf(pd->lvs_name, sizeof(pd->lvs_name), "%s", lvs_name ? lvs_name : "");
+	snprintf(pd->name, sizeof(pd->name), "%s", name ? name : "");
+	pd->enqueued_at = (uint64_t)time(NULL);
+	pd->reason = reason;
+	TAILQ_INSERT_TAIL(&g_pending_deletes, pd, link);
+
+	SPDK_NOTICELOG("delete of '%s' is pending: %s%s\n", pd->name,
+		       s3lvol_pending_reason_str(reason),
+		       pending_reason_auto(reason)
+		       ? " (will complete once the blocker clears)"
+		       : " (needs an explicit retry)");
+
+	pending_poller_sync();
+	pending_persist(lvs_uuid);
+}
+
+bool
+s3lvol_snapshot_pending_test(const struct spdk_uuid *lvs_uuid,
+			     const struct spdk_uuid *lvol_uuid)
+{
+	if (!lvs_uuid || !lvol_uuid) {
+		return false;
+	}
+	return pending_delete_find(lvs_uuid, lvol_uuid) != NULL;
+}
+
+bool
+s3lvol_snapshot_pending_deferred(const struct spdk_uuid *lvs_uuid,
+				 const struct spdk_uuid *lvol_uuid)
+{
+	struct s3lvol_pending_delete *pd;
+
+	if (!lvs_uuid || !lvol_uuid) {
+		return false;
+	}
+	pd = pending_delete_find(lvs_uuid, lvol_uuid);
+	return pd && pending_reason_auto(pd->reason);
+}
+
+void
+s3lvol_snapshot_pending_clear(const struct spdk_uuid *lvs_uuid,
+			      const struct spdk_uuid *lvol_uuid)
+{
+	struct s3lvol_pending_delete *pd;
+
+	if (!lvs_uuid || !lvol_uuid) {
+		return;
+	}
+	pd = pending_delete_find(lvs_uuid, lvol_uuid);
+	if (pd) {
+		TAILQ_REMOVE(&g_pending_deletes, pd, link);
+		free(pd);
+		pending_poller_sync();
+		pending_persist(lvs_uuid);
+	}
+}
+
+/* Every mark belonging to one lvstore, dropped in one go.
+ *
+ * Called from the unload / destroy / free paths: past a teardown the marks name
+ * lvols that no longer exist, and an lvstore that is attached again can hand the
+ * same names to different objects. Marks that outlive their lvstore are how the
+ * poller could end up deleting something nobody asked it to. */
+void
+s3lvol_snapshot_pending_clear_lvs(const struct spdk_uuid *lvs_uuid)
+{
+	struct s3lvol_pending_delete *pd, *tmp;
+
+	if (!lvs_uuid) {
+		return;
+	}
+	TAILQ_FOREACH_SAFE(pd, &g_pending_deletes, link, tmp) {
+		if (spdk_uuid_compare(&pd->lvs_uuid, lvs_uuid) == 0) {
+			TAILQ_REMOVE(&g_pending_deletes, pd, link);
+			free(pd);
+		}
+	}
+	pending_poller_sync();
+
+	{
+		struct pending_persist *p, *ptmp;
+
+		TAILQ_FOREACH_SAFE(p, &g_pending_persist, link, ptmp) {
+			if (spdk_uuid_compare(&p->lvs_uuid, lvs_uuid) != 0) {
+				continue;
+			}
+			if (p->ctl.in_flight || p->ctl.dirty) {
+				/* A PUT is still using this entry. Keep it so the
+				 * completion cannot run against a later attach, and
+				 * ask for one more write of the now-empty queue. */
+				p->dying = true;
+				p->ctl.dirty = true;
+				if (!p->ctl.in_flight) {
+					pending_persist(lvs_uuid);
+				}
+			} else {
+				pending_persist_drop(p);
+			}
+		}
+	}
+}
+
+int
+s3lvol_pending_foreach(s3lvol_pending_cb cb, void *cb_arg)
+{
+	struct s3lvol_pending_delete *pd, *tmp;
+	unsigned n = 0;
+
+	if (!cb) {
+		return -EINVAL;
+	}
+
+	/* _SAFE so a callback that cancels the entry it is looking at -- which is
+	 * the natural way to write "drop everything matching X" -- does not walk
+	 * off a freed link. */
+	TAILQ_FOREACH_SAFE(pd, &g_pending_deletes, link, tmp) {
+		struct s3lvol_pending_entry e = {
+			.lvs_uuid    = pd->lvs_uuid,
+			.lvol_uuid   = pd->lvol_uuid,
+			.lvs_name    = pd->lvs_name,
+			.lvol_name   = pd->name,
+			.enqueued_at = pd->enqueued_at,
+			.reason      = pd->reason,
+			.deferred    = pending_reason_auto(pd->reason),
+		};
+
+		cb(cb_arg, &e);
+		n++;
+	}
+	return (int)n;
+}
+
+/* ==========================================================================
+ * The poller
+ * ========================================================================== */
+
+struct pending_destroy_ctx {
+	struct spdk_uuid lvs_uuid;
+	struct spdk_uuid lvol_uuid;
+	char             name[SPDK_LVOL_NAME_MAX];
+};
+
+static void
+pending_destroy_done(void *cb_arg, int lvolerrno)
+{
+	struct pending_destroy_ctx *ctx = cb_arg;
+
+	if (lvolerrno == 0) {
+		/* s3lvol_lvol_destroyed() has already dropped the mark; this is
+		 * the line that says the *queue* is what finished it. */
+		SPDK_NOTICELOG("pending delete of '%s' completed\n", ctx->name);
+	} else {
+		/* The pre-checks below are the same ones the immediate path
+		 * applies, so a failure here is something they cannot see -- a
+		 * bdev that would not unregister, blobstore refusing for a
+		 * reason of its own. Retrying it every minute forever would only
+		 * repeat it, so the entry is dropped and the failure reported
+		 * once. The snapshot is still there and the caller can ask
+		 * again.
+		 *
+		 * The destroy's own error path has just re-recorded the mark
+		 * (s3lvol_lvol_destroyed), which is why this clears rather than
+		 * simply leaves it out. */
+		s3lvol_snapshot_pending_clear(&ctx->lvs_uuid, &ctx->lvol_uuid);
+		SPDK_ERRLOG("pending delete of '%s' failed: %s. Dropped from the "
+			    "queue; retry it explicitly if it is still wanted.\n",
+			    ctx->name, spdk_strerror(-lvolerrno));
+	}
+	free(ctx);
+}
+
+/* Whether this lvol can be deleted right now.
+ *
+ * Deliberately the same predicates, in the same order, as the refusals in
+ * s3lvol_lvol_destroy(): a deferred delete has to be exactly as safe as
+ * deleting on the spot would have been, and the way to guarantee that is to ask
+ * the same questions rather than a summary of them. */
+static bool
+pending_lvol_deletable(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol,
+		       const char **why)
+{
+	/* A mounted namespace is never touched from here. The delete would block
+	 * in bdev unregister until the host disconnects, and the host did not ask
+	 * for that -- the caller has to deactivate first. */
+	if (s3lvol_active_find(lvol->name)) {
+		*why = "the volume is active";
+		return false;
+	}
+	if (s3lvol_export_inflight_pinning(lvs, lvol->name)) {
+		*why = "an export is still publishing";
+		return false;
+	}
+
+	/* Asked as a state rather than a yes/no, because the two ways an export
+	 * stops pinning are not equally good. A stale lease is evidence: an
+	 * importer wrote it and stopped renewing, so nobody is reading. An export
+	 * with no lease is not -- its TTL lapses on its own, and completing a
+	 * delete on that basis is exactly the hazard §5.3 of
+	 * docs/pending-delete-design.md refuses to automate. So LEGACY is skipped
+	 * whether or not the TTL has passed, which also covers an entry that was
+	 * recorded before the first lease GET had answered. */
+	switch (s3lvol_export_pin_state(lvs, lvol->name)) {
+	case S3LVOL_EXPORT_PIN_LEASE:
+		*why = "an importer may still be reading an export of it";
+		return false;
+	case S3LVOL_EXPORT_PIN_LEGACY:
+		*why = "an export with no lease names it; only an explicit retry "
+		       "can complete this";
+		return false;
+	case S3LVOL_EXPORT_PIN_STALE:
+	case S3LVOL_EXPORT_PIN_NONE:
+	default:
+		break;
+	}
+
+	if (lvol->blob) {
+		size_t clone_count = 0;
+		int rc;
+
+		rc = spdk_blob_get_clones(lvol->lvol_store->blobstore,
+					  lvol->blob_id, NULL, &clone_count);
+		if (rc != 0 && rc != -ENOMEM) {
+			*why = "the clone count is unreadable";
+			return false;
+		}
+		if (clone_count > 1) {
+			*why = "it still has more than one clone";
+			return false;
+		}
+	}
+	if (lvol->action_in_progress) {
+		*why = "an operation is in progress on it";
+		return false;
+	}
+	return true;
+}
+
+static int
+pending_poll(void *arg)
+{
+	struct pending_destroy_ctx *batch[S3LVOL_PENDING_BATCH];
+	struct spdk_lvol *lvols[S3LVOL_PENDING_BATCH];
+	struct s3lvol_lvstore *lvs;
+	unsigned n = 0;
+	unsigned i;
+
+	/* Pass one collects, pass two destroys. The destroy path unregisters a
+	 * bdev and frees the lvol from its completion, which can reach back into
+	 * the very list being walked here -- so nothing is destroyed while
+	 * iterating. */
+	for (lvs = s3lvol_lvstore_first(); lvs && n < S3LVOL_PENDING_BATCH;
+	     lvs = s3lvol_lvstore_next(lvs)) {
+		struct spdk_lvol_store *store = s3lvol_lvstore_get_lvs(lvs);
+		struct spdk_lvol *lvol;
+
+		if (!store) {
+			continue;	/* still loading */
+		}
+
+		TAILQ_FOREACH(lvol, &store->lvols, link) {
+			struct s3lvol_pending_delete *pd;
+			const char *why = NULL;
+
+			if (n == S3LVOL_PENDING_BATCH) {
+				break;
+			}
+
+			pd = pending_delete_find(&store->uuid, &lvol->uuid);
+			if (!pd) {
+				continue;
+			}
+
+			/* An export-blocked entry may have been recorded before
+			 * the first lease GET answered, when it was not yet
+			 * knowable whether the export has a lease at all. Once it
+			 * is, correct the record -- otherwise
+			 * rcow_get_pending_deletes would keep promising that an
+			 * intent completes itself when it never will, or the
+			 * reverse. */
+			if (pd->reason == S3LVOL_PENDING_EXPORT ||
+			    pd->reason == S3LVOL_PENDING_EXPORT_LEGACY) {
+				enum s3lvol_pending_reason was = pd->reason;
+
+				pd->reason =
+					s3lvol_export_pin_state(lvs, lvol->name) ==
+					S3LVOL_EXPORT_PIN_LEGACY
+					? S3LVOL_PENDING_EXPORT_LEGACY
+					: S3LVOL_PENDING_EXPORT;
+				if (pd->reason != was) {
+					pending_persist(&store->uuid);
+				}
+			}
+
+			if (!pending_reason_auto(pd->reason)) {
+				continue;
+			}
+			if (!pending_lvol_deletable(lvs, lvol, &why)) {
+				SPDK_DEBUGLOG(vbdev_s3lvol,
+					      "pending delete of '%s' still waiting: %s\n",
+					      lvol->name, why);
+				continue;
+			}
+
+			batch[n] = calloc(1, sizeof(*batch[n]));
+			if (!batch[n]) {
+				break;
+			}
+			spdk_uuid_copy(&batch[n]->lvs_uuid, &store->uuid);
+			spdk_uuid_copy(&batch[n]->lvol_uuid, &lvol->uuid);
+			snprintf(batch[n]->name, sizeof(batch[n]->name), "%s",
+				 lvol->name);
+			lvols[n] = lvol;
+			n++;
+		}
+	}
+
+	for (i = 0; i < n; i++) {
+		int rc;
+
+		SPDK_NOTICELOG("completing the pending delete of '%s'\n",
+			       batch[i]->name);
+
+		rc = s3lvol_lvol_destroy(lvols[i], pending_destroy_done, batch[i]);
+		if (rc != 0) {
+			/* A synchronous refusal means a blocker appeared between
+			 * the check above and this call, or one the check cannot
+			 * see. The destroy has re-recorded the mark itself, so the
+			 * entry simply stays and the next tick tries again. */
+			SPDK_DEBUGLOG(vbdev_s3lvol,
+				      "pending delete of '%s' not started: %s\n",
+				      batch[i]->name, spdk_strerror(-rc));
+			free(batch[i]);
+		}
+	}
+
+	return n ? SPDK_POLLER_BUSY : SPDK_POLLER_IDLE;
+}
+
+/* ==========================================================================
+ * Persistence
+ *
+ * One object per lvstore, next to the exports registry it is modelled on. The
+ * queue has to survive a restart for the same reason it exists at all: a delete
+ * that is waiting for a clone to go away would otherwise be forgotten by the
+ * next attach, and the caller was told it did not need to do anything else.
+ *
+ * Unlike the exports and imports registries, a failure here is never fatal.
+ * Those two protect data -- forgetting an export lets a delete break a live
+ * importer, forgetting an import opens a clone against nothing -- while the
+ * worst case here is a leaked or forgotten *intent*: the snapshot is still
+ * there, and the delete can be asked for again. So every path below logs and
+ * carries on, and an lvstore whose pending registry is unreadable still
+ * attaches.
+ * ========================================================================== */
+
+/* Generous, and deliberately not the queue's limit -- there is none (see the
+ * header). It caps only what one *file* may describe, so a corrupt or absurd
+ * object cannot make the decoder allocate without bound. Reaching it means the
+ * tail of the queue is not restored; the deletes it names have to be reissued,
+ * which is the same cost as the crash window. */
+#define S3LVOL_PENDING_MAX_PERSISTED 4096
+
+#define S3LVOL_PENDING_VERSION 1
+
+static void
+pending_registry_key(const char *prefix, char *out, size_t out_len)
+{
+	snprintf(out, out_len, "%s/meta/pending-deletes.json", prefix);
+}
+
+static struct s3lvol_lvstore *
+pending_lvs_by_uuid(const struct spdk_uuid *lvs_uuid)
+{
+	struct s3lvol_lvstore *lvs;
+
+	for (lvs = s3lvol_lvstore_first(); lvs; lvs = s3lvol_lvstore_next(lvs)) {
+		struct spdk_lvol_store *store = s3lvol_lvstore_get_lvs(lvs);
+
+		/* Uuid, not name: unload can be followed by a same-name attach
+		 * with a new blobstore uuid, and a late GET of the old registry
+		 * must not populate that wrapper. */
+		if (store && spdk_uuid_compare(&store->uuid, lvs_uuid) == 0) {
+			return lvs;
+		}
+	}
+	return NULL;
+}
+
+static enum s3lvol_pending_reason
+pending_reason_parse(const char *s)
+{
+	if (!s) {
+		return S3LVOL_PENDING_FAILED;
+	}
+	if (strcmp(s, "export") == 0) {
+		return S3LVOL_PENDING_EXPORT;
+	}
+	if (strcmp(s, "export_inflight") == 0) {
+		return S3LVOL_PENDING_EXPORT_INFLIGHT;
+	}
+	if (strcmp(s, "clone_count") == 0) {
+		return S3LVOL_PENDING_CLONE_COUNT;
+	}
+	if (strcmp(s, "decouple") == 0) {
+		return S3LVOL_PENDING_DECOUPLE;
+	}
+	/* Including "failed" and anything a newer version wrote: an unrecognised
+	 * blocker is one this build cannot reason about, and treating it as
+	 * needing an explicit retry is the direction that cannot delete
+	 * something by accident. */
+	return S3LVOL_PENDING_FAILED;
+}
+
+static int
+pending_serialize(struct s3lvol_lvstore *lvs, const struct spdk_uuid *lvs_uuid,
+		  char **out, size_t *out_len)
+{
+	struct s3lvol_json_buf buf = {0};
+	struct spdk_json_write_ctx *w;
+	struct s3lvol_pending_delete *pd;
+	int rc;
+
+	w = spdk_json_write_begin(s3lvol_json_buf_append, &buf, 0);
+	if (!w) {
+		return -ENOMEM;
+	}
+
+	spdk_json_write_object_begin(w);
+	spdk_json_write_named_uint32(w, "version", S3LVOL_PENDING_VERSION);
+	spdk_json_write_named_array_begin(w, "pending_deletes");
+
+	TAILQ_FOREACH(pd, &g_pending_deletes, link) {
+		char uuid_str[SPDK_UUID_STRING_LEN];
+
+		if (spdk_uuid_compare(&pd->lvs_uuid, lvs_uuid) != 0) {
+			continue;
+		}
+
+		spdk_uuid_fmt_lower(uuid_str, sizeof(uuid_str), &pd->lvol_uuid);
+
+		spdk_json_write_object_begin(w);
+		/* The uuid is the identity; the name is written so an entry whose
+		 * lvstore is not loaded can still be reported. */
+		spdk_json_write_named_string(w, "lvol_uuid", uuid_str);
+		spdk_json_write_named_string(w, "lvol_name", pd->name);
+		spdk_json_write_named_string(w, "lvs_name",
+					     lvs ? s3lvol_lvstore_get_name(lvs) : "");
+		spdk_json_write_named_uint64(w, "enqueued_at", pd->enqueued_at);
+		spdk_json_write_named_string(w, "reason",
+					     s3lvol_pending_reason_str(pd->reason));
+		spdk_json_write_object_end(w);
+	}
+
+	spdk_json_write_array_end(w);
+	spdk_json_write_object_end(w);
+
+	rc = spdk_json_write_end(w);
+	if (rc != 0 || !buf.data) {
+		free(buf.data);
+		return rc != 0 ? rc : -ENOMEM;
+	}
+
+	*out = buf.data;
+	*out_len = buf.len;
+	return 0;
+}
+
+/* ---- save ---- */
+
+struct pending_save_ctx {
+	char              *json;
+	struct iovec       iov;
+	char               key[S3_EXPORT_KEY_MAX];
+	struct spdk_uuid   lvs_uuid;
+};
+
+static struct pending_persist *
+pending_persist_find(const struct spdk_uuid *lvs_uuid)
+{
+	struct pending_persist *p;
+
+	TAILQ_FOREACH(p, &g_pending_persist, link) {
+		if (spdk_uuid_compare(&p->lvs_uuid, lvs_uuid) == 0) {
+			return p;
+		}
+	}
+	return NULL;
+}
+
+static struct pending_persist *
+pending_persist_get(const struct spdk_uuid *lvs_uuid)
+{
+	struct pending_persist *p = pending_persist_find(lvs_uuid);
+
+	if (p) {
+		return p;
+	}
+	p = calloc(1, sizeof(*p));
+	if (!p) {
+		return NULL;
+	}
+	spdk_uuid_copy(&p->lvs_uuid, lvs_uuid);
+	TAILQ_INSERT_TAIL(&g_pending_persist, p, link);
+	return p;
+}
+
+static void
+pending_persist_drop(struct pending_persist *p)
+{
+	TAILQ_REMOVE(&g_pending_persist, p, link);
+	s3_client_put(p->client);
+	free(p);
+}
+
+static void
+pending_persist_bind(struct pending_persist *p, struct s3lvol_lvstore *lvs)
+{
+	if (!p->client) {
+		p->client = s3lvol_lvstore_get_client(lvs);
+		s3_client_get(p->client);
+	}
+	if (p->key[0] == '\0') {
+		pending_registry_key(s3lvol_lvstore_get_name(lvs), p->key,
+				      sizeof(p->key));
+	}
+}
+
+static void
+pending_save_done(void *cb_arg, int status)
+{
+	struct pending_save_ctx *ctx = cb_arg;
+	struct pending_persist *p;
+
+	if (status != 0) {
+		SPDK_WARNLOG("Failed to write '%s': %s. Deletes queued since the "
+			     "last successful write will be forgotten if this node "
+			     "restarts, and have to be asked for again.\n",
+			     ctx->key, spdk_strerror(-status));
+	}
+
+	p = pending_persist_find(&ctx->lvs_uuid);
+	free(ctx->json);
+	free(ctx);
+
+	if (p && pending_persist_end(&p->ctl)) {
+		pending_persist(&p->lvs_uuid);
+		return;
+	}
+	if (p && p->dying) {
+		pending_persist_drop(p);
+	}
+}
+
+/* Answer first, persist after.
+ *
+ * The RPC has already told the caller the delete was accepted, and waiting for
+ * S3 before answering would put a round trip on the one path that is supposed to
+ * be a registry write. The window that opens is "enqueued, crashed before the
+ * PUT landed", whose cost is one delete the caller has to reissue -- the same
+ * window the exports registry accepts, and there the stakes are higher.
+ *
+ * One PUT per lvstore. A later mutation while a PUT is in flight marks the
+ * registry dirty; completion serialises the *current* marks, so a slow set(A)
+ * cannot land after cancel(A). */
+static void
+pending_persist(const struct spdk_uuid *lvs_uuid)
+{
+	struct s3lvol_lvstore *lvs = pending_lvs_by_uuid(lvs_uuid);
+	struct pending_persist *p;
+	struct pending_save_ctx *ctx;
+	struct s3_client *client;
+	size_t len;
+	int rc;
+
+	p = lvs ? pending_persist_get(lvs_uuid) : pending_persist_find(lvs_uuid);
+	if (!p) {
+		return;
+	}
+
+	if (!lvs) {
+		/* Unload dropped the marks. A PUT still in flight has to land an
+		 * empty registry so a later attach does not restore them; anything
+		 * else has nothing to write. */
+		if (!p->dying || !p->client || p->key[0] == '\0') {
+			p->ctl.in_flight = false;
+			p->ctl.dirty = false;
+			if (p->dying) {
+				pending_persist_drop(p);
+			}
+			return;
+		}
+	} else {
+		if (p->dying) {
+			p->dying = false;
+		}
+		pending_persist_bind(p, lvs);
+	}
+
+	if (!pending_persist_begin(&p->ctl)) {
+		return;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		p->ctl.in_flight = false;
+		return;
+	}
+	spdk_uuid_copy(&ctx->lvs_uuid, lvs_uuid);
+	snprintf(ctx->key, sizeof(ctx->key), "%s", p->key);
+
+	rc = pending_serialize(lvs, lvs_uuid, &ctx->json, &len);
+	if (rc != 0) {
+		free(ctx);
+		if (pending_persist_end(&p->ctl)) {
+			pending_persist(lvs_uuid);
+		}
+		return;
+	}
+	ctx->iov.iov_base = ctx->json;
+	ctx->iov.iov_len = len;
+
+	client = lvs ? s3lvol_lvstore_get_client(lvs) : p->client;
+	rc = s3_put(client, ctx->key, &ctx->iov, 1, false, pending_save_done, ctx);
+	if (rc != 0) {
+		SPDK_WARNLOG("Could not submit the pending-delete registry write "
+			     "for '%s': %s\n", ctx->key, spdk_strerror(-rc));
+		free(ctx->json);
+		free(ctx);
+		if (pending_persist_end(&p->ctl)) {
+			pending_persist(lvs_uuid);
+		}
+	}
+}
+
+/* ---- load ---- */
+
+struct pending_entry_json {
+	char    *lvol_uuid;
+	char    *lvol_name;
+	char    *lvs_name;
+	char    *reason;
+	uint64_t enqueued_at;
+};
+
+static const struct spdk_json_object_decoder pending_entry_decoders[] = {
+	{"lvol_uuid", offsetof(struct pending_entry_json, lvol_uuid), spdk_json_decode_string, false},
+	{"lvol_name", offsetof(struct pending_entry_json, lvol_name), spdk_json_decode_string, true},
+	{"lvs_name", offsetof(struct pending_entry_json, lvs_name), spdk_json_decode_string, true},
+	{"reason", offsetof(struct pending_entry_json, reason), spdk_json_decode_string, true},
+	{"enqueued_at", offsetof(struct pending_entry_json, enqueued_at), spdk_json_decode_uint64, true},
+};
+
+struct pending_entries_holder {
+	struct pending_entry_json e[S3LVOL_PENDING_MAX_PERSISTED];
+	size_t                    n;
+};
+
+struct pending_json {
+	uint32_t                      version;
+	struct pending_entries_holder entries;
+};
+
+static int
+decode_pending_entry(const struct spdk_json_val *val, void *out)
+{
+	return spdk_json_decode_object(val, pending_entry_decoders,
+				       SPDK_COUNTOF(pending_entry_decoders), out);
+}
+
+static int
+decode_pending_entries(const struct spdk_json_val *val, void *out)
+{
+	struct pending_entries_holder *h = out;
+
+	return spdk_json_decode_array(val, decode_pending_entry, h->e,
+				      S3LVOL_PENDING_MAX_PERSISTED, &h->n,
+				      sizeof(h->e[0]));
+}
+
+static const struct spdk_json_object_decoder pending_decoders[] = {
+	{"version", offsetof(struct pending_json, version), spdk_json_decode_uint32, false},
+	{"pending_deletes", offsetof(struct pending_json, entries), decode_pending_entries, false},
+};
+
+static int
+pending_parse(struct s3lvol_lvstore *lvs, const void *json, size_t len)
+{
+	struct spdk_lvol_store *store = s3lvol_lvstore_get_lvs(lvs);
+	const char *lvs_name = s3lvol_lvstore_get_name(lvs);
+	struct pending_json j = {0};
+	struct spdk_json_val *values = NULL;
+	char *copy = NULL;
+	ssize_t num_values;
+	size_t i;
+	unsigned restored = 0;
+	int rc;
+
+	if (!store) {
+		return -EINVAL;
+	}
+
+	copy = malloc(len);
+	if (!copy) {
+		return -ENOMEM;
+	}
+	memcpy(copy, json, len);
+
+	/* Counted without DECODE_IN_PLACE for the reason spelled out in the
+	 * exports registry: that flag unescapes into the buffer even when there
+	 * is nowhere to put the values, so the second pass would parse a
+	 * document the first one had already rewritten. */
+	num_values = spdk_json_parse(copy, len, NULL, 0, NULL, 0);
+	if (num_values <= 0) {
+		SPDK_WARNLOG("pending-delete registry of '%s' is not valid JSON; "
+			     "ignoring it\n", lvs_name);
+		rc = -EINVAL;
+		goto out;
+	}
+	values = calloc((size_t)num_values, sizeof(*values));
+	if (!values) {
+		rc = -ENOMEM;
+		goto out;
+	}
+	num_values = spdk_json_parse(copy, len, values, (size_t)num_values, NULL,
+				     SPDK_JSON_PARSE_FLAG_DECODE_IN_PLACE);
+	if (num_values <= 0) {
+		SPDK_WARNLOG("pending-delete registry of '%s' did not parse on the "
+			     "second pass (%zd); ignoring it\n", lvs_name, num_values);
+		rc = -EINVAL;
+		goto out;
+	}
+	if (spdk_json_decode_object(values, pending_decoders,
+				    SPDK_COUNTOF(pending_decoders), &j) != 0) {
+		SPDK_WARNLOG("pending-delete registry of '%s' could not be decoded; "
+			     "ignoring it\n", lvs_name);
+		rc = -EINVAL;
+		goto out;
+	}
+	if (j.version != S3LVOL_PENDING_VERSION) {
+		/* Ignored rather than refused. The exports registry fails the
+		 * attach on an unknown version because acting without it risks
+		 * data; here it would refuse to attach an otherwise healthy
+		 * lvstore over a queue of intents. */
+		SPDK_WARNLOG("pending-delete registry of '%s' is version %" PRIu32
+			     ", this build understands %d; ignoring it. Queued "
+			     "deletes have to be asked for again.\n",
+			     lvs_name, j.version, S3LVOL_PENDING_VERSION);
+		rc = 0;
+		goto out;
+	}
+
+	for (i = 0; i < j.entries.n; i++) {
+		struct pending_entry_json *e = &j.entries.e[i];
+		struct s3lvol_pending_delete *pd;
+		struct spdk_uuid lvol_uuid;
+
+		if (spdk_uuid_parse(&lvol_uuid, e->lvol_uuid) != 0) {
+			SPDK_WARNLOG("pending-delete registry of '%s' has an entry "
+				     "with an unparseable uuid '%s'; skipping it\n",
+				     lvs_name, e->lvol_uuid);
+			continue;
+		}
+		if (pending_delete_find(&store->uuid, &lvol_uuid)) {
+			continue;	/* already recorded in this run */
+		}
+
+		pd = calloc(1, sizeof(*pd));
+		if (!pd) {
+			break;
+		}
+		spdk_uuid_copy(&pd->lvs_uuid, &store->uuid);
+		spdk_uuid_copy(&pd->lvol_uuid, &lvol_uuid);
+		snprintf(pd->lvs_name, sizeof(pd->lvs_name), "%s", lvs_name);
+		snprintf(pd->name, sizeof(pd->name), "%s",
+			 e->lvol_name ? e->lvol_name : "");
+		pd->enqueued_at = e->enqueued_at;
+		pd->reason = pending_reason_parse(e->reason);
+		TAILQ_INSERT_TAIL(&g_pending_deletes, pd, link);
+		restored++;
+	}
+
+	if (restored) {
+		SPDK_NOTICELOG("lvstore '%s' has %u delete%s still pending\n",
+			       lvs_name, restored, restored == 1 ? "" : "s");
+		pending_poller_sync();
+	}
+	rc = 0;
+
+out:
+	for (i = 0; i < j.entries.n; i++) {
+		free(j.entries.e[i].lvol_uuid);
+		free(j.entries.e[i].lvol_name);
+		free(j.entries.e[i].lvs_name);
+		free(j.entries.e[i].reason);
+	}
+	free(values);
+	free(copy);
+	return rc;
+}
+
+enum pending_load_hold_stage {
+	PENDING_LOAD_HOLD_NONE = 0,
+	PENDING_LOAD_HOLD_HEAD,
+	PENDING_LOAD_HOLD_GET,
+};
+
+struct pending_load_ctx {
+	struct s3_client          *client;
+	struct spdk_uuid           lvs_uuid;
+	char                       lvs_name[SPDK_LVS_NAME_MAX];
+	char                      *body;
+	uint64_t                   size;
+	char                       key[S3_EXPORT_KEY_MAX];
+	int                        parked_status;
+	uint64_t                   parked_bytes;
+	bool                       parked_get;
+	bool                       parked;
+	TAILQ_ENTRY(pending_load_ctx) park_link;
+};
+
+static enum pending_load_hold_stage g_pending_load_hold;
+static TAILQ_HEAD(, pending_load_ctx) g_pending_load_parked =
+	TAILQ_HEAD_INITIALIZER(g_pending_load_parked);
+
+static void pending_load_continue_head(struct pending_load_ctx *ctx, int status);
+static void pending_load_continue_get(struct pending_load_ctx *ctx, int status,
+				       uint64_t bytes_read);
+
+static struct s3lvol_lvstore *
+pending_load_live_lvs(const struct pending_load_ctx *ctx)
+{
+	return pending_lvs_by_uuid(&ctx->lvs_uuid);
+}
+
+static void
+pending_load_unpark(struct pending_load_ctx *ctx)
+{
+	if (!ctx->parked) {
+		return;
+	}
+	TAILQ_REMOVE(&g_pending_load_parked, ctx, park_link);
+	ctx->parked = false;
+}
+
+static void
+pending_load_park(struct pending_load_ctx *ctx, int status, uint64_t bytes,
+		  bool is_get)
+{
+	ctx->parked_status = status;
+	ctx->parked_bytes = bytes;
+	ctx->parked_get = is_get;
+	if (!ctx->parked) {
+		TAILQ_INSERT_TAIL(&g_pending_load_parked, ctx, park_link);
+		ctx->parked = true;
+	}
+	SPDK_NOTICELOG("pending-delete load %s parked for '%s'\n",
+		       is_get ? "GET" : "HEAD", ctx->lvs_name);
+}
+
+static void
+pending_load_done(struct pending_load_ctx *ctx, int status)
+{
+	if (status != 0) {
+		SPDK_WARNLOG("pending-delete registry of '%s' was not loaded (%s); "
+			     "queued deletes have to be asked for again\n",
+			     ctx->lvs_name, spdk_strerror(-status));
+	}
+	pending_load_unpark(ctx);
+	if (ctx->client) {
+		s3_client_put(ctx->client);
+	}
+	free(ctx->body);
+	free(ctx);
+}
+
+static void
+pending_load_continue_get(struct pending_load_ctx *ctx, int status,
+			    uint64_t bytes_read)
+{
+	struct s3lvol_lvstore *lvs;
+
+	if (status != 0) {
+		pending_load_done(ctx, status);
+		return;
+	}
+
+	lvs = pending_load_live_lvs(ctx);
+	if (!lvs) {
+		SPDK_NOTICELOG("pending-delete load dropped for '%s': lvstore gone\n",
+			       ctx->lvs_name);
+		pending_load_done(ctx, 0);
+		return;
+	}
+	pending_load_done(ctx, pending_parse(lvs, ctx->body, bytes_read));
+}
+
+static void
+pending_load_got_body(void *cb_arg, uint64_t bytes_read, int status)
+{
+	struct pending_load_ctx *ctx = cb_arg;
+
+	if (g_pending_load_hold == PENDING_LOAD_HOLD_GET) {
+		pending_load_park(ctx, status, bytes_read, true);
+		return;
+	}
+	pending_load_continue_get(ctx, status, bytes_read);
+}
+
+static void
+pending_load_continue_head(struct pending_load_ctx *ctx, int status)
+{
+	struct s3lvol_lvstore *lvs;
+	int rc;
+
+	if (status == -ENOENT || (status == 0 && ctx->size == 0)) {
+		pending_load_done(ctx, 0);
+		return;
+	}
+	if (status != 0) {
+		pending_load_done(ctx, status);
+		return;
+	}
+
+	lvs = pending_load_live_lvs(ctx);
+	if (!lvs) {
+		SPDK_NOTICELOG("pending-delete load dropped after HEAD for '%s': "
+			       "lvstore gone\n", ctx->lvs_name);
+		pending_load_done(ctx, 0);
+		return;
+	}
+
+	if (ctx->size > 64u * 1024 * 1024) {
+		SPDK_WARNLOG("'%s' is %" PRIu64 " bytes, which is not a plausible "
+			     "pending-delete registry; ignoring it\n",
+			     ctx->key, ctx->size);
+		pending_load_done(ctx, -EINVAL);
+		return;
+	}
+
+	ctx->body = malloc(ctx->size);
+	if (!ctx->body) {
+		pending_load_done(ctx, -ENOMEM);
+		return;
+	}
+
+	rc = s3_get_range(ctx->client, ctx->key, 0, ctx->size, ctx->body,
+			   pending_load_got_body, ctx);
+	if (rc != 0) {
+		pending_load_done(ctx, rc);
+	}
+}
+
+static void
+pending_load_head_done(void *cb_arg, int status)
+{
+	struct pending_load_ctx *ctx = cb_arg;
+
+	if (g_pending_load_hold == PENDING_LOAD_HOLD_HEAD) {
+		pending_load_park(ctx, status, 0, false);
+		return;
+	}
+	pending_load_continue_head(ctx, status);
+}
+
+int
+s3lvol_pending_load_hold(const char *stage)
+{
+	if (!stage || stage[0] == '\0' || strcmp(stage, "none") == 0) {
+		g_pending_load_hold = PENDING_LOAD_HOLD_NONE;
+		return 0;
+	}
+	if (strcmp(stage, "head") == 0) {
+		g_pending_load_hold = PENDING_LOAD_HOLD_HEAD;
+		return 0;
+	}
+	if (strcmp(stage, "get") == 0) {
+		g_pending_load_hold = PENDING_LOAD_HOLD_GET;
+		return 0;
+	}
+	return -EINVAL;
+}
+
+const char *
+s3lvol_pending_load_hold_name(void)
+{
+	switch (g_pending_load_hold) {
+	case PENDING_LOAD_HOLD_HEAD:
+		return "head";
+	case PENDING_LOAD_HOLD_GET:
+		return "get";
+	case PENDING_LOAD_HOLD_NONE:
+	default:
+		return "none";
+	}
+}
+
+unsigned
+s3lvol_pending_load_parked_count(void)
+{
+	struct pending_load_ctx *ctx;
+	unsigned n = 0;
+
+	TAILQ_FOREACH(ctx, &g_pending_load_parked, park_link) {
+		n++;
+	}
+	return n;
+}
+
+unsigned
+s3lvol_pending_load_release(void)
+{
+	struct pending_load_ctx *ctx;
+	unsigned n = 0;
+
+	g_pending_load_hold = PENDING_LOAD_HOLD_NONE;
+	while ((ctx = TAILQ_FIRST(&g_pending_load_parked)) != NULL) {
+		bool is_get = ctx->parked_get;
+		int status = ctx->parked_status;
+		uint64_t bytes = ctx->parked_bytes;
+
+		pending_load_unpark(ctx);
+		n++;
+		if (is_get) {
+			pending_load_continue_get(ctx, status, bytes);
+		} else {
+			pending_load_continue_head(ctx, status);
+		}
+	}
+	return n;
+}
+
+void
+s3lvol_pending_load(struct s3lvol_lvstore *lvs)
+{
+	struct pending_load_ctx *ctx;
+	struct spdk_lvol_store *store;
+	struct s3_client *client;
+	const char *name;
+	int rc;
+
+	if (!lvs) {
+		return;
+	}
+	store = s3lvol_lvstore_get_lvs(lvs);
+	client = s3lvol_lvstore_get_client(lvs);
+	name = s3lvol_lvstore_get_name(lvs);
+	if (!store || !client || !name) {
+		return;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		return;
+	}
+	ctx->client = client;
+	s3_client_get(client);
+	ctx->lvs_uuid = store->uuid;
+	snprintf(ctx->lvs_name, sizeof(ctx->lvs_name), "%s", name);
+	pending_registry_key(name, ctx->key, sizeof(ctx->key));
+
+	rc = s3_head(client, ctx->key, &ctx->size, pending_load_head_done, ctx);
+	if (rc != 0) {
+		pending_load_done(ctx, rc);
+	}
+}

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_pending.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_pending.c
@@ -454,10 +454,10 @@ pending_lvol_deletable(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol,
 	 * stops pinning are not equally good. A stale lease is evidence: an
 	 * importer wrote it and stopped renewing, so nobody is reading. An export
 	 * with no lease is not -- its TTL lapses on its own, and completing a
-	 * delete on that basis is exactly the hazard §5.3 of
-	 * docs/pending-delete-design.md refuses to automate. So LEGACY is skipped
-	 * whether or not the TTL has passed, which also covers an entry that was
-	 * recorded before the first lease GET had answered. */
+	 * delete on that basis is exactly the hazard that refuses to automate.
+	 * So LEGACY is skipped whether or not the TTL has passed, which also
+	 * covers an entry that was recorded before the first lease GET had
+	 * answered. */
 	switch (s3lvol_export_pin_state(lvs, lvol->name)) {
 	case S3LVOL_EXPORT_PIN_LEASE:
 		*why = "an importer may still be reading an export of it";

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
@@ -758,17 +758,44 @@ static const struct spdk_json_object_decoder rpc_create_clone_decoders[] = {
  * Also, callers should not hand-assemble a bdev name for nvmf -- the correct
  * entry point is rcow_active_bdev, which takes the lvol name (not the bdev
  * name). */
+/* Carries the one fact the reply needs beyond the new name: whether taking this
+ * snapshot cancelled a decouple. Known synchronously, but reported from the
+ * completion, which is why it cannot simply be a local variable. */
+struct rpc_derive_ctx {
+	struct spdk_jsonrpc_request *request;
+	bool                         cancelled_decouple;
+};
+
 static void
 rpc_derive_lvol_cb(void *cb_arg, struct spdk_lvol *lvol, int lvolerrno)
 {
-	struct spdk_jsonrpc_request *request = cb_arg;
+	struct rpc_derive_ctx *ctx = cb_arg;
+	struct spdk_json_write_ctx *w;
 
 	if (lvolerrno != 0) {
-		rpc_lvol_respond_err(request, lvolerrno, NULL);
+		rpc_lvol_respond_err(ctx->request, lvolerrno, NULL);
+		free(ctx);
 		return;
 	}
 
-	rpc_lvol_respond_ok(request, lvol->name);
+	if (!ctx->cancelled_decouple) {
+		rpc_lvol_respond_ok(ctx->request, lvol->name);
+		free(ctx);
+		return;
+	}
+
+	/* Said out loud rather than logged only. The caller asked for this volume to
+	 * be decoupled -- by default, without naming it -- and that is not going to
+	 * happen now: the snapshot holds the external parent, so the chain keeps
+	 * reading the source export, and this node keeps renewing its lease. A caller
+	 * that wanted a self-contained volume has to know it did not get one. */
+	w = spdk_jsonrpc_begin_result(ctx->request);
+	spdk_json_write_object_begin(w);
+	spdk_json_write_named_string(w, "name", lvol->name);
+	spdk_json_write_named_bool(w, "decouple_cancelled", true);
+	spdk_json_write_object_end(w);
+	spdk_jsonrpc_end_result(ctx->request, w);
+	free(ctx);
 }
 
 /* Shared by both: decode, resolve, dispatch. The only differences are the decoder
@@ -781,6 +808,7 @@ rpc_derive_lvol(struct spdk_jsonrpc_request *request,
 		size_t decoder_count, bool snapshot)
 {
 	struct rpc_lvol_derive req = {0};
+	struct rpc_derive_ctx *ctx;
 	struct s3lvol_lvstore *lvs;
 	struct spdk_lvol *lvol;
 	int rc;
@@ -802,15 +830,28 @@ rpc_derive_lvol(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		rpc_lvol_respond_err(request, -ENOMEM, NULL);
+		goto cleanup;
+	}
+	ctx->request = request;
+
 	if (snapshot) {
 		rc = s3lvol_lvol_create_snapshot(lvs, lvol, req.new_name,
-						 rpc_derive_lvol_cb, request);
+						 &ctx->cancelled_decouple,
+						 rpc_derive_lvol_cb, ctx);
 	} else {
+		/* No cancellation on this path: create_clone derives from a snapshot,
+		 * which never has a decouple of its own -- the queue holds the volume
+		 * the snapshot was taken from. So the field stays false and the reply
+		 * keeps its old shape. */
 		rc = s3lvol_lvol_create_clone(lvs, lvol, req.new_name,
-					      rpc_derive_lvol_cb, request);
+					      rpc_derive_lvol_cb, ctx);
 	}
 	if (rc != 0) {
 		rpc_lvol_respond_err(request, rc, NULL);
+		free(ctx);
 	}
 
 cleanup:
@@ -1703,6 +1744,15 @@ rpc_rcow_get_lvstores(struct spdk_jsonrpc_request *request,
 				spdk_json_write_named_bool(w, "delete_pending",
 							   pending);
 			}
+			/* How deep the snapshot chain under this lvol is, because
+			 * crossing S3LVOL_DEFAULT_MAX_CHAIN_DEPTH turns an export of
+			 * it into a full copy that nothing ever reclaims. The target
+			 * warns when a derive crosses the soft threshold, but a
+			 * warning only reaches whoever reads the log at the time; a
+			 * control plane deciding whether to prune needs to be able to
+			 * ask. 0 for a deactivated volume, like the cluster counts. */
+			spdk_json_write_named_uint32(w, "chain_depth",
+				s3lvol_lvol_chain_depth(lvs, lvol));
 			spdk_json_write_object_end(w);
 		}
 		spdk_json_write_array_end(w);
@@ -2371,6 +2421,67 @@ cleanup:
 	free(req.export_uuid);
 }
 SPDK_RPC_REGISTER("rcow_release_export", rpc_rcow_release_export,
+		  SPDK_RPC_RUNTIME)
+
+/* Turn a reference export into a copied one, so this node stops owing anybody the
+ * snapshot behind it.
+ *
+ * The counterpart to rcow_release_export, and the choice between them is whose
+ * data survives. Release deletes the export and refuses while anything reads it;
+ * this keeps the export readable for ever by copying what it references, and the
+ * snapshot becomes deletable. It is what a node runs when it wants its space back
+ * without waiting for every importer to finish.
+ *
+ * Importers need not be told: the manifest is replaced in place, and a reader
+ * discovers it when the objects it holds stop existing. */
+static void
+rpc_rcow_materialise_export(struct spdk_jsonrpc_request *request,
+			    const struct spdk_json_val *params)
+{
+	struct rpc_export_id req = {0};
+	struct rpc_lvol_op_ctx *ctx;
+	struct s3lvol_lvstore *lvs;
+	int rc;
+
+	if (spdk_json_decode_object(params, rpc_export_id_decoders,
+				    SPDK_COUNTOF(rpc_export_id_decoders), &req)) {
+		rpc_lvol_respond_err(request, 0, "Invalid parameters");
+		goto cleanup;
+	}
+
+	lvs = rpc_lvstore_for(request, req.lvs_name);
+	if (!lvs) {
+		goto cleanup;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		rpc_lvol_respond_err(request, -ENOMEM, NULL);
+		goto cleanup;
+	}
+	ctx->request   = request;
+	ctx->lvol_name = strdup(req.export_uuid);
+	if (!ctx->lvol_name) {
+		free(ctx);
+		rpc_lvol_respond_err(request, -ENOMEM, NULL);
+		goto cleanup;
+	}
+
+	/* Answers when the copy is done, not when it starts: the caller's next move
+	 * is usually to delete the snapshot, and that is only allowed once this has
+	 * finished. Unlike an export, which hands back a uuid to poll. */
+	rc = s3lvol_export_materialise(lvs, req.export_uuid, rpc_lvol_op_cb, ctx);
+	if (rc != 0) {
+		free(ctx->lvol_name);
+		free(ctx);
+		rpc_lvol_respond_err(request, rc, NULL);
+	}
+
+cleanup:
+	free(req.lvs_name);
+	free(req.export_uuid);
+}
+SPDK_RPC_REGISTER("rcow_materialise_export", rpc_rcow_materialise_export,
 		  SPDK_RPC_RUNTIME)
 
 /* What this node currently publishes, and what it currently reads through to.

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
@@ -3663,7 +3663,7 @@ rpc_rcow_get_bdev(struct spdk_jsonrpc_request *request,
 	 * never activated. Checked before anything is allocated. */
 	if (req.device_name) {
 		if (!s3lvol_active_find(req.device_name)) {
-			rpc_lvol_respond_errf(request, "'%s' is not active",
+			rpc_lvol_respond_errf(request, "'%s' is not active (not found)",
 					      req.device_name);
 			goto cleanup;
 		}

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
@@ -24,7 +24,7 @@
  *     rcow_create_lvol / rcow_delete_lvol / rcow_resize_lvol
  *     rcow_create_snapshot / rcow_create_clone
  *     rcow_export_snapshot / rcow_get_snapshot_status / rcow_import_lvol
- *     rcow_release_export / rcow_get_imports / rcow_decouple_lvol
+ *     rcow_release_export / rcow_get_exports / rcow_get_imports / rcow_decouple_lvol
  *     rcow_get_decouple
  *     rcow_active_bdev / rcow_deactive_bdev / rcow_get_bdev
  *
@@ -145,6 +145,28 @@ rpc_lvol_respond_ok(struct spdk_jsonrpc_request *request, const char *name)
 	rpc_lvol_write_response(request, true, name);
 }
 
+/* A delete that was accepted as an intent rather than carried out.
+ *
+ * Deliberately a success: the caller asked for the snapshot to go away, and it
+ * will, without them having to do anything else -- reporting -EBUSY would say
+ * the opposite. The envelope is the usual one so every existing caller keeps
+ * reading the name off stdout unchanged; the extra field is there for the ones
+ * that want to tell "gone now" from "gone shortly" (test/tools/s3lvol_rpc.py
+ * --raw shows it). */
+static void
+rpc_lvol_respond_deferred(struct spdk_jsonrpc_request *request, const char *name)
+{
+	struct spdk_json_write_ctx *w;
+
+	w = spdk_jsonrpc_begin_result(request);
+	spdk_json_write_object_begin(w);
+	spdk_json_write_named_bool(w, "bool_value", true);
+	spdk_json_write_named_string(w, "string_value", name);
+	spdk_json_write_named_bool(w, "deferred", true);
+	spdk_json_write_object_end(w);
+	spdk_jsonrpc_end_result(request, w);
+}
+
 static void
 rpc_lvol_respond_err(struct spdk_jsonrpc_request *request, int err,
 		     const char *msg)
@@ -181,7 +203,7 @@ rpc_lvol_respond_errf(struct spdk_jsonrpc_request *request, const char *fmt, ...
  * Structured answers, carried inside string_value
  *
  * Four of these RPCs have more than a name to report: rcow_get_bdev,
- * rcow_get_decouple and rcow_get_imports answer with a list, and
+ * rcow_get_decouple, rcow_get_exports and rcow_get_imports answer with a list, and
  * rcow_active_bdev with the placement it picked. The unified reply has one string
  * to put that in, so the document is serialised and handed over as that string;
  * the caller parses it a second time.
@@ -1193,9 +1215,24 @@ rpc_rcow_delete_lvol(struct spdk_jsonrpc_request *request,
 
 	rc = s3lvol_lvol_destroy(lvol, rpc_lvol_op_cb, ctx);
 	if (rc != 0) {
+		/* Every refusal in the destroy path happens before anything is torn
+		 * down, so the lvol is still there to ask. If the refusal recorded an
+		 * intent the poller will finish on its own, the caller is done: say
+		 * so instead of handing them an error to react to. */
+		bool deferred = lvol->lvol_store &&
+				s3lvol_snapshot_pending_deferred(&lvol->lvol_store->uuid,
+								 &lvol->uuid);
+
 		free(ctx->lvol_name);
 		free(ctx);
-		rpc_lvol_respond_err(request, rc, NULL);
+		if (deferred) {
+			SPDK_NOTICELOG("rcow_delete_lvol '%s' deferred: it will be "
+				       "completed once the blocker clears\n",
+				       lvol->name);
+			rpc_lvol_respond_deferred(request, lvol->name);
+		} else {
+			rpc_lvol_respond_err(request, rc, NULL);
+		}
 	}
 
 cleanup:
@@ -2336,14 +2373,91 @@ cleanup:
 SPDK_RPC_REGISTER("rcow_release_export", rpc_rcow_release_export,
 		  SPDK_RPC_RUNTIME)
 
-/* What this node currently reads through to.
+/* What this node currently publishes, and what it currently reads through to.
  *
- * The list arrives as a JSON array in string_value; see the note on rpc_json_buf.
+ * Both lists come from the in-memory registries, as a JSON array in
+ * string_value; see the note on rpc_json_buf. There is no listing of what a
+ * *bucket* holds -- that needs s3_list_objects(), which is still -ENOTSUP.
  *
- * There is no bdev_s3lvol_list_exports counterpart yet: listing what a *bucket*
- * holds needs s3_list_objects(), which is still -ENOTSUP. This one is answered
- * from the in-memory registry, and it is the interesting direction anyway --
- * "which of my volumes still depend on somebody else". */
+ * rcow_get_exports is the source side: every reference (and dense) export this
+ * node still owes, including ones whose TTL has passed. The uuid is what
+ * rcow_release_export takes; rcow_get_lvstores only reports export_status on
+ * the snapshot, which is why a leaked registry used to be visible only in the
+ * attach log.
+ *
+ * rcow_get_imports is the other direction: which of this node's volumes still
+ * depend on somebody else. */
+static void
+rpc_rcow_get_exports(struct spdk_jsonrpc_request *request,
+		     const struct spdk_json_val *params)
+{
+	struct rpc_lvstore_name req = {0};
+	struct s3lvol_lvstore *lvs;
+	struct rpc_json_buf buf;
+	struct spdk_json_write_ctx *w;
+
+	if (params && spdk_json_decode_object(params, rpc_lvstore_name_decoders,
+					      SPDK_COUNTOF(rpc_lvstore_name_decoders),
+					      &req)) {
+		rpc_lvol_respond_err(request, 0, "Invalid parameters");
+		free(req.lvs_name);
+		return;
+	}
+
+	w = rpc_json_buf_begin(&buf);
+	if (!w) {
+		rpc_lvol_respond_err(request, -ENOMEM, NULL);
+		free(req.lvs_name);
+		return;
+	}
+
+	spdk_json_write_array_begin(w);
+
+	for (lvs = s3lvol_lvstore_first(); lvs != NULL; lvs = s3lvol_lvstore_next(lvs)) {
+		struct s3lvol_export *exp;
+
+		if (req.lvs_name && strcmp(req.lvs_name, s3lvol_lvstore_get_name(lvs)) != 0) {
+			continue;
+		}
+		for (exp = s3lvol_export_first(lvs); exp != NULL;
+		     exp = s3lvol_export_next(exp)) {
+			struct s3lvol_export_entry e;
+
+			s3lvol_export_get(exp, &e);
+			spdk_json_write_object_begin(w);
+			spdk_json_write_named_string(w, "lvs_name",
+						     s3lvol_lvstore_get_name(lvs));
+			spdk_json_write_named_string(w, "export_uuid", e.export_uuid);
+			spdk_json_write_named_string(w, "snapshot", e.snapshot);
+			spdk_json_write_named_uint64(w, "blob_id", e.blob_id);
+			spdk_json_write_named_string(w, "layout",
+						     e.is_ref ? S3_EXPORT_LAYOUT_REF_STR :
+						     S3_EXPORT_LAYOUT_DENSE_STR);
+			spdk_json_write_named_uint32(w, "generation", e.generation);
+			spdk_json_write_named_uint64(w, "expires_at", e.expires_at);
+			spdk_json_write_named_bool(w, "expired", e.expired);
+			spdk_json_write_named_bool(w, "lease_aware", e.lease_aware);
+			spdk_json_write_named_bool(w, "lease_checked", e.lease_checked);
+			spdk_json_write_named_bool(w, "lease_absent", e.lease_absent);
+			spdk_json_write_named_bool(w, "lease_watch", e.lease_watch);
+			spdk_json_write_named_uint64(w, "lease_updated_at",
+						     e.lease_updated_at);
+			spdk_json_write_named_uint32(w, "lease_renew_s", e.lease_renew_s);
+			spdk_json_write_named_string(w, "pin",
+						     s3lvol_export_pin_str(e.pin));
+			spdk_json_write_named_bool(w, "snapshot_alive", e.snapshot_alive);
+			spdk_json_write_named_bool(w, "reaping", e.reaping);
+			spdk_json_write_object_end(w);
+		}
+	}
+
+	spdk_json_write_array_end(w);
+	rpc_json_buf_respond(request, w, &buf);
+	free(req.lvs_name);
+}
+SPDK_RPC_REGISTER("rcow_get_exports", rpc_rcow_get_exports,
+		  SPDK_RPC_RUNTIME)
+
 static void
 rpc_rcow_get_imports(struct spdk_jsonrpc_request *request,
 			    const struct spdk_json_val *params)
@@ -2405,6 +2519,228 @@ rpc_rcow_get_imports(struct spdk_jsonrpc_request *request,
 	free(req.lvs_name);
 }
 SPDK_RPC_REGISTER("rcow_get_imports", rpc_rcow_get_imports,
+		  SPDK_RPC_RUNTIME)
+
+/* ==========================================================================
+ * Pending deletes: deletes that were asked for and could not be carried out
+ *
+ * rcow_get_pending_deletes     what is queued, and whether it completes itself
+ * rcow_cancel_pending_delete   withdraw the intent
+ *
+ * The queue exists because some refusals clear without anyone doing anything --
+ * the extra clone is deleted, the decouple finishes -- and the delete the caller
+ * asked for would then simply succeed. See vbdev_s3lvol_pending.c for which
+ * blockers are completed automatically and which deliberately are not.
+ * ========================================================================== */
+
+struct pending_list_ctx {
+	struct spdk_json_write_ctx *w;
+	const char                 *lvs_filter;	/* NULL means every lvstore */
+};
+
+static void
+pending_list_cb(void *cb_arg, const struct s3lvol_pending_entry *e)
+{
+	struct pending_list_ctx *ctx = cb_arg;
+	char uuid_str[SPDK_UUID_STRING_LEN];
+
+	if (ctx->lvs_filter && strcmp(ctx->lvs_filter, e->lvs_name) != 0) {
+		return;
+	}
+
+	spdk_uuid_fmt_lower(uuid_str, sizeof(uuid_str), &e->lvol_uuid);
+
+	spdk_json_write_object_begin(ctx->w);
+	spdk_json_write_named_string(ctx->w, "lvs_name", e->lvs_name);
+	spdk_json_write_named_string(ctx->w, "lvol_name", e->lvol_name);
+	spdk_json_write_named_string(ctx->w, "lvol_uuid", uuid_str);
+	spdk_json_write_named_uint64(ctx->w, "enqueued_at", e->enqueued_at);
+	spdk_json_write_named_string(ctx->w, "reason",
+				     s3lvol_pending_reason_str(e->reason));
+	/* The field that tells the caller whether they still have to do
+	 * something: false means the blocker needs a decision (a published
+	 * export), and the delete waits for an explicit retry. */
+	spdk_json_write_named_bool(ctx->w, "deferred", e->deferred);
+	spdk_json_write_object_end(ctx->w);
+}
+
+/* The list arrives as a JSON array in string_value; see the note on
+ * rpc_json_buf. Takes an optional lvs_name filter -- the whole queue is small,
+ * but a node with several lvstores usually cares about one of them. */
+static void
+rpc_rcow_get_pending_deletes(struct spdk_jsonrpc_request *request,
+			     const struct spdk_json_val *params)
+{
+	struct rpc_lvstore_name req = {0};
+	struct pending_list_ctx ctx;
+	struct rpc_json_buf buf;
+	struct spdk_json_write_ctx *w;
+
+	if (params && spdk_json_decode_object(params, rpc_lvstore_name_decoders,
+					      SPDK_COUNTOF(rpc_lvstore_name_decoders),
+					      &req)) {
+		rpc_lvol_respond_err(request, 0, "Invalid parameters");
+		free(req.lvs_name);
+		return;
+	}
+
+	w = rpc_json_buf_begin(&buf);
+	if (!w) {
+		rpc_lvol_respond_err(request, -ENOMEM, NULL);
+		free(req.lvs_name);
+		return;
+	}
+
+	ctx.w = w;
+	ctx.lvs_filter = req.lvs_name;
+
+	spdk_json_write_array_begin(w);
+	s3lvol_pending_foreach(pending_list_cb, &ctx);
+	spdk_json_write_array_end(w);
+
+	rpc_json_buf_respond(request, w, &buf);
+	free(req.lvs_name);
+}
+SPDK_RPC_REGISTER("rcow_get_pending_deletes", rpc_rcow_get_pending_deletes,
+		  SPDK_RPC_RUNTIME)
+
+struct rpc_pending_cancel {
+	char *lvs_name;		/* optional: disambiguates a name used twice */
+	char *lvol_name;
+};
+
+static const struct spdk_json_object_decoder rpc_pending_cancel_decoders[] = {
+	{"lvs_name", offsetof(struct rpc_pending_cancel, lvs_name), spdk_json_decode_string, true},
+	{"lvol_name", offsetof(struct rpc_pending_cancel, lvol_name), spdk_json_decode_string, false},
+};
+
+struct pending_cancel_ctx {
+	const char *lvs_name;
+	const char *lvol_name;
+	unsigned    removed;
+};
+
+static void
+pending_cancel_cb(void *cb_arg, const struct s3lvol_pending_entry *e)
+{
+	struct pending_cancel_ctx *ctx = cb_arg;
+
+	if (strcmp(ctx->lvol_name, e->lvol_name) != 0) {
+		return;
+	}
+	if (ctx->lvs_name && strcmp(ctx->lvs_name, e->lvs_name) != 0) {
+		return;
+	}
+	/* s3lvol_pending_foreach() walks the list safely against exactly this. */
+	s3lvol_snapshot_pending_clear(&e->lvs_uuid, &e->lvol_uuid);
+	ctx->removed++;
+}
+
+/* Withdraw a queued delete.
+ *
+ * Idempotent, and that is the point: cancelling something that has already been
+ * executed, or was never queued, leaves the caller in the state they asked for
+ * ("this snapshot is not going to be deleted behind my back"), so it succeeds
+ * rather than making them handle a race they cannot avoid. Mirrors
+ * rcow_deactive_bdev.
+ *
+ * Cancelling does not resurrect anything: the snapshot was never touched, only
+ * the intent was recorded. */
+static void
+rpc_rcow_cancel_pending_delete(struct spdk_jsonrpc_request *request,
+			       const struct spdk_json_val *params)
+{
+	struct rpc_pending_cancel req = {0};
+	struct pending_cancel_ctx ctx = {0};
+
+	if (spdk_json_decode_object(params, rpc_pending_cancel_decoders,
+				    SPDK_COUNTOF(rpc_pending_cancel_decoders),
+				    &req)) {
+		rpc_lvol_respond_err(request, 0, "Invalid parameters");
+		goto cleanup;
+	}
+
+	ctx.lvs_name  = req.lvs_name;
+	ctx.lvol_name = req.lvol_name;
+
+	s3lvol_pending_foreach(pending_cancel_cb, &ctx);
+
+	SPDK_NOTICELOG("rcow_cancel_pending_delete '%s': %u entr%s withdrawn\n",
+		       req.lvol_name, ctx.removed,
+		       ctx.removed == 1 ? "y" : "ies");
+
+	rpc_lvol_respond_ok(request, req.lvol_name);
+
+cleanup:
+	free(req.lvs_name);
+	free(req.lvol_name);
+}
+SPDK_RPC_REGISTER("rcow_cancel_pending_delete", rpc_rcow_cancel_pending_delete,
+		  SPDK_RPC_RUNTIME)
+
+/* Park pending-delete registry HEAD or GET until a later release.
+ *
+ * Tests only. Attach stays fire-and-forget; this delays the S3 callbacks so a
+ * script can unload (or attach a same-name replacement) while the load is
+ * still in flight. Production callers never set a stage. */
+struct rpc_pending_load_hold {
+	char *stage;
+	bool  release;
+};
+
+static const struct spdk_json_object_decoder rpc_pending_load_hold_decoders[] = {
+	{"stage",   offsetof(struct rpc_pending_load_hold, stage),   spdk_json_decode_string, true},
+	{"release", offsetof(struct rpc_pending_load_hold, release), spdk_json_decode_bool,   true},
+};
+
+static void
+rpc_rcow_pending_load_hold(struct spdk_jsonrpc_request *request,
+			    const struct spdk_json_val *params)
+{
+	struct rpc_pending_load_hold req = {0};
+	struct rpc_json_buf buf;
+	struct spdk_json_write_ctx *w;
+	unsigned released = 0;
+	int rc;
+
+	if (params && spdk_json_decode_object(params, rpc_pending_load_hold_decoders,
+						SPDK_COUNTOF(rpc_pending_load_hold_decoders),
+						&req)) {
+		rpc_lvol_respond_err(request, 0, "Invalid parameters");
+		free(req.stage);
+		return;
+	}
+
+	if (req.stage) {
+		rc = s3lvol_pending_load_hold(req.stage);
+		if (rc != 0) {
+			rpc_lvol_respond_errf(request,
+					     "stage must be head, get, or none");
+			free(req.stage);
+			return;
+		}
+	}
+	if (req.release) {
+		released = s3lvol_pending_load_release();
+	}
+
+	w = rpc_json_buf_begin(&buf);
+	if (!w) {
+		rpc_lvol_respond_err(request, -ENOMEM, NULL);
+		free(req.stage);
+		return;
+	}
+
+	spdk_json_write_object_begin(w);
+	spdk_json_write_named_string(w, "stage", s3lvol_pending_load_hold_name());
+	spdk_json_write_named_uint32(w, "parked", s3lvol_pending_load_parked_count());
+	spdk_json_write_named_uint32(w, "released", released);
+	spdk_json_write_object_end(w);
+
+	rpc_json_buf_respond(request, w, &buf);
+	free(req.stage);
+}
+SPDK_RPC_REGISTER("rcow_pending_load_hold", rpc_rcow_pending_load_hold,
 		  SPDK_RPC_RUNTIME)
 
 /* ==========================================================================

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
@@ -654,20 +654,30 @@ static const struct spdk_json_object_decoder rpc_create_lvol_decoders[] = {
 	{"size_gib",  offsetof(struct rpc_create_lvol, size_gib),  spdk_json_decode_uint64, false},
 };
 
+struct rpc_create_lvol_ctx {
+	struct spdk_jsonrpc_request *request;
+	char                         name[SPDK_LVOL_NAME_MAX];
+};
+
 static void
 rpc_create_lvol_cb(void *cb_arg, struct spdk_lvol *lvol, int lvolerrno)
 {
-	struct spdk_jsonrpc_request *request = cb_arg;
+	struct rpc_create_lvol_ctx *ctx = cb_arg;
 
 	if (lvolerrno != 0) {
-		rpc_lvol_respond_err(request, lvolerrno, NULL);
+		SPDK_ERRLOG("rcow_create_lvol '%s' failed: %s\n", ctx->name,
+			    spdk_strerror(-lvolerrno));
+		rpc_lvol_respond_err(ctx->request, lvolerrno, NULL);
+		free(ctx);
 		return;
 	}
 
 	/* Returns the lvol name; the caller takes it to rcow_active_bdev --
 	 * NOT nvmf_subsystem_add_ns, which bypasses the active volume registry
 	 * and would not be replayed on crash recovery. */
-	rpc_lvol_respond_ok(request, lvol->name);
+	SPDK_NOTICELOG("rcow_create_lvol '%s' completed\n", lvol->name);
+	rpc_lvol_respond_ok(ctx->request, lvol->name);
+	free(ctx);
 }
 
 /* GiB -> bytes; the ceiling and the zero check are shared with the other two,
@@ -680,6 +690,7 @@ rpc_rcow_create_lvol(struct spdk_jsonrpc_request *request,
 			    const struct spdk_json_val *params)
 {
 	struct rpc_create_lvol req = {0};
+	struct rpc_create_lvol_ctx *ctx;
 	struct s3lvol_lvstore *lvs;
 	const char *problem;
 	char errbuf[128];
@@ -695,12 +706,16 @@ rpc_rcow_create_lvol(struct spdk_jsonrpc_request *request,
 
 	problem = rcow_gib_problem("size_gib", req.size_gib, errbuf, sizeof(errbuf));
 	if (problem) {
+		SPDK_WARNLOG("rcow_create_lvol '%s' refused: %s\n", req.lvol_name,
+			     problem);
 		rpc_lvol_respond_err(request, 0, problem);
 		goto cleanup;
 	}
 
 	lvs = s3lvol_lvstore_pick_one();
 	if (!lvs) {
+		SPDK_WARNLOG("rcow_create_lvol '%s' refused: no unique lvstore\n",
+			     req.lvol_name);
 		rpc_lvol_respond_err(request, 0,
 			"this RPC creates volumes in the one lvstore that exists; "
 			"there are currently none, or more than one (it takes no "
@@ -708,11 +723,25 @@ rpc_rcow_create_lvol(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		rpc_lvol_respond_err(request, -ENOMEM, NULL);
+		goto cleanup;
+	}
+	ctx->request = request;
+	snprintf(ctx->name, sizeof(ctx->name), "%s", req.lvol_name);
+
+	SPDK_NOTICELOG("rcow_create_lvol '%s' requested (%" PRIu64 " GiB)\n",
+		       req.lvol_name, req.size_gib);
+
 	rc = s3lvol_lvol_create(lvs, req.lvol_name,
 				RCOW_GIB_TO_BYTES(req.size_gib), true,
-				rpc_create_lvol_cb, request);
+				rpc_create_lvol_cb, ctx);
 	if (rc != 0) {
+		SPDK_ERRLOG("rcow_create_lvol '%s' failed: %s\n", req.lvol_name,
+			    spdk_strerror(-rc));
 		rpc_lvol_respond_err(request, rc, NULL);
+		free(ctx);
 	}
 
 cleanup:
@@ -764,6 +793,9 @@ static const struct spdk_json_object_decoder rpc_create_clone_decoders[] = {
 struct rpc_derive_ctx {
 	struct spdk_jsonrpc_request *request;
 	bool                         cancelled_decouple;
+	bool                         snapshot;
+	char                         from[SPDK_LVOL_NAME_MAX];
+	char                         to[SPDK_LVOL_NAME_MAX];
 };
 
 static void
@@ -771,11 +803,28 @@ rpc_derive_lvol_cb(void *cb_arg, struct spdk_lvol *lvol, int lvolerrno)
 {
 	struct rpc_derive_ctx *ctx = cb_arg;
 	struct spdk_json_write_ctx *w;
+	const char *op = ctx->snapshot ? "rcow_create_snapshot" : "rcow_create_clone";
 
 	if (lvolerrno != 0) {
+		SPDK_ERRLOG("%s '%s' from '%s' failed: %s\n", op, ctx->to, ctx->from,
+			    spdk_strerror(-lvolerrno));
 		rpc_lvol_respond_err(ctx->request, lvolerrno, NULL);
 		free(ctx);
 		return;
+	}
+
+	if (ctx->cancelled_decouple) {
+		/* The caller asked for this volume to be decoupled -- by default,
+		 * without naming it -- and that is not going to happen now: the
+		 * snapshot holds the external parent, so the chain keeps reading the
+		 * source export, and this node keeps renewing its lease. In the reply
+		 * so Cubelet does not have to scrape logs, and here so a post-mortem
+		 * can find the same fact. */
+		SPDK_NOTICELOG("%s '%s' from '%s' completed; decouple of the source "
+			       "was cancelled\n", op, lvol->name, ctx->from);
+	} else {
+		SPDK_NOTICELOG("%s '%s' from '%s' completed\n", op, lvol->name,
+			       ctx->from);
 	}
 
 	if (!ctx->cancelled_decouple) {
@@ -784,11 +833,6 @@ rpc_derive_lvol_cb(void *cb_arg, struct spdk_lvol *lvol, int lvolerrno)
 		return;
 	}
 
-	/* Said out loud rather than logged only. The caller asked for this volume to
-	 * be decoupled -- by default, without naming it -- and that is not going to
-	 * happen now: the snapshot holds the external parent, so the chain keeps
-	 * reading the source export, and this node keeps renewing its lease. A caller
-	 * that wanted a self-contained volume has to know it did not get one. */
 	w = spdk_jsonrpc_begin_result(ctx->request);
 	spdk_json_write_object_begin(w);
 	spdk_json_write_named_string(w, "name", lvol->name);
@@ -820,6 +864,9 @@ rpc_derive_lvol(struct spdk_jsonrpc_request *request,
 
 	lvol = s3lvol_lvol_find_any(req.lvol_name);
 	if (!lvol) {
+		SPDK_WARNLOG("%s: lvol '%s' not found in any lvstore\n",
+			     snapshot ? "rcow_create_snapshot" : "rcow_create_clone",
+			     req.lvol_name);
 		rpc_lvol_respond_errf(request, "lvol '%s' not found in any lvstore",
 				      req.lvol_name);
 		goto cleanup;
@@ -836,6 +883,13 @@ rpc_derive_lvol(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 	ctx->request = request;
+	ctx->snapshot = snapshot;
+	snprintf(ctx->from, sizeof(ctx->from), "%s", req.lvol_name);
+	snprintf(ctx->to, sizeof(ctx->to), "%s", req.new_name);
+
+	SPDK_NOTICELOG("%s '%s' from '%s' requested\n",
+		       snapshot ? "rcow_create_snapshot" : "rcow_create_clone",
+		       req.new_name, req.lvol_name);
 
 	if (snapshot) {
 		rc = s3lvol_lvol_create_snapshot(lvs, lvol, req.new_name,
@@ -850,6 +904,9 @@ rpc_derive_lvol(struct spdk_jsonrpc_request *request,
 					      rpc_derive_lvol_cb, ctx);
 	}
 	if (rc != 0) {
+		SPDK_ERRLOG("%s '%s' from '%s' failed: %s\n",
+			    snapshot ? "rcow_create_snapshot" : "rcow_create_clone",
+			    req.new_name, req.lvol_name, spdk_strerror(-rc));
 		rpc_lvol_respond_err(request, rc, NULL);
 		free(ctx);
 	}
@@ -1036,11 +1093,14 @@ rpc_resize_lvol_cb(void *cb_arg, int lvolerrno)
 	lvol->action_in_progress = false;
 
 	if (lvolerrno != 0) {
+		SPDK_ERRLOG("rcow_resize_lvol '%s' failed: %s\n", lvol->name,
+			    spdk_strerror(-lvolerrno));
 		rpc_lvol_respond_err(request, lvolerrno, NULL);
 		free(ctx);
 		return;
 	}
 
+	SPDK_NOTICELOG("rcow_resize_lvol '%s' completed\n", lvol->name);
 	rpc_lvol_respond_ok(request, lvol->name);
 	free(ctx);
 }
@@ -1083,6 +1143,8 @@ rpc_rcow_resize_lvol(struct spdk_jsonrpc_request *request,
 	 * spdk_lvol::action_in_progress exists for this and is unused upstream, so
 	 * it only ever means "an s3lvol RPC is working on this lvol". */
 	if (lvol->action_in_progress) {
+		SPDK_WARNLOG("rcow_resize_lvol '%s' refused: another operation is "
+			     "in progress\n", lvol->name);
 		rpc_lvol_respond_err(request, 0,
 				     "another operation is in progress on this lvol");
 		goto cleanup;
@@ -1097,11 +1159,16 @@ rpc_rcow_resize_lvol(struct spdk_jsonrpc_request *request,
 	ctx->lvol = lvol;
 	lvol->action_in_progress = true;
 
+	SPDK_NOTICELOG("rcow_resize_lvol '%s' requested (%" PRIu64 " GiB)\n",
+		       lvol->name, req.size_gib);
+
 	rc = s3lvol_lvol_resize(lvol, RCOW_GIB_TO_BYTES(req.size_gib),
 				rpc_resize_lvol_cb, ctx);
 	if (rc != 0) {
 		lvol->action_in_progress = false;
 		free(ctx);
+		SPDK_ERRLOG("rcow_resize_lvol '%s' failed: %s\n", lvol->name,
+			    spdk_strerror(-rc));
 		rpc_lvol_respond_err(request, rc, NULL);
 	}
 
@@ -1910,6 +1977,8 @@ rpc_rcow_export_snapshot(struct spdk_jsonrpc_request *request,
 
 	lvol = s3lvol_lvol_find_any(req.snapshot_name);
 	if (!lvol) {
+		SPDK_WARNLOG("rcow_export_snapshot '%s' refused: snapshot not found\n",
+			     req.snapshot_name);
 		rpc_lvol_respond_errf(request,
 				      "snapshot '%s' not found in any lvstore",
 				      req.snapshot_name);
@@ -1935,6 +2004,8 @@ rpc_rcow_export_snapshot(struct spdk_jsonrpc_request *request,
 		 * reasons it was -- and a client that only reads stdout sees nothing at
 		 * all, since the message travels in the failed reply. The target log
 		 * carries the detail; this at least says what the call was about. */
+		SPDK_ERRLOG("rcow_export_snapshot '%s' failed: %s\n",
+			    req.snapshot_name, spdk_strerror(-rc));
 		rpc_lvol_respond_errf(request,
 				      "could not start exporting snapshot '%s': %s "
 				      "(the target log says why)",
@@ -1942,6 +2013,8 @@ rpc_rcow_export_snapshot(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
+	SPDK_NOTICELOG("rcow_export_snapshot '%s' started as %s\n",
+		       req.snapshot_name, uuid);
 	rpc_lvol_respond_ok(request, uuid);
 
 cleanup:
@@ -2147,15 +2220,25 @@ rpc_lvstore_for(struct spdk_jsonrpc_request *request, const char *lvs_name)
 	return lvs;
 }
 
+struct rpc_import_ctx {
+	struct spdk_jsonrpc_request *request;
+	char                         lvol_name[SPDK_LVOL_NAME_MAX];
+	char                         export_uuid[SPDK_UUID_STRING_LEN];
+};
+
 static void
 rpc_import_lvol_cb(void *cb_arg, struct spdk_lvol *lvol, int lvolerrno)
 {
-	struct spdk_jsonrpc_request *request = cb_arg;
+	struct rpc_import_ctx *ctx = cb_arg;
 	struct spdk_json_write_ctx *w;
 	const char *mode;
 
 	if (lvolerrno != 0) {
-		rpc_lvol_respond_err(request, lvolerrno, NULL);
+		SPDK_ERRLOG("rcow_import_lvol '%s' from export %s failed: %s\n",
+			    ctx->lvol_name, ctx->export_uuid,
+			    spdk_strerror(-lvolerrno));
+		rpc_lvol_respond_err(ctx->request, lvolerrno, NULL);
+		free(ctx);
 		return;
 	}
 
@@ -2175,13 +2258,17 @@ rpc_import_lvol_cb(void *cb_arg, struct spdk_lvol *lvol, int lvolerrno)
 	 * disagree with what was actually built. */
 	mode = spdk_blob_is_esnap_clone(lvol->blob) ? "esnap" : "local_clone";
 
-	w = spdk_jsonrpc_begin_result(request);
+	SPDK_NOTICELOG("rcow_import_lvol '%s' from export %s completed (%s)\n",
+		       lvol->name, ctx->export_uuid, mode);
+
+	w = spdk_jsonrpc_begin_result(ctx->request);
 	spdk_json_write_object_begin(w);
 	spdk_json_write_named_bool(w, "bool_value", true);
 	spdk_json_write_named_string(w, "string_value", lvol->name);
 	spdk_json_write_named_string(w, "mode", mode);
 	spdk_json_write_object_end(w);
-	spdk_jsonrpc_end_result(request, w);
+	spdk_jsonrpc_end_result(ctx->request, w);
+	free(ctx);
 }
 
 static void
@@ -2192,6 +2279,7 @@ rpc_rcow_import_lvol(struct spdk_jsonrpc_request *request,
 	 * call says so, so an absent flag keeps the default while an explicit false
 	 * overrides it. */
 	struct rpc_import_lvol req = { .decouple = true };
+	struct rpc_import_ctx *ctx;
 	struct s3lvol_import_opts opts = {0};
 	struct s3lvol_lvstore *lvs;
 	int rc;
@@ -2207,14 +2295,30 @@ rpc_rcow_import_lvol(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		rpc_lvol_respond_err(request, -ENOMEM, NULL);
+		goto cleanup;
+	}
+	ctx->request = request;
+	snprintf(ctx->lvol_name, sizeof(ctx->lvol_name), "%s", req.lvol_name);
+	snprintf(ctx->export_uuid, sizeof(ctx->export_uuid), "%s", req.export_uuid);
+
 	opts.lvol_name     = req.lvol_name;
 	opts.export_uuid   = req.export_uuid;
 	opts.src_namespace = req.src_namespace;
 	opts.decouple      = req.decouple;
 
-	rc = s3lvol_lvol_import(lvs, &opts, rpc_import_lvol_cb, request);
+	SPDK_NOTICELOG("rcow_import_lvol '%s' from export %s requested "
+		       "(decouple=%s)\n", req.lvol_name, req.export_uuid,
+		       req.decouple ? "true" : "false");
+
+	rc = s3lvol_lvol_import(lvs, &opts, rpc_import_lvol_cb, ctx);
 	if (rc != 0) {
+		SPDK_ERRLOG("rcow_import_lvol '%s' from export %s failed: %s\n",
+			    req.lvol_name, req.export_uuid, spdk_strerror(-rc));
 		rpc_lvol_respond_err(request, rc, NULL);
+		free(ctx);
 	}
 
 cleanup:
@@ -2991,6 +3095,8 @@ rpc_rcow_active_bdev(struct spdk_jsonrpc_request *request,
 	}
 
 	if (s3lvol_active_load() != 0) {
+		SPDK_WARNLOG("rcow_active_bdev '%s' refused: the active registry "
+			     "could not be read\n", req.device_name);
 		rpc_lvol_respond_err(request, 0,
 				     "the active registry could not be read");
 		goto cleanup;
@@ -2998,6 +3104,8 @@ rpc_rcow_active_bdev(struct spdk_jsonrpc_request *request,
 
 	lvol = s3lvol_lvol_find_any(req.device_name);
 	if (!lvol) {
+		SPDK_WARNLOG("rcow_active_bdev '%s' refused: no such lvol or "
+			     "snapshot\n", req.device_name);
 		rpc_lvol_respond_errf(request, "no such lvol or snapshot: %s",
 				      req.device_name);
 		goto cleanup;
@@ -3010,6 +3118,8 @@ rpc_rcow_active_bdev(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
+	SPDK_NOTICELOG("rcow_active_bdev '%s' requested\n", req.device_name);
+
 	/* Already active: report where it is rather than adding a second namespace
 	 * for the same volume. Activation has to be repeatable, because a caller
 	 * that timed out will retry. */
@@ -3020,6 +3130,9 @@ rpc_rcow_active_bdev(struct spdk_jsonrpc_request *request,
 		if (strcmp(existing->uuid, lvol->uuid_str) != 0) {
 			/* Same name, different volume: the recorded namespace still
 			 * refers to whatever was there before. */
+			SPDK_WARNLOG("rcow_active_bdev '%s' refused: recorded uuid "
+				     "%s does not match volume uuid %s\n",
+				     req.device_name, existing->uuid, lvol->uuid_str);
 			rpc_lvol_respond_errf(request,
 				"'%s' is recorded as active with uuid %s but the "
 				"volume of that name now has uuid %s; deactivate "
@@ -3038,6 +3151,9 @@ rpc_rcow_active_bdev(struct spdk_jsonrpc_request *request,
 		 * elsewhere. So neither; say what is wrong and let the caller decide. */
 		if ((req.subsys != RCOW_SUBSYS_UNSET && req.subsys != existing->subsys) ||
 		    (req.nsid != 0 && req.nsid != existing->nsid)) {
+			SPDK_WARNLOG("rcow_active_bdev '%s' refused: already at "
+				     "subsys %" PRIu32 " nsid %" PRIu32 "\n",
+				     existing->name, existing->subsys, existing->nsid);
 			rpc_lvol_respond_errf(request,
 				"'%s' is already active at subsys %" PRIu32 " nsid "
 				"%" PRIu32 ", not at the requested subsys %" PRIu32
@@ -3049,6 +3165,8 @@ rpc_rcow_active_bdev(struct spdk_jsonrpc_request *request,
 			goto cleanup;
 		}
 
+		SPDK_NOTICELOG("rcow_active_bdev '%s' already active as %s nsid "
+			       "%" PRIu32 "\n", existing->name, nqn, existing->nsid);
 		rpc_active_respond(request, existing->name, existing->uuid, nqn,
 				   existing->subsys, existing->nsid, true);
 		goto cleanup;
@@ -3155,6 +3273,8 @@ rpc_deactive_detached(void *cb_arg, uint32_t nsid, int status)
 	int rc;
 
 	if (status != 0) {
+		SPDK_ERRLOG("rcow_deactive_bdev '%s' failed: %s\n", ctx->name,
+			    spdk_strerror(-status));
 		rpc_lvol_respond_errf(ctx->request, "could not detach '%s': %s",
 				      ctx->name, spdk_strerror(-status));
 		free(ctx);
@@ -3176,7 +3296,7 @@ rpc_deactive_detached(void *cb_arg, uint32_t nsid, int status)
 		return;
 	}
 
-	SPDK_NOTICELOG("deactivated '%s'\n", ctx->name);
+	SPDK_NOTICELOG("rcow_deactive_bdev '%s' completed\n", ctx->name);
 	rpc_lvol_respond_ok(ctx->request, ctx->name);
 	free(ctx);
 }
@@ -3199,7 +3319,11 @@ rpc_rcow_deactive_bdev(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
+	SPDK_NOTICELOG("rcow_deactive_bdev '%s' requested\n", req.device_name);
+
 	if (s3lvol_active_load() != 0) {
+		SPDK_WARNLOG("rcow_deactive_bdev '%s' refused: the active registry "
+			     "could not be read\n", req.device_name);
 		rpc_lvol_respond_err(request, 0,
 				     "the active registry could not be read");
 		goto cleanup;
@@ -3210,7 +3334,8 @@ rpc_rcow_deactive_bdev(struct spdk_jsonrpc_request *request,
 		/* Not active is the desired end state, so this succeeds. An error here
 		 * would force every teardown script to tell "was not active" apart
 		 * from "could not be deactivated". */
-		SPDK_NOTICELOG("'%s' is not active; nothing to do\n", req.device_name);
+		SPDK_NOTICELOG("rcow_deactive_bdev '%s': not active; nothing to do\n",
+			       req.device_name);
 		rpc_lvol_respond_ok(request, req.device_name);
 		goto cleanup;
 	}
@@ -3228,6 +3353,8 @@ rpc_rcow_deactive_bdev(struct spdk_jsonrpc_request *request,
 
 	rc = s3lvol_nvmf_remove_ns(nqn, nsid, rpc_deactive_detached, ctx);
 	if (rc != 0) {
+		SPDK_ERRLOG("rcow_deactive_bdev '%s' failed: %s\n", req.device_name,
+			    spdk_strerror(-rc));
 		rpc_lvol_respond_errf(request,
 				      "could not start the detach of '%s': %s",
 				      req.device_name, spdk_strerror(-rc));

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
@@ -3408,6 +3408,15 @@ SPDK_RPC_REGISTER("rcow_deactive_bdev", rpc_rcow_deactive_bdev,
 #define GET_BDEV_WAIT_MS_DEFAULT 5000
 #define GET_BDEV_POLL_US         (20 * 1000)
 
+/* A path that passed once can still vanish: udev processes the previous
+ * namespace's REMOVE after the new sysfs is already visible, unlinks /dev,
+ * then creates the node again. An empty udev queue rules that out, so the
+ * usual answer costs nothing beyond one access(2). This fallback is for the
+ * case where the queue never looks quiet because unrelated devices keep it
+ * busy: accept a path that passed two polls in a row instead of waiting out
+ * traffic that has nothing to do with this lvol. */
+#define GET_BDEV_CONFIRM_POLLS   2
+
 /* A path is "/dev/nvme31n64" and change; PATH_MAX here would make the snapshot
  * of a full registry (32 x 64 namespaces) eight megabytes. */
 #define GET_BDEV_PATH_MAX        64
@@ -3454,25 +3463,30 @@ struct get_bdev_ctx {
 	uint32_t                     wait_ms;
 };
 
-/* Resolve one entry, reporting success only once the /dev node is there.
+/*
+ * Resolve one entry only once /dev is the live block device for this uuid.
  *
- * sysfs carries the namespace first and udev creates the node afterwards, so a
- * path taken straight from sysfs can still fail to open -- which is the whole
- * reason this RPC does the waiting rather than its callers.
- *
- * Touches sysfs and /dev only, no shared state: safe on the wait thread. */
+ * sysfs publishes the namespace before udev creates the node, so a path taken
+ * from sysfs can still fail to open -- which is why this RPC waits. Checking
+ * that the name exists, or even that it is a block device, is not enough:
+ * after deactive then reactivate at the same nsid, the /dev node can still
+ * belong to the previous occupant while sysfs already names the new uuid.
+ */
 static bool
 get_bdev_resolve(struct get_bdev_entry *e)
 {
 	char dev[GET_BDEV_PATH_MAX];
 
 	if (e->path[0] != '\0') {
-		return true;
+		if (s3lvol_nvmf_device_is_ready(e->path, e->uuid)) {
+			return true;
+		}
+		e->path[0] = '\0';
 	}
 	if (s3lvol_nvmf_resolve_device(e->uuid, dev, sizeof(dev)) != 0) {
 		return false;
 	}
-	if (access(dev, F_OK) != 0) {
+	if (!s3lvol_nvmf_device_is_ready(dev, e->uuid)) {
 		return false;
 	}
 
@@ -3605,11 +3619,21 @@ get_bdev_wait_thread(void *arg)
 {
 	struct get_bdev_ctx *ctx = arg;
 	uint32_t waited_ms = 0;
+	uint32_t consecutive = 0;
 
 	/* Nobody joins this thread -- see s3_spawner_pthread_create_async. */
 	pthread_detach(pthread_self());
 
-	while (get_bdev_resolve_all(ctx) > 0 && waited_ms < ctx->wait_ms) {
+	while (waited_ms < ctx->wait_ms) {
+		if (get_bdev_resolve_all(ctx) == 0) {
+			consecutive++;
+			if (s3lvol_nvmf_udev_settled() ||
+			    consecutive >= GET_BDEV_CONFIRM_POLLS) {
+				break;
+			}
+		} else {
+			consecutive = 0;
+		}
 		usleep(GET_BDEV_POLL_US);
 		waited_ms += GET_BDEV_POLL_US / 1000;
 	}
@@ -3718,11 +3742,22 @@ rpc_rcow_get_bdev(struct spdk_jsonrpc_request *request,
 		ctx->count = i;
 	}
 
-	/* The common case by a wide margin: everything is already up, so answer
-	 * without a thread. This is also what a caller asking wait_ms=0 gets,
-	 * and what happens once the cap on concurrent waits is reached. */
-	if (get_bdev_resolve_all(ctx) == 0 || ctx->wait_ms == 0 ||
-	    g_get_bdev_waiters >= GET_BDEV_MAX_WAITERS) {
+	/* wait_ms=0 is the historical unwaited answer. The cap is the same:
+	 * better an unconfirmed path than one thread per concurrent caller. */
+	if (ctx->wait_ms == 0 || g_get_bdev_waiters >= GET_BDEV_MAX_WAITERS) {
+		get_bdev_resolve_all(ctx);
+		get_bdev_respond(ctx);
+		ctx = NULL;
+		goto cleanup;
+	}
+
+	/* Answer on this thread whenever the answer is already good: every path
+	 * resolved and udev idle. That is the steady state, it costs one
+	 * access(2), and it keeps repeat queries as cheap as they were before
+	 * there was a wait at all -- callers are expected to come back for the
+	 * path after an active, so the wait below is for those few moments
+	 * rather than something every query pays for. */
+	if (get_bdev_resolve_all(ctx) == 0 && s3lvol_nvmf_udev_settled()) {
 		get_bdev_respond(ctx);
 		ctx = NULL;
 		goto cleanup;

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
@@ -313,13 +313,32 @@ import_lease_start(struct s3lvol_import *imp)
 	snprintf(imp->lease_key, sizeof(imp->lease_key), "%s/meta/exports/%s.lease",
 		 m->src.prefix, m->uuid_str);
 
-	/* Renew at a third of the remaining TTL, floored at one second so a
-	 * short-lived export is still protected. An export already past its
-	 * deadline gets the same floor: renewing can only make the source
-	 * *less* likely to delete, which is the safe direction. */
+	/* Renew at a third of the remaining TTL, bounded below.
+	 *
+	 * The floor is not a tuning constant. The interval is reported to the source
+	 * as renew_s and the source's grace period is three times it, so a small
+	 * interval buys a small window to stay alive in -- and the verdict on the
+	 * other side, STALE, is acted on by a poller with nobody watching. An export
+	 * imported at or past its deadline yields remaining = 0, and the old
+	 * one-second floor then asked the source to delete the snapshot if two
+	 * consecutive PUTs were late.
+	 *
+	 * Nothing rejects an expired export at import, so that is reachable rather
+	 * than theoretical: the manifest is still perfectly readable, and the TTL
+	 * says when the source stops promising, not when the data goes.
+	 *
+	 * S3LVOL_LEASE_RENEW_MIN_SEC times three is exactly the minimum grace the
+	 * source applies, so an import at the floor and a source at its floor agree
+	 * by construction rather than by two numbers happening to be compatible. The
+	 * source clamps this anyway -- it does not trust a cadence it is told -- so
+	 * this end is about the cost of the PUTs and about telling the truth in
+	 * renew_s, not about being the safety property. */
 	now = (uint64_t)time(NULL);
 	remaining = (m->expires_at > now) ? (m->expires_at - now) : 0;
-	ttl = (remaining / 3) ? (remaining / 3) : 1;
+	ttl = remaining / 3;
+	if (ttl < S3LVOL_LEASE_RENEW_MIN_SEC) {
+		ttl = S3LVOL_LEASE_RENEW_MIN_SEC;
+	}
 	imp->lease_interval_us = ttl * SPDK_SEC_TO_USEC;
 
 	imp->lease_poller = SPDK_POLLER_REGISTER(import_lease_renew, imp,
@@ -331,6 +350,19 @@ import_lease_start(struct s3lvol_import *imp)
 		imp->lease_client = NULL;
 		return;
 	}
+
+	/* Written now, not at the first tick.
+	 *
+	 * SPDK_POLLER_REGISTER fires after one period, so until then there is no
+	 * lease object at all -- and an absent lease on a lease-aware export whose
+	 * deadline has passed is STALE, which the source's poller acts on by itself.
+	 * At the old one-second period that window was too small to matter. At twenty
+	 * seconds it is a hole big enough to lose a snapshot through, opened by the
+	 * very change meant to make this safer.
+	 *
+	 * Its failure is not checked for the same reason the periodic one's is not:
+	 * the next tick retries, and there is no state to keep straight. */
+	import_lease_renew(imp);
 
 	SPDK_NOTICELOG("export %s lease renewing every %" PRIu64 " second(s)\n",
 		       m->uuid_str, ttl);

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
@@ -1269,6 +1269,9 @@ export_report(struct export_ctx *ctx, int status)
 			    "such export; re-export to try again.\n",
 			    ctx->info.export_uuid, ctx->info.snapshot_name,
 			    spdk_strerror(-status));
+	} else {
+		SPDK_NOTICELOG("Export %s of snapshot '%s' completed\n",
+			       ctx->info.export_uuid, ctx->info.snapshot_name);
 	}
 
 	if (ctx->channel) {
@@ -3870,8 +3873,7 @@ s3lvol_decouple_dequeue_lvol(struct spdk_lvol *lvol)
  * impossible rather than merely slow. And letting it proceed is worse than
  * either: the snapshot takes the external snapshot identity with it, and the
  * decouple then materialises every remaining cluster before failing its detach
- * with "blob is not a clone of an external snapshot" -- measured, see
- * docs/import-reference-snapshot-design.md §9.2.
+ * with "blob is not a clone of an external snapshot".
  *
  * Answers:
  *   0  nothing to cancel, or cancelled already -- the caller may go straight on
@@ -3952,13 +3954,12 @@ s3lvol_lvol_decouple(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol,
 	 * snapshot, so after one is taken the volume has no external parent left to
 	 * clear (-EINVAL above) and the snapshot could not be materialised either --
 	 * nothing could stop the chain depending on the source export except deleting
-	 * it. Measured, and written up as §9.2 of
-	 * docs/import-reference-snapshot-design.md.
+	 * it.
 	 *
 	 * What it takes is lifting md_ro for the copy, which
 	 * spdk_blob_materialize_cluster() now does and which blobstore itself does
 	 * whenever it modifies a snapshot. Nothing a reader sees changes: the bytes
-	 * move from "fetched through the export" to "held locally". §9.5 measures the
+	 * move from "fetched through the export" to "held locally". The design measures the
 	 * whole thing, including that the snapshot's clones keep reading correctly
 	 * while it happens. */
 

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
@@ -77,10 +77,23 @@ struct s3lvol_import {
 	 *
 	 * The lease writes to the *source* bucket, so it needs its own client:
 	 * s3lvol_lvstore_get_client() reaches this lvstore's bucket, which is
-	 * only the same one when the import stays within a bucket. */
+	 * only the same one when the import stays within a bucket.
+	 *
+	 * One key per source, not one per import. A derived export names the prefixes
+	 * of every node its data passed through, and each of those nodes decides
+	 * independently whether its snapshot is still needed -- so renewing only the
+	 * export this import names would leave the node that actually holds the older
+	 * chunks free to delete them. The keys are renewed against the *original*
+	 * exports rather than through the intermediate, which is what lets the
+	 * middleman go away: nothing in the chain depends on it still running.
+	 *
+	 * One client and one poller regardless, because every source shares the
+	 * endpoint, bucket and region of `src` -- the writer refuses to reference
+	 * anything else -- and they all share the interval. */
 	struct spdk_poller          *lease_poller;
 	struct s3_client            *lease_client;
-	char                         lease_key[S3_EXPORT_KEY_MAX];
+	char                       (*lease_keys)[S3_EXPORT_KEY_MAX];
+	uint32_t                     num_lease_keys;
 	uint64_t                     lease_interval_us;
 
 	TAILQ_ENTRY(s3lvol_import)  link;
@@ -97,6 +110,9 @@ static int import_lease_renew(void *arg);
 static void import_lease_put_done(void *cb_arg, int status);
 static void import_build_target(const struct s3lvol_import *imp,
 				struct s3_target *out);
+static int imports_save(struct s3lvol_lvstore *lvs, spdk_lvs_op_complete cb_fn,
+			 void *cb_arg);
+static void import_on_swap(void *arg, struct s3_export_manifest *m);
 
 /* ==========================================================================
  * Registry
@@ -211,18 +227,21 @@ import_add(struct s3lvol_lvstore *lvs, struct s3_export_manifest *m,
 static void
 import_lease_put_done(void *cb_arg, int status)
 {
-	char *uuid_str = cb_arg;
+	char *key = cb_arg;
 
 	/* No state to update. A failure means the lease went stale for a while,
-	 * which the source's grace period exists to absorb. Logged at debug level
-	 * so a *sustained* failure is still visible in the noise. cb_arg is a
-	 * strdup()'d copy precisely so this can run after import_remove() freed
-	 * the import -- a PUT can still be in flight when that happens. */
+	 * which the source's grace period exists to absorb. cb_arg is a strdup()'d
+	 * copy precisely so this can run after import_remove() freed the import -- a
+	 * PUT can still be in flight when that happens.
+	 *
+	 * The key rather than the export uuid, because an import renews several and
+	 * they are not equally interesting: the one that fails is the prefix whose
+	 * node may now delete data this volume is still reading. */
 	if (status != 0) {
-		SPDK_WARNLOG("lease renew failed for export %s: %s\n",
-			     uuid_str, spdk_strerror(-status));
+		SPDK_WARNLOG("lease renew failed for '%s': %s\n",
+			     key, spdk_strerror(-status));
 	}
-	free(uuid_str);
+	free(key);
 }
 
 static int
@@ -232,7 +251,7 @@ import_lease_renew(void *arg)
 	char body[128];
 	struct iovec iov;
 	uint64_t now = (uint64_t)time(NULL);
-	char *uuid_str;
+	uint32_t i;
 
 	/* The body is a tiny JSON document. The source needs three things from
 	 * it: that the object was recently written (updated_at), who wrote it
@@ -248,19 +267,31 @@ import_lease_renew(void *arg)
 	iov.iov_base = body;
 	iov.iov_len  = strlen(body);
 
-	/* Owned by the completion callback, not by this stack frame: s3_put()
-	 * copies the body but not cb_arg, and the callback outlives the poller. */
-	uuid_str = strdup(imp->m->uuid_str);
-	if (!uuid_str) {
-		return SPDK_POLLER_IDLE;
-	}
+	/* Every source, one PUT each. The same body goes to all of them: it says who
+	 * is reading and how often it will say so again, neither of which depends on
+	 * which prefix is being renewed.
+	 *
+	 * Each is submitted independently and a failure of one does not stop the
+	 * rest. They protect different nodes' snapshots, so skipping the others
+	 * because one failed would turn one unreachable prefix into every prefix
+	 * going stale. */
+	for (i = 0; i < imp->num_lease_keys; i++) {
+		char *key;
 
-	if (s3_put(imp->lease_client, imp->lease_key, &iov, 1, false,
-		   import_lease_put_done, uuid_str) != 0) {
-		/* The next poller tick retries; nothing else to do. */
-		SPDK_WARNLOG("lease renew submit failed for export %s\n",
-			     imp->m->uuid_str);
-		free(uuid_str);
+		/* Owned by the completion callback, not by this stack frame: s3_put()
+		 * copies the body but not cb_arg, and the callback outlives the
+		 * poller -- and, after import_remove(), the keys array itself. */
+		key = strdup(imp->lease_keys[i]);
+		if (!key) {
+			continue;
+		}
+
+		if (s3_put(imp->lease_client, key, &iov, 1, false,
+			   import_lease_put_done, key) != 0) {
+			/* The next poller tick retries; nothing else to do. */
+			SPDK_WARNLOG("lease renew submit failed for '%s'\n", key);
+			free(key);
+		}
 	}
 
 	/* Fixed period, not re-armed by the PUT: the poller keeps ticking, and
@@ -281,6 +312,11 @@ import_lease_stop(struct s3lvol_import *imp)
 		s3_client_put(imp->lease_client);
 		imp->lease_client = NULL;
 	}
+	/* Safe with PUTs still in flight: each one carries its own copy of the key,
+	 * which is why import_lease_renew() strdup()s rather than passing these. */
+	free(imp->lease_keys);
+	imp->lease_keys = NULL;
+	imp->num_lease_keys = 0;
 }
 
 /* Start the lease for an import, if it has one. A dense export pins nothing and
@@ -310,8 +346,63 @@ import_lease_start(struct s3lvol_import *imp)
 		return;
 	}
 
-	snprintf(imp->lease_key, sizeof(imp->lease_key), "%s/meta/exports/%s.lease",
-		 m->src.prefix, m->uuid_str);
+	/* One key per source. Entry 0 is this export's own -- its objects are under
+	 * the prefix that published the manifest, so the lease is the manifest's own
+	 * uuid. Every later entry names the export that governs it, and the lease goes
+	 * there directly rather than to the node this manifest came from: that node
+	 * may already be gone, and the objects are not its to protect. */
+	imp->lease_keys = calloc(m->num_srcs ? m->num_srcs : 1,
+				 sizeof(*imp->lease_keys));
+	if (!imp->lease_keys) {
+		SPDK_WARNLOG("No memory for the lease keys of export %s. The source "
+			     "may delete its snapshot while this import still reads "
+			     "it.\n", m->uuid_str);
+		s3_client_put(imp->lease_client);
+		imp->lease_client = NULL;
+		return;
+	}
+
+	if (m->num_srcs == 0) {
+		/* A ref manifest always has at least entry 0 once parsed, so this is
+		 * only reachable for one built in memory. Kept because losing the lease
+		 * entirely is a worse failure than an extra branch. */
+		snprintf(imp->lease_keys[0], sizeof(imp->lease_keys[0]),
+			 "%s/meta/exports/%s.lease", m->src.prefix, m->uuid_str);
+		imp->num_lease_keys = 1;
+	} else {
+		uint32_t j;
+
+		for (j = 0; j < m->num_srcs; j++) {
+			const char *uuid = (j == 0) ? m->uuid_str
+					   : m->srcs[j].export_uuid;
+
+			if (uuid[0] == '\0') {
+				/* Nothing to renew against: the manifest names the prefix
+				 * but not the export governing it. Said out loud, because
+				 * it means those chunks are not protected by anything this
+				 * node does. */
+				SPDK_WARNLOG("Export %s names prefix '%s' without an export "
+					     "uuid, so its lease cannot be renewed. That "
+					     "node may delete the snapshot behind those "
+					     "chunks while this import still reads them.\n",
+					     m->uuid_str, m->srcs[j].prefix);
+				continue;
+			}
+			snprintf(imp->lease_keys[imp->num_lease_keys],
+				 sizeof(imp->lease_keys[0]),
+				 "%s/meta/exports/%s.lease", m->srcs[j].prefix, uuid);
+			imp->num_lease_keys++;
+		}
+	}
+
+	if (imp->num_lease_keys == 0) {
+		SPDK_WARNLOG("Export %s has no renewable lease\n", m->uuid_str);
+		free(imp->lease_keys);
+		imp->lease_keys = NULL;
+		s3_client_put(imp->lease_client);
+		imp->lease_client = NULL;
+		return;
+	}
 
 	/* Renew at a third of the remaining TTL, bounded below.
 	 *
@@ -346,6 +437,9 @@ import_lease_start(struct s3lvol_import *imp)
 	if (!imp->lease_poller) {
 		SPDK_WARNLOG("Could not start the lease poller for export %s\n",
 			     m->uuid_str);
+		free(imp->lease_keys);
+		imp->lease_keys = NULL;
+		imp->num_lease_keys = 0;
 		s3_client_put(imp->lease_client);
 		imp->lease_client = NULL;
 		return;
@@ -364,8 +458,19 @@ import_lease_start(struct s3lvol_import *imp)
 	 * the next tick retries, and there is no state to keep straight. */
 	import_lease_renew(imp);
 
-	SPDK_NOTICELOG("export %s lease renewing every %" PRIu64 " second(s)\n",
-		       m->uuid_str, ttl);
+	SPDK_NOTICELOG("export %s renewing %u lease(s) every %" PRIu64 " second(s)\n",
+		       m->uuid_str, imp->num_lease_keys, ttl);
+	if (imp->num_lease_keys > 1) {
+		uint32_t j;
+
+		/* Listed individually because this is the set of nodes that must keep
+		 * their snapshots for this volume to stay readable, and it is not
+		 * derivable from anything else an operator can see here. */
+		for (j = 0; j < imp->num_lease_keys; j++) {
+			SPDK_NOTICELOG("export %s lease [%u]: %s\n", m->uuid_str, j,
+				       imp->lease_keys[j]);
+		}
+	}
 }
 
 static void
@@ -813,6 +918,34 @@ import_build_target(const struct s3lvol_import *imp, struct s3_target *out)
 	out->auth_mode      = S3_AUTH_ENV;
 }
 
+static void
+import_on_swap(void *arg, struct s3_export_manifest *m)
+{
+	struct s3lvol_import *imp = arg;
+	struct s3_export_manifest *old;
+
+	if (!imp || !m || !imp->m) {
+		return;
+	}
+	if (m->generation <= imp->m->generation) {
+		return;
+	}
+
+	old = imp->m;
+	s3_export_manifest_ref(m);
+	imp->m = m;
+	s3_export_manifest_unref(old);
+
+	if (!imp->lvs) {
+		return;
+	}
+	if (imports_save(imp->lvs, NULL, NULL) != 0) {
+		SPDK_WARNLOG("Could not persist generation %u of import %s; a "
+			     "restart would inherit the previous generation\n",
+			     m->generation, m->uuid_str);
+	}
+}
+
 int
 s3lvol_esnap_dev_create(void *bs_ctx, void *blob_ctx, struct spdk_blob *blob,
 			const void *esnap_id, uint32_t id_len,
@@ -866,8 +999,13 @@ s3lvol_esnap_dev_create(void *bs_ctx, void *blob_ctx, struct spdk_blob *blob,
 	rc = s3_export_bs_dev_create(client, imp->m, bs_dev);
 	if (rc != 0) {
 		s3_client_put(client);
+		return rc;
 	}
-	return rc;
+	/* A 404 refetch swaps the device's manifest first. Without this the
+	 * import registry, derived exports, and same-bucket decouple would keep
+	 * naming the generation materialisation has already deleted. */
+	s3_export_bs_dev_set_on_swap(*bs_dev, import_on_swap, imp);
+	return 0;
 }
 
 /* ==========================================================================
@@ -962,6 +1100,80 @@ export_inflight_remove(const char *uuid)
 		TAILQ_REMOVE(&g_inflight, inf, link);
 		free(inf);
 	}
+}
+
+/* Mutations of manifests that already exist (replacement or release).
+ *
+ * Kept separate from g_inflight: that list means "the uuid has been handed out
+ * but no durable export exists yet" and drives rcow_get_snapshot_status. A
+ * replacement remains a perfectly usable DONE export throughout, but release,
+ * another replacement, and a new export reusing the uuid must not race its
+ * final PUT or DELETE. */
+struct export_rewrite {
+	char                         uuid_str[SPDK_UUID_STRING_LEN];
+	TAILQ_ENTRY(export_rewrite)  link;
+};
+
+static TAILQ_HEAD(, export_rewrite) g_export_rewrites =
+	TAILQ_HEAD_INITIALIZER(g_export_rewrites);
+
+static struct export_rewrite *
+export_rewrite_find(const char *uuid)
+{
+	struct export_rewrite *rw;
+
+	TAILQ_FOREACH(rw, &g_export_rewrites, link) {
+		if (strcmp(rw->uuid_str, uuid) == 0) {
+			return rw;
+		}
+	}
+	return NULL;
+}
+
+static struct export_rewrite *
+export_rewrite_add(const char *uuid)
+{
+	struct export_rewrite *rw;
+
+	if (export_rewrite_find(uuid)) {
+		return NULL;
+	}
+	rw = calloc(1, sizeof(*rw));
+	if (!rw) {
+		return NULL;
+	}
+	snprintf(rw->uuid_str, sizeof(rw->uuid_str), "%s", uuid);
+	TAILQ_INSERT_TAIL(&g_export_rewrites, rw, link);
+	return rw;
+}
+
+static void
+export_rewrite_remove(struct export_rewrite *rw)
+{
+	if (rw) {
+		TAILQ_REMOVE(&g_export_rewrites, rw, link);
+		free(rw);
+	}
+}
+
+static bool
+export_rewrite_pins_snapshot(struct s3lvol_lvstore *lvs, const char *snapshot)
+{
+	struct export_rewrite *rw;
+
+	TAILQ_FOREACH(rw, &g_export_rewrites, link) {
+		struct s3lvol_export_entry info;
+		struct s3lvol_export *exp = s3lvol_export_find(lvs, rw->uuid_str);
+
+		if (!exp) {
+			continue;
+		}
+		s3lvol_export_get(exp, &info);
+		if (strcmp(info.snapshot, snapshot) == 0) {
+			return true;
+		}
+	}
+	return false;
 }
 
 bool
@@ -1136,22 +1348,30 @@ export_copy_done(void *cb_arg, struct s3_export_manifest *m, int status)
 
 /* Everything the manifest says about where it came from. Both engines record the
  * same thing, so it is filled in once. */
+/* Where the export's objects live, and which snapshot they came from.
+ *
+ * Split out from export_fill_src() because materialising needs exactly this and
+ * has no export_ctx: it republishes an existing export rather than starting one,
+ * so it has a uuid and a snapshot name where the export path has a whole request.
+ * Keeping one copy matters more here than the extra function -- the *importing*
+ * node feeds these fields to s3_client_get_or_create() every time it reopens the
+ * clone, so two versions that drift produce a manifest that fails much later, on
+ * another machine.
+ */
 static int
-export_fill_src(struct export_ctx *ctx, struct s3_export_source *src)
+export_fill_src_for(struct s3lvol_lvstore *lvs, struct spdk_lvol *snapshot,
+		    struct s3_export_source *src)
 {
-	const char *ns = s3lvol_lvstore_get_namespace(ctx->lvs);
+	const char *ns = s3lvol_lvstore_get_namespace(lvs);
 	const struct s3_target *tgt = rcow_namespace_to_target(ns);
 
-	/* The manifest records where the source lives, and that record is what the
-	 * *importing* node feeds to s3_client_get_or_create() through
-	 * import_build_target() every time it reopens the clone. An empty endpoint
-	 * here would therefore produce a manifest that fails much later, on another
-	 * node, at attach time -- so refuse to write one rather than paper over it. */
+	/* An empty endpoint would produce a manifest that fails at attach time on
+	 * the importing node, so refuse to write one rather than paper over it. */
 	if (!tgt || !tgt->endpoint || !tgt->bucket) {
 		SPDK_ERRLOG("lvstore '%s': namespace '%s' does not resolve to a COS "
 			    "target, so the manifest could not say where the exported "
 			    "objects live\n",
-			    s3lvol_lvstore_get_name(ctx->lvs), ns ? ns : "(none)");
+			    s3lvol_lvstore_get_name(lvs), ns ? ns : "(none)");
 		return -ENOENT;
 	}
 
@@ -1160,15 +1380,26 @@ export_fill_src(struct export_ctx *ctx, struct s3_export_source *src)
 		 tgt->region ? tgt->region : "");
 	snprintf(src->bucket, sizeof(src->bucket), "%s", tgt->bucket);
 	snprintf(src->prefix, sizeof(src->prefix), "%s",
-		 s3lvol_lvstore_get_name(ctx->lvs));
+		 s3lvol_lvstore_get_name(lvs));
 	snprintf(src->lvs_name, sizeof(src->lvs_name), "%s",
-		 s3lvol_lvstore_get_name(ctx->lvs));
-	snprintf(src->snapshot, sizeof(src->snapshot), "%s", ctx->snapshot->name);
-	src->blob_id = spdk_blob_get_id(ctx->snapshot->blob);
+		 s3lvol_lvstore_get_name(lvs));
+	snprintf(src->snapshot, sizeof(src->snapshot), "%s", snapshot->name);
+	src->blob_id = spdk_blob_get_id(snapshot->blob);
 	/* The identity of the source, as opposed to blob_id, which blobstore hands
 	 * back out after a delete. See the field's comment in s3_export.h. */
 	snprintf(src->snapshot_uuid, sizeof(src->snapshot_uuid), "%s",
-		 ctx->snapshot->uuid_str);
+		 snapshot->uuid_str);
+	return 0;
+}
+
+static int
+export_fill_src(struct export_ctx *ctx, struct s3_export_source *src)
+{
+	int rc = export_fill_src_for(ctx->lvs, ctx->snapshot, src);
+
+	if (rc != 0) {
+		return rc;
+	}
 
 	snprintf(ctx->info.snapshot_name, sizeof(ctx->info.snapshot_name), "%s",
 		 ctx->snapshot->name);
@@ -1205,17 +1436,26 @@ blob_by_id(struct spdk_lvol_store *store, spdk_blob_id id)
  * Every layer resolves through the same chunk map -- one bs_dev, one address
  * space -- so this costs a list lookup per layer and no I/O at all.
  *
+ * The one layer that does not is an esnap clone, whose inherited data is under the
+ * exporting lvstore's prefix. The walk stops there and \p esnap_uuid receives the
+ * export uuid it reads through, empty when the chain ended in a blob instead. The
+ * clone is still part of the chain: what it wrote since the import is local like
+ * anything else, and only what it inherited is not.
+ *
  * Failures here are all routing answers, not errors: the copy engine reads through
  * blobstore, which flattens the chain by itself, so it can handle every case this
  * declines.
  */
 static int
 export_build_chain(struct s3lvol_lvstore *lvs, struct spdk_blob *snapshot,
-		   struct spdk_blob **chain, uint32_t max, uint32_t *out_len)
+		   struct spdk_blob **chain, uint32_t max, uint32_t *out_len,
+		   char *esnap_uuid, size_t esnap_uuid_len)
 {
 	struct spdk_lvol_store *store = s3lvol_lvstore_get_lvs(lvs);
 	struct spdk_blob *cur = snapshot;
 	uint32_t n = 0;
+
+	esnap_uuid[0] = '\0';
 
 	while (true) {
 		spdk_blob_id pid;
@@ -1234,15 +1474,29 @@ export_build_chain(struct s3lvol_lvstore *lvs, struct spdk_blob *snapshot,
 		 * wrong would end the walk early and silently drop everything the esnap
 		 * parent holds.
 		 *
-		 * The parent's data is under another lvstore's prefix, so this chunk map
-		 * cannot resolve it at all. That is also why it matters whether the
-		 * importing node still reads through to an export: a volume with no
-		 * parent can be handed off zero-copy again. */
+		 * The clone itself stays in the chain: it owns whatever was written since
+		 * the import, and those clusters are in this lvstore's chunk map like any
+		 * other. What it inherits is not -- that lives under the exporting
+		 * lvstore's prefix -- so the walk stops here and the esnap id is handed
+		 * back instead. The caller turns it into the manifest those chunks can be
+		 * named out of, or falls back to copying if it cannot. */
 		if (spdk_blob_is_esnap_clone(cur)) {
-			SPDK_NOTICELOG("Snapshot chain reaches an external snapshot, whose "
-				       "data is not in this lvstore's chunk map; exporting "
-				       "by copying instead.\n");
-			return -ENOTSUP;
+			const void *id = NULL;
+			size_t id_len = 0;
+
+			if (spdk_blob_get_esnap_id(cur, &id, &id_len) != 0 ||
+			    id_len == 0 || id_len >= esnap_uuid_len) {
+				/* The id is the export uuid the import wrote. Anything else
+				 * means this clone was not made by an import, so there is no
+				 * manifest to inherit from. */
+				SPDK_NOTICELOG("Snapshot chain reaches an external snapshot "
+					       "whose id is not an export uuid (%zu byte(s)); "
+					       "exporting by copying instead.\n", id_len);
+				return -ENOTSUP;
+			}
+			memcpy(esnap_uuid, id, id_len);
+			esnap_uuid[id_len] = '\0';
+			break;
 		}
 
 		pid = spdk_blob_get_parent_snapshot(store->blobstore,
@@ -1268,6 +1522,61 @@ export_build_chain(struct s3lvol_lvstore *lvs, struct spdk_blob *snapshot,
 	return 0;
 }
 
+/* How many layers export_build_chain() would walk for this blob.
+ *
+ * Deliberately the same walk as above, counting instead of collecting, and that
+ * duplication is the point: this number is only worth reporting if it is the
+ * number the export path will act on. Anything that made the two disagree would
+ * put the warning at a different depth from the fallback it warns about, which is
+ * worse than not warning at all.
+ *
+ * So the three stopping conditions are mirrored exactly -- esnap clone before
+ * asking for a parent (see the walk for why that order matters), no parent, and a
+ * parent no lvol of this store has open. Unlike the walk this has no maximum: the
+ * caller wants to know how far past a threshold it is, and returning "32" for
+ * everything deeper would hide precisely the case worth seeing. A cycle is
+ * impossible -- a snapshot chain is built by parenting new blobs onto old ones --
+ * but the count is bounded anyway by the blob count of the store, since every step
+ * moves to a distinct parent.
+ *
+ * Costs one list lookup per layer and no I/O, so it is cheap enough to answer per
+ * lvol in an RPC that already walks them all.
+ */
+uint32_t
+s3lvol_lvol_chain_depth(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol)
+{
+	struct spdk_lvol_store *store;
+	struct spdk_blob *cur;
+	uint32_t n = 0;
+
+	if (!lvs || !lvol || !lvol->blob) {
+		return 0;
+	}
+	store = s3lvol_lvstore_get_lvs(lvs);
+	if (!store) {
+		return 0;
+	}
+
+	cur = lvol->blob;
+	while (cur) {
+		spdk_blob_id pid;
+
+		n++;
+
+		if (spdk_blob_is_esnap_clone(cur)) {
+			break;
+		}
+		pid = spdk_blob_get_parent_snapshot(store->blobstore,
+						    spdk_blob_get_id(cur));
+		if (pid == SPDK_BLOBID_INVALID) {
+			break;
+		}
+		cur = blob_by_id(store, pid);
+	}
+
+	return n;
+}
+
 /* Name the objects the snapshot already occupies, and upload only the manifest.
  *
  * This is the path a handoff is supposed to take: no data is read and none is
@@ -1282,14 +1591,37 @@ export_ref(struct export_ctx *ctx)
 	struct spdk_lvol_store *store = s3lvol_lvstore_get_lvs(ctx->lvs);
 	struct spdk_blob *chain[S3LVOL_DEFAULT_MAX_CHAIN_DEPTH];
 	struct s3_export_ref_opts opts = {0};
+	char esnap_uuid[SPDK_UUID_STRING_LEN];
 	uint32_t chain_len = 0;
 	int rc;
 
 	rc = export_build_chain(ctx->lvs, ctx->snapshot->blob, chain,
-				SPDK_COUNTOF(chain), &chain_len);
+				SPDK_COUNTOF(chain), &chain_len,
+				esnap_uuid, sizeof(esnap_uuid));
 	if (rc != 0) {
 		export_copy(ctx);
 		return;
+	}
+
+	/* The chain bottomed out in an export rather than in a blob, so the chunks
+	 * older than the import have to be named out of that export's manifest. It is
+	 * in memory already: the import registry holds it for as long as any volume
+	 * reads through it, which is precisely the condition for being here.
+	 *
+	 * A missing entry is not an error to report. It means this node is reading
+	 * through an export it has no manifest for, which the load path refuses to
+	 * let happen -- so the honest response is to copy, which needs no manifest. */
+	if (esnap_uuid[0] != '\0') {
+		struct s3lvol_import *imp = import_find(ctx->lvs, esnap_uuid);
+
+		if (!imp) {
+			SPDK_NOTICELOG("Snapshot reads through export %s, which this "
+				       "lvstore has no manifest for; exporting by copying "
+				       "instead.\n", esnap_uuid);
+			export_copy(ctx);
+			return;
+		}
+		opts.parent = imp->m;
 	}
 
 	opts.bs_dev = s3lvol_lvstore_get_bs_dev(ctx->lvs);
@@ -1308,6 +1640,21 @@ export_ref(struct export_ctx *ctx)
 
 	rc = s3_export_run_ref(&opts, export_copy_done, ctx);
 	if (rc == -ENOTSUP) {
+		export_copy(ctx);
+		return;
+	}
+	if (rc == -E2BIG) {
+		/* More distinct prefixes than a manifest can name, which a volume
+		 * reaches by being handed on enough times. A routing answer like
+		 * -ENOTSUP, not a failure: copying collapses the whole lineage back to
+		 * one prefix, so it is exactly the case that needs it.
+		 *
+		 * Kept as its own branch rather than folded into -ENOTSUP because it
+		 * says something an operator would want to see -- a volume that has
+		 * travelled far enough to stop being handed on for free. */
+		SPDK_NOTICELOG("Export %s: the lineage names more prefixes than a "
+			       "manifest can hold. Exporting by copying instead, which "
+			       "collapses it back to one.\n", ctx->info.export_uuid);
 		export_copy(ctx);
 		return;
 	}
@@ -1514,6 +1861,12 @@ s3lvol_lvol_export(struct s3lvol_lvstore *lvs, struct spdk_lvol *snapshot,
 			    "Create one first.\n", snapshot->name);
 		return -EINVAL;
 	}
+	if (snapshot->action_in_progress ||
+	    export_rewrite_pins_snapshot(lvs, snapshot->name)) {
+		SPDK_ERRLOG("snapshot '%s' is being decoupled or an export of it is "
+			    "being rewritten\n", snapshot->name);
+		return -EBUSY;
+	}
 
 	ctx = calloc(1, sizeof(*ctx));
 	if (!ctx) {
@@ -1586,6 +1939,12 @@ s3lvol_lvol_export(struct s3lvol_lvstore *lvs, struct spdk_lvol *snapshot,
 		free(ctx);
 		return -EEXIST;
 	}
+	if (export_rewrite_find(ctx->info.export_uuid)) {
+		SPDK_ERRLOG("export %s is being rewritten or released\n",
+			    ctx->info.export_uuid);
+		free(ctx);
+		return -EBUSY;
+	}
 
 	/* Registered before the drain, which can complete synchronously: the export
 	 * has to be observable, and the snapshot protected, from here on. */
@@ -1607,6 +1966,267 @@ s3lvol_lvol_export(struct s3lvol_lvstore *lvs, struct spdk_lvol *snapshot,
 
 	export_drain(ctx);
 	return 0;
+}
+
+/* ==========================================================================
+ * Materialising: stop owing anybody the snapshot
+ *
+ * A reference export names this lvstore's live chunk objects. That is why it pins
+ * the snapshot: those objects cannot be reclaimed while an importer may read
+ * them, and the pin has no expiry that means anything -- an importer renewing its
+ * lease keeps the snapshot undeletable for as long as it likes.
+ *
+ * Materialising is the way out. The snapshot is read once, uploaded as the
+ * export's own copies, and the manifest republished as dense with a higher
+ * generation. The export then owes nothing and the snapshot becomes deletable.
+ *
+ * Importers are not notified and need not be. They keep reading the old objects
+ * until those disappear with the snapshot; the resulting 404 makes them refetch,
+ * find the higher generation and carry on against the copies. Which is why the
+ * ordering matters in one direction only: the new manifest must exist before the
+ * old objects go, or a reader refetches into the very manifest that sent it to a
+ * missing key.
+ * ========================================================================== */
+
+struct materialise_ctx {
+	struct s3lvol_lvstore    *lvs;
+	char                      uuid_str[SPDK_UUID_STRING_LEN];
+	char                      snapshot[SPDK_LVOL_NAME_MAX];
+	struct spdk_io_channel   *channel;
+	struct export_rewrite    *rewrite;
+	uint32_t                  generation;
+
+	spdk_lvol_op_complete     cb_fn;
+	void                     *cb_arg;
+};
+
+static void
+materialise_report(struct materialise_ctx *ctx, int status)
+{
+	spdk_lvol_op_complete cb_fn = ctx->cb_fn;
+	void *cb_arg = ctx->cb_arg;
+
+	if (ctx->channel) {
+		spdk_bs_free_io_channel(ctx->channel);
+	}
+	export_rewrite_remove(ctx->rewrite);
+	if (status != 0) {
+		/* The export is untouched: the manifest is only replaced once the
+		 * copies are up, so a failure here leaves the reference export exactly
+		 * as it was and the snapshot still pinned. Retryable. */
+		SPDK_ERRLOG("Materialising export %s of snapshot '%s' failed: %s. The "
+			    "export is unchanged and still references the snapshot.\n",
+			    ctx->uuid_str, ctx->snapshot, spdk_strerror(-status));
+	}
+	free(ctx);
+	if (cb_fn) {
+		cb_fn(cb_arg, status);
+	}
+}
+
+static void
+materialise_saved(void *cb_arg, int status)
+{
+	struct materialise_ctx *ctx = cb_arg;
+
+	if (status != 0) {
+		/* The manifest on S3 already says dense, so importers are served
+		 * correctly and the data is safe. What is lost is this node's own
+		 * record: a restart reads the registry back, sees a reference export,
+		 * and refuses to delete the snapshot again. Wrong in the safe
+		 * direction, and worth a loud line because the fix is to materialise
+		 * again rather than to look for a corrupted export. */
+		SPDK_ERRLOG("export %s was materialised on S3 but the registry could "
+			    "not be saved: %s. A restart will treat it as a reference "
+			    "export again and keep pinning snapshot '%s'; materialise "
+			    "it again to clear that.\n",
+			    ctx->uuid_str, spdk_strerror(-status), ctx->snapshot);
+	} else {
+		SPDK_NOTICELOG("export %s is now a copy at generation %u; snapshot "
+			       "'%s' is no longer pinned by it\n",
+			       ctx->uuid_str, ctx->generation, ctx->snapshot);
+	}
+
+	/* Reported as success either way: the export *is* materialised, which is
+	 * what the caller asked for. Failing here would invite a retry that redoes
+	 * the whole copy for a bookkeeping problem. */
+	materialise_report(ctx, 0);
+}
+
+static void
+materialise_done(void *cb_arg, struct s3_export_manifest *m, int status)
+{
+	struct materialise_ctx *ctx = cb_arg;
+	struct s3lvol_export *exp;
+	int rc;
+
+	if (status != 0 || !m) {
+		materialise_report(ctx, status != 0 ? status : -EIO);
+		return;
+	}
+
+	ctx->generation = m->generation;
+	s3_export_manifest_unref(m);
+
+	/* The registry entry follows the manifest, not the other way round: until
+	 * the manifest is published the export still references the snapshot, and a
+	 * registry that said otherwise would let the snapshot be deleted under a
+	 * reader. */
+	exp = s3lvol_export_find(ctx->lvs, ctx->uuid_str);
+	if (!exp) {
+		/* Released while the copy was running. The objects it uploaded are
+		 * orphans under exports/<uuid>/, which GC collects with the rest of
+		 * the prefix; nothing to undo here. */
+		SPDK_WARNLOG("export %s was released while being materialised; its "
+			     "copies are orphaned and will be collected\n",
+			     ctx->uuid_str);
+		materialise_report(ctx, 0);
+		return;
+	}
+
+	s3lvol_export_set_materialised(exp, ctx->generation);
+
+	rc = s3lvol_export_registry_save(ctx->lvs, materialise_saved, ctx);
+	if (rc != 0) {
+		materialise_saved(ctx, rc);
+	}
+}
+
+int
+s3lvol_export_materialise(struct s3lvol_lvstore *lvs, const char *export_uuid,
+			  spdk_lvol_op_complete cb_fn, void *cb_arg)
+{
+	struct spdk_lvol_store *store;
+	struct s3lvol_export_entry entry;
+	struct materialise_ctx *ctx;
+	struct s3lvol_export *exp;
+	struct spdk_lvol *snapshot;
+	struct s3_export_opts opts = {0};
+	uint64_t cluster_size;
+	int rc;
+
+	if (!lvs || !export_uuid) {
+		return -EINVAL;
+	}
+
+	exp = s3lvol_export_find(lvs, export_uuid);
+	if (!exp) {
+		SPDK_ERRLOG("lvstore '%s' has no export %s\n",
+			    s3lvol_lvstore_get_name(lvs), export_uuid);
+		return -ENOENT;
+	}
+	s3lvol_export_get(exp, &entry);
+
+	if (!entry.is_ref) {
+		/* Already holds its own copies, so there is nothing to free the
+		 * snapshot from. Not an error: a caller sweeping several exports
+		 * should be able to ask about each without checking first. */
+		return -EALREADY;
+	}
+
+	/* An export still being written names the same snapshot and would publish
+	 * over the manifest this is about to replace, in either order. */
+	if (export_inflight_find(export_uuid)) {
+		SPDK_ERRLOG("export %s is still being written\n", export_uuid);
+		return -EBUSY;
+	}
+	if (export_rewrite_find(export_uuid)) {
+		SPDK_ERRLOG("export %s is already being rewritten\n", export_uuid);
+		return -EBUSY;
+	}
+
+	snapshot = s3lvol_lvol_find(lvs, entry.snapshot);
+	if (!snapshot || !snapshot->blob) {
+		/* The manifest references objects belonging to a snapshot this lvstore
+		 * no longer has. Nothing can be copied, and the export is unreadable
+		 * whatever happens next. */
+		SPDK_ERRLOG("export %s names snapshot '%s', which lvstore '%s' does "
+			    "not have; there is nothing left to copy\n",
+			    export_uuid, entry.snapshot,
+			    s3lvol_lvstore_get_name(lvs));
+		return -ENOENT;
+	}
+	if (!spdk_blob_is_read_only(snapshot->blob)) {
+		/* Would make the copy a torn mixture of two points in time, the same
+		 * reason export refuses a writable volume. */
+		SPDK_ERRLOG("'%s' is writable; refusing to copy it\n", entry.snapshot);
+		return -EINVAL;
+	}
+	if (snapshot->action_in_progress) {
+		SPDK_ERRLOG("snapshot '%s' has another operation in progress\n",
+			    entry.snapshot);
+		return -EBUSY;
+	}
+
+	store = s3lvol_lvstore_get_lvs(lvs);
+	cluster_size = spdk_bs_get_cluster_size(store->blobstore);
+	if ((cluster_size & (cluster_size - 1)) != 0) {
+		SPDK_ERRLOG("lvstore '%s' has a cluster size of %" PRIu64 " which is "
+			    "not a power of two\n", s3lvol_lvstore_get_name(lvs),
+			    cluster_size);
+		return -ENOTSUP;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		return -ENOMEM;
+	}
+	ctx->lvs    = lvs;
+	ctx->cb_fn  = cb_fn;
+	ctx->cb_arg = cb_arg;
+	snprintf(ctx->uuid_str, sizeof(ctx->uuid_str), "%s", export_uuid);
+	snprintf(ctx->snapshot, sizeof(ctx->snapshot), "%s", entry.snapshot);
+	ctx->rewrite = export_rewrite_add(export_uuid);
+	if (!ctx->rewrite) {
+		free(ctx);
+		return -ENOMEM;
+	}
+
+	ctx->channel = spdk_bs_alloc_io_channel(store->blobstore);
+	if (!ctx->channel) {
+		export_rewrite_remove(ctx->rewrite);
+		free(ctx);
+		return -ENOMEM;
+	}
+
+	opts.client       = s3lvol_lvstore_get_client(lvs);
+	opts.prefix       = s3lvol_lvstore_get_name(lvs);
+	opts.uuid_str     = ctx->uuid_str;
+	opts.blob         = snapshot->blob;
+	opts.channel      = ctx->channel;
+	opts.chunk_size   = (uint32_t)cluster_size;
+	opts.cluster_size = (uint32_t)cluster_size;
+
+	/* Same shape as a fresh dense export, with two differences that matter.
+	 *
+	 * generation is one past what is published, which is the whole mechanism an
+	 * importer uses to tell a refetch apart from the manifest it already has.
+	 * Without it a reader would refetch, see the same generation, and conclude
+	 * its objects were deleted rather than moved.
+	 *
+	 * expires_at stays 0. A deadline was only ever a promise to keep a snapshot
+	 * for somebody else, and after this there is no snapshot in it. */
+	rc = export_fill_src_for(lvs, snapshot, &opts.src);
+	if (rc != 0) {
+		spdk_bs_free_io_channel(ctx->channel);
+		export_rewrite_remove(ctx->rewrite);
+		free(ctx);
+		return rc;
+	}
+	opts.generation = entry.generation + 1;
+
+	SPDK_NOTICELOG("Materialising export %s: copying snapshot '%s' so it stops "
+		       "being referenced (generation %u -> %u)\n",
+		       export_uuid, entry.snapshot, entry.generation,
+		       opts.generation);
+
+	rc = s3_export_run(&opts, materialise_done, ctx);
+	if (rc != 0) {
+		spdk_bs_free_io_channel(ctx->channel);
+		export_rewrite_remove(ctx->rewrite);
+		free(ctx);
+	}
+	return rc;
 }
 
 /* Whether the snapshot an export names can be deleted right now.
@@ -2383,6 +3003,22 @@ struct s3lvol_decouple {
 
 	int                        status;
 
+	/* Set to abort at the next cluster boundary. Checked by decouple_next(),
+	 * which is the one place this can safely happen: it is entered only from
+	 * decouple_start() and from the message decouple_cluster_done() sends, so
+	 * no materialisation is ever in flight when it runs. An aborted run leaves
+	 * the volume exactly as an interrupted one does -- some clusters local, the
+	 * rest still read through the export, the esnap parent untouched, since
+	 * clear_external_parent() only happens after the last cluster -- so there
+	 * is nothing to roll back and the clusters already copied are kept. */
+	bool                       cancelled;
+
+	/* Told when a cancellation has taken effect, so whoever asked for it can go
+	 * on. Separate from cb_fn: that one belongs to whoever asked for the
+	 * decouple, and still has to hear -ECANCELED. */
+	spdk_lvol_op_complete      cancel_cb_fn;
+	void                      *cancel_cb_arg;
+
 	spdk_lvol_op_complete      cb_fn;
 	void                      *cb_arg;
 
@@ -2390,6 +3026,319 @@ struct s3lvol_decouple {
 };
 
 static TAILQ_HEAD(, s3lvol_decouple) g_decouples = TAILQ_HEAD_INITIALIZER(g_decouples);
+
+struct decouple_rewrite_entry {
+	char                    uuid_str[SPDK_UUID_STRING_LEN];
+	uint64_t                expires_at;
+	uint32_t                generation;
+	struct export_rewrite  *rewrite;
+};
+
+struct decouple_rewrite_ctx {
+	struct s3lvol_decouple       *decouple;
+	struct decouple_rewrite_entry *entries;
+	size_t                         count;
+	size_t                         current;
+	struct spdk_blob              *chain[S3LVOL_DEFAULT_MAX_CHAIN_DEPTH];
+	uint32_t                       chain_len;
+	struct s3_export_source        src;
+	struct spdk_poller            *drain_retry_poller;
+	uint32_t                       drain_retries;
+	int                            first_error;
+	bool                           registry_changed;
+};
+
+static void decouple_finish(struct s3lvol_decouple *d);
+static void decouple_rewrite_next(struct decouple_rewrite_ctx *ctx);
+
+static void
+decouple_rewrite_next_msg(void *arg)
+{
+	decouple_rewrite_next(arg);
+}
+
+static void
+decouple_rewrite_complete(struct decouple_rewrite_ctx *ctx)
+{
+	struct s3lvol_decouple *d = ctx->decouple;
+	size_t i;
+
+	spdk_poller_unregister(&ctx->drain_retry_poller);
+	for (i = ctx->current; i < ctx->count; i++) {
+		export_rewrite_remove(ctx->entries[i].rewrite);
+		ctx->entries[i].rewrite = NULL;
+	}
+	free(ctx->entries);
+	free(ctx);
+	decouple_finish(d);
+}
+
+static void
+decouple_rewrite_saved(void *cb_arg, int status)
+{
+	struct decouple_rewrite_ctx *ctx = cb_arg;
+
+	if (status != 0) {
+		/* Every published manifest already points only at local objects. A stale
+		 * registry can merely resume leases which are no longer needed; it
+		 * cannot let an upstream snapshot be deleted too early. */
+		SPDK_ERRLOG("snapshot '%s' was decoupled and its exports were rewritten, "
+			    "but the export registry could not be saved: %s. A restart "
+			    "may resume unnecessary upstream leases.\n",
+			    ctx->decouple->lvol_name, spdk_strerror(-status));
+	}
+	if (ctx->first_error != 0) {
+		SPDK_ERRLOG("snapshot '%s' is local, but one or more exports could not "
+			    "be redirected to it: %s. Their upstream leases remain; "
+			    "rcow_materialise_export can be used as a fallback.\n",
+			    ctx->decouple->lvol_name,
+			    spdk_strerror(-ctx->first_error));
+	}
+	decouple_rewrite_complete(ctx);
+}
+
+static void
+decouple_rewrite_done(void *cb_arg, struct s3_export_manifest *m, int status)
+{
+	struct decouple_rewrite_ctx *ctx = cb_arg;
+	struct decouple_rewrite_entry *entry = &ctx->entries[ctx->current];
+	struct s3lvol_export_entry current;
+	struct s3lvol_export *exp;
+
+	if (status != 0 || !m) {
+		if (ctx->first_error == 0) {
+			ctx->first_error = status != 0 ? status : -EIO;
+		}
+		SPDK_ERRLOG("could not redirect export %s after snapshot '%s' was "
+			    "decoupled: %s; keeping its upstream leases\n",
+			    entry->uuid_str, ctx->decouple->lvol_name,
+			    spdk_strerror(-(status != 0 ? status : -EIO)));
+		goto next;
+	}
+
+	exp = s3lvol_export_find(ctx->decouple->lvs, entry->uuid_str);
+	if (!exp) {
+		SPDK_WARNLOG("export %s disappeared while its manifest was being "
+			     "redirected; the replacement is unrecorded\n",
+			     entry->uuid_str);
+		goto next;
+	}
+	s3lvol_export_get(exp, &current);
+	if (!current.is_ref || current.generation != entry->generation) {
+		if (ctx->first_error == 0) {
+			ctx->first_error = -ESTALE;
+		}
+		SPDK_ERRLOG("export %s changed from generation %u while its local "
+			    "replacement was being published; keeping its registry "
+			    "state and upstream leases\n",
+			    entry->uuid_str, entry->generation);
+		goto next;
+	}
+
+	/* Publishing completed before this mutation. From this point the export
+	 * names only this lvstore, so its upstream leases can safely stop. */
+	s3lvol_export_set_local_ref(exp, m->generation);
+	ctx->registry_changed = true;
+	SPDK_NOTICELOG("export %s now references local snapshot '%s' at generation "
+		       "%u; its upstream leases have stopped\n",
+		       entry->uuid_str, ctx->decouple->lvol_name, m->generation);
+
+next:
+	if (m) {
+		s3_export_manifest_unref(m);
+	}
+	export_rewrite_remove(entry->rewrite);
+	entry->rewrite = NULL;
+	ctx->current++;
+	/* s3_export_run_ref() can reject synchronously. Bounce the next entry so a
+	 * run of such failures cannot recurse once per export and exhaust the
+	 * reactor stack. */
+	spdk_thread_send_msg(spdk_get_thread(), decouple_rewrite_next_msg, ctx);
+}
+
+static void
+decouple_rewrite_next(struct decouple_rewrite_ctx *ctx)
+{
+	struct decouple_rewrite_entry *entry;
+	struct s3_export_ref_opts opts = {0};
+	int rc;
+
+	if (ctx->current == ctx->count) {
+		if (ctx->registry_changed) {
+			rc = s3lvol_export_registry_save(ctx->decouple->lvs,
+							 decouple_rewrite_saved, ctx);
+			if (rc != 0) {
+				decouple_rewrite_saved(ctx, rc);
+			}
+		} else {
+			decouple_rewrite_saved(ctx, 0);
+		}
+		return;
+	}
+
+	entry = &ctx->entries[ctx->current];
+	if (entry->generation == UINT32_MAX) {
+		if (ctx->first_error == 0) {
+			ctx->first_error = -EOVERFLOW;
+		}
+		SPDK_ERRLOG("export %s is already at the maximum manifest generation; "
+			    "it cannot be redirected automatically\n", entry->uuid_str);
+		export_rewrite_remove(entry->rewrite);
+		entry->rewrite = NULL;
+		ctx->current++;
+		spdk_thread_send_msg(spdk_get_thread(), decouple_rewrite_next_msg, ctx);
+		return;
+	}
+
+	opts.bs_dev       = s3lvol_lvstore_get_bs_dev(ctx->decouple->lvs);
+	opts.chain        = ctx->chain;
+	opts.chain_len    = ctx->chain_len;
+	opts.client       = s3lvol_lvstore_get_client(ctx->decouple->lvs);
+	opts.prefix       = s3lvol_lvstore_get_name(ctx->decouple->lvs);
+	opts.uuid_str     = entry->uuid_str;
+	opts.cluster_size = (uint32_t)ctx->decouple->cluster_size;
+	opts.expires_at   = entry->expires_at;
+	opts.generation   = entry->generation + 1;
+	opts.src          = ctx->src;
+
+	rc = s3_export_run_ref(&opts, decouple_rewrite_done, ctx);
+	if (rc != 0) {
+		decouple_rewrite_done(ctx, NULL, rc);
+	}
+}
+
+static void
+decouple_rewrite_drained(void *cb_arg, int status)
+{
+	struct decouple_rewrite_ctx *ctx = cb_arg;
+	struct s3lvol_decouple *d = ctx->decouple;
+	char esnap_uuid[SPDK_UUID_STRING_LEN];
+	int rc;
+
+	spdk_poller_unregister(&ctx->drain_retry_poller);
+	if (status != 0) {
+		ctx->first_error = status;
+		decouple_rewrite_saved(ctx, 0);
+		return;
+	}
+
+	rc = export_build_chain(d->lvs, d->lvol->blob, ctx->chain,
+				SPDK_COUNTOF(ctx->chain), &ctx->chain_len,
+				esnap_uuid, sizeof(esnap_uuid));
+	if (rc == 0 && esnap_uuid[0] != '\0') {
+		/* clear_external_parent completed before this path started. Seeing an
+		 * external parent now means publishing a local-only manifest would
+		 * silently omit inherited data. */
+		rc = -EIO;
+	}
+	if (rc == 0) {
+		rc = export_fill_src_for(d->lvs, d->lvol, &ctx->src);
+	}
+	if (rc != 0) {
+		ctx->first_error = rc;
+		decouple_rewrite_saved(ctx, 0);
+		return;
+	}
+
+	decouple_rewrite_next(ctx);
+}
+
+static void decouple_rewrite_flush_done(void *cb_arg, int status);
+
+static int
+decouple_rewrite_drain_retry(void *arg)
+{
+	struct decouple_rewrite_ctx *ctx = arg;
+
+	spdk_poller_unregister(&ctx->drain_retry_poller);
+	s3lvol_lvstore_flush(ctx->decouple->lvs, decouple_rewrite_flush_done, ctx);
+	return SPDK_POLLER_BUSY;
+}
+
+static void
+decouple_rewrite_flush_done(void *cb_arg, int status)
+{
+	struct decouple_rewrite_ctx *ctx = cb_arg;
+
+	if (status == -EBUSY && ctx->drain_retries < EXPORT_DRAIN_MAX_RETRIES) {
+		ctx->drain_retries++;
+		ctx->drain_retry_poller =
+			SPDK_POLLER_REGISTER(decouple_rewrite_drain_retry, ctx,
+					     EXPORT_DRAIN_RETRY_US);
+		if (ctx->drain_retry_poller) {
+			return;
+		}
+	}
+	decouple_rewrite_drained(ctx, status);
+}
+
+/* Redirect every already-published reference export of this snapshot after the
+ * snapshot has become local. The export uuid stays stable; generation is what
+ * tells existing importers that a 404 should be retried against the replacement.
+ */
+static void
+decouple_rewrite_exports(struct s3lvol_decouple *d)
+{
+	struct decouple_rewrite_ctx *ctx;
+	struct s3lvol_export_entry info;
+	struct s3lvol_export *exp;
+	size_t count = 0, i = 0;
+
+	for (exp = s3lvol_export_first(d->lvs); exp; exp = s3lvol_export_next(exp)) {
+		s3lvol_export_get(exp, &info);
+		if (info.is_ref && strcmp(info.snapshot, d->lvol_name) == 0) {
+			count++;
+		}
+	}
+	if (count == 0) {
+		decouple_finish(d);
+		return;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		SPDK_ERRLOG("snapshot '%s' is local, but there is no memory to redirect "
+			    "its %zu reference export(s); upstream leases remain\n",
+			    d->lvol_name, count);
+		decouple_finish(d);
+		return;
+	}
+	ctx->entries = calloc(count, sizeof(*ctx->entries));
+	if (!ctx->entries) {
+		free(ctx);
+		SPDK_ERRLOG("snapshot '%s' is local, but there is no memory to redirect "
+			    "its %zu reference export(s); upstream leases remain\n",
+			    d->lvol_name, count);
+		decouple_finish(d);
+		return;
+	}
+	ctx->decouple = d;
+	ctx->count = count;
+
+	for (exp = s3lvol_export_first(d->lvs); exp && i < count;
+	     exp = s3lvol_export_next(exp)) {
+		s3lvol_export_get(exp, &info);
+		if (!info.is_ref || strcmp(info.snapshot, d->lvol_name) != 0) {
+			continue;
+		}
+		snprintf(ctx->entries[i].uuid_str, sizeof(ctx->entries[i].uuid_str),
+			 "%s", info.export_uuid);
+		ctx->entries[i].expires_at = info.expires_at;
+		ctx->entries[i].generation = info.generation;
+		ctx->entries[i].rewrite = export_rewrite_add(info.export_uuid);
+		if (!ctx->entries[i].rewrite) {
+			ctx->first_error = export_rewrite_find(info.export_uuid) ?
+					   -EBUSY : -ENOMEM;
+			decouple_rewrite_saved(ctx, 0);
+			return;
+		}
+		i++;
+	}
+
+	SPDK_NOTICELOG("snapshot '%s' is local; redirecting %zu reference export(s) "
+		       "before completing its decouple\n", d->lvol_name, count);
+	s3lvol_lvstore_flush(d->lvs, decouple_rewrite_flush_done, ctx);
+}
 
 /* True when the manifest has no object anywhere under this cluster, i.e. the
  * parent would serve it as zeroes and there is nothing to copy.
@@ -2415,12 +3364,26 @@ decouple_finish(struct s3lvol_decouple *d)
 {
 	spdk_lvol_op_complete cb_fn = d->cb_fn;
 	void *cb_arg = d->cb_arg;
+	spdk_lvol_op_complete cancel_cb_fn = d->cancel_cb_fn;
+	void *cancel_cb_arg = d->cancel_cb_arg;
 	int status = d->status;
 
 	if (status == 0) {
 		SPDK_NOTICELOG("lvol '%s' no longer reads export %s: %" PRIu64
 			       " cluster(s) materialised\n", d->lvol_name, d->uuid_str,
 			       d->done);
+	} else if (status == -ECANCELED) {
+		/* Not an error, and deliberately not sharing the message below: that
+		 * one says the volume can be decoupled again, which is untrue here.
+		 * A cancellation is asked for by create_snapshot, and once the
+		 * snapshot exists the external parent belongs to it, so this volume
+		 * has nothing left to decouple from. The clusters copied so far are
+		 * kept -- they hold the parent's bytes, and the snapshot inherits
+		 * them. */
+		SPDK_NOTICELOG("Decoupling lvol '%s' from export %s was cancelled "
+			       "after %" PRIu64 " of %" PRIu64 " cluster(s); the "
+			       "%" PRIu64 " already materialised are kept\n",
+			       d->lvol_name, d->uuid_str, d->done, d->total, d->done);
 	} else {
 		SPDK_ERRLOG("Decoupling lvol '%s' from export %s failed after %" PRIu64
 			    " of %" PRIu64 " cluster(s): %s. The volume still reads "
@@ -2447,6 +3410,14 @@ decouple_finish(struct s3lvol_decouple *d)
 	if (cb_fn) {
 		cb_fn(cb_arg, status);
 	}
+
+	/* Last, so that whatever the cancellation was making room for -- a snapshot --
+	 * runs with this decouple gone from every list and action_in_progress already
+	 * cleared above. Otherwise the snapshot would meet the flag it just waited
+	 * for. */
+	if (cancel_cb_fn) {
+		cancel_cb_fn(cancel_cb_arg, 0);
+	}
 }
 
 static void
@@ -2465,7 +3436,7 @@ decouple_cleared(void *cb_arg, int bserrno)
 	 * objects. Ordered this way because the reverse leaves a blob naming an
 	 * export that no attach can resolve. */
 	s3lvol_imports_recheck(d->lvs, d->uuid_str);
-	decouple_finish(d);
+	decouple_rewrite_exports(d);
 }
 
 static void decouple_next(struct s3lvol_decouple *d);
@@ -2531,6 +3502,16 @@ static void
 decouple_next(struct s3lvol_decouple *d)
 {
 	uint64_t cluster;
+
+	/* The abort point. Safe precisely here: both ways into this function -- the
+	 * initial call from decouple_start() and the message sent by
+	 * decouple_cluster_done() -- arrive with no materialisation outstanding, so
+	 * stopping needs no wait and no rollback. See struct s3lvol_decouple. */
+	if (d->cancelled) {
+		d->status = -ECANCELED;
+		decouple_finish(d);
+		return;
+	}
 
 	while (d->cluster < d->num_clusters && decouple_cluster_is_hole(d, d->cluster)) {
 		d->cluster++;
@@ -2697,8 +3678,9 @@ s3lvol_lvol_decouple_pending(const struct spdk_lvol *lvol)
 }
 
 /* Start materialising now. The caller has already established that this volume is
- * an esnap clone, writable, not already running or queued, and that nothing else
- * is decoupling the same export. */
+ * an esnap clone, not already running or queued, and that nothing else is
+ * decoupling the same export. It may be read-only: a snapshot is what a reference
+ * chain has to materialise to become independent of its source export. */
 static int
 decouple_start(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol,
 	       const char *uuid_str, spdk_lvol_op_complete cb_fn, void *cb_arg)
@@ -2843,6 +3825,26 @@ decouple_start_next_queued(void)
 	}
 }
 
+/* Drop a queued decouple and tell whoever asked for it. `reason` completes the
+ * sentence "lvol X was waiting to be decoupled from export Y and ...", so that a
+ * log line says which of the two callers below took it out of the queue -- the
+ * volume going away, or a snapshot being taken of it. */
+static void
+decouple_dequeue(struct decouple_queued *q, const char *lvol_name, const char *reason)
+{
+	spdk_lvol_op_complete cb_fn = q->cb_fn;
+	void *cb_arg = q->cb_arg;
+
+	SPDK_NOTICELOG("lvol '%s' was waiting to be decoupled from export %s and %s; "
+		       "dropping it from the queue\n", lvol_name, q->uuid_str, reason);
+	TAILQ_REMOVE(&g_decouple_queue, q, link);
+	free(q);
+
+	if (cb_fn) {
+		cb_fn(cb_arg, -ECANCELED);
+	}
+}
+
 /* Forget a queued decouple because its volume is going away.
  *
  * A queued volume does not hold action_in_progress, so nothing stops it being
@@ -2852,24 +3854,74 @@ void
 s3lvol_decouple_dequeue_lvol(struct spdk_lvol *lvol)
 {
 	struct decouple_queued *q = decouple_queued_find(lvol);
-	spdk_lvol_op_complete cb_fn;
-	void *cb_arg;
 
 	if (!q) {
 		return;
 	}
+	decouple_dequeue(q, lvol->name, "is going away");
+}
 
-	SPDK_NOTICELOG("lvol '%s' was waiting to be decoupled from export %s and is "
-		       "going away; dropping it from the queue\n", lvol->name,
-		       q->uuid_str);
-	TAILQ_REMOVE(&g_decouple_queue, q, link);
-	cb_fn  = q->cb_fn;
-	cb_arg = q->cb_arg;
-	free(q);
+/* Stop decoupling this volume, because a snapshot of it is being taken.
+ *
+ * Why cancel rather than refuse. `decouple` defaults to true and is started
+ * before rcow_import_lvol even answers, so "import a volume, then snapshot it" --
+ * an ordinary thing to want -- always arrives while a decouple is in progress.
+ * Refusing there (which is what derive_check used to do) makes that sequence
+ * impossible rather than merely slow. And letting it proceed is worse than
+ * either: the snapshot takes the external snapshot identity with it, and the
+ * decouple then materialises every remaining cluster before failing its detach
+ * with "blob is not a clone of an external snapshot" -- measured, see
+ * docs/import-reference-snapshot-design.md §9.2.
+ *
+ * Answers:
+ *   0  nothing to cancel, or cancelled already -- the caller may go straight on
+ *   1  cancellation under way; cb_fn will be called once it has taken effect
+ *   <0 error
+ *
+ * The distinction matters because the queued case completes synchronously while a
+ * running one cannot: it has to reach the next cluster boundary first. */
+int
+s3lvol_decouple_cancel(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn,
+		       void *cb_arg)
+{
+	struct decouple_queued *q;
+	struct s3lvol_decouple *d;
 
-	if (cb_fn) {
-		cb_fn(cb_arg, -ECANCELED);
+	if (!lvol) {
+		return -EINVAL;
 	}
+
+	q = decouple_queued_find(lvol);
+	if (q) {
+		/* Never started, so there is nothing to unwind and nothing to wait
+		 * for. Note this leaves the volume with no materialised clusters at
+		 * all, which is correct: it never read anything out of the export. */
+		decouple_dequeue(q, lvol->name, "is being snapshotted");
+		return 0;
+	}
+
+	d = decouple_find(lvol);
+	if (!d) {
+		return 0;
+	}
+
+	if (d->cancel_cb_fn) {
+		/* Two derives racing on one volume. Refused rather than chained: the
+		 * second caller would be woken by the first one's cancellation and
+		 * proceed on an assumption it never made. */
+		SPDK_ERRLOG("lvol '%s' is already having its decouple cancelled\n",
+			    lvol->name);
+		return -EBUSY;
+	}
+
+	d->cancelled     = true;
+	d->cancel_cb_fn  = cb_fn;
+	d->cancel_cb_arg = cb_arg;
+
+	SPDK_NOTICELOG("Cancelling the decouple of lvol '%s' from export %s so it can "
+		       "be snapshotted; %" PRIu64 " of %" PRIu64 " cluster(s) done\n",
+		       d->lvol_name, d->uuid_str, d->done, d->total);
+	return 1;
 }
 
 int
@@ -2892,15 +3944,23 @@ s3lvol_lvol_decouple(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol,
 		return -EINVAL;
 	}
 
-	/* A snapshot cannot be decoupled: materialising a cluster is a write, and its
-	 * metadata is read-only. It is also not what the caller wants -- the way to
-	 * free a snapshot of an imported volume from the export is to delete it, or
-	 * to decouple the volume it was taken from before taking it. */
-	if (spdk_blob_is_read_only(lvol->blob)) {
-		SPDK_ERRLOG("lvol '%s' is read-only (a snapshot?) and cannot be "
-			    "decoupled\n", lvol->name);
-		return -EPERM;
-	}
+	/* Read-only is allowed, and is the case that matters.
+	 *
+	 * This used to refuse, on the grounds that materialising a cluster writes and
+	 * a snapshot's metadata is read-only. The refusal is what made a reference
+	 * chain permanent: create_snapshot hands the external snapshot to the
+	 * snapshot, so after one is taken the volume has no external parent left to
+	 * clear (-EINVAL above) and the snapshot could not be materialised either --
+	 * nothing could stop the chain depending on the source export except deleting
+	 * it. Measured, and written up as §9.2 of
+	 * docs/import-reference-snapshot-design.md.
+	 *
+	 * What it takes is lifting md_ro for the copy, which
+	 * spdk_blob_materialize_cluster() now does and which blobstore itself does
+	 * whenever it modifies a snapshot. Nothing a reader sees changes: the bytes
+	 * move from "fetched through the export" to "held locally". §9.5 measures the
+	 * whole thing, including that the snapshot's clones keep reading correctly
+	 * while it happens. */
 
 	if (decouple_find(lvol)) {
 		SPDK_ERRLOG("lvol '%s' is already being decoupled\n", lvol->name);
@@ -2913,6 +3973,11 @@ s3lvol_lvol_decouple(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol,
 	}
 	if (lvol->action_in_progress) {
 		SPDK_ERRLOG("another operation is in progress on lvol '%s'\n",
+			    lvol->name);
+		return -EBUSY;
+	}
+	if (export_rewrite_pins_snapshot(lvs, lvol->name)) {
+		SPDK_ERRLOG("an export of lvol '%s' is already being rewritten\n",
 			    lvol->name);
 		return -EBUSY;
 	}
@@ -3151,6 +4216,7 @@ struct release_ctx {
 	uint32_t                   pending;
 	uint64_t                   deleted;
 	int                        status;
+	struct export_rewrite    *rewrite;
 
 	spdk_lvol_op_complete      cb_fn;
 	void                      *cb_arg;
@@ -3170,6 +4236,7 @@ release_finish(struct release_ctx *ctx)
 
 	s3_export_manifest_unref(ctx->m);
 	free(ctx->body);
+	export_rewrite_remove(ctx->rewrite);
 	free(ctx);
 
 	if (cb_fn) {
@@ -3408,11 +4475,30 @@ s3lvol_export_release(struct s3lvol_lvstore *lvs, const char *export_uuid,
 		      spdk_lvol_op_complete cb_fn, void *cb_arg)
 {
 	struct s3lvol_lvstore *other;
+	struct s3lvol_export *published;
 	struct release_ctx *ctx;
 	int rc;
 
 	if (!lvs || !export_uuid) {
 		return -EINVAL;
+	}
+	if (export_rewrite_find(export_uuid)) {
+		SPDK_ERRLOG("export %s is being rewritten; release it after that "
+			    "finishes\n", export_uuid);
+		return -EBUSY;
+	}
+	published = s3lvol_export_find(lvs, export_uuid);
+	if (published) {
+		struct s3lvol_export_entry info;
+		struct spdk_lvol *snapshot;
+
+		s3lvol_export_get(published, &info);
+		snapshot = info.is_ref ? s3lvol_lvol_find(lvs, info.snapshot) : NULL;
+		if (snapshot && snapshot->action_in_progress) {
+			SPDK_ERRLOG("export %s names snapshot '%s', which is being "
+				    "decoupled\n", export_uuid, info.snapshot);
+			return -EBUSY;
+		}
 	}
 
 	/* Refuse while a volume *in this process* still reads through to it. Deleting
@@ -3471,11 +4557,17 @@ s3lvol_export_release(struct s3lvol_lvstore *lvs, const char *export_uuid,
 	ctx->cb_fn  = cb_fn;
 	ctx->cb_arg = cb_arg;
 	snprintf(ctx->uuid_str, sizeof(ctx->uuid_str), "%s", export_uuid);
+	ctx->rewrite = export_rewrite_add(export_uuid);
+	if (!ctx->rewrite) {
+		free(ctx);
+		return -ENOMEM;
+	}
 	s3_export_manifest_key(ctx->uuid_str, ctx->key, sizeof(ctx->key));
 
 	rc = s3_head(s3lvol_lvstore_get_client(lvs), ctx->key, &ctx->size,
 		     release_head_done, ctx);
 	if (rc != 0) {
+		export_rewrite_remove(ctx->rewrite);
 		free(ctx);
 	}
 	return rc;

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
@@ -48,6 +48,7 @@
 #include "spdk_internal/lvolstore.h"
 
 #include "s3lvol/s3_export.h"
+#include "s3lvol/s3_client.h"
 
 #include "vbdev_s3lvol.h"
 
@@ -2962,8 +2963,10 @@ s3lvol_lvol_import(struct s3lvol_lvstore *lvs, const struct s3lvol_import_opts *
  * allocations and needs 16 TiB of free clusters to succeed at all.
  *
  * Here the manifest says which chunks exist, so only the clusters covering them
- * are copied. Everything else stays a hole, and the volume stays thin. The cost
- * is the data, once.
+ * are copied. Same-bucket imports use CopyObject plus a chunk-map insert
+ * (s3_bs_dev ingest) instead of GET+WAL; the GET path remains the fallback when
+ * the buckets differ or ingest cannot start. Everything else stays a hole, and
+ * the volume stays thin. The cost is the data, once.
  *
  * === What it costs the volume ===
  *
@@ -3015,6 +3018,7 @@ struct s3lvol_decouple {
 	 * clear_external_parent() only happens after the last cluster -- so there
 	 * is nothing to roll back and the clusters already copied are kept. */
 	bool                       cancelled;
+	bool                       ingest;
 
 	/* Told when a cancellation has taken effect, so whoever asked for it can go
 	 * on. Separate from cb_fn: that one belongs to whoever asked for the
@@ -3360,10 +3364,69 @@ decouple_cluster_is_hole(const struct s3lvol_decouple *d, uint64_t cluster)
 	return s3_export_manifest_range_is_zeroes(d->m, first, last - first + 1);
 }
 
+#define DECOUPLE_PREFETCH 16
+
+static int
+decouple_ingest_src(void *cb_arg, uint64_t chunk_index,
+		    char *src_key, size_t key_len, uint32_t *valid_bytes)
+{
+	struct s3lvol_decouple *d = cb_arg;
+
+	return s3_export_manifest_object_key(d->m, chunk_index, src_key, key_len,
+					     valid_bytes);
+}
+
+static void
+decouple_prefetch(struct s3lvol_decouple *d)
+{
+	struct spdk_bs_dev *bs = s3lvol_lvstore_get_bs_dev(d->lvs);
+	uint64_t c, io_units;
+	uint32_t n = 0;
+
+	if (!d->ingest || !bs || !d->lvol || d->cluster_size < S3LVOL_BLOCK_SIZE) {
+		return;
+	}
+	io_units = d->cluster_size / S3LVOL_BLOCK_SIZE;
+	for (c = d->cluster; c < d->num_clusters && n < DECOUPLE_PREFETCH; c++) {
+		uint64_t first_io;
+
+		if (decouple_cluster_is_hole(d, c)) {
+			continue;
+		}
+		first_io = c * io_units;
+		if (spdk_blob_get_next_allocated_io_unit(d->lvol->blob, first_io) ==
+		    first_io) {
+			continue;
+		}
+		s3_bs_dev_ingest_prefetch(bs, first_io, io_units);
+		n++;
+	}
+}
+
 static void decouple_start_next_queued(void);
+static void decouple_finish_complete(struct s3lvol_decouple *d);
+
+static void
+decouple_ingest_ended(void *arg, int status)
+{
+	(void)status;
+	decouple_finish_complete(arg);
+}
 
 static void
 decouple_finish(struct s3lvol_decouple *d)
+{
+	if (d->ingest) {
+		d->ingest = false;
+		s3_bs_dev_ingest_end(s3lvol_lvstore_get_bs_dev(d->lvs),
+				     decouple_ingest_ended, d);
+		return;
+	}
+	decouple_finish_complete(d);
+}
+
+static void
+decouple_finish_complete(struct s3lvol_decouple *d)
 {
 	spdk_lvol_op_complete cb_fn = d->cb_fn;
 	void *cb_arg = d->cb_arg;
@@ -3455,6 +3518,8 @@ decouple_cluster_done(void *cb_arg, int bserrno)
 {
 	struct s3lvol_decouple *d = cb_arg;
 
+	spdk_blob_allow_esnap_copy(d->lvol->blob, false);
+
 	if (bserrno != 0) {
 		d->status = bserrno;
 		decouple_finish(d);
@@ -3516,6 +3581,8 @@ decouple_next(struct s3lvol_decouple *d)
 		return;
 	}
 
+	decouple_prefetch(d);
+
 	while (d->cluster < d->num_clusters && decouple_cluster_is_hole(d, d->cluster)) {
 		d->cluster++;
 	}
@@ -3558,6 +3625,7 @@ decouple_next(struct s3lvol_decouple *d)
 
 	cluster = d->cluster++;
 
+	spdk_blob_allow_esnap_copy(d->lvol->blob, true);
 	spdk_blob_materialize_cluster(d->lvol->blob, d->channel, cluster,
 				      decouple_cluster_done, d);
 }
@@ -3769,9 +3837,27 @@ decouple_start(struct s3lvol_lvstore *lvs, struct spdk_lvol *lvol,
 	lvol->action_in_progress = true;
 	TAILQ_INSERT_TAIL(&g_decouples, d, link);
 
-	SPDK_NOTICELOG("Decoupling lvol '%s' from export %s: %" PRIu64 " of %" PRIu64
-		       " cluster(s) hold data\n", d->lvol_name, d->uuid_str, d->total,
-		       d->num_clusters);
+	struct spdk_bs_dev *bs = s3lvol_lvstore_get_bs_dev(lvs);
+	struct s3_client *client = s3lvol_lvstore_get_client(lvs);
+	const char *bucket = s3_client_bucket(client);
+
+	if (bs && bucket && bucket[0] != '\0' && d->m->src.bucket[0] != '\0' &&
+	    strcmp(bucket, d->m->src.bucket) == 0 &&
+	    s3_bs_dev_get_chunk_size(bs) == d->chunk_size &&
+	    s3_bs_dev_ingest_begin(bs, d->m->src.bucket,
+				   decouple_ingest_src, d) == 0) {
+		d->ingest = true;
+		SPDK_NOTICELOG("Decoupling lvol '%s' from export %s via CopyObject "
+			       "(bucket %s): %" PRIu64 " of %" PRIu64
+			       " cluster(s) hold data\n",
+			       d->lvol_name, d->uuid_str, bucket, d->total,
+			       d->num_clusters);
+	} else {
+		SPDK_NOTICELOG("Decoupling lvol '%s' from export %s: %" PRIu64
+			       " of %" PRIu64 " cluster(s) hold data\n",
+		       d->lvol_name, d->uuid_str, d->total,
+			       d->num_clusters);
+	}
 
 	decouple_next(d);
 	return 0;

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_xfer.c
@@ -3364,7 +3364,8 @@ decouple_cluster_is_hole(const struct s3lvol_decouple *d, uint64_t cluster)
 	return s3_export_manifest_range_is_zeroes(d->m, first, last - first + 1);
 }
 
-#define DECOUPLE_PREFETCH 16
+/* Matches S3_INGEST_SLOTS: keep CopyObject in flight up to the slot table. */
+#define DECOUPLE_PREFETCH 32
 
 static int
 decouple_ingest_src(void *cb_arg, uint64_t chunk_index,

--- a/CubeS3lvol/patches/0002-blob-add-spdk_blob_materialize_cluster.patch
+++ b/CubeS3lvol/patches/0002-blob-add-spdk_blob_materialize_cluster.patch
@@ -51,22 +51,48 @@ Two properties worth stating because callers depend on them:
     a channel -- a channel is per thread per blobstore -- and without this they
     lose nearly every cluster to it, silently.
 
-Nothing existing is touched: the new function only calls what the inflate path
-calls. blob_ut passes unchanged (500 tests).
+One existing behaviour does change: md_ro. A read-only blob used to be refused
+here, and that refusal is what made a reference chain permanent. Snapshotting an
+esnap clone hands the external snapshot to the snapshot, so afterwards the volume
+has no external parent to clear and the snapshot could not be materialised
+either -- nothing could free the chain from its source except deleting it. Since
+materialising allocates clusters and copies the parent's bytes into them, what a
+reader sees is identical either way, so the flag is lifted for the duration and
+restored on every exit. That is what blobstore already does whenever it modifies
+a snapshot's metadata: delete_snapshot_freeze_io_cb() saves md_ro, clears it,
+syncs, and puts it back, including for a snapshot that is itself an esnap clone.
+Data stays protected by data_ro, which is untouched -- the operation submitted is
+a read.
+
+Deleting the check rather than lifting the flag would not do:
+blob_insert_cluster_msg() marks the blob dirty, and md_ro together with a dirty
+blob is the state spdk_blob_sync_md() asserts against. Restoring is therefore
+ordered after the metadata sync, which is guaranteed because
+blob_op_cluster_msg_cb() -- what completes the user operation the completion
+waits on -- runs only once blob_sync_md() is done.
+
+Unlike the delete path this does not freeze I/O, for the same reason a decouple
+does not: readers have to keep working while the copying goes on, and a cluster
+arriving under a reader is ordinary copy-on-write, which the allocation path
+already serialises. Measured with a clone reading its parent throughout the
+materialisation, 258 reads with no mismatch, and with the source objects deleted
+and the store re-attached before the final read so that no cache could answer it.
+
+blob_ut passes unchanged.
 
 Signed-off-by: Changpeng Liu <changpeliu@tencent.com>
 Assisted-by: CodeBuddy
 ---
- include/spdk/blob.h    |  33 ++++++++
- lib/blob/blobstore.c   | 157 +++++++++++++++++++++++++++++++++++++++++
- lib/blob/spdk_blob.map |   1 +
- 3 files changed, 191 insertions(+)
+  include/spdk/blob.h    |  33 ++++++++
+  lib/blob/blobstore.c   | 203 +++++++++++++++++++++++++++++++++++++++++++++++++
+  lib/blob/spdk_blob.map |   1 +
+  3 files changed, 237 insertions(+)
 
 diff --git a/include/spdk/blob.h b/include/spdk/blob.h
-index fc61ca2c8..1f146e6f4 100644
+index fe98215..71b2e62 100644
 --- a/include/spdk/blob.h
 +++ b/include/spdk/blob.h
-@@ -831,6 +831,39 @@ void spdk_bs_inflate_blob(struct spdk_blob_store *bs, struct spdk_io_channel *ch
+@@ -804,6 +804,39 @@ void spdk_bs_inflate_blob(struct spdk_blob_store *bs, struct spdk_io_channel *ch
  void spdk_bs_blob_decouple_parent(struct spdk_blob_store *bs, struct spdk_io_channel *channel,
  				  spdk_blob_id blobid, spdk_blob_op_complete cb_fn, void *cb_arg);
  
@@ -107,10 +133,10 @@ index fc61ca2c8..1f146e6f4 100644
   * Perform a shallow copy of a blob to a blobstore device.
   *
 diff --git a/lib/blob/blobstore.c b/lib/blob/blobstore.c
-index 61d20f435..5b27ced43 100644
+index 08b7915..15699bc 100644
 --- a/lib/blob/blobstore.c
 +++ b/lib/blob/blobstore.c
-@@ -7352,6 +7352,163 @@ spdk_bs_blob_decouple_parent(struct spdk_blob_store *bs, struct spdk_io_channel
+@@ -7334,6 +7334,209 @@ spdk_bs_blob_decouple_parent(struct spdk_blob_store *bs, struct spdk_io_channel
  }
  /* END spdk_bs_inflate_blob */
  
@@ -123,7 +149,32 @@ index 61d20f435..5b27ced43 100644
 +	uint64_t		 attempts;
 +	spdk_blob_op_complete	 cb_fn;
 +	void			*cb_arg;
++
++	/* md_ro as the caller had it, restored on every way out of here.
++	 *
++	 * Allocating a cluster writes metadata, so md_ro has to come off for the
++	 * duration -- see the comment in spdk_blob_materialize_cluster(). It lives
++	 * in the context rather than on the stack because it has to survive the
++	 * retry loop in materialize_cluster_cpl(), which re-enters
++	 * materialize_cluster_attempt() from a different call stack. */
++	bool			 md_ro;
 +};
++
++/* Give md_ro back. Called from every exit after it was taken off, and only from
++ * those: the early returns in spdk_blob_materialize_cluster() all happen before
++ * the context exists.
++ *
++ * Ordered after the metadata sync, never before it. blob_insert_cluster_msg()
++ * marks the blob dirty and syncs it, and blob_op_cluster_msg_cb() -- which is
++ * what completes the user operation this waits on -- runs only once that sync is
++ * done. Restoring earlier would leave the blob md_ro *and* dirty, which is the
++ * state spdk_blob_sync_md() asserts against. */
++static void
++materialize_cluster_restore_md_ro(struct materialize_cluster_ctx *ctx)
++{
++	assert(ctx->blob->state == SPDK_BLOB_STATE_CLEAN || ctx->md_ro == false);
++	ctx->blob->md_ro = ctx->md_ro;
++}
 +
 +/* An attempt is only spent when another allocation on the same channel was in
 + * flight, and each of those completes, so this bounds a pathological case and not
@@ -171,6 +222,7 @@ index 61d20f435..5b27ced43 100644
 +		bserrno = -EAGAIN;
 +	}
 +
++	materialize_cluster_restore_md_ro(ctx);
 +	ctx->cb_fn(ctx->cb_arg, bserrno);
 +	free(ctx);
 +}
@@ -186,6 +238,7 @@ index 61d20f435..5b27ced43 100644
 +
 +	if (blob->active.clusters[ctx->cluster] != 0) {
 +		/* In place now, whoever put it there. That is all that was asked. */
++		materialize_cluster_restore_md_ro(ctx);
 +		ctx->cb_fn(ctx->cb_arg, 0);
 +		free(ctx);
 +		return;
@@ -210,6 +263,7 @@ index 61d20f435..5b27ced43 100644
 +
 +	op = bs_user_op_alloc(ctx->channel, &cpl, SPDK_BLOB_READ, blob, NULL, 0, io_unit, 0);
 +	if (!op) {
++		materialize_cluster_restore_md_ro(ctx);
 +		ctx->cb_fn(ctx->cb_arg, -ENOMEM);
 +		free(ctx);
 +		return;
@@ -226,12 +280,6 @@ index 61d20f435..5b27ced43 100644
 +
 +	assert(blob != NULL);
 +	assert(cb_fn != NULL);
-+
-+	if (blob->md_ro) {
-+		SPDK_ERRLOG("blob 0x%" PRIx64 ": metadata is read only\n", blob->id);
-+		cb_fn(cb_arg, -EPERM);
-+		return;
-+	}
 +
 +	if (cluster >= blob->active.num_clusters) {
 +		SPDK_ERRLOG("blob 0x%" PRIx64 ": cluster %" PRIu64 " is past the end\n",
@@ -263,6 +311,30 @@ index 61d20f435..5b27ced43 100644
 +	ctx->blob = blob;
 +	ctx->channel = channel;
 +	ctx->cluster = cluster;
++
++	/* Take md_ro off for the duration.
++	 *
++	 * A read-only blob is the interesting caller, not an accident: materialising
++	 * a snapshot is how a chain of clones stops depending on an external
++	 * snapshot, and a snapshot is md_ro by definition. Refusing here made that
++	 * impossible while making no data safer -- this allocates clusters and copies
++	 * the parent's bytes into them, so what a reader sees does not change either
++	 * way. Data stays protected by data_ro, which is untouched: the operation
++	 * submitted below is a read.
++	 *
++	 * Lifting the flag is what blobstore already does whenever it has to modify a
++	 * snapshot's metadata -- see delete_snapshot_freeze_io_cb(), which saves it,
++	 * clears it, and puts it back, including for a snapshot that is itself an
++	 * esnap clone. Deleting the check instead of lifting the flag would not work:
++	 * blob_insert_cluster_msg() marks the blob dirty, and md_ro with a dirty blob
++	 * is the state spdk_blob_sync_md() asserts against.
++	 *
++	 * Unlike the delete path this does not freeze I/O, for the same reason a
++	 * decouple does not: readers have to keep working while the copying goes on,
++	 * and a cluster arriving under a reader is ordinary copy-on-write, which the
++	 * allocation path below already serialises. */
++	ctx->md_ro = blob->md_ro;
++	blob->md_ro = false;
 +	ctx->cb_fn = cb_fn;
 +	ctx->cb_arg = cb_arg;
 +
@@ -275,10 +347,10 @@ index 61d20f435..5b27ced43 100644
  
  struct shallow_copy_ctx {
 diff --git a/lib/blob/spdk_blob.map b/lib/blob/spdk_blob.map
-index 09886f49d..7cbb0fd74 100644
+index d4d85c2..c1a9c7c 100644
 --- a/lib/blob/spdk_blob.map
 +++ b/lib/blob/spdk_blob.map
-@@ -41,6 +41,7 @@
+@@ -40,6 +40,7 @@
  	spdk_bs_delete_blob;
  	spdk_bs_inflate_blob;
  	spdk_bs_blob_decouple_parent;
@@ -286,6 +358,3 @@ index 09886f49d..7cbb0fd74 100644
  	spdk_bs_blob_shallow_copy;
  	spdk_bs_blob_set_parent;
  	spdk_bs_blob_set_external_parent;
--- 
-2.43.5
-

--- a/CubeS3lvol/patches/0006-blob-allow-esnap-dev-copy.patch
+++ b/CubeS3lvol/patches/0006-blob-allow-esnap-dev-copy.patch
@@ -1,0 +1,105 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: CubeS3lvol <cubes3lvol@local>
+Date: Fri, 4 Sep 2026 16:55:00 +0800
+Subject: [PATCH] blob: scope esnap bs_dev->copy to an explicit per-blob gate
+
+blob_can_copy() normally refuses a device-level copy for every external-
+snapshot clone. A materialiser whose destination implements copy() needs
+to opt the blob in so it can bind a server-side copied object instead of
+doing GET+write.
+
+The copy callback is installed on the blobstore's shared destination
+device, however, so its presence cannot be the opt-in: while blob X is
+being materialised, an ordinary CoW on unrelated esnap blob Y would also
+enter X's callback and resolve Y's parent LBA against X's manifest.
+
+spdk_blob_allow_esnap_copy() raises a per-blob flag. Ordinary blobs
+retain the old device-copy path; an esnap clone can use dest->copy only
+while that flag is set.
+
+Assisted-by: Cursor:Grok-4.6
+---
+
+diff --git a/include/spdk/blob.h b/include/spdk/blob.h
+index b5f4980..d56f0e3 100644
+--- a/include/spdk/blob.h
++++ b/include/spdk/blob.h
+@@ -787,6 +787,17 @@ bool spdk_blob_is_thin_provisioned(struct spdk_blob *blob);
+  */
+ bool spdk_blob_is_esnap_clone(const struct spdk_blob *blob);
+ 
++/**
++ * Permit (or forbid) this esnap clone to use the destination blobstore's
++ * optional copy() callback.
++ *
++ * dest->copy is device-wide. An ingest that installs it for one clone would
++ * otherwise also catch ordinary CoW on every other esnap clone that shares the
++ * blobstore. Call this with true only around the copy that is meant to use
++ * that callback, and with false from every completion path.
++ */
++void spdk_blob_allow_esnap_copy(struct spdk_blob *blob, bool allow);
++
+ /**
+  * Delete an existing blob from the given blobstore.
+  *
+diff --git a/lib/blob/blobstore.c b/lib/blob/blobstore.c
+index 4050a18..c832593 100644
+--- a/lib/blob/blobstore.c
++++ b/lib/blob/blobstore.c
+@@ -2842,10 +2842,26 @@ blob_can_copy(struct spdk_blob *blob, uint64_t cluster_start_io_unit, uint64_t *
+ {
+ 	uint64_t lba = bs_dev_io_unit_to_lba(blob, blob->back_bs_dev, cluster_start_io_unit);
+ 
+-	return (!blob_is_esnap_clone(blob) && blob->bs->dev->copy != NULL) &&
++	/*
++	 * dest->copy is device-wide, while an esnap parent belongs to one blob.
++	 * Let ordinary blobs keep the original device-copy path, but let an esnap
++	 * use it only while spdk_blob_allow_esnap_copy() has opted that exact blob
++	 * in. Otherwise an ingest installed for blob X would catch an unrelated CoW
++	 * on blob Y and resolve Y's parent LBA against X's manifest.
++	 */
++	return (!blob_is_esnap_clone(blob) ||
++		__atomic_load_n(&blob->esnap_copy_refcnt, __ATOMIC_ACQUIRE) != 0) &&
++	       (blob->bs->dev->copy != NULL) &&
+ 	       blob->back_bs_dev->translate_lba(blob->back_bs_dev, lba, base_lba);
+ }
+ 
++void
++spdk_blob_allow_esnap_copy(struct spdk_blob *blob, bool allow)
++{
++	assert(blob != NULL);
++	__atomic_store_n(&blob->esnap_copy_refcnt, allow ? 1u : 0u, __ATOMIC_RELEASE);
++}
++
+ static void
+ blob_copy(struct spdk_blob_copy_cluster_ctx *ctx, spdk_bs_user_op_t *op, uint64_t src_lba)
+ {
+diff --git a/lib/blob/blobstore.h b/lib/blob/blobstore.h
+index 0338a24..8b514b5 100644
+--- a/lib/blob/blobstore.h
++++ b/lib/blob/blobstore.h
+@@ -123,6 +123,12 @@ struct spdk_blob {
+ 	bool		data_ro;
+ 	bool		md_ro;
+ 
++	/* Non-zero while this esnap blob is allowed to use dest->copy.
++	 * blob_can_copy() uses it so a device-wide copy callback installed for
++	 * one ingest cannot catch CoW on another esnap blob in the same
++	 * blobstore. Raised by spdk_blob_allow_esnap_copy(). */
++	uint32_t	esnap_copy_refcnt;
++
+ 	uint64_t	invalid_flags;
+ 	uint64_t	data_ro_flags;
+ 	uint64_t	md_ro_flags;
+diff --git a/lib/blob/spdk_blob.map b/lib/blob/spdk_blob.map
+index 6c92965..95a6447 100644
+--- a/lib/blob/spdk_blob.map
++++ b/lib/blob/spdk_blob.map
+@@ -38,6 +38,7 @@
+ 	spdk_blob_is_clone;
+ 	spdk_blob_is_thin_provisioned;
+ 	spdk_blob_is_esnap_clone;
++	spdk_blob_allow_esnap_copy;
+ 	spdk_bs_delete_blob;
+ 	spdk_bs_inflate_blob;
+ 	spdk_bs_blob_decouple_parent;

--- a/CubeS3lvol/patches/README.md
+++ b/CubeS3lvol/patches/README.md
@@ -47,9 +47,11 @@ patch here must satisfy:
 3. **It can be proposed upstream on its own.** If a patch is not suitable for
    upstream, that is usually a sign the design went astray.
 
-0004 is the **only patch that modifies an existing function**; the reason for the
-exception is written in its own section. Read that section before adding a
-second such patch, and make sure the reason is of the same kind.
+0004 is the **only patch that modifies an existing function for a behaviour
+change on an existing path**; 0006 also edits an existing function, but only
+removes an exclusion that is idle until a device installs `copy` (see that
+section). Read both sections before adding a third such patch, and make sure
+the reason is of the same kind.
 
 ## 0001-blob-add-spdk_blob_get_io_unit_lba.patch
 
@@ -256,3 +258,27 @@ which just makes the next person step on the same rake.
 
 **Rule 3 still holds**: this change can be proposed upstream on its own; it
 reads more like a bug fix.
+
+## 0006-blob-allow-esnap-dev-copy.patch
+
+Changes `blob_can_copy()` so an esnap clone may use `dest->copy` only while
+`spdk_blob_allow_esnap_copy(blob, true)` is in effect for that blob.
+
+**This is a second patch that modifies an existing function.** The gate is
+`dest->copy != NULL` plus a per-blob flag. The second half is essential because
+`dest` is the blobstore-wide device: CopyObject ingest for volume X installs
+its manifest-bound callback there, while another esnap volume Y in the same
+lvstore remains writable. Gating only on the pointer would route Y's ordinary
+CoW through X's manifest and silently bind the wrong object.
+
+**Why.** `blob_can_copy()` assumed a copy is an offload on one disk (`src_lba`
+and `dst_lba` on the same device) and therefore excluded esnap clones, whose
+parent is a different `bs_dev`. s3lvol's destination `copy()` during a
+same-bucket decouple treats `src_lba` as an LBA on the export parent and
+`dst_lba` as the newly allocated cluster, and implements the copy as S3
+CopyObject plus a chunk-map insert. Without this, `allocate_and_copy_cluster()`
+always GET+writes an esnap cluster, which is the slow decouple path.
+
+Ordinary blobs retain the original device-copy behaviour. Ordinary CoW on an
+esnap clone remains GET+write. s3lvol raises the blob-local gate around each
+`spdk_blob_materialize_cluster()` and clears it from the completion callback.

--- a/CubeS3lvol/test/README.md
+++ b/CubeS3lvol/test/README.md
@@ -12,7 +12,7 @@ them in this order -- the earlier ones are faster and need less environment.
 ## Running everything with one command
 
 ```sh
-make check           # 23 suites, 928 assertions, about 6 minutes (= test/run_all.sh)
+make check           # 24 suites (= test/run_all.sh; dataplane needs root + S3)
 make check-offline   # only the suites needing no credentials and no root: 11, 491 assertions, about 40 seconds
 test/run_all.sh --list          # show what would run and what the environment has
 test/run_all.sh --no-dataplane  # both integration layers, no dataplane
@@ -146,6 +146,7 @@ export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
 ./test/dataplane/run_export_test.sh    -e cos.ap-nanjing.myqcloud.com -b <bucket> -r ap-nanjing
 ./test/dataplane/run_selfimport_test.sh    # reads /data/cubelet/s3.cfg, no arguments
 ./test/dataplane/run_snapdelete_test.sh    # same
+./test/dataplane/run_cubecow_client_test.sh    # same; cubecow/Cubelet RPC order
 ./test/dataplane/run_activation_test.sh    # same
 ./test/dataplane/run_fs_test.sh            # same; really does mkfs.xfs + mount
 ./test/dataplane/run_guards_test.sh        # same; the two accidental-deletion guards
@@ -266,6 +267,18 @@ export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
   blobstore (a snapshot with a clone cannot be deleted), while an esnap clone's
   parent is pinned by the export, which can be released and also expires (the
   REF default TTL is only 3600 s). So it is safer, not just faster.
+
+- `run_cubecow_client_test.sh` -- the cubecow / Cubelet client contract. Cubelet
+  never calls JSON-RPC itself; cubecow always uses the same 11 `rcow_*` methods
+  in a fixed order, and that order is what this suite drives. Existing suites
+  cover the mechanisms (export, clone isolation, two-process import) but not
+  the composition Cubelet actually issues: seal (ext4, umount, inactive snap,
+  delete the work volume), N clones from one template plus resize of a clone,
+  three snapshots exported at once and polled by `snapshot_name`, a refused
+  template delete whose error must not contain `not found`, a failed import
+  that must not leave a named lvol, and `import(decouple=true)` followed by
+  `rcow_active_bdev` without waiting for decouple. It reads `s3.cfg` and uses
+  its own lvstore / WAL / registries.
 
 - `run_snapdelete_test.sh` -- 23 assertions. **Deleting a snapshot while its
   source volume is still alive**, and the boundaries of that.
@@ -443,8 +456,8 @@ export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
   next round red while **the round that actually produced it shows all green**,
   wrong on both ends.
 
-Common conventions of the dataplane scripts (seven take `-e/-b/-r`
-arguments, the other six read `/data/cubelet/s3.cfg` themselves):
+Common conventions of the dataplane scripts (those that take `-e/-b/-r`
+versus those that read `/data/cubelet/s3.cfg` themselves):
 
 | Environment variable | Effect |
 |----------|------|
@@ -488,10 +501,16 @@ test/tools/s3lvol_rpc.py --retry-pending   # re-issue the snapshot deletes that
 ```
 
 `--retry-pending` acts on the pending-delete marks a refused snapshot delete
-leaves behind (`PEND` in `--ls`). The marks are in the target's memory only,
-nothing retries them automatically, and there is no cancel -- see
+leaves behind (`PEND` in `--ls`). A ~60s poller already completes leased
+exports, extra clones, and finished decouples; `--retry-pending` is for
+lease-less exports, failed destroys, and not waiting out the poller. Marks are
+persisted to `<prefix>/meta/pending-deletes.json` (crash before that PUT
+forgets the intent). Withdraw a mark with `rcow_cancel_pending_delete`; see
 [Retrying a refused snapshot delete](../README.md#retrying-a-refused-snapshot-delete---retry-pending)
-in the main README for the full contract.
+in the main README for the full contract, including the race if the poller
+has already submitted destroy. `run_pending_delete_test.sh` step [11] uses
+`rcow_pending_load_hold` to delay that registry's HEAD and GET around unload
+(test-only; production never parks attach).
 
 Especially useful when debugging a hung target: a process a test script left
 behind can be asked for its state directly.

--- a/CubeS3lvol/test/README.md
+++ b/CubeS3lvol/test/README.md
@@ -13,18 +13,15 @@ them in this order -- the earlier ones are faster and need less environment.
 
 ```sh
 make check           # 24 suites (= test/run_all.sh; dataplane needs root + S3)
-make check-offline   # only the suites needing no credentials and no root: 11, 491 assertions, about 40 seconds
+make check-offline   # suites needing no credentials and no root (see `test/run_all.sh --list`)
 test/run_all.sh --list          # show what would run and what the environment has
 test/run_all.sh --no-dataplane  # both integration layers, no dataplane
 ```
 
 The reason `run_all.sh` exists is that the suites' preconditions had drifted
-apart: ten integration tests run anywhere, two need real credentials, ten
-dataplane scripts need root + credentials + a writable `/data` + exclusive use
-of the machine's nvme stack; and the arguments differ too (seven take
-`-e/-b/-r`, six read `s3.cfg` themselves). So "run the tests" had become
-"remember twenty-two invocations", and in practice meant running only the two
-or three related to whatever had just changed.
+apart: which tests need credentials, root, or a writable `/data` lives in
+`run_all.sh --list` (and the skip reasons it prints), not in a count that
+rots every time a suite is added.
 
 A few design decisions, each corresponding to a way a run can "look green while
 testing nothing":

--- a/CubeS3lvol/test/dataplane/probe_chain_depth.sh
+++ b/CubeS3lvol/test/dataplane/probe_chain_depth.sh
@@ -1,27 +1,37 @@
 #!/usr/bin/env bash
-# 快照链深的可见性探针
+# Visibility probe for snapshot chain depth.
 #
-# 为什么需要它：export_build_chain() 走本地快照链，深度超过
-# S3LVOL_DEFAULT_MAX_CHAIN_DEPTH(32) 时返回 -E2BIG，于是 export_snapshot **静默**
-# 退化成整卷拷贝。拷贝本身是正确的退路，问题是产出的 dense export 永远不会被
-# reaper 回收（reaper 只收 REF），所以代价是永久的：一条注册表条目 + 一份全卷副本。
+# Why it exists: export_build_chain() walks the local snapshot chain and returns
+# -E2BIG once depth exceeds S3LVOL_DEFAULT_MAX_CHAIN_DEPTH (32). export_snapshot
+# then **silently** falls back to a whole-volume copy. The copy is a correct
+# fallback; the problem is that the resulting dense export is never reaped
+# (the reaper only collects REF), so the cost is permanent: one registry entry
+# plus a full-volume replica.
 #
-# 而在此之前，什么都不会告诉你链在变长。日志里只有一行 "exporting by copying
-# instead"，和一次正常导出几乎无法区分——也就是说生产上已经发生过也无从得知。
+# Until that point nothing tells you the chain is growing. The log has a single
+# "exporting by copying instead" line that is almost indistinguishable from a
+# normal export -- so this can already have happened in production with no
+# record of it.
 #
-# 快照是用户的，不该因为链长就拒绝创建。所以做法是：软阈值(24)告警 + 链深随
-# rcow_get_lvstores 上报，让控制面能在悬崖之前决策，而不是事后发现。
+# Snapshots belong to the user; creating one must not be refused because the
+# chain is long. So: warn at a soft threshold (24) and report chain_depth via
+# rcow_get_lvstores, so the control plane can act before the cliff rather than
+# discover it afterwards.
 #
-# 判据：
-#   [2] chain_depth 随每次快照 +1，且 RPC 真的报出来（不是恒 0 或恒定值）
-#   [3] 跨过软阈值 24 时出现告警，且 24 之前没有
-#   [4] 越过硬上限 32 之后告警换成更强的措辞
-#   [5] 删掉一个中间快照，链深真的下降 —— 这是告警建议的动作，必须真的有效
-#   [6] 链深 32 内导出仍是 ref（零拷贝没有被这些改动碰坏）
+# Checks:
+#   [2] chain_depth increases by 1 on every snapshot, and the RPC actually
+#       reports it (not a constant 0 or a stuck value)
+#   [3] a warning appears at the soft threshold of 24, and not before
+#   [4] past the hard limit of 32 the warning uses stronger wording
+#   [5] deleting an intermediate snapshot actually shortens the chain -- that
+#       is the action the warning recommends, so it has to work
+#   [6] an export within depth 32 is still a ref (zero-copy was not broken)
 #
-# [5] 是最要紧的一条。告警让用户去删中间快照，如果那个动作其实不管用，这个告警
-# 就是在指使用户做无用功。删中间快照靠的是 blobstore 把被删层 merge 进它唯一的
-# clone（clone_count == 1 才可删），纯元数据、对 S3 零 IO。
+# [5] is the one that matters most. The warning tells the user to delete an
+# intermediate snapshot; if that does nothing, the warning is sending them on
+# a wild goose chase. Deleting an intermediate snapshot is blobstore merging
+# the deleted layer into its only clone (allowed only when clone_count == 1):
+# metadata only, zero S3 I/O.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -38,10 +48,10 @@ RPC_SOCK=/tmp/pchain.sock
 TGT_LOG=/tmp/pchain_target.log
 WORKDIR="$(mktemp -d /tmp/pchain.XXXXXX)"
 
-# 软阈值 24、硬上限 32，与 include/s3lvol/s3_types.h 一致。
+# Soft threshold 24, hard limit 32: same as include/s3lvol/s3_types.h.
 SOFT=24
 HARD=32
-# 建到 34 层：越过硬上限两层，好让 [4] 的强告警确实被触发。
+# Build to 34 layers: two past the hard limit so [4]'s stronger warning fires.
 BUILD_TO=34
 
 TGT_PID=""
@@ -54,10 +64,10 @@ ok()   { echo "     [PASS] $*"; }
 bad()  { echo "     [FAIL] $*"; FAILED=$((FAILED + 1)); }
 want() { if [ "$2" = "$3" ]; then ok "$1 ($2)"; else bad "$1: got '$2', want '$3'"; fi; }
 
-# chain_depth 字段，从 rcow_get_lvstores 的 JSON 里取一个 lvol 的。
+# chain_depth of one lvol, taken from rcow_get_lvstores JSON.
 #
-# --raw 输出的是 JSON-RPC 的 result 成员本身，也就是顶层直接是 lvstore 数组，
-# 而不是 {"result": [...]}。
+# --raw prints the JSON-RPC result member itself: a top-level lvstore array,
+# not {"result": [...]}.
 depth_of()
 {
 	raw rcow_get_lvstores '' 2>/dev/null | python3 -c '
@@ -119,85 +129,89 @@ raw bdev_aio_create "$(printf '{"filename":"%s","name":"pc_wal0","block_size":40
 	"${WAL}")" >/dev/null 2>&1
 
 echo
-info "[1] 一个卷，准备把它的快照链拉长"
+info "[1] one volume, about to grow its snapshot chain"
 rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"pc_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
 	"${LVS}" "${BK}")" >/dev/null || { echo "create lvstore"; exit 1; }
 rpc rcow_create_lvol '{"lvol_name":"v","size_gib":1}' >/dev/null || { echo "lvol"; exit 1; }
 D0="$(depth_of v)"
-want "一个没有父的卷，链深为 1" "${D0}" "1"
+want "an unparented volume has chain depth 1" "${D0}" "1"
 
 echo
-info "[2] 每建一个快照，链深应当 +1"
+info "[2] each snapshot should increase chain depth by 1"
 MARK="$(wc -l <"${TGT_LOG}")"
 MISMATCH=0
 SOFT_FIRST=""
 for i in $(seq 1 "${BUILD_TO}"); do
 	rpc rcow_create_snapshot "$(printf '{"lvol_name":"v","snapshot_name":"s%d"}' "$i")" \
-		>/dev/null 2>&1 || { bad "快照 s${i} 创建失败"; break; }
-	# 卷本身 + i 个快照 = i+1 层
+		>/dev/null 2>&1 || { bad "snapshot s${i} failed"; break; }
+	# The volume itself plus i snapshots = i+1 layers.
 	D="$(depth_of v)"
 	EXPECT=$((i + 1))
 	if [ "${D}" != "${EXPECT}" ]; then
-		bad "建了 ${i} 个快照后，v 的链深是 '${D}'，应为 ${EXPECT}"
+		bad "after ${i} snapshot(s), v's chain depth is '${D}', want ${EXPECT}"
 		MISMATCH=$((MISMATCH + 1))
 		[ "${MISMATCH}" -ge 3 ] && break
 	fi
 	[ "${EXPECT}" = "${SOFT}" ] && SOFT_FIRST="$(wc -l <"${TGT_LOG}")"
 done
-[ "${MISMATCH}" = "0" ] && ok "链深逐级递增，一直到 $(depth_of v)"
-want "最终链深" "$(depth_of v)" "$((BUILD_TO + 1))"
+[ "${MISMATCH}" = "0" ] && ok "chain depth stepped up to $(depth_of v)"
+want "final chain depth" "$(depth_of v)" "$((BUILD_TO + 1))"
 
 echo
-info "[3] 软阈值 ${SOFT}：之前不该吵，到了要说"
+info "[3] soft threshold ${SOFT}: quiet before it, a warning at it"
 NEW="$(tail -n "+${MARK}" "${TGT_LOG}")"
-# 告警文本里带着链深，所以可以精确地问"第一次告警是在哪个深度"。
+# The warning text includes the depth, so the first one can be pinned to a layer.
 FIRST_WARN_DEPTH="$(printf '%s\n' "${NEW}" \
 	| grep -ao 'is [0-9]* snapshot(s) deep' | head -1 | grep -o '[0-9]*')"
 if [ -z "${FIRST_WARN_DEPTH}" ]; then
-	bad "整个过程没有任何链深告警"
+	bad "no chain-depth warning at all"
 elif [ "${FIRST_WARN_DEPTH}" = "${SOFT}" ]; then
-	ok "第一条告警恰好出现在深度 ${SOFT}"
+	ok "the first warning appeared at depth ${SOFT}"
 else
-	bad "第一条告警出现在深度 ${FIRST_WARN_DEPTH}，应为 ${SOFT}"
+	bad "the first warning appeared at depth ${FIRST_WARN_DEPTH}, want ${SOFT}"
 fi
-# 告警必须指出可以做什么，否则运维只知道有问题、不知道怎么办。
+# The warning has to say what to do, otherwise operators know there is a
+# problem and not how to fix it.
 if printf '%s' "${NEW}" | grep -q 'Deleting an intermediate snapshot'; then
-	ok "并且说明了该怎么办（删中间快照）"
+	ok "and it says what to do (delete an intermediate snapshot)"
 else
-	bad "告警没有给出可执行的建议"
+	bad "the warning has no actionable advice"
 fi
 
 echo
-info "[4] 越过硬上限 ${HARD} 之后，措辞应当更强"
+info "[4] past the hard limit ${HARD}, the wording should be stronger"
 if printf '%s' "${NEW}" | grep -q "past the limit of ${HARD}"; then
 	ok "$(printf '%s' "${NEW}" | grep -ao "is [0-9]* snapshot(s) deep, past the limit of ${HARD}" | head -1)"
 else
-	bad "越过 ${HARD} 之后没有出现更强的告警"
+	bad "no stronger warning after crossing ${HARD}"
 fi
 if printf '%s' "${NEW}" | grep -q 'copy the whole volume'; then
-	ok "并且点明了后果是整卷拷贝"
+	ok "and it names the consequence (a whole-volume copy)"
 else
-	bad "强告警没有说明后果"
+	bad "the stronger warning does not name the consequence"
 fi
 
 echo
-info "[5] 删一个中间快照，链深必须真的下降"
-# 这是 [3]/[4] 建议的动作。如果它不管用，那两条告警就是在指使用户做无用功。
+info "[5] deleting an intermediate snapshot must actually shorten the chain"
+# This is the action [3]/[4] recommend. If it does nothing, those warnings are
+# sending the user on a wild goose chase.
 BEFORE="$(depth_of v)"
-# s2 是中间层：它有父(s1)也有子(s3)，clone_count 恰好为 1，所以可删。
+# s2 is an intermediate layer: it has a parent (s1) and a child (s3), and
+# clone_count is exactly 1, so it is deletable.
 DEL="$(rpc rcow_delete_lvol "$(printf '{"lvol_name":"s2","lvs_name":"%s"}' "${LVS}")" 2>&1)"
 info "delete s2: ${DEL}"
 sleep 2
 AFTER="$(depth_of v)"
 if [ -n "${AFTER}" ] && [ "${AFTER}" -lt "${BEFORE}" ] 2>/dev/null; then
-	ok "删掉一个中间快照后链深 ${BEFORE} -> ${AFTER}"
+	ok "after deleting an intermediate snapshot, depth ${BEFORE} -> ${AFTER}"
 else
-	bad "链深没有下降（${BEFORE} -> ${AFTER:-<空>}）：告警建议的动作无效"
+	bad "depth did not drop (${BEFORE} -> ${AFTER:-<empty>}): the recommended action is a no-op"
 fi
 
 echo
-info "[6] ${HARD} 层以内导出仍应是零拷贝"
-# 这些改动只增加了观测，不该影响路由。用一个浅链的快照来验。
+info "[6] an export within ${HARD} layers should still be zero-copy"
+# These changes only add observability; they must not change routing. Check
+# with a shallow-chain snapshot.
 rpc rcow_create_lvol '{"lvol_name":"w","size_gib":1}' >/dev/null 2>&1
 rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${LVS}")" >/dev/null 2>&1
 rpc rcow_create_snapshot '{"lvol_name":"w","snapshot_name":"ws"}' >/dev/null 2>&1
@@ -214,16 +228,17 @@ if [ -n "${EXP}" ]; then
 	done
 	LAYOUT="$(python3 "${GET_MANIFEST}" -e "${EP}" -b "${BK}" -r "${RG}" -u "${EXP}" \
 		--field layout 2>/dev/null)"
-	want "浅链快照的导出仍是 ref" "${LAYOUT}" "ref"
+	want "a shallow-chain snapshot still exports as ref" "${LAYOUT}" "ref"
 else
-	bad "导出 ws 失败"
+	bad "export of ws failed"
 fi
 
 echo
 echo "===== SUMMARY"
 if [ "${FAILED}" = "0" ]; then
-	echo "  链深可查、跨软阈值告警、且告警建议的补救动作确实有效。"
+	echo "  chain depth is reported, the soft threshold warns, and the"
+	echo "  recommended remedy actually shortens the chain."
 else
-	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+	echo "  ${FAILED} failure(s) -- see [FAIL] above"
 fi
 exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/probe_chain_depth.sh
+++ b/CubeS3lvol/test/dataplane/probe_chain_depth.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# 快照链深的可见性探针
+#
+# 为什么需要它：export_build_chain() 走本地快照链，深度超过
+# S3LVOL_DEFAULT_MAX_CHAIN_DEPTH(32) 时返回 -E2BIG，于是 export_snapshot **静默**
+# 退化成整卷拷贝。拷贝本身是正确的退路，问题是产出的 dense export 永远不会被
+# reaper 回收（reaper 只收 REF），所以代价是永久的：一条注册表条目 + 一份全卷副本。
+#
+# 而在此之前，什么都不会告诉你链在变长。日志里只有一行 "exporting by copying
+# instead"，和一次正常导出几乎无法区分——也就是说生产上已经发生过也无从得知。
+#
+# 快照是用户的，不该因为链长就拒绝创建。所以做法是：软阈值(24)告警 + 链深随
+# rcow_get_lvstores 上报，让控制面能在悬崖之前决策，而不是事后发现。
+#
+# 判据：
+#   [2] chain_depth 随每次快照 +1，且 RPC 真的报出来（不是恒 0 或恒定值）
+#   [3] 跨过软阈值 24 时出现告警，且 24 之前没有
+#   [4] 越过硬上限 32 之后告警换成更强的措辞
+#   [5] 删掉一个中间快照，链深真的下降 —— 这是告警建议的动作，必须真的有效
+#   [6] 链深 32 内导出仍是 ref（零拷贝没有被这些改动碰坏）
+#
+# [5] 是最要紧的一条。告警让用户去删中间快照，如果那个动作其实不管用，这个告警
+# 就是在指使用户做无用功。删中间快照靠的是 blobstore 把被删层 merge 进它唯一的
+# clone（clone_count == 1 才可删），纯元数据、对 S3 零 IO。
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+GET_MANIFEST="${ROOT}/test/tools/s3_get_manifest.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+LVS=pchain
+WAL=/tmp/pchain_wal.img
+RPC_SOCK=/tmp/pchain.sock
+TGT_LOG=/tmp/pchain_target.log
+WORKDIR="$(mktemp -d /tmp/pchain.XXXXXX)"
+
+# 软阈值 24、硬上限 32，与 include/s3lvol/s3_types.h 一致。
+SOFT=24
+HARD=32
+# 建到 34 层：越过硬上限两层，好让 [4] 的强告警确实被触发。
+BUILD_TO=34
+
+TGT_PID=""
+FAILED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+ok()   { echo "     [PASS] $*"; }
+bad()  { echo "     [FAIL] $*"; FAILED=$((FAILED + 1)); }
+want() { if [ "$2" = "$3" ]; then ok "$1 ($2)"; else bad "$1: got '$2', want '$3'"; fi; }
+
+# chain_depth 字段，从 rcow_get_lvstores 的 JSON 里取一个 lvol 的。
+#
+# --raw 输出的是 JSON-RPC 的 result 成员本身，也就是顶层直接是 lvstore 数组，
+# 而不是 {"result": [...]}。
+depth_of()
+{
+	raw rcow_get_lvstores '' 2>/dev/null | python3 -c '
+import json, sys
+want = sys.argv[1]
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if isinstance(d, dict):
+    d = d.get("result") or []
+for lvs in d:
+    for l in (lvs.get("lvols") or []):
+        if l.get("name") == want:
+            print(l.get("chain_depth", ""))
+            sys.exit(0)
+' "$1"
+}
+
+cleanup()
+{
+	set +u
+	[ -n "${TGT_PID}" ] && { kill "${TGT_PID}" 2>/dev/null; sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null; }
+	rcow_load_credentials
+	python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+		-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+		-p "${LVS}/" >/dev/null 2>&1
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+			-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+			-p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo "===== log: ${TGT_LOG}"
+}
+trap cleanup EXIT
+
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${WAL}"
+truncate -s 320M "${WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${LVS}/" >/dev/null 2>&1
+
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"pc_wal0","block_size":4096}' \
+	"${WAL}")" >/dev/null 2>&1
+
+echo
+info "[1] 一个卷，准备把它的快照链拉长"
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"pc_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${LVS}" "${BK}")" >/dev/null || { echo "create lvstore"; exit 1; }
+rpc rcow_create_lvol '{"lvol_name":"v","size_gib":1}' >/dev/null || { echo "lvol"; exit 1; }
+D0="$(depth_of v)"
+want "一个没有父的卷，链深为 1" "${D0}" "1"
+
+echo
+info "[2] 每建一个快照，链深应当 +1"
+MARK="$(wc -l <"${TGT_LOG}")"
+MISMATCH=0
+SOFT_FIRST=""
+for i in $(seq 1 "${BUILD_TO}"); do
+	rpc rcow_create_snapshot "$(printf '{"lvol_name":"v","snapshot_name":"s%d"}' "$i")" \
+		>/dev/null 2>&1 || { bad "快照 s${i} 创建失败"; break; }
+	# 卷本身 + i 个快照 = i+1 层
+	D="$(depth_of v)"
+	EXPECT=$((i + 1))
+	if [ "${D}" != "${EXPECT}" ]; then
+		bad "建了 ${i} 个快照后，v 的链深是 '${D}'，应为 ${EXPECT}"
+		MISMATCH=$((MISMATCH + 1))
+		[ "${MISMATCH}" -ge 3 ] && break
+	fi
+	[ "${EXPECT}" = "${SOFT}" ] && SOFT_FIRST="$(wc -l <"${TGT_LOG}")"
+done
+[ "${MISMATCH}" = "0" ] && ok "链深逐级递增，一直到 $(depth_of v)"
+want "最终链深" "$(depth_of v)" "$((BUILD_TO + 1))"
+
+echo
+info "[3] 软阈值 ${SOFT}：之前不该吵，到了要说"
+NEW="$(tail -n "+${MARK}" "${TGT_LOG}")"
+# 告警文本里带着链深，所以可以精确地问"第一次告警是在哪个深度"。
+FIRST_WARN_DEPTH="$(printf '%s\n' "${NEW}" \
+	| grep -ao 'is [0-9]* snapshot(s) deep' | head -1 | grep -o '[0-9]*')"
+if [ -z "${FIRST_WARN_DEPTH}" ]; then
+	bad "整个过程没有任何链深告警"
+elif [ "${FIRST_WARN_DEPTH}" = "${SOFT}" ]; then
+	ok "第一条告警恰好出现在深度 ${SOFT}"
+else
+	bad "第一条告警出现在深度 ${FIRST_WARN_DEPTH}，应为 ${SOFT}"
+fi
+# 告警必须指出可以做什么，否则运维只知道有问题、不知道怎么办。
+if printf '%s' "${NEW}" | grep -q 'Deleting an intermediate snapshot'; then
+	ok "并且说明了该怎么办（删中间快照）"
+else
+	bad "告警没有给出可执行的建议"
+fi
+
+echo
+info "[4] 越过硬上限 ${HARD} 之后，措辞应当更强"
+if printf '%s' "${NEW}" | grep -q "past the limit of ${HARD}"; then
+	ok "$(printf '%s' "${NEW}" | grep -ao "is [0-9]* snapshot(s) deep, past the limit of ${HARD}" | head -1)"
+else
+	bad "越过 ${HARD} 之后没有出现更强的告警"
+fi
+if printf '%s' "${NEW}" | grep -q 'copy the whole volume'; then
+	ok "并且点明了后果是整卷拷贝"
+else
+	bad "强告警没有说明后果"
+fi
+
+echo
+info "[5] 删一个中间快照，链深必须真的下降"
+# 这是 [3]/[4] 建议的动作。如果它不管用，那两条告警就是在指使用户做无用功。
+BEFORE="$(depth_of v)"
+# s2 是中间层：它有父(s1)也有子(s3)，clone_count 恰好为 1，所以可删。
+DEL="$(rpc rcow_delete_lvol "$(printf '{"lvol_name":"s2","lvs_name":"%s"}' "${LVS}")" 2>&1)"
+info "delete s2: ${DEL}"
+sleep 2
+AFTER="$(depth_of v)"
+if [ -n "${AFTER}" ] && [ "${AFTER}" -lt "${BEFORE}" ] 2>/dev/null; then
+	ok "删掉一个中间快照后链深 ${BEFORE} -> ${AFTER}"
+else
+	bad "链深没有下降（${BEFORE} -> ${AFTER:-<空>}）：告警建议的动作无效"
+fi
+
+echo
+info "[6] ${HARD} 层以内导出仍应是零拷贝"
+# 这些改动只增加了观测，不该影响路由。用一个浅链的快照来验。
+rpc rcow_create_lvol '{"lvol_name":"w","size_gib":1}' >/dev/null 2>&1
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${LVS}")" >/dev/null 2>&1
+rpc rcow_create_snapshot '{"lvol_name":"w","snapshot_name":"ws"}' >/dev/null 2>&1
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${LVS}")" >/dev/null 2>&1
+sleep 2
+EXP="$(rpc rcow_export_snapshot '{"snapshot_name":"ws"}' 2>&1 | tr -d '"[:space:]\n')"
+if [ -n "${EXP}" ]; then
+	UUIDS="${EXP}"
+	for _ in $(seq 60); do
+		ST="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP}")" \
+			2>/dev/null | tr -d '"[:space:]\n')"
+		case "${ST}" in *DONE*) break ;; esac
+		sleep 1
+	done
+	LAYOUT="$(python3 "${GET_MANIFEST}" -e "${EP}" -b "${BK}" -r "${RG}" -u "${EXP}" \
+		--field layout 2>/dev/null)"
+	want "浅链快照的导出仍是 ref" "${LAYOUT}" "ref"
+else
+	bad "导出 ws 失败"
+fi
+
+echo
+echo "===== SUMMARY"
+if [ "${FAILED}" = "0" ]; then
+	echo "  链深可查、跨软阈值告警、且告警建议的补救动作确实有效。"
+else
+	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+fi
+exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/probe_concurrent_decouple.sh
+++ b/CubeS3lvol/test/dataplane/probe_concurrent_decouple.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Does decoupling one export while another is being materialised corrupt it?
+#
+# What points here. The same export was decoupled three times on the same node,
+# from the same objects, and read a different amount each time:
+#
+#   16:51:18  32 read(s),    139264 bytes,  4 served as zeroes   -> unmountable
+#   17:11:18  74 read(s),  12701696 bytes,  4 served as zeroes   -> fine
+#   17:11:57  13 read(s),   4272128 bytes,  0 served as zeroes   -> fine
+#
+# The manifest describes 4231168 bytes across ten chunks, so the last line is the
+# shape a correct run has. The first read 3% of that and left nine of the ten
+# chunks reading as zeroes, which is why the mount that followed failed on the
+# root inode's checksum.
+#
+# The difference is not the export. It is what else was running. The failing run
+# started at 16:51:16 while a 2048-cluster, 2.4 GB decouple of a *different*
+# export had been going since 16:47:40 and did not finish until 16:53:46. The two
+# clean runs were the only decouple on the node at the time.
+#
+# Concurrent decouples of one export now queue (9d3429e), but these were different
+# exports, so nothing serialises them. This run reproduces that: a big export is
+# put into materialisation, a small one is started underneath it, and the small
+# one's bytes are then compared against the objects the manifest names.
+#
+# Verified per chunk rather than by mounting: a filesystem answers yes or no,
+# while the chunk comparison says which chunk lost what, and that is what
+# distinguishes a short read from a wrong offset.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TOOLS_DIR="${REPO_ROOT}/test/tools"
+TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+RPC_SOCK="/var/run/s3lvol.sock"
+
+SRC_LVS="ccsrc"
+DST_LVS="ccdst"
+SRC_WAL="/data/s3lvol_ccsrc.img"
+DST_WAL="/data/s3lvol_ccdst.img"
+NQN="nqn.2026-08.io.spdk:ccdec"
+PORT=4433
+
+# The big volume is what occupies the materialiser; the small one is the victim
+# whose bytes are checked. The field case was 2048 clusters against 10.
+BIG_GIB=2
+BIG_FILL_MB=700
+SMALL_GIB=1
+SMALL_FILL_MB=4
+
+# -x removes every namespace from the subsystem before the two decouples start, so
+# nothing on the host can be reading, prefetching or writing while they run. It is
+# the control for "is the host involved at all": if the corruption still happens
+# with no block device in existence, the host is not part of it.
+ENDPOINT=""; BUCKET=""; REGION="ap-nanjing"; NO_HOST=0
+while getopts "e:b:r:x" opt; do
+	case "${opt}" in
+	e) ENDPOINT="${OPTARG}" ;;
+	b) BUCKET="${OPTARG}" ;;
+	r) REGION="${OPTARG}" ;;
+	x) NO_HOST=1 ;;
+	*) exit 1 ;;
+	esac
+done
+[ -n "${ENDPOINT}" ] && [ -n "${BUCKET}" ] || { echo "need -e and -b" >&2; exit 1; }
+[ -n "${AWS_ACCESS_KEY_ID:-}" ] || { echo "need credentials" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d /tmp/ccdec.XXXXXX)"
+TGT_LOG="${WORKDIR}/target.log"
+MNT="${WORKDIR}/mnt"
+mkdir -p "${MNT}"
+
+rpc()  { python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" "$1" "${2:-}"; }
+raw()  { python3 /tmp/rpc_raw.py "${RPC_SOCK}" "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+
+CONNECTED=0
+cleanup() {
+	set +u
+	[ "${CONNECTED}" = "1" ] && { umount "${MNT}" 2>/dev/null; \
+		nvme disconnect -n "${NQN}" >/dev/null 2>&1; }
+	[ -n "${TGT_PID:-}" ] && kill "${TGT_PID}" 2>/dev/null
+	sleep 2
+	kill -9 "${TGT_PID}" 2>/dev/null
+	echo
+	echo "===== decouple accounting ====="
+	grep -aE "Decoupling lvol|materialised|Releasing imported export" "${TGT_LOG}"
+	echo "===== S3 client errors, if any ====="
+	grep -aiE "GetObject|short|truncat|timeout|retry|curl|http=[45]" "${TGT_LOG}" \
+		| tail -15
+	echo "===== log: ${TGT_LOG} ====="
+}
+trap cleanup EXIT
+
+pkill -9 -f s3lvol_tgt 2>/dev/null; sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 512M "${SRC_WAL}"
+truncate -s 512M "${DST_WAL}"
+
+info "starting target"
+"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}")" >/dev/null
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"ccsrc_wal0","block_size":4096}' \
+	"${SRC_WAL}")" >/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"ccdst_wal0","block_size":4096}' \
+	"${DST_WAL}")" >/dev/null 2>&1
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":8,"wal_bdev":"ccsrc_wal0","journal_size_mb":64,"wal_size_mb":192}' \
+	"${SRC_LVS}" "${BUCKET}")" >/dev/null || { echo "src lvstore failed"; exit 1; }
+
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"CCDEC000000000000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose() {
+	raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+		"${NQN}" "$1")" 2>/dev/null \
+		| python3 -c "import json,sys; print(json.load(sys.stdin).get('result',''))" 2>/dev/null
+}
+unexpose() {
+	local nsid
+	nsid="$(raw nvmf_get_subsystems 2>/dev/null | python3 -c "
+import json, sys
+nqn, bdev = sys.argv[1], sys.argv[2]
+try: subs = json.load(sys.stdin).get('result', [])
+except Exception: subs = []
+for s in subs:
+    if s.get('nqn') != nqn: continue
+    for n in s.get('namespaces', []):
+        if n.get('bdev_name') == bdev:
+            print(n.get('nsid')); break
+" "${NQN}" "$1" 2>/dev/null)"
+	[ -n "${nsid}" ] && raw nvmf_subsystem_remove_ns \
+		"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "${nsid}")" >/dev/null 2>&1
+}
+ctrl_of_nqn() {
+	local c
+	for c in /sys/class/nvme/nvme*; do
+		[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done
+	return 1
+}
+wait_dev() {
+	local nsid="$1" deadline=$(( $(date +%s) + 25 )) ctrl dev
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		ctrl="$(ctrl_of_nqn)" && {
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		}
+		sleep 0.2
+	done
+	return 1
+}
+export_and_wait() {
+	local snap="$1" uuid
+	uuid="$(rpc rcow_export_snapshot "$(printf '{"snapshot_name":"%s"}' "${snap}")" \
+		2>&1 | tr -d '"[:space:]')"
+	[ -n "${uuid}" ] || return 1
+	local deadline=$(( $(date +%s) + 180 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		case "$(rpc rcow_get_snapshot_status \
+			"$(printf '{"export_uuid":"%s"}' "${uuid}")" 2>/dev/null)" in
+		*DONE*) printf '%s' "${uuid}"; return 0 ;;
+		esac
+		sleep 1
+	done
+	return 1
+}
+
+# ---- two source volumes, exported.
+info "building the big volume (${BIG_FILL_MB} MiB of data)"
+rpc rcow_create_lvol "$(printf '{"lvol_name":"big","size_gib":%d}' "${BIG_GIB}")" >/dev/null
+NSID_BIG="$(expose "${SRC_LVS}/big")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 3
+BIG_DEV="$(wait_dev "${NSID_BIG}")" || { echo "big device missing"; exit 1; }
+dd if=/dev/urandom of="${BIG_DEV}" bs=1M count="${BIG_FILL_MB}" \
+	oflag=direct conv=fsync status=none
+
+info "building the small volume with a real ext4"
+rpc rcow_create_lvol "$(printf '{"lvol_name":"small","size_gib":%d}' "${SMALL_GIB}")" >/dev/null
+NSID_SMALL="$(expose "${SRC_LVS}/small")"
+SMALL_DEV="$(wait_dev "${NSID_SMALL}")" || { echo "small device missing"; exit 1; }
+mkfs.ext4 -F -O metadata_csum,64bit "${SMALL_DEV}" >/dev/null 2>&1
+mount "${SMALL_DEV}" "${MNT}" || { echo "mount of small failed"; exit 1; }
+mkdir -p "${MNT}/data"
+dd if=/dev/urandom of="${MNT}/data/blob.bin" bs=1M count="${SMALL_FILL_MB}" status=none
+for i in $(seq 1 12); do echo "file ${i}" > "${MNT}/data/f${i}.txt"; done
+sync
+umount "${MNT}"
+sync
+
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_checkpoint_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 5
+
+rpc rcow_create_snapshot '{"lvol_name":"big","snapshot_name":"big-snap"}' >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"small","snapshot_name":"small-snap"}' >/dev/null
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 4
+
+BIG_UUID="$(export_and_wait big-snap)" || { echo "big export failed"; exit 1; }
+SMALL_UUID="$(export_and_wait small-snap)" || { echo "small export failed"; exit 1; }
+info "big export   ${BIG_UUID}"
+info "small export ${SMALL_UUID}"
+
+# Record what the small export's chunks must contain, read through the export
+# itself before any of this. Whatever a correct decouple produces has to match.
+unexpose "${SRC_LVS}/big"
+unexpose "${SRC_LVS}/small"
+sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1 \
+	|| { echo "unload of source failed"; exit 1; }
+sleep 2
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":8,"wal_bdev":"ccdst_wal0","journal_size_mb":64,"wal_size_mb":192}' \
+	"${DST_LVS}" "${BUCKET}")" >/dev/null || { echo "dst lvstore failed"; exit 1; }
+info "destination lvstore ready"
+
+# Reference: import the small export WITHOUT decoupling, so reads go straight to
+# the objects, and take a per-chunk fingerprint.
+raw rcow_import_lvol "$(printf '{"lvol_name":"ref","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+	"${SMALL_UUID}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "ref import failed"; exit 1; }
+NSID_REF="$(expose "${DST_LVS}/ref")"
+REF_DEV="$(wait_dev "${NSID_REF}")" || { echo "ref device missing"; exit 1; }
+info "reference (esnap, no decouple): ${REF_DEV}"
+for off in $(seq 0 63); do
+	dd if="${REF_DEV}" bs=1M count=1 skip="${off}" iflag=direct 2>/dev/null \
+		| md5sum | cut -c1-32
+done > "${WORKDIR}/ref.txt"
+info "reference fingerprint taken over the first 64 MiB"
+
+if [ "${NO_HOST}" = "1" ]; then
+	unexpose "${DST_LVS}/ref"
+	nvme disconnect -n "${NQN}" >/dev/null 2>&1
+	CONNECTED=0
+	sleep 2
+	info "control run: no namespace is exposed while the decouples run"
+fi
+
+# ---- the experiment.
+info "starting the BIG decouple, then the small one underneath it"
+raw rcow_import_lvol "$(printf '{"lvol_name":"vbig","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+	"${BIG_UUID}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "big import failed"; exit 1; }
+
+# Wait until the big one is demonstrably running, so the small one really does
+# land underneath it rather than after it.
+for _ in $(seq 100); do
+	n="$(raw rcow_get_decouple 2>/dev/null | python3 -c "
+import json,sys
+try: rows=json.load(sys.stdin).get('result',[])
+except Exception: rows=[]
+print(len([r for r in rows if r.get('lvol_name')=='vbig' and not r.get('queued')]))
+" 2>/dev/null)"
+	[ "${n}" = "1" ] && break
+	sleep 0.1
+done
+info "big decouple is running; importing the small one with decouple:true"
+
+raw rcow_import_lvol "$(printf '{"lvol_name":"vsmall","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+	"${SMALL_UUID}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "small import failed"; exit 1; }
+
+# Both must finish before anything is judged.
+for _ in $(seq 600); do
+	left="$(raw rcow_get_decouple 2>/dev/null | python3 -c "
+import json,sys
+try: rows=json.load(sys.stdin).get('result',[])
+except Exception: rows=[]
+print(len(rows))
+" 2>/dev/null)"
+	[ "${left}" = "0" ] && break
+	sleep 1
+done
+info "both decouples finished"
+sleep 3
+
+NSID_SMALL2="$(expose "${DST_LVS}/vsmall")"
+if [ "${CONNECTED}" != "1" ]; then
+	nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+	CONNECTED=1
+	sleep 3
+fi
+SMALL2_DEV="$(wait_dev "${NSID_SMALL2}")" || { echo "vsmall device missing"; exit 1; }
+info "materialised small volume: ${SMALL2_DEV}"
+for off in $(seq 0 63); do
+	dd if="${SMALL2_DEV}" bs=1M count=1 skip="${off}" iflag=direct 2>/dev/null \
+		| md5sum | cut -c1-32
+done > "${WORKDIR}/got.txt"
+
+echo
+echo "================ RESULT ================"
+DIFF_COUNT="$(paste "${WORKDIR}/ref.txt" "${WORKDIR}/got.txt" \
+	| awk '$1 != $2 { n++ } END { print n + 0 }')"
+if [ "${DIFF_COUNT}" -eq 0 ]; then
+	echo "chunks differing from the export: 0 -- concurrent decouple is clean"
+	echo "The field failure is not explained by concurrency alone."
+else
+	echo "chunks differing from the export: ${DIFF_COUNT} of 64 -- REPRODUCED"
+	echo
+	echo "  chunk  through-export      after-concurrent-decouple"
+	paste "${WORKDIR}/ref.txt" "${WORKDIR}/got.txt" | awk '
+		$1 != $2 { printf "  %5d  %-18s %s\n", NR - 1, substr($1,1,16), substr($2,1,16) }' \
+		| head -20
+fi
+
+echo
+info "and the filesystem's verdict"
+e2fsck -fn "${SMALL2_DEV}" 2>&1 | head -10 | sed 's/^/     /'
+if mount -o ro "${SMALL2_DEV}" "${MNT}" 2>/dev/null; then
+	echo "     mount: OK, $(ls "${MNT}/data" 2>/dev/null | wc -l) entries under data/"
+	umount "${MNT}"
+else
+	echo "     mount: FAILED -- same symptom as the field"
+fi

--- a/CubeS3lvol/test/dataplane/probe_decouple_window.sh
+++ b/CubeS3lvol/test/dataplane/probe_decouple_window.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# Does reading a volume while its decouple is still running return something a
+# filesystem would reject?
+#
+# In the field a volume was exposed to the host 1.85 s before its decouple
+# finished, and the mount that followed failed with "inode #2 checksum invalid",
+# while re-importing the same export later mounted cleanly. The export's data is
+# known good -- it was verified byte for byte against its S3 objects and mounts
+# fine. That leaves the window: the device is readable before materialisation is
+# complete.
+#
+# spdk_blob_materialize_cluster() is supposed to make this safe. Each cluster is
+# copy-on-write: a reader either takes the old path (through the esnap to the
+# export) or the new one (the local cluster), and both hold the same bytes. Nothing
+# in the I/O path consults the decouple state, and materialise uses its own
+# channel. So either the window really is safe and the field failure has another
+# cause, or that reasoning has a hole in it.
+#
+# The experiment: build an export from a real ext4, import it, and from the moment
+# the device appears read the superblock and root inode repeatedly while the
+# decouple runs. Every sample is compared against what the same regions read after
+# the decouple has finished. A single differing sample settles it.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TOOLS_DIR="${REPO_ROOT}/test/tools"
+TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+RPC_SOCK="/var/run/s3lvol.sock"
+
+SRC_LVS="dcwsrc"
+DST_LVS="dcwdst"
+SRC_WAL="/data/s3lvol_dcwsrc.img"
+DST_WAL="/data/s3lvol_dcwdst.img"
+NQN="nqn.2026-08.io.spdk:dcwin"
+PORT=4431
+# Big enough that materialising takes long enough to sample during, small enough
+# to keep the run short. Every megabyte here is one 1 MiB chunk to fetch.
+VOL_GIB=1
+FILL_MB=4
+
+ENDPOINT=""; BUCKET=""; REGION="ap-nanjing"
+while getopts "e:b:r:" opt; do
+	case "${opt}" in
+	e) ENDPOINT="${OPTARG}" ;;
+	b) BUCKET="${OPTARG}" ;;
+	r) REGION="${OPTARG}" ;;
+	*) exit 1 ;;
+	esac
+done
+[ -n "${ENDPOINT}" ] && [ -n "${BUCKET}" ] || { echo "need -e and -b" >&2; exit 1; }
+[ -n "${AWS_ACCESS_KEY_ID:-}" ] || { echo "need credentials" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d /tmp/dcw.XXXXXX)"
+TGT_LOG="${WORKDIR}/target.log"
+MNT="${WORKDIR}/mnt"
+mkdir -p "${MNT}"
+
+rpc()  { python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" "$1" "${2:-}"; }
+raw()  { python3 /tmp/rpc_raw.py "${RPC_SOCK}" "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+
+CONNECTED=0
+cleanup() {
+	set +u
+	[ "${CONNECTED}" = "1" ] && { umount "${MNT}" 2>/dev/null; \
+		nvme disconnect -n "${NQN}" >/dev/null 2>&1; }
+	[ -n "${TGT_PID:-}" ] && kill "${TGT_PID}" 2>/dev/null
+	sleep 2
+	kill -9 "${TGT_PID}" 2>/dev/null
+	echo
+	echo "===== decouple / materialise lines ====="
+	grep -aE "Decoupling|materialised|no longer reads" "${TGT_LOG}" | tail -8
+	echo "===== log: ${TGT_LOG} ====="
+}
+trap cleanup EXIT
+
+pkill -9 -f s3lvol_tgt 2>/dev/null; sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 320M "${SRC_WAL}"
+truncate -s 320M "${DST_WAL}"
+
+info "starting target"
+"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_cos_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}")" >/dev/null
+
+# One blobstore per process, so the two lvstores take turns rather than coexisting:
+# the source is built and exported, then unloaded before the destination is made.
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"src_wal0","block_size":4096}' \
+	"${SRC_WAL}")" >/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"dst_wal0","block_size":4096}' \
+	"${DST_WAL}")" >/dev/null 2>&1
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"src_wal0","journal_size_mb":64,"wal_size_mb":128}' \
+	"${SRC_LVS}" "${BUCKET}")" >/dev/null || {
+	echo "create_lvstore ${SRC_LVS} failed"; exit 1; }
+info "source lvstore ready"
+
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"DCW0000000000000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose() {
+	raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+		"${NQN}" "$1")" 2>/dev/null \
+		| python3 -c "import json,sys; print(json.load(sys.stdin).get('result',''))" 2>/dev/null
+}
+ctrl_of_nqn() {
+	local c
+	for c in /sys/class/nvme/nvme*; do
+		[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done
+	return 1
+}
+wait_dev() {
+	local nsid="$1" deadline=$(( $(date +%s) + 20 )) ctrl dev
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		ctrl="$(ctrl_of_nqn)" && {
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		}
+		sleep 0.2
+	done
+	return 1
+}
+
+# ---- source: a real ext4 with real files, so the checks below are the same ones
+# ---- a mount would make.
+info "creating source volume and filling it"
+rpc rcow_create_lvol "$(printf '{"lvol_name":"src","size_gib":%d}' "${VOL_GIB}")" >/dev/null
+NSID_SRC="$(expose "${SRC_LVS}/src")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 3
+SRC_DEV="$(wait_dev "${NSID_SRC}")" || { echo "source device never appeared"; exit 1; }
+info "source device ${SRC_DEV}"
+
+mkfs.ext4 -F -O metadata_csum,64bit "${SRC_DEV}" >/dev/null 2>&1 || {
+	echo "mkfs failed"; exit 1; }
+mount "${SRC_DEV}" "${MNT}" || { echo "mount failed"; exit 1; }
+mkdir -p "${MNT}/data"
+dd if=/dev/urandom of="${MNT}/data/blob.bin" bs=1M count="${FILL_MB}" status=none
+# Few files, matching the volume this reproduces: it held fifteen. A sparse volume
+# is the interesting shape here -- almost every cluster is a hole, and holes are
+# the part of materialisation this run is aimed at.
+for i in $(seq 1 12); do echo "file ${i}" > "${MNT}/data/f${i}.txt"; done
+sync
+umount "${MNT}"
+sync
+
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_checkpoint_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 4
+
+rpc rcow_create_snapshot '{"lvol_name":"src","snapshot_name":"src-snap"}' >/dev/null
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 3
+
+EXP_UUID="$(rpc rcow_export_snapshot '{"snapshot_name":"src-snap"}' 2>&1 \
+	| tr -d '"[:space:]')"
+[ -n "${EXP_UUID}" ] || { echo "export failed"; exit 1; }
+info "exported as ${EXP_UUID}"
+for _ in $(seq 120); do
+	st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP_UUID}")" \
+		2>/dev/null | tr -d '"[:space:]')"
+	case "${st}" in *DONE*) break ;; esac
+	sleep 1
+done
+info "export status: ${st:-unknown}"
+
+# The source is done with; its namespace goes away with it so the host stops
+# holding the device open, and only then can the destination take the blobstore.
+SRC_NSID="$(raw nvmf_get_subsystems 2>/dev/null | python3 -c "
+import json, sys
+nqn = sys.argv[1]
+try: subs = json.load(sys.stdin).get('result', [])
+except Exception: subs = []
+for s in subs:
+    if s.get('nqn') != nqn: continue
+    for n in s.get('namespaces', []):
+        if n.get('bdev_name', '').endswith('/src'):
+            print(n.get('nsid')); break
+" "${NQN}" 2>/dev/null)"
+[ -n "${SRC_NSID}" ] && raw nvmf_subsystem_remove_ns \
+	"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "${SRC_NSID}")" >/dev/null 2>&1
+sleep 2
+
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1 \
+	|| { echo "unload of source failed"; exit 1; }
+sleep 2
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"dst_wal0","journal_size_mb":64,"wal_size_mb":128}' \
+	"${DST_LVS}" "${BUCKET}")" >/dev/null || {
+	echo "create_lvstore ${DST_LVS} failed"; exit 1; }
+info "destination lvstore ready"
+
+# ---- the experiment: import with decouple, then read while it runs.
+info "importing with decouple:true and sampling during materialisation"
+raw rcow_import_lvol "$(printf '{"lvol_name":"imp","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+	"${EXP_UUID}" "${DST_LVS}")" >/dev/null 2>"${WORKDIR}/import.err" || {
+	echo "import failed"; cat "${WORKDIR}/import.err"; exit 1; }
+
+NSID_IMP="$(expose "${DST_LVS}/imp")"
+IMP_DEV="$(wait_dev "${NSID_IMP}")" || { echo "imported device never appeared"; exit 1; }
+info "imported device ${IMP_DEV} (decouple may still be running)"
+
+# The two regions a mount reads first and trusts absolutely: the superblock lives
+# at byte 1024, the root inode in group 0's inode table. Both are inside the first
+# megabyte, which is also the first cluster to be materialised -- so if the window
+# is unsafe at all, it is unsafe here.
+SAMPLES=0
+DIFFS=0
+declare -A SEEN
+while :; do
+	busy="$(raw rcow_get_decouple 2>/dev/null | python3 -c "
+import json,sys
+try: rows=json.load(sys.stdin).get('result',[])
+except Exception: rows=[]
+print(len([r for r in rows if r.get('lvol_name')=='imp']))
+" 2>/dev/null)"
+	h="$(dd if="${IMP_DEV}" bs=4096 count=256 iflag=direct 2>/dev/null | md5sum | cut -c1-32)"
+	SAMPLES=$((SAMPLES + 1))
+	SEEN["${h}"]=1
+	[ "${busy}" = "0" ] && break
+	[ "${SAMPLES}" -gt 400 ] && break
+	sleep 0.05
+done
+info "sampled the first MiB ${SAMPLES} time(s) during/after decouple"
+
+# Settle, then take the authoritative reading.
+sleep 3
+FINAL="$(dd if="${IMP_DEV}" bs=4096 count=256 iflag=direct 2>/dev/null | md5sum | cut -c1-32)"
+DISTINCT="${#SEEN[@]}"
+info "distinct first-MiB contents observed: ${DISTINCT}"
+for h in "${!SEEN[@]}"; do
+	if [ "${h}" != "${FINAL}" ]; then
+		DIFFS=$((DIFFS + 1))
+		info "  differs from settled value: ${h}"
+	fi
+done
+info "settled value: ${FINAL}"
+
+echo
+if [ "${DIFFS}" -eq 0 ]; then
+	echo "RESULT: the window is consistent -- every sample matched the settled"
+	echo "        content, so reading during materialisation returned the same"
+	echo "        bytes throughout. The field failure needs another explanation."
+else
+	echo "RESULT: the window is NOT consistent -- ${DIFFS} of ${DISTINCT} distinct"
+	echo "        readings differed from the settled content. A mount landing here"
+	echo "        can read a superblock or root inode that does not match its"
+	echo "        checksum, which is exactly what was reported."
+fi
+
+# And the filesystem's own verdict, which is the one that matters.
+echo
+info "fsck and mount after the decouple settled"
+e2fsck -fn "${IMP_DEV}" 2>&1 | head -8 | sed 's/^/     /'
+if mount -o ro "${IMP_DEV}" "${MNT}" 2>/dev/null; then
+	echo "     mount: OK, $(ls "${MNT}/data" | wc -l) entries under data/"
+	umount "${MNT}"
+else
+	echo "     mount: FAILED"
+fi

--- a/CubeS3lvol/test/dataplane/probe_esnap_clone.sh
+++ b/CubeS3lvol/test/dataplane/probe_esnap_clone.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# Phase 1 探针 #2：从"引用式快照"克隆（clone of a reference snapshot）
+#
+# 形状与 probe_esnap_snapshot.sh 相同（一个 target、两个 lvstore 轮流、
+# nvmf_subsystem_add_ns 暴露 bdev、/sys/class/nvme 定位设备）。
+#
+# 为什么要单独探一次 clone：
+#
+#   create_clone 的 derive_check 检查的是**被克隆的快照 S**，而不是 V ——
+#   decouple 队列里排的是 V，所以 decouple_pending(S) 大概率为假，
+#   clone 可能今天就能通过。真正要证的是数据正确性，而不是能否调用。
+#
+# 要回答：
+#   1. 从 S（esnap clone V 的快照）克隆 C，当前代码会拒绝吗？
+#   2. C 能否读到正确数据（C -> S -> esnap -> 源 export A）？
+#   3. 写 C 之后：C 读到新数据、S 保持不变吗（跨 esnap 边界的 COW）？
+#   4. C 是否零拷贝——写之前 ALLOC 为 0，只为写入的部分分配？
+#   5. decouple V 之后、删除 V 之后，S 与 C 是否仍然正确？
+#   6. 直接克隆 V（可写卷）是否仍被正确拒绝（应当拒绝，不是要改的行为）？
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+SRC_LVS=pclone_src
+DST_LVS=pclone_dst
+SRC_WAL=/tmp/pclone_src_wal.img
+DST_WAL=/tmp/pclone_dst_wal.img
+RPC_SOCK=/tmp/pclone.sock
+TGT_LOG=/tmp/pclone_target.log
+NQN="nqn.2026-08.io.spdk:pclone"
+PORT="4471"
+WORKDIR="$(mktemp -d /tmp/pclone.XXXXXX)"
+FILL_MB=16
+WRITE_MB=4
+
+TGT_PID=""
+CONNECTED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+
+cleanup()
+{
+	set +u
+	[ "${CONNECTED}" = "1" ] && nvme disconnect -n "${NQN}" >/dev/null 2>&1
+	if [ -n "${TGT_PID}" ]; then
+		kill "${TGT_PID}" 2>/dev/null
+		sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null
+	fi
+	rcow_load_credentials
+	for p in "${SRC_LVS}" "${DST_LVS}"; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "${p}/" >/dev/null 2>&1
+	done
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${SRC_WAL}" "${DST_WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo
+	grep -aE 'external snapshot|esnap|not a clone|only a read-only|create snapshot|snapshot/clone|Decoupling|materialised|Deleted lvol' \
+		"${TGT_LOG}" 2>/dev/null | tail -18
+	echo "===== log: ${TGT_LOG}   workdir: ${WORKDIR}"
+}
+trap cleanup EXIT
+
+# --------------------------------------------------------------------------
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 320M "${SRC_WAL}"
+truncate -s 320M "${DST_WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+info "endpoint ${EP}  bucket ${BK}"
+for p in "${SRC_LVS}" "${DST_LVS}"; do
+	python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${p}/" >/dev/null 2>&1
+done
+
+info "starting target"
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config failed"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"src_wal0","block_size":4096}' "${SRC_WAL}")" \
+	>/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"dst_wal0","block_size":4096}' "${DST_WAL}")" \
+	>/dev/null 2>&1
+
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"src_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${SRC_LVS}" "${BK}")" >/dev/null || { echo "create ${SRC_LVS} failed"; exit 1; }
+info "source lvstore ready"
+
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"PCLONE000000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose()
+{
+	raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+		"${NQN}" "$1")" 2>/dev/null | tr -d '[:space:]'
+}
+
+unexpose()
+{
+	local nsid="$1"
+	[ -n "${nsid}" ] && raw nvmf_subsystem_remove_ns \
+		"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "${nsid}")" >/dev/null 2>&1
+	return 0
+}
+
+ctrl_of_nqn()
+{
+	local c
+	for c in /sys/class/nvme/nvme*; do
+		[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done
+	return 1
+}
+
+wait_dev()
+{
+	local nsid="$1" deadline ctrl dev
+	deadline=$(( $(date +%s) + 30 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if ctrl="$(ctrl_of_nqn)"; then
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		fi
+		sleep 0.3
+	done
+	return 1
+}
+
+# Read the first FILL_MB of a volume by name: expose, read, unexpose.
+read_vol()
+{
+	local name="$1" nsid dev md5
+	nsid="$(expose "${DST_LVS}/${name}")"
+	[ -n "${nsid}" ] || { echo "EXPOSE_FAILED"; return 1; }
+	dev="$(wait_dev "${nsid}")" || { unexpose "${nsid}"; echo "NO_DEV"; return 1; }
+	md5="$(dd if="${dev}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+	unexpose "${nsid}"
+	sleep 1
+	printf '%s' "${md5}"
+}
+
+# The ALLOC column of rcow_get_lvstores --ls, for one volume. SIZE prints as
+# two fields ("1.0 GiB"), so ALLOC is $5.
+alloc_of()
+{
+	rpc --ls rcow_get_lvstores 2>/dev/null | awk -v n="$1" '$1 == n { print $5; exit }'
+}
+
+# --------------------------------------------------------------------------
+# [1] source: a volume with known content -> snapshot -> REF export
+# --------------------------------------------------------------------------
+info "[1] source volume, filled"
+rpc rcow_create_lvol '{"lvol_name":"src","size_gib":1}' >/dev/null \
+	|| { echo "create_lvol failed"; exit 1; }
+NSID_SRC="$(expose "${SRC_LVS}/src")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 2
+SRC_DEV="$(wait_dev "${NSID_SRC}")" || { echo "source device never appeared"; exit 1; }
+info "source device ${SRC_DEV}"
+
+PAT="${WORKDIR}/pattern.bin"
+dd if=/dev/urandom of="${PAT}" bs=1M count="${FILL_MB}" status=none
+PAT_MD5="$(md5sum "${PAT}" | cut -d' ' -f1)"
+dd if="${PAT}" of="${SRC_DEV}" bs=1M oflag=direct status=none
+sync
+SRC_READ="$(dd if="${SRC_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+info "pattern ${PAT_MD5}; read back $([ "${SRC_READ}" = "${PAT_MD5}" ] && echo match || echo MISMATCH)"
+
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"src","snapshot_name":"src-snap"}' >/dev/null \
+	|| { echo "snapshot failed"; exit 1; }
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 3
+
+EXP_UUID="$(rpc rcow_export_snapshot '{"snapshot_name":"src-snap"}' 2>&1 | tr -d '"[:space:]\n')"
+UUIDS="${EXP_UUID}"
+[ -n "${EXP_UUID}" ] || { echo "export failed"; exit 1; }
+info "exported as ${EXP_UUID}"
+for _ in $(seq 120); do
+	st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP_UUID}")" 2>/dev/null \
+		| tr -d '"[:space:]\n')"
+	case "${st}" in *DONE*) break ;; esac
+	sleep 1
+done
+info "export status: ${st:-unknown}"
+
+unexpose "${NSID_SRC}"
+sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1 \
+	|| { echo "unload source failed"; exit 1; }
+sleep 2
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"dst_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${DST_LVS}" "${BK}")" >/dev/null || { echo "create ${DST_LVS} failed"; exit 1; }
+info "destination lvstore ready"
+
+# --------------------------------------------------------------------------
+# [2] import V, snapshot it (probe #1 established both work)
+# --------------------------------------------------------------------------
+echo
+info "[2] import V (decouple:false), snapshot it as S"
+IMP_OUT="$(rpc rcow_import_lvol "$(printf '{"lvol_name":"V","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+	"${EXP_UUID}" "${DST_LVS}")" 2>&1)"
+info "import reply: ${IMP_OUT}"
+SNAP_OUT="$(rpc rcow_create_snapshot '{"lvol_name":"V","snapshot_name":"S"}' 2>&1)"
+info "create_snapshot reply: ${SNAP_OUT}"
+
+# --------------------------------------------------------------------------
+# [3] the question: clone C from S -- refused by today's derive_check?
+# --------------------------------------------------------------------------
+echo
+info "[3] create_clone C from S (derive_check runs against S, not V)"
+CLONE_OUT="$(rpc rcow_create_clone '{"snapshot_name":"S","clone_name":"C"}' 2>&1)"
+CLONE_RC=$?
+info "create_clone reply: ${CLONE_OUT}  (rc=${CLONE_RC})"
+
+# And the case that must stay refused: cloning a writable volume.
+echo
+info "[3b] create_clone from V (writable) -- must be refused"
+CLONE_V_OUT="$(rpc rcow_create_clone '{"snapshot_name":"V","clone_name":"CV"}' 2>&1)"
+info "create_clone-from-V reply: ${CLONE_V_OUT}"
+
+rpc --ls rcow_get_lvstores
+
+# --------------------------------------------------------------------------
+# [4] does C read A's data, and is it zero-copy?
+# --------------------------------------------------------------------------
+echo
+info "[4] read C, and check its ALLOC"
+C_ALLOC_BEFORE="$(alloc_of C)"
+C_MD5="$(read_vol C)" || true
+info "C ALLOC before any write = ${C_ALLOC_BEFORE:-n/a}"
+info "C read = ${C_MD5}  $([ "${C_MD5}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+
+# --------------------------------------------------------------------------
+# [5] write to C: C must change, S must not (COW across the esnap boundary)
+# --------------------------------------------------------------------------
+echo
+info "[5] write ${WRITE_MB} MiB into C, then compare C and S"
+NEW="${WORKDIR}/newdata.bin"
+dd if=/dev/urandom of="${NEW}" bs=1M count="${WRITE_MB}" status=none
+
+# What C must read afterwards: the new bytes over the first WRITE_MB of the
+# pattern. Built locally so the comparison is exact rather than "different".
+EXPECT="${WORKDIR}/expect_c.bin"
+cp "${PAT}" "${EXPECT}"
+dd if="${NEW}" of="${EXPECT}" bs=1M conv=notrunc status=none
+EXPECT_MD5="$(md5sum "${EXPECT}" | cut -d' ' -f1)"
+
+NSID_C="$(expose "${DST_LVS}/C")"
+if [ -n "${NSID_C}" ] && C_DEV="$(wait_dev "${NSID_C}")"; then
+	dd if="${NEW}" of="${C_DEV}" bs=1M oflag=direct status=none
+	sync
+	C2_MD5="$(dd if="${C_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+	info "C after write = ${C2_MD5}  $([ "${C2_MD5}" = "${EXPECT_MD5}" ] && echo "MATCH ✓ (writes landed, rest still reads A)" || echo "MISMATCH ✗")"
+else
+	info "C could not be exposed for writing"
+	C2_MD5=""
+fi
+unexpose "${NSID_C}"
+sleep 1
+
+S_MD5="$(read_vol S)" || true
+info "S after C was written = ${S_MD5}  $([ "${S_MD5}" = "${PAT_MD5}" ] && echo "MATCH ✓ (S untouched)" || echo "MISMATCH ✗ (C's write leaked into S)")"
+
+C_ALLOC_AFTER="$(alloc_of C)"
+info "C ALLOC after writing ${WRITE_MB} MiB = ${C_ALLOC_AFTER:-n/a}  (cluster = 1 MiB here)"
+rpc --ls rcow_get_lvstores
+
+# --------------------------------------------------------------------------
+# [6] decouple V, then delete V: S and C must both survive
+# --------------------------------------------------------------------------
+echo
+info "[6] decouple V, then delete it"
+rpc rcow_decouple_lvol '{"lvol_name":"V"}' >/dev/null 2>&1 \
+	&& info "decouple submitted" || info "decouple submit failed"
+for i in $(seq 240); do
+	busy="$(rpc rcow_get_decouple 2>/dev/null | python3 -c '
+import json,sys
+try: rows=json.load(sys.stdin)
+except Exception: rows=[]
+if isinstance(rows, dict): rows=rows.get("queue", [])
+print(len([r for r in rows if r.get("lvol_name")=="V"]))' 2>/dev/null)"
+	[ "${busy}" = "0" ] && break
+	sleep 1
+done
+info "decouple settled (waited ${i}s)"
+
+S_AFTER_DEC="$(read_vol S)" || true
+C_AFTER_DEC="$(read_vol C)" || true
+info "S after V decoupled = ${S_AFTER_DEC}  $([ "${S_AFTER_DEC}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+info "C after V decoupled = ${C_AFTER_DEC}  $([ "${C_AFTER_DEC}" = "${EXPECT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+
+DEL_V="$(rpc rcow_delete_lvol '{"lvol_name":"V"}' 2>&1)"
+info "delete V reply: ${DEL_V}"
+rpc --ls rcow_get_lvstores
+
+S_AFTER_DEL="$(read_vol S)" || true
+C_AFTER_DEL="$(read_vol C)" || true
+info "S after V deleted = ${S_AFTER_DEL}  $([ "${S_AFTER_DEL}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+info "C after V deleted = ${C_AFTER_DEL}  $([ "${C_AFTER_DEL}" = "${EXPECT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+
+echo
+echo "===== SUMMARY"
+echo "  pattern (what A holds)      : ${PAT_MD5}"
+echo "  expected C after its write  : ${EXPECT_MD5}"
+echo
+echo "  clone C from S              : ${CLONE_OUT}"
+echo "  clone from writable V       : ${CLONE_V_OUT}"
+echo "  C ALLOC before / after write: ${C_ALLOC_BEFORE:-n/a} / ${C_ALLOC_AFTER:-n/a}"
+echo
+echo "  C read (before write)       : ${C_MD5:-not read}"
+echo "  C read (after write)        : ${C2_MD5:-not read}"
+echo "  S read (after C written)    : ${S_MD5:-not read}"
+echo "  S / C after V decoupled     : ${S_AFTER_DEC:-not read} / ${C_AFTER_DEC:-not read}"
+echo "  S / C after V deleted       : ${S_AFTER_DEL:-not read} / ${C_AFTER_DEL:-not read}"

--- a/CubeS3lvol/test/dataplane/probe_esnap_clone.sh
+++ b/CubeS3lvol/test/dataplane/probe_esnap_clone.sh
@@ -1,22 +1,28 @@
 #!/usr/bin/env bash
-# Phase 1 探针 #2：从"引用式快照"克隆（clone of a reference snapshot）
+# Phase 1 probe #2: clone of a reference snapshot.
 #
-# 形状与 probe_esnap_snapshot.sh 相同（一个 target、两个 lvstore 轮流、
-# nvmf_subsystem_add_ns 暴露 bdev、/sys/class/nvme 定位设备）。
+# Same shape as probe_esnap_snapshot.sh (one target, two lvstores in turn,
+# nvmf_subsystem_add_ns to expose the bdev, /sys/class/nvme to find the
+# device).
 #
-# 为什么要单独探一次 clone：
+# Why clone is probed separately:
 #
-#   create_clone 的 derive_check 检查的是**被克隆的快照 S**，而不是 V ——
-#   decouple 队列里排的是 V，所以 decouple_pending(S) 大概率为假，
-#   clone 可能今天就能通过。真正要证的是数据正确性，而不是能否调用。
+#   create_clone's derive_check looks at **the snapshot being cloned, S**,
+#   not V -- the decouple queue holds V, so decouple_pending(S) is almost
+#   certainly false, and clone may already succeed today. What has to be
+#   proven is data correctness, not whether the call is allowed.
 #
-# 要回答：
-#   1. 从 S（esnap clone V 的快照）克隆 C，当前代码会拒绝吗？
-#   2. C 能否读到正确数据（C -> S -> esnap -> 源 export A）？
-#   3. 写 C 之后：C 读到新数据、S 保持不变吗（跨 esnap 边界的 COW）？
-#   4. C 是否零拷贝——写之前 ALLOC 为 0，只为写入的部分分配？
-#   5. decouple V 之后、删除 V 之后，S 与 C 是否仍然正确？
-#   6. 直接克隆 V（可写卷）是否仍被正确拒绝（应当拒绝，不是要改的行为）？
+# Questions:
+#   1. Cloning C from S (the snapshot of esnap clone V): does current code
+#      refuse?
+#   2. Can C read the right data (C -> S -> esnap -> source export A)?
+#   3. After writing C: does C see the new data and S stay unchanged
+#      (COW across the esnap boundary)?
+#   4. Is C zero-copy -- ALLOC 0 before the write, allocated only for what
+#      was written?
+#   5. After decoupling V and after deleting V, are S and C still correct?
+#   6. Is cloning V itself (a writable volume) still correctly refused
+#      (it should be; that is not behaviour to change)?
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/CubeS3lvol/test/dataplane/probe_esnap_decouple.sh
+++ b/CubeS3lvol/test/dataplane/probe_esnap_decouple.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+# Phase 1 探针 #3：快照/克隆 与 decouple 的相互作用
+#
+# !! 历史探针，结论已记入 docs/import-reference-snapshot-design.md §9.2。
+#    它当时需要 derive_check 的两个拒绝分支被 #if 0 关掉才跑得到场景二，
+#    而**代码已经变了**：create_snapshot 现在会取消进行中的 decouple（§3.1），
+#    所以场景二不再需要补丁，也不再复现它当年测到的那个失败——
+#    下面找 "blob is not a clone of an external snapshot" 的 grep 现在应当
+#    什么都找不到，那正是修复生效的样子。
+#    要验证当前行为，用 test/dataplane/run_snapshot_cancel_test.sh。
+#
+# 起因：探针 #2 发现 create_snapshot 之后 `decouple V` 被拒绝，报
+#   "lvol 'V' does not read through to an export; there is nothing to decouple"
+# —— 也就是说快照 S 接管了 esnap 身份，V 退化成 S 的普通 clone。
+#
+# 这直接影响 import-reference-snapshot-design §9 里"decouple 正常完成"那句
+# 结论是否成立，必须核实。
+#
+# 要回答：
+#   A. 快照之后，谁还是 esnap clone？V 还是 S？
+#   B. `decouple V` 被拒之后，能否改为 decouple S（只读快照）？
+#   C. import(decouple:true) 时 decouple 已在飞行中，此时建快照 ——
+#      那个 decouple 最终是成功还是失败？失败信息是什么？
+#      （derive_check 注释预言的是 "blob is not a clone of an external
+#        snapshot"，即物化做完了、最后一步摘 parent 时失败）
+#   D. 无论 decouple 成败，数据是否始终正确？
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+SRC_LVS=pdec_src
+DST_LVS=pdec_dst
+SRC_WAL=/tmp/pdec_src_wal.img
+DST_WAL=/tmp/pdec_dst_wal.img
+RPC_SOCK=/tmp/pdec.sock
+TGT_LOG=/tmp/pdec_target.log
+NQN="nqn.2026-08.io.spdk:pdec"
+PORT="4472"
+WORKDIR="$(mktemp -d /tmp/pdec.XXXXXX)"
+FILL_MB=16
+WRITE_MB=4
+
+TGT_PID=""
+CONNECTED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+
+cleanup()
+{
+	set +u
+	[ "${CONNECTED}" = "1" ] && nvme disconnect -n "${NQN}" >/dev/null 2>&1
+	if [ -n "${TGT_PID}" ]; then
+		kill "${TGT_PID}" 2>/dev/null
+		sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null
+	fi
+	rcow_load_credentials
+	for p in "${SRC_LVS}" "${DST_LVS}"; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "${p}/" >/dev/null 2>&1
+	done
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${SRC_WAL}" "${DST_WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo
+	grep -aE 'external snapshot|esnap|not a clone|only a read-only|create snapshot|snapshot/clone|Decoupling|materialised|Deleted lvol' \
+		"${TGT_LOG}" 2>/dev/null | tail -18
+	echo "===== log: ${TGT_LOG}   workdir: ${WORKDIR}"
+}
+trap cleanup EXIT
+
+# --------------------------------------------------------------------------
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 320M "${SRC_WAL}"
+truncate -s 320M "${DST_WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+info "endpoint ${EP}  bucket ${BK}"
+for p in "${SRC_LVS}" "${DST_LVS}"; do
+	python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${p}/" >/dev/null 2>&1
+done
+
+info "starting target"
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config failed"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"src_wal0","block_size":4096}' "${SRC_WAL}")" \
+	>/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"dst_wal0","block_size":4096}' "${DST_WAL}")" \
+	>/dev/null 2>&1
+
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"src_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${SRC_LVS}" "${BK}")" >/dev/null || { echo "create ${SRC_LVS} failed"; exit 1; }
+info "source lvstore ready"
+
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"PDEC00000000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose()
+{
+	raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+		"${NQN}" "$1")" 2>/dev/null | tr -d '[:space:]'
+}
+
+unexpose()
+{
+	local nsid="$1"
+	[ -n "${nsid}" ] && raw nvmf_subsystem_remove_ns \
+		"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "${nsid}")" >/dev/null 2>&1
+	return 0
+}
+
+ctrl_of_nqn()
+{
+	local c
+	for c in /sys/class/nvme/nvme*; do
+		[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done
+	return 1
+}
+
+wait_dev()
+{
+	local nsid="$1" deadline ctrl dev
+	deadline=$(( $(date +%s) + 30 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if ctrl="$(ctrl_of_nqn)"; then
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		fi
+		sleep 0.3
+	done
+	return 1
+}
+
+# Read the first FILL_MB of a volume by name: expose, read, unexpose.
+read_vol()
+{
+	local name="$1" nsid dev md5
+	nsid="$(expose "${DST_LVS}/${name}")"
+	[ -n "${nsid}" ] || { echo "EXPOSE_FAILED"; return 1; }
+	dev="$(wait_dev "${nsid}")" || { unexpose "${nsid}"; echo "NO_DEV"; return 1; }
+	md5="$(dd if="${dev}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+	unexpose "${nsid}"
+	sleep 1
+	printf '%s' "${md5}"
+}
+
+# The ALLOC column of rcow_get_lvstores --ls, for one volume. SIZE prints as
+# two fields ("1.0 GiB"), so ALLOC is $5.
+alloc_of()
+{
+	rpc --ls rcow_get_lvstores 2>/dev/null | awk -v n="$1" '$1 == n { print $5; exit }'
+}
+
+# --------------------------------------------------------------------------
+# [1] source: a volume with known content -> snapshot -> REF export
+# --------------------------------------------------------------------------
+info "[1] source volume, filled"
+rpc rcow_create_lvol '{"lvol_name":"src","size_gib":1}' >/dev/null \
+	|| { echo "create_lvol failed"; exit 1; }
+NSID_SRC="$(expose "${SRC_LVS}/src")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 2
+SRC_DEV="$(wait_dev "${NSID_SRC}")" || { echo "source device never appeared"; exit 1; }
+info "source device ${SRC_DEV}"
+
+PAT="${WORKDIR}/pattern.bin"
+dd if=/dev/urandom of="${PAT}" bs=1M count="${FILL_MB}" status=none
+PAT_MD5="$(md5sum "${PAT}" | cut -d' ' -f1)"
+dd if="${PAT}" of="${SRC_DEV}" bs=1M oflag=direct status=none
+sync
+SRC_READ="$(dd if="${SRC_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+info "pattern ${PAT_MD5}; read back $([ "${SRC_READ}" = "${PAT_MD5}" ] && echo match || echo MISMATCH)"
+
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"src","snapshot_name":"src-snap"}' >/dev/null \
+	|| { echo "snapshot failed"; exit 1; }
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 3
+
+EXP_UUID="$(rpc rcow_export_snapshot '{"snapshot_name":"src-snap"}' 2>&1 | tr -d '"[:space:]\n')"
+UUIDS="${EXP_UUID}"
+[ -n "${EXP_UUID}" ] || { echo "export failed"; exit 1; }
+info "exported as ${EXP_UUID}"
+for _ in $(seq 120); do
+	st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP_UUID}")" 2>/dev/null \
+		| tr -d '"[:space:]\n')"
+	case "${st}" in *DONE*) break ;; esac
+	sleep 1
+done
+info "export status: ${st:-unknown}"
+
+unexpose "${NSID_SRC}"
+sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1 \
+	|| { echo "unload source failed"; exit 1; }
+sleep 2
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"dst_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${DST_LVS}" "${BK}")" >/dev/null || { echo "create ${DST_LVS} failed"; exit 1; }
+info "destination lvstore ready"
+
+# --------------------------------------------------------------------------
+# [2] 场景一：import(decouple:false) -> 快照 -> 谁持有 esnap？
+# --------------------------------------------------------------------------
+echo
+info "[2] scenario 1: import with decouple:false, then snapshot"
+rpc rcow_import_lvol "$(printf '{"lvol_name":"V","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+	"${EXP_UUID}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "import failed"; exit 1; }
+rpc rcow_create_snapshot '{"lvol_name":"V","snapshot_name":"S"}' >/dev/null 2>&1 \
+	|| { echo "snapshot failed"; exit 1; }
+rpc --ls rcow_get_lvstores
+
+echo
+info "[A] who still reads through to the export?"
+DEC_V="$(rpc rcow_decouple_lvol '{"lvol_name":"V"}' 2>&1)"
+info "decouple V  -> ${DEC_V}"
+DEC_S="$(rpc rcow_decouple_lvol '{"lvol_name":"S"}' 2>&1)"
+info "decouple S  -> ${DEC_S}"
+
+# 队列里现在有什么（若 S 被接受，等它跑完）
+for i in $(seq 240); do
+	busy="$(rpc rcow_get_decouple 2>/dev/null | python3 -c '
+import json,sys
+try: rows=json.load(sys.stdin)
+except Exception: rows=[]
+if isinstance(rows, dict): rows=rows.get("queue", [])
+print(len(rows))' 2>/dev/null)"
+	[ "${busy}" = "0" ] && break
+	sleep 1
+done
+info "decouple queue drained (waited ${i}s)"
+
+S_MD5_1="$(read_vol S)" || true
+V_MD5_1="$(read_vol V)" || true
+info "S = ${S_MD5_1}  $([ "${S_MD5_1}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+info "V = ${V_MD5_1}  $([ "${V_MD5_1}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+rpc --ls rcow_get_lvstores
+
+# 清掉场景一，为场景二腾地方
+rpc rcow_delete_lvol '{"lvol_name":"V"}' >/dev/null 2>&1
+rpc rcow_delete_lvol '{"lvol_name":"S"}' >/dev/null 2>&1
+sleep 2
+
+# --------------------------------------------------------------------------
+# [3] 场景二：import(decouple:true)，decouple 在飞行中时建快照
+#     —— 这是 derive_check 注释预言会出问题的那个窗口
+#     需要 derive_check 的两个拒绝分支被临时移除（#if 0）才能走到
+# --------------------------------------------------------------------------
+echo
+info "[3] scenario 2: import with decouple:true, snapshot while it is in flight"
+rpc rcow_import_lvol "$(printf '{"lvol_name":"V2","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+	"${EXP_UUID}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "import V2 failed"; exit 1; }
+
+DEC_NOW="$(rpc rcow_get_decouple 2>/dev/null | python3 -c '
+import json,sys
+try: rows=json.load(sys.stdin)
+except Exception: rows=[]
+if isinstance(rows, dict): rows=rows.get("queue", [])
+print(len([r for r in rows if r.get("lvol_name")=="V2"]))' 2>/dev/null)"
+info "decouple entries for V2 at this moment: ${DEC_NOW}"
+
+SNAP2="$(rpc rcow_create_snapshot '{"lvol_name":"V2","snapshot_name":"S2"}' 2>&1)"
+info "create_snapshot during decouple -> ${SNAP2}"
+
+LOG_MARK="$(wc -l < "${TGT_LOG}")"
+for i in $(seq 300); do
+	busy="$(rpc rcow_get_decouple 2>/dev/null | python3 -c '
+import json,sys
+try: rows=json.load(sys.stdin)
+except Exception: rows=[]
+if isinstance(rows, dict): rows=rows.get("queue", [])
+print(len([r for r in rows if r.get("lvol_name")=="V2"]))' 2>/dev/null)"
+	[ "${busy}" = "0" ] && break
+	sleep 1
+done
+info "V2 left the decouple queue after ${i}s"
+
+echo
+info "[C] what the decouple actually did (log lines since the snapshot):"
+tail -n +"${LOG_MARK}" "${TGT_LOG}" | grep -aE 'Decoupl|decouple|materialis|no longer reads|not a clone|external snapshot' \
+	| sed 's/^/       /' | tail -10
+
+S2_MD5="$(read_vol S2)" || true
+V2_MD5="$(read_vol V2)" || true
+info "S2 = ${S2_MD5}  $([ "${S2_MD5}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+info "V2 = ${V2_MD5}  $([ "${V2_MD5}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+rpc --ls rcow_get_lvstores
+
+echo
+info "[B2] after that, can either of them be decoupled?"
+info "decouple V2 -> $(rpc rcow_decouple_lvol '{"lvol_name":"V2"}' 2>&1)"
+info "decouple S2 -> $(rpc rcow_decouple_lvol '{"lvol_name":"S2"}' 2>&1)"
+for i in $(seq 240); do
+	busy="$(rpc rcow_get_decouple 2>/dev/null | python3 -c '
+import json,sys
+try: rows=json.load(sys.stdin)
+except Exception: rows=[]
+if isinstance(rows, dict): rows=rows.get("queue", [])
+print(len(rows))' 2>/dev/null)"
+	[ "${busy}" = "0" ] && break
+	sleep 1
+done
+S2_MD5_B="$(read_vol S2)" || true
+info "S2 after that = ${S2_MD5_B}  $([ "${S2_MD5_B}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+
+echo
+echo "===== SUMMARY"
+echo "  pattern                       : ${PAT_MD5}"
+echo
+echo "  -- scenario 1: snapshot after import (no decouple in flight)"
+echo "     decouple V (post-snapshot) : ${DEC_V}"
+echo "     decouple S (post-snapshot) : ${DEC_S}"
+echo "     S / V data                 : ${S_MD5_1:-n/a} / ${V_MD5_1:-n/a}"
+echo
+echo "  -- scenario 2: snapshot taken while a decouple was in flight"
+echo "     create_snapshot            : ${SNAP2}"
+echo "     S2 / V2 data               : ${S2_MD5:-n/a} / ${V2_MD5:-n/a}"
+echo "     S2 after further decouples : ${S2_MD5_B:-n/a}"

--- a/CubeS3lvol/test/dataplane/probe_esnap_decouple.sh
+++ b/CubeS3lvol/test/dataplane/probe_esnap_decouple.sh
@@ -1,29 +1,35 @@
 #!/usr/bin/env bash
-# Phase 1 探针 #3：快照/克隆 与 decouple 的相互作用
+# Phase 1 probe #3: how snapshot/clone interact with decouple.
 #
-# !! 历史探针，结论已记入 docs/import-reference-snapshot-design.md §9.2。
-#    它当时需要 derive_check 的两个拒绝分支被 #if 0 关掉才跑得到场景二，
-#    而**代码已经变了**：create_snapshot 现在会取消进行中的 decouple（§3.1），
-#    所以场景二不再需要补丁，也不再复现它当年测到的那个失败——
-#    下面找 "blob is not a clone of an external snapshot" 的 grep 现在应当
-#    什么都找不到，那正是修复生效的样子。
-#    要验证当前行为，用 test/dataplane/run_snapshot_cancel_test.sh。
+# !! Historical probe; conclusions are in
+#    docs/import-reference-snapshot-design.md §9.2.
+#    It needed derive_check's two refuse branches #if 0'd out to even reach
+#    scenario 2, and **the code has changed**: create_snapshot now cancels
+#    an in-flight decouple (§3.1), so scenario 2 no longer needs a patch
+#    and no longer reproduces the failure it measured then --
+#    grepping for "blob is not a clone of an external snapshot" should now
+#    find nothing, which is what the fix looks like.
+#    For current behaviour use test/dataplane/run_snapshot_cancel_test.sh.
 #
-# 起因：探针 #2 发现 create_snapshot 之后 `decouple V` 被拒绝，报
+# Origin: probe #2 found that after create_snapshot, `decouple V` is refused
+# with
 #   "lvol 'V' does not read through to an export; there is nothing to decouple"
-# —— 也就是说快照 S 接管了 esnap 身份，V 退化成 S 的普通 clone。
+# -- i.e. snapshot S took the esnap identity and V became an ordinary clone
+# of S.
 #
-# 这直接影响 import-reference-snapshot-design §9 里"decouple 正常完成"那句
-# 结论是否成立，必须核实。
+# That directly affects whether the sentence in import-reference-snapshot-design
+# §9 that "decouple finishes normally" still holds; it has to be checked.
 #
-# 要回答：
-#   A. 快照之后，谁还是 esnap clone？V 还是 S？
-#   B. `decouple V` 被拒之后，能否改为 decouple S（只读快照）？
-#   C. import(decouple:true) 时 decouple 已在飞行中，此时建快照 ——
-#      那个 decouple 最终是成功还是失败？失败信息是什么？
-#      （derive_check 注释预言的是 "blob is not a clone of an external
-#        snapshot"，即物化做完了、最后一步摘 parent 时失败）
-#   D. 无论 decouple 成败，数据是否始终正确？
+# Questions:
+#   A. After the snapshot, who is still an esnap clone -- V or S?
+#   B. After `decouple V` is refused, can S (the read-only snapshot) be
+#      decoupled instead?
+#   C. import(decouple:true) with decouple already in flight, then snapshot --
+#      does that decouple succeed or fail, and with what message?
+#      (The derive_check comment predicted "blob is not a clone of an
+#      external snapshot": materialise finished, then detaching the parent
+#      as the last step failed.)
+#   D. Whatever decouple does, is the data always correct?
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -224,7 +230,7 @@ rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_g
 info "destination lvstore ready"
 
 # --------------------------------------------------------------------------
-# [2] 场景一：import(decouple:false) -> 快照 -> 谁持有 esnap？
+# [2] Scenario 1: import(decouple:false) -> snapshot -> who holds the esnap?
 # --------------------------------------------------------------------------
 echo
 info "[2] scenario 1: import with decouple:false, then snapshot"
@@ -241,7 +247,7 @@ info "decouple V  -> ${DEC_V}"
 DEC_S="$(rpc rcow_decouple_lvol '{"lvol_name":"S"}' 2>&1)"
 info "decouple S  -> ${DEC_S}"
 
-# 队列里现在有什么（若 S 被接受，等它跑完）
+# What is in the queue now (if S was accepted, wait for it to finish).
 for i in $(seq 240); do
 	busy="$(rpc rcow_get_decouple 2>/dev/null | python3 -c '
 import json,sys
@@ -260,15 +266,16 @@ info "S = ${S_MD5_1}  $([ "${S_MD5_1}" = "${PAT_MD5}" ] && echo "MATCH ✓" || e
 info "V = ${V_MD5_1}  $([ "${V_MD5_1}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
 rpc --ls rcow_get_lvstores
 
-# 清掉场景一，为场景二腾地方
+# Drop scenario 1 to make room for scenario 2.
 rpc rcow_delete_lvol '{"lvol_name":"V"}' >/dev/null 2>&1
 rpc rcow_delete_lvol '{"lvol_name":"S"}' >/dev/null 2>&1
 sleep 2
 
 # --------------------------------------------------------------------------
-# [3] 场景二：import(decouple:true)，decouple 在飞行中时建快照
-#     —— 这是 derive_check 注释预言会出问题的那个窗口
-#     需要 derive_check 的两个拒绝分支被临时移除（#if 0）才能走到
+# [3] Scenario 2: import(decouple:true), snapshot while decouple is in flight
+#     -- the window the derive_check comment predicted would go wrong
+#     Originally needed derive_check's two refuse branches temporarily
+#     removed (#if 0) to even reach it
 # --------------------------------------------------------------------------
 echo
 info "[3] scenario 2: import with decouple:true, snapshot while it is in flight"

--- a/CubeS3lvol/test/dataplane/probe_esnap_snapshot.sh
+++ b/CubeS3lvol/test/dataplane/probe_esnap_snapshot.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
-# Phase 1 第 0 步探针：esnap clone 上的 create_snapshot 语义
+# Phase 1 step-0 probe: create_snapshot semantics on an esnap clone.
 #
-# 形状照抄 test/dataplane/probe_decouple_window.sh：一个 target、两个 lvstore
-# 轮流（一个进程只装得下一个 blobstore：源建好并导出后 unload，目标才建），
-# 用 nvmf_subsystem_add_ns 直接暴露 bdev，再从 /sys/class/nvme 定位宿主设备。
+# Shape copied from test/dataplane/probe_decouple_window.sh: one target, two
+# lvstores in turn (one process holds one blobstore: unload the source after
+# it is built and exported, then create the destination), expose the bdev
+# with nvmf_subsystem_add_ns, then find the host device under
+# /sys/class/nvme.
 #
-# 要回答：
-#   1. 对 esnap clone V 做 create_snapshot 能否成功、产出什么？
-#   2. S 能否读到正确的数据（读穿到源 export A）？
-#   3. 随后 decouple V，S 的数据是否仍然正确？
-#      —— lvstore.c:2531-2535 声称的 hazard 是否真实
+# Questions:
+#   1. Does create_snapshot on esnap clone V succeed, and what does it
+#      produce?
+#   2. Can S read the right data (through to source export A)?
+#   3. After then decoupling V, is S still correct?
+#      -- is the hazard claimed at lvstore.c:2531-2535 real?
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -258,7 +261,7 @@ info "decouple settled (waited ${i}s)"
 
 if [ -n "${NSID_S}" ] && S_DEV2="$(wait_dev "${NSID_S}")" || NSID_S="$(expose "${DST_LVS}/S")" && S_DEV2="$(wait_dev "${NSID_S}")"; then
 	S2_MD5="$(dd if="${S_DEV2}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
-	info "S read (after V decoupled) = ${S2_MD5}  $([ "${S2_MD5}" = "${PAT_MD5}" ] && echo "MATCH ✓ S 仍然正确" || echo "MISMATCH ✗ S 被 decouple 破坏")"
+	info "S read (after V decoupled) = ${S2_MD5}  $([ "${S2_MD5}" = "${PAT_MD5}" ] && echo "MATCH ✓ S still correct" || echo "MISMATCH ✗ S was broken by the decouple")"
 else
 	info "S could not be re-read after the decouple"
 fi
@@ -287,8 +290,8 @@ if rpc --ls rcow_get_lvstores 2>/dev/null | grep -qE '^S '; then
 		S3_MD5="$(dd if="${S_DEV3}" bs=1M count="${FILL_MB}" iflag=direct status=none \
 			| md5sum | cut -d' ' -f1)"
 		info "S read (after V deleted) = ${S3_MD5}  $([ "${S3_MD5}" = "${PAT_MD5}" ] \
-			&& echo "MATCH ✓ S 独立于 V（持有自己的 esnap parent）" \
-			|| echo "MISMATCH ✗ S 依赖 V，删 V 后失效")"
+			&& echo "MATCH ✓ S is independent of V (holds its own esnap parent)" \
+			|| echo "MISMATCH ✗ S depends on V and broke after V was deleted")"
 	else
 		info "S could not be read after deleting V"
 	fi

--- a/CubeS3lvol/test/dataplane/probe_esnap_snapshot.sh
+++ b/CubeS3lvol/test/dataplane/probe_esnap_snapshot.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# Phase 1 第 0 步探针：esnap clone 上的 create_snapshot 语义
+#
+# 形状照抄 test/dataplane/probe_decouple_window.sh：一个 target、两个 lvstore
+# 轮流（一个进程只装得下一个 blobstore：源建好并导出后 unload，目标才建），
+# 用 nvmf_subsystem_add_ns 直接暴露 bdev，再从 /sys/class/nvme 定位宿主设备。
+#
+# 要回答：
+#   1. 对 esnap clone V 做 create_snapshot 能否成功、产出什么？
+#   2. S 能否读到正确的数据（读穿到源 export A）？
+#   3. 随后 decouple V，S 的数据是否仍然正确？
+#      —— lvstore.c:2531-2535 声称的 hazard 是否真实
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+SRC_LVS=pesnap_src
+DST_LVS=pesnap_dst
+SRC_WAL=/tmp/pesnap_src_wal.img
+DST_WAL=/tmp/pesnap_dst_wal.img
+RPC_SOCK=/tmp/pesnap.sock
+TGT_LOG=/tmp/pesnap_target.log
+NQN="nqn.2026-08.io.spdk:pesnap"
+PORT="4470"
+WORKDIR="$(mktemp -d /tmp/pesnap.XXXXXX)"
+MNT="${WORKDIR}/mnt"
+FILL_MB=16
+
+TGT_PID=""
+CONNECTED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+# Arbitrary methods (nvmf_*) with the answer left whole.
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+
+cleanup()
+{
+	set +u
+	[ "${CONNECTED}" = "1" ] && nvme disconnect -n "${NQN}" >/dev/null 2>&1
+	if [ -n "${TGT_PID}" ]; then
+		kill "${TGT_PID}" 2>/dev/null
+		sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null
+	fi
+	rcow_load_credentials
+	for p in "${SRC_LVS}" "${DST_LVS}"; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "${p}/" >/dev/null 2>&1
+	done
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${SRC_WAL}" "${DST_WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo
+	grep -aE 'external snapshot|esnap|not a clone|create snapshot|snapshot/clone|Decoupling|materialised' \
+		"${TGT_LOG}" 2>/dev/null | tail -15
+	echo "===== log: ${TGT_LOG}   workdir: ${WORKDIR}"
+}
+trap cleanup EXIT
+
+# --------------------------------------------------------------------------
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 320M "${SRC_WAL}"
+truncate -s 320M "${DST_WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+info "endpoint ${EP}  bucket ${BK}"
+for p in "${SRC_LVS}" "${DST_LVS}"; do
+	python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${p}/" >/dev/null 2>&1
+done
+
+# The target reads credentials from its own environment.
+info "starting target"
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config failed"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"src_wal0","block_size":4096}' "${SRC_WAL}")" \
+	>/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"dst_wal0","block_size":4096}' "${DST_WAL}")" \
+	>/dev/null 2>&1
+
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"src_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${SRC_LVS}" "${BK}")" >/dev/null || { echo "create ${SRC_LVS} failed"; exit 1; }
+info "source lvstore ready"
+
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"PESNAP000000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose()
+{
+	# --raw prints the result member as it arrived, which for
+	# nvmf_subsystem_add_ns is the nsid number itself -- not an object with a
+	# "result" key, so there is nothing to parse out of it.
+	raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+		"${NQN}" "$1")" 2>/dev/null | tr -d '[:space:]'
+}
+
+unexpose()
+{
+	local nsid="$1"
+	[ -n "${nsid}" ] && raw nvmf_subsystem_remove_ns \
+		"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "${nsid}")" >/dev/null 2>&1
+	return 0
+}
+
+ctrl_of_nqn()
+{
+	local c
+	for c in /sys/class/nvme/nvme*; do
+		[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done
+	return 1
+}
+
+wait_dev()
+{
+	local nsid="$1" deadline ctrl dev
+	deadline=$(( $(date +%s) + 30 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if ctrl="$(ctrl_of_nqn)"; then
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		fi
+		sleep 0.3
+	done
+	return 1
+}
+
+# --------------------------------------------------------------------------
+# [1] source: a volume with known content -> snapshot -> REF export
+# --------------------------------------------------------------------------
+info "[1] source volume, filled"
+rpc rcow_create_lvol "$(printf '{"lvol_name":"src","size_gib":1}')" >/dev/null \
+	|| { echo "create_lvol failed"; exit 1; }
+NSID_SRC="$(expose "${SRC_LVS}/src")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 2
+SRC_DEV="$(wait_dev "${NSID_SRC}")" || { echo "source device never appeared"; exit 1; }
+info "source device ${SRC_DEV}"
+
+PAT="${WORKDIR}/pattern.bin"
+dd if=/dev/urandom of="${PAT}" bs=1M count="${FILL_MB}" status=none
+PAT_MD5="$(md5sum "${PAT}" | cut -d' ' -f1)"
+dd if="${PAT}" of="${SRC_DEV}" bs=1M oflag=direct status=none
+sync
+SRC_READ="$(dd if="${SRC_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+info "pattern ${PAT_MD5}; read back ${SRC_READ} $([ "${SRC_READ}" = "${PAT_MD5}" ] && echo match || echo MISMATCH)"
+
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"src","snapshot_name":"src-snap"}' >/dev/null \
+	|| { echo "snapshot failed"; exit 1; }
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 3
+
+EXP_UUID="$(rpc rcow_export_snapshot '{"snapshot_name":"src-snap"}' 2>&1 | tr -d '"[:space:]\n')"
+UUIDS="${EXP_UUID}"
+[ -n "${EXP_UUID}" ] || { echo "export failed"; exit 1; }
+info "exported as ${EXP_UUID}"
+for _ in $(seq 120); do
+	st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP_UUID}")" 2>/dev/null \
+		| tr -d '"[:space:]\n')"
+	case "${st}" in *DONE*) break ;; esac
+	sleep 1
+done
+info "export status: ${st:-unknown}"
+
+# The source is done with: its namespace goes, then the lvstore, so the
+# destination can take the one blobstore this process can hold.
+unexpose "${NSID_SRC}"
+sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1 \
+	|| { echo "unload source failed"; exit 1; }
+sleep 2
+
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"dst_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${DST_LVS}" "${BK}")" >/dev/null || { echo "create ${DST_LVS} failed"; exit 1; }
+info "destination lvstore ready"
+
+# --------------------------------------------------------------------------
+# [2] import without decoupling: V is a real esnap clone, nothing queued
+# --------------------------------------------------------------------------
+info "[2] import with decouple:false"
+IMP_OUT="$(rpc rcow_import_lvol "$(printf '{"lvol_name":"V","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+	"${EXP_UUID}" "${DST_LVS}")" 2>&1)"
+info "import reply: ${IMP_OUT}"
+
+echo
+info "[3] create snapshot of V  (does derive_check allow it?)"
+SNAP_OUT="$(rpc rcow_create_snapshot '{"lvol_name":"V","snapshot_name":"S"}' 2>&1)"
+info "create_snapshot reply: ${SNAP_OUT}"
+rpc --ls rcow_get_lvstores
+
+# --------------------------------------------------------------------------
+# [4] can S be read, and does it hold A's data?
+# --------------------------------------------------------------------------
+echo
+info "[4] read S"
+NSID_S="$(expose "${DST_LVS}/S")"
+info "S exposed as nsid ${NSID_S}"
+if [ -n "${NSID_S}" ] && S_DEV="$(wait_dev "${NSID_S}")"; then
+	S_MD5="$(dd if="${S_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+	info "S read = ${S_MD5}  $([ "${S_MD5}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+else
+	info "S could not be exposed/read"
+	S_MD5=""
+fi
+unexpose "${NSID_S}"
+sleep 2
+
+# --------------------------------------------------------------------------
+# [5] V itself, then decouple it, then S again
+# --------------------------------------------------------------------------
+echo
+info "[5] read V, decouple it, then read S again"
+NSID_V="$(expose "${DST_LVS}/V")"
+V_MD5=""
+if [ -n "${NSID_V}" ] && V_DEV="$(wait_dev "${NSID_V}")"; then
+	V_MD5="$(dd if="${V_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+	info "V read (before decouple) = ${V_MD5}  $([ "${V_MD5}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+else
+	info "V could not be exposed/read"
+fi
+
+rpc rcow_decouple_lvol '{"lvol_name":"V"}' >/dev/null 2>&1 \
+	&& info "decouple submitted" || info "decouple submit failed"
+for i in $(seq 240); do
+	busy="$(rpc rcow_get_decouple 2>/dev/null | python3 -c '
+import json,sys
+try: rows=json.load(sys.stdin)
+except Exception: rows=[]
+if isinstance(rows, dict): rows=rows.get("queue", [])
+print(len([r for r in rows if r.get("lvol_name")=="V"]))' 2>/dev/null)"
+	[ "${busy}" = "0" ] && break
+	sleep 1
+done
+info "decouple settled (waited ${i}s)"
+
+if [ -n "${NSID_S}" ] && S_DEV2="$(wait_dev "${NSID_S}")" || NSID_S="$(expose "${DST_LVS}/S")" && S_DEV2="$(wait_dev "${NSID_S}")"; then
+	S2_MD5="$(dd if="${S_DEV2}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+	info "S read (after V decoupled) = ${S2_MD5}  $([ "${S2_MD5}" = "${PAT_MD5}" ] && echo "MATCH ✓ S 仍然正确" || echo "MISMATCH ✗ S 被 decouple 破坏")"
+else
+	info "S could not be re-read after the decouple"
+fi
+unexpose "${NSID_S}"
+
+# --------------------------------------------------------------------------
+# [6] delete V, then read S again.
+#
+# The distinction that matters for the pin table: does S hold the esnap
+# parent itself (a), in which case V can go at any time, or does S read
+# through V (b), so that deleting V would strand it? Only a delete of V
+# separates them -- while V exists, both readings give the same bytes.
+# --------------------------------------------------------------------------
+echo
+info "[6] delete V, then read S"
+unexpose "${NSID_V}"
+sleep 2
+DEL_OUT="$(rpc rcow_delete_lvol '{"lvol_name":"V"}' 2>&1)"
+info "delete V reply: ${DEL_OUT}"
+rpc --ls rcow_get_lvstores
+
+S3_MD5=""
+if rpc --ls rcow_get_lvstores 2>/dev/null | grep -qE '^S '; then
+	NSID_S3="$(expose "${DST_LVS}/S")"
+	if [ -n "${NSID_S3}" ] && S_DEV3="$(wait_dev "${NSID_S3}")"; then
+		S3_MD5="$(dd if="${S_DEV3}" bs=1M count="${FILL_MB}" iflag=direct status=none \
+			| md5sum | cut -d' ' -f1)"
+		info "S read (after V deleted) = ${S3_MD5}  $([ "${S3_MD5}" = "${PAT_MD5}" ] \
+			&& echo "MATCH ✓ S 独立于 V（持有自己的 esnap parent）" \
+			|| echo "MISMATCH ✗ S 依赖 V，删 V 后失效")"
+	else
+		info "S could not be read after deleting V"
+	fi
+	unexpose "${NSID_S3}"
+else
+	info "S is gone (deleting V took it with it)"
+fi
+
+echo
+rpc --ls rcow_get_lvstores
+
+echo
+echo "===== SUMMARY"
+echo "  pattern        : ${PAT_MD5}"
+echo "  V before decouple: ${V_MD5:-not read}"
+echo "  S before decouple: ${S_MD5:-not read}"
+echo "  S after  decouple: ${S2_MD5:-not read}"
+echo "  S after  V deleted: ${S3_MD5:-not read}"

--- a/CubeS3lvol/test/dataplane/probe_lease_floor.sh
+++ b/CubeS3lvol/test/dataplane/probe_lease_floor.sh
@@ -1,19 +1,26 @@
 #!/usr/bin/env bash
-# 租约下限探针：短 TTL 的导入是否还会每秒续约，租约对象是否立刻出现
+# Lease-floor probe: does importing a short-TTL export still renew every
+# second, and does the lease object appear immediately?
 #
-# 回答两件在正常 TTL 下看不见的事：
+# Two things that never show up at a normal TTL:
 #
-#   1. 一个 TTL 只剩几秒（或已过期）的 export，被导入后续约间隔是多少。
-#      改动前是 max(1, remaining/3) —— 坍缩到 1 秒，并把 renew_s:1 写进租约，
-#      源端据此把宽限期算成 3 秒。三秒是一次慢 PUT 的量级，而源端判定
-#      STALE 之后是无人值守地删快照。
-#   2. 租约对象在 import 之后多久出现。poller 要等一个周期才首次触发，
-#      所以把间隔从 1 秒抬到 20 秒，会把这个空窗一并放大到 20 秒 ——
-#      而空窗期内 lease_updated_at 为 0，对已过期的 lease-aware export
-#      同样判 STALE。抬下限就必须同时补首次写入，这里验证补上了。
+#   1. After importing an export whose TTL has a few seconds left (or has
+#      already expired), what is the renew interval? Before the change it
+#      was max(1, remaining/3) -- collapsing to 1 second, with renew_s:1
+#      written into the lease, from which the source computes a 3-second
+#      grace. Three seconds is the scale of one slow PUT, and after the
+#      source marks STALE it deletes the snapshot unattended.
+#   2. How soon after import does the lease object appear? The poller waits
+#      one period before the first tick, so raising the interval from 1 s
+#      to 20 s would also stretch that empty window to 20 s -- and while it
+#      is empty, lease_updated_at is 0, which for an already-expired
+#      lease-aware export is also STALE. Raising the floor therefore has to
+#      write the first lease immediately; this checks that it does.
 #
-# 只用一个 lvstore：import 到本 lvstore 会退化成本地 clone，不走 esnap，
-# 所以这里用两个（源导出后 unload，目标再建），形状照抄 probe_esnap_snapshot.sh。
+# One lvstore is not enough: importing into the same lvstore degrades to a
+# local clone and never takes the esnap path. Two are used (unload after
+# the source exports, then create the destination), matching
+# probe_esnap_snapshot.sh.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -184,8 +191,9 @@ fi
 echo
 echo "===== SUMMARY"
 if [ "${FAILED}" = "0" ]; then
-	echo "  过期 export 的导入不再每秒续约，租约在 import 时即写入。"
+	echo "  importing an expired export no longer renews every second;"
+	echo "  the lease is written at import."
 else
-	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+	echo "  ${FAILED} failure(s) -- see [FAIL] above"
 fi
 exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/probe_lease_floor.sh
+++ b/CubeS3lvol/test/dataplane/probe_lease_floor.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# 租约下限探针：短 TTL 的导入是否还会每秒续约，租约对象是否立刻出现
+#
+# 回答两件在正常 TTL 下看不见的事：
+#
+#   1. 一个 TTL 只剩几秒（或已过期）的 export，被导入后续约间隔是多少。
+#      改动前是 max(1, remaining/3) —— 坍缩到 1 秒，并把 renew_s:1 写进租约，
+#      源端据此把宽限期算成 3 秒。三秒是一次慢 PUT 的量级，而源端判定
+#      STALE 之后是无人值守地删快照。
+#   2. 租约对象在 import 之后多久出现。poller 要等一个周期才首次触发，
+#      所以把间隔从 1 秒抬到 20 秒，会把这个空窗一并放大到 20 秒 ——
+#      而空窗期内 lease_updated_at 为 0，对已过期的 lease-aware export
+#      同样判 STALE。抬下限就必须同时补首次写入，这里验证补上了。
+#
+# 只用一个 lvstore：import 到本 lvstore 会退化成本地 clone，不走 esnap，
+# 所以这里用两个（源导出后 unload，目标再建），形状照抄 probe_esnap_snapshot.sh。
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+SRC_LVS=please_src
+DST_LVS=please_dst
+SRC_WAL=/tmp/please_src_wal.img
+DST_WAL=/tmp/please_dst_wal.img
+RPC_SOCK=/tmp/please.sock
+TGT_LOG=/tmp/please_target.log
+WORKDIR="$(mktemp -d /tmp/please.XXXXXX)"
+
+# Short enough that remaining/3 lands well under the floor, so the floor is what
+# decides. Not zero: an expired export is the other case and is checked separately
+# below by waiting the TTL out before importing.
+SHORT_TTL=6
+
+TGT_PID=""
+UUIDS=""
+FAILED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+ok()   { echo "     [PASS] $*"; }
+bad()  { echo "     [FAIL] $*"; FAILED=$((FAILED + 1)); }
+want() { if [ "$2" = "$3" ]; then ok "$1 ($2)"; else bad "$1: got '$2', want '$3'"; fi; }
+
+cleanup()
+{
+	set +u
+	[ -n "${TGT_PID}" ] && { kill "${TGT_PID}" 2>/dev/null; sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null; }
+	rcow_load_credentials
+	for p in "${SRC_LVS}" "${DST_LVS}"; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+			-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+			-p "${p}/" >/dev/null 2>&1
+	done
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+			-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+			-p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${SRC_WAL}" "${DST_WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo "===== log: ${TGT_LOG}"
+}
+trap cleanup EXIT
+
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 320M "${SRC_WAL}"
+truncate -s 320M "${DST_WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+for p in "${SRC_LVS}" "${DST_LVS}"; do
+	python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${p}/" >/dev/null 2>&1
+done
+
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config failed"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"src_wal0","block_size":4096}' \
+	"${SRC_WAL}")" >/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"dst_wal0","block_size":4096}' \
+	"${DST_WAL}")" >/dev/null 2>&1
+
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"src_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${SRC_LVS}" "${BK}")" >/dev/null || { echo "create src failed"; exit 1; }
+
+echo
+info "[1] a snapshot exported with ttl_sec=${SHORT_TTL}"
+rpc rcow_create_lvol '{"lvol_name":"v","size_gib":1}' >/dev/null || { echo "lvol"; exit 1; }
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"v","snapshot_name":"s"}' >/dev/null \
+	|| { echo "snapshot"; exit 1; }
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 2
+
+EXP="$(rpc rcow_export_snapshot "$(printf '{"snapshot_name":"s","ttl_sec":%d}' \
+	"${SHORT_TTL}")" 2>&1 | tr -d '"[:space:]\n')"
+[ -n "${EXP}" ] || { echo "export failed"; exit 1; }
+UUIDS="${EXP}"
+for _ in $(seq 60); do
+	st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP}")" \
+		2>/dev/null | tr -d '"[:space:]\n')"
+	case "${st}" in *DONE*) break ;; esac
+	sleep 1
+done
+info "exported ${EXP} (status ${st:-?})"
+
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1
+sleep 2
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"dst_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${DST_LVS}" "${BK}")" >/dev/null || { echo "create dst failed"; exit 1; }
+
+# Waited out deliberately: this is the case that used to derive remaining = 0 and
+# therefore a one-second renew. Nothing refuses an expired export at import.
+echo
+info "[2] letting the TTL lapse, then importing the expired export"
+sleep "$((SHORT_TTL + 2))"
+
+MARK="$(wc -l <"${TGT_LOG}")"
+rpc rcow_import_lvol "$(printf '{"lvol_name":"i","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+	"${EXP}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "import failed"; exit 1; }
+
+INTERVAL="$(tail -n "+${MARK}" "${TGT_LOG}" \
+	| grep -aoE 'renewing [0-9]+ lease\(s\) every [0-9]+ second' \
+	| grep -aoE 'every [0-9]+' | grep -aoE '[0-9]+' | head -1)"
+info "renew interval reported: ${INTERVAL:-<none>} s"
+want "an expired export renews at the floor, not every second" "${INTERVAL:-0}" "20"
+
+# The lease has to exist now, not one period from now. Checked at 5 s: comfortably
+# inside the 20 s period, so a pass means it was written at start rather than by
+# the first tick.
+echo
+info "[3] the lease object appears without waiting for the first tick"
+sleep 5
+if python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" \
+		-p "${SRC_LVS}/meta/exports/${EXP}.lease" --list 2>/dev/null \
+		| grep -q "${EXP}"; then
+	ok "the lease was written at import, ${INTERVAL:-?} s before the first tick"
+else
+	bad "no lease object 5 s after import: the window the floor opened is real"
+fi
+
+# And renew_s in the body is what the source turns into a grace period, so it has
+# to say the floor too -- an honest 20 gives 60 s, a stale 1 would give 3.
+RENEW_S="$(python3 - <<PY 2>"${WORKDIR}/renew_s.err"
+import json, os, sys
+sys.path.insert(0, "${ROOT}/test/tools")
+# s3_prefix_rm's Client, not s3_bucket's -- both exist and only this one has
+# _base_path(). s3_get_manifest.py imports the same one.
+from s3_prefix_rm import Client
+c = Client("${EP}", "${BK}", "${RG}", False,
+           os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"])
+key = "${SRC_LVS}/meta/exports/${EXP}.lease"
+st, body = c.request("GET", c._base_path() + "/" + key)
+if st != 200:
+    sys.stderr.write("GET %s -> HTTP %d\n" % (key, st))
+    sys.exit(1)
+print(json.loads(body).get("renew_s", ""))
+PY
+)"
+if [ -n "${RENEW_S}" ]; then
+	want "the lease reports that cadence, so the source's grace is 3x it" \
+		"${RENEW_S}" "20"
+else
+	# Not downgraded to a note: renew_s is the number the source multiplies by
+	# three, so an unread one leaves the actual hazard unverified.
+	bad "could not read renew_s back: $(tail -1 "${WORKDIR}/renew_s.err")"
+fi
+
+echo
+echo "===== SUMMARY"
+if [ "${FAILED}" = "0" ]; then
+	echo "  过期 export 的导入不再每秒续约，租约在 import 时即写入。"
+else
+	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+fi
+exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/probe_manifest_refetch.sh
+++ b/CubeS3lvol/test/dataplane/probe_manifest_refetch.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# 重取探针：源端物化后，导入端的读能否透明恢复
+#
+# 要验证的是 B 方案 —— 404 不向上报错，而是挂起该 I/O、重取 manifest、
+# 换用新的、再重试一次。客户端应当只看到一次变慢的读，而不是一次 I/O 错误。
+#
+# 场景是手工造的，因为源端的物化路径（第 5 步的写侧）还没接通。这里用
+# 三步模拟"源端搬走了对象"之后的 S3 状态：
+#
+#   1. 正常导入一个 ref export，读一遍确认数据对；
+#   2. 把 <src-lvs>/data/ 下的对象复制到另一个 prefix，发布一份
+#      generation+1、source.prefix 指向新位置的 manifest，再删掉原对象；
+#   3. 再读一遍。旧 manifest 指向的键已经不存在，所以每个 chunk 都会 404。
+#
+# 为什么是"换 prefix"而不是"改成 dense"：dense 会改变 manifest 必须携带的
+# 字段和 crc 的分段方式，手工伪造的多半会被 parse() 拒掉 —— 那样探针失败在
+# 自己的伪造上，对重取路径什么也没证明。换 prefix 保持了全部校验和与不变量，
+# 同时让旧 manifest 里的每个键都 404，这正是要测的条件。
+#
+# 判据有两条，缺一不可：
+#   - 读**成功**且 md5 与写入一致（B 方案生效，而不是把错误抛上去）；
+#   - 日志里出现且只出现一次 refetch（去重生效 —— 一次大读会拆成很多
+#     chunk GET，物化后它们同时 404，每个都触发一次重取的话就是一串
+#     重复的 manifest GET 和几次互相竞争的 swap）。
+#
+# 注意：这里不 unload/reload lvstore。重取是内存里的行为，重启会重新
+# 读 manifest 从而绕过它 —— 那样测的就不是这条路径了。
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+SRC_LVS=prefetch_src
+DST_LVS=prefetch_dst
+SRC_WAL=/tmp/prefetch_src_wal.img
+DST_WAL=/tmp/prefetch_dst_wal.img
+RPC_SOCK=/tmp/prefetch.sock
+TGT_LOG=/tmp/prefetch_target.log
+NQN="nqn.2026-09.io.spdk:prefetch"
+PORT="4474"
+WORKDIR="$(mktemp -d /tmp/prefetch.XXXXXX)"
+FILL_MB=8
+
+TGT_PID=""
+CONNECTED=0
+UUIDS=""
+FAILED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+ok()   { echo "     [PASS] $*"; }
+bad()  { echo "     [FAIL] $*"; FAILED=$((FAILED + 1)); }
+want() { if [ "$2" = "$3" ]; then ok "$1 ($2)"; else bad "$1: got '$2', want '$3'"; fi; }
+
+cleanup()
+{
+	set +u
+	[ "${CONNECTED}" = "1" ] && nvme disconnect -n "${NQN}" >/dev/null 2>&1
+	[ -n "${TGT_PID}" ] && { kill "${TGT_PID}" 2>/dev/null; sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null; }
+	rcow_load_credentials
+	for p in "${SRC_LVS}" "${SRC_LVS}-moved" "${DST_LVS}"; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+			-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+			-p "${p}/" >/dev/null 2>&1
+	done
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+			-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+			-p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${SRC_WAL}" "${DST_WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo "===== log: ${TGT_LOG}"
+}
+trap cleanup EXIT
+
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 320M "${SRC_WAL}"
+truncate -s 320M "${DST_WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+for p in "${SRC_LVS}" "${DST_LVS}"; do
+	python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${p}/" >/dev/null 2>&1
+done
+
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"src_wal0","block_size":4096}' \
+	"${SRC_WAL}")" >/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"dst_wal0","block_size":4096}' \
+	"${DST_WAL}")" >/dev/null 2>&1
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"PREFETCH0000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose() { raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+	"${NQN}" "$1")" 2>/dev/null | tr -d '[:space:]'; }
+unexpose() { [ -n "$1" ] && raw nvmf_subsystem_remove_ns \
+	"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "$1")" >/dev/null 2>&1; return 0; }
+ctrl_of_nqn() { local c; for c in /sys/class/nvme/nvme*; do
+	[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done; return 1; }
+wait_dev()
+{
+	local nsid="$1" deadline ctrl dev
+	deadline=$(( $(date +%s) + 30 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if ctrl="$(ctrl_of_nqn)"; then
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		fi
+		sleep 0.3
+	done
+	return 1
+}
+
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"src_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${SRC_LVS}" "${BK}")" >/dev/null || { echo "create src"; exit 1; }
+
+echo
+info "[1] source: write, snapshot, export"
+rpc rcow_create_lvol '{"lvol_name":"v","size_gib":1}' >/dev/null || { echo "lvol"; exit 1; }
+NSID="$(expose "${SRC_LVS}/v")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 2
+DEV="$(wait_dev "${NSID}")" || { echo "src device"; exit 1; }
+
+PAT="${WORKDIR}/pat.bin"
+dd if=/dev/urandom of="${PAT}" bs=1M count="${FILL_MB}" status=none
+PAT_MD5="$(md5sum "${PAT}" | cut -d' ' -f1)"
+dd if="${PAT}" of="${DEV}" bs=1M count="${FILL_MB}" oflag=direct conv=fsync status=none
+sync
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"v","snapshot_name":"s"}' >/dev/null || exit 1
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 3
+
+EXP="$(rpc rcow_export_snapshot '{"snapshot_name":"s"}' 2>&1 | tr -d '"[:space:]\n')"
+[ -n "${EXP}" ] || { echo "export"; exit 1; }
+UUIDS="${EXP}"
+for _ in $(seq 90); do
+	st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP}")" \
+		2>/dev/null | tr -d '"[:space:]\n')"
+	case "${st}" in *DONE*) break ;; esac
+	sleep 1
+done
+info "export ${EXP}"
+
+unexpose "${NSID}"; sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1
+sleep 2
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"dst_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${DST_LVS}" "${BK}")" >/dev/null || { echo "create dst"; exit 1; }
+
+echo
+info "[2] import and read once through the ref manifest"
+rpc rcow_import_lvol "$(printf '{"lvol_name":"i","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+	"${EXP}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "import"; exit 1; }
+NSID="$(expose "${DST_LVS}/i")"
+sleep 2
+DEV="$(wait_dev "${NSID}")" || { echo "dst device"; exit 1; }
+sync; echo 3 >/proc/sys/vm/drop_caches 2>/dev/null || true
+want "the import reads correctly to begin with" \
+	"$(dd if="${DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)" \
+	"${PAT_MD5}"
+
+echo
+info "[3] simulating the source materialising it"
+# Copy the chunks to the dense layout's keys, publish a dense manifest one
+# generation newer, and delete the originals -- which is the S3 state a
+# materialisation leaves behind.
+python3 - <<PY >"${WORKDIR}/materialise.log" 2>&1
+import json, os, sys
+sys.path.insert(0, "${ROOT}/test/tools")
+# Two Clients with the same name and different capabilities: s3_prefix_rm's can
+# list and knows _base_path(), s3_bucket's is the only one whose request() takes
+# a body. Both are used rather than extending either, since this is a probe.
+from s3_prefix_rm import Client as RmClient
+from s3_bucket import Client as PutClient, path_for
+
+ak = os.environ["AWS_ACCESS_KEY_ID"]
+sk = os.environ["AWS_SECRET_ACCESS_KEY"]
+rm = RmClient("${EP}", "${BK}", "${RG}", False, ak, sk)
+put = PutClient("${EP}", "${BK}", "${RG}", False, ak, sk)
+base = rm._base_path()
+
+def get(key):
+    st, body = rm.request("GET", base + "/" + key)
+    return st, body
+
+def put_obj(key, data):
+    return put.request("PUT", path_for("${BK}", False, "/" + key), body=data)[0]
+
+st, body = get("exports/${EXP}.json")
+assert st == 200, "manifest GET %d" % st
+m = json.loads(body)
+print("layout=%s generation=%s chunks=%s present=%s" %
+      (m.get("layout"), m.get("generation"), m.get("num_chunks"),
+       m.get("present_chunks")))
+assert m["layout"] == "ref", "expected a ref export to start from"
+
+# The objects move to a *different prefix*, and the manifest keeps its ref
+# layout with source.prefix pointing at the new one.
+#
+# Not rewritten as dense, deliberately. Dense changes which fields the manifest
+# must carry and how the crc is staged, so a hand-built one would most likely be
+# rejected by parse() -- and a probe that fails on its own forgery proves
+# nothing about the refetch. Moving the prefix keeps every checksum and every
+# invariant intact while still making every key in the old manifest 404, which
+# is the condition being tested.
+NEW_PREFIX = "${SRC_LVS}-moved"
+src_keys = list(rm.list_keys("${SRC_LVS}/data/"))
+print("source data objects: %d" % len(src_keys))
+assert src_keys, "no source objects to move"
+
+for k in src_keys:
+    st, data = get(k)
+    assert st == 200, "GET %s -> %d" % (k, st)
+    dst = NEW_PREFIX + "/data/" + k.rsplit("/", 1)[1]
+    st = put_obj(dst, data)
+    assert st in (200, 204), "PUT %s -> %d" % (dst, st)
+print("copied %d object(s) to %s/data/" % (len(src_keys), NEW_PREFIX))
+
+m["source"]["prefix"] = NEW_PREFIX
+m["generation"] = int(m.get("generation", 0)) + 1
+st = put_obj("exports/${EXP}.json", json.dumps(m).encode())
+assert st in (200, 204), "manifest PUT %d" % st
+print("published generation %d pointing at %s" % (m["generation"], NEW_PREFIX))
+
+for k in src_keys:
+    rm.delete(k)
+print("deleted %d original object(s)" % len(src_keys))
+PY
+if [ $? -ne 0 ]; then
+	bad "could not simulate the materialisation"
+	sed 's/^/       /' "${WORKDIR}/materialise.log"
+	echo; echo "===== SUMMARY"; echo "  ${FAILED} 项失败"; exit "${FAILED}"
+fi
+sed 's/^/       /' "${WORKDIR}/materialise.log"
+ok "the source's objects are gone and a newer manifest is published"
+
+echo
+info "[4] reading again: every chunk now 404s against the held manifest"
+MARK="$(wc -l <"${TGT_LOG}")"
+sync; echo 3 >/proc/sys/vm/drop_caches 2>/dev/null || true
+GOT="$(dd if="${DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none 2>"${WORKDIR}/read.err" \
+	| md5sum | cut -d' ' -f1)"
+
+# The whole point of B: the read succeeds rather than reporting an error.
+want "the read still returns the right data" "${GOT}" "${PAT_MD5}"
+
+NEW="$(tail -n "+${MARK}" "${TGT_LOG}")"
+if printf '%s' "${NEW}" | grep -q 'refetching the manifest'; then
+	ok "it went through a refetch"
+else
+	bad "no refetch in the log; the 404 was not recognised"
+fi
+# One large read splits into many chunk GETs and they all miss at once, so this
+# is what says the dedup works rather than issuing one manifest GET per miss.
+NREF="$(printf '%s\n' "${NEW}" | grep -c 'refetching the manifest' || true)"
+want "and only one, however many chunks missed" "${NREF}" "1"
+
+if printf '%s' "${NEW}" | grep -q 'now reading generation'; then
+	ok "$(printf '%s' "${NEW}" | grep -o 'now reading generation.*' | head -1)"
+else
+	bad "the manifest was never swapped"
+fi
+
+echo
+info "[5] and it stays on the new manifest"
+MARK="$(wc -l <"${TGT_LOG}")"
+sync; echo 3 >/proc/sys/vm/drop_caches 2>/dev/null || true
+want "a second read is still correct" \
+	"$(dd if="${DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)" \
+	"${PAT_MD5}"
+NREF2="$(tail -n "+${MARK}" "${TGT_LOG}" | grep -c 'refetching the manifest' || true)"
+want "with no further refetch" "${NREF2}" "0"
+
+echo
+echo "===== SUMMARY"
+if [ "${FAILED}" = "0" ]; then
+	echo "  物化后读透明恢复：404 触发一次重取，换用新 manifest，数据正确。"
+else
+	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+fi
+exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/probe_manifest_refetch.sh
+++ b/CubeS3lvol/test/dataplane/probe_manifest_refetch.sh
@@ -1,30 +1,40 @@
 #!/usr/bin/env bash
-# 重取探针：源端物化后，导入端的读能否透明恢复
+# Refetch probe: after the source materialises, can the importer's reads
+# recover transparently?
 #
-# 要验证的是 B 方案 —— 404 不向上报错，而是挂起该 I/O、重取 manifest、
-# 换用新的、再重试一次。客户端应当只看到一次变慢的读，而不是一次 I/O 错误。
+# This is plan B -- a 404 is not reported up; the I/O is held, the manifest
+# is refetched, swapped in, and retried once. The client should see one
+# slower read, not an I/O error.
 #
-# 场景是手工造的，因为源端的物化路径（第 5 步的写侧）还没接通。这里用
-# 三步模拟"源端搬走了对象"之后的 S3 状态：
+# The scene is built by hand because the source materialise path (the write
+# side of step 5) was not wired yet. Three steps fake the S3 state after
+# "the source moved the objects":
 #
-#   1. 正常导入一个 ref export，读一遍确认数据对；
-#   2. 把 <src-lvs>/data/ 下的对象复制到另一个 prefix，发布一份
-#      generation+1、source.prefix 指向新位置的 manifest，再删掉原对象；
-#   3. 再读一遍。旧 manifest 指向的键已经不存在，所以每个 chunk 都会 404。
+#   1. Import a ref export normally and read once to confirm the data.
+#   2. Copy objects under <src-lvs>/data/ to another prefix, publish a
+#      generation+1 manifest whose source.prefix points there, then delete
+#      the originals.
+#   3. Read again. Every key in the old manifest is gone, so every chunk
+#      404s.
 #
-# 为什么是"换 prefix"而不是"改成 dense"：dense 会改变 manifest 必须携带的
-# 字段和 crc 的分段方式，手工伪造的多半会被 parse() 拒掉 —— 那样探针失败在
-# 自己的伪造上，对重取路径什么也没证明。换 prefix 保持了全部校验和与不变量，
-# 同时让旧 manifest 里的每个键都 404，这正是要测的条件。
+# Why "move the prefix" rather than "rewrite as dense": dense changes which
+# fields the manifest must carry and how the crc is staged, so a hand-built
+# one would likely be rejected by parse() -- and a probe that fails on its
+# own forgery proves nothing about refetch. Moving the prefix keeps every
+# checksum and every invariant intact while still making every key in the
+# old manifest 404, which is the condition being tested.
 #
-# 判据有两条，缺一不可：
-#   - 读**成功**且 md5 与写入一致（B 方案生效，而不是把错误抛上去）；
-#   - 日志里出现且只出现一次 refetch（去重生效 —— 一次大读会拆成很多
-#     chunk GET，物化后它们同时 404，每个都触发一次重取的话就是一串
-#     重复的 manifest GET 和几次互相竞争的 swap）。
+# Two checks, both required:
+#   - the read **succeeds** and the md5 matches what was written (plan B
+#     took effect, rather than throwing the error up);
+#   - the log shows exactly one refetch (dedup works -- one large read
+#     splits into many chunk GETs; after materialise they all 404 at once,
+#     and without dedup that would be a string of duplicate manifest GETs
+#     and racing swaps).
 #
-# 注意：这里不 unload/reload lvstore。重取是内存里的行为，重启会重新
-# 读 manifest 从而绕过它 —— 那样测的就不是这条路径了。
+# The lvstore is not unloaded/reloaded. Refetch is in-memory; a restart
+# would re-read the manifest and skip this path, which is not what is
+# being tested.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -253,7 +263,7 @@ PY
 if [ $? -ne 0 ]; then
 	bad "could not simulate the materialisation"
 	sed 's/^/       /' "${WORKDIR}/materialise.log"
-	echo; echo "===== SUMMARY"; echo "  ${FAILED} 项失败"; exit "${FAILED}"
+	echo; echo "===== SUMMARY"; echo "  ${FAILED} failure(s)"; exit "${FAILED}"
 fi
 sed 's/^/       /' "${WORKDIR}/materialise.log"
 ok "the source's objects are gone and a newer manifest is published"
@@ -298,8 +308,10 @@ want "with no further refetch" "${NREF2}" "0"
 echo
 echo "===== SUMMARY"
 if [ "${FAILED}" = "0" ]; then
-	echo "  物化后读透明恢复：404 触发一次重取，换用新 manifest，数据正确。"
+	echo "  reads recover transparently after materialise: a 404 triggers"
+	echo "  one refetch, the new manifest is swapped in, and the data is"
+	echo "  correct."
 else
-	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+	echo "  ${FAILED} failure(s) -- see [FAIL] above"
 fi
 exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/probe_materialise.sh
+++ b/CubeS3lvol/test/dataplane/probe_materialise.sh
@@ -1,26 +1,35 @@
 #!/usr/bin/env bash
-# 物化探针：源端能否收回被 export 钉住的快照
+# Materialise probe: can the source reclaim a snapshot pinned by an export?
 #
-# 这是整条链路的目的所在。ref export 引用源 lvstore 的活对象，所以它钉住快照 ——
-# 只要还有 importer 在续租，快照就删不掉，无论对方是否真的还需要数据。物化是
-# 唯一的出路：源端把数据拷成 export 自有的副本，重新发布 dense manifest（generation+1），
-# 此后 export 不再欠任何人，快照可以删。
+# This is the point of the whole path. A ref export names live objects on the
+# source lvstore, so it pins the snapshot -- as long as an importer is still
+# renewing, the snapshot cannot be deleted, whether or not anyone still needs
+# the data. Materialise is the only way out: the source copies the data into
+# objects the export owns, republishes a dense manifest (generation+1), and
+# after that the export owes nobody anything and the snapshot can go.
 #
-# 判据按因果顺序排列，每一条都不能少：
+# Checks, in causal order; none of them is optional:
 #
-#   [2] 手工写一份新鲜租约，让源端相信有 importer 在读
-#   [3] 物化前：快照删不掉（钉住的证据 —— 否则后面的"可删"证明不了任何事）
-#   [4] 物化：RPC 成功，manifest 变成 dense 且 generation 递增、TTL 归零
-#   [5] 物化后：快照可以删掉了 —— 这是整个功能的目的
-#   [6] 源端 unload 之后再导入：数据仍然正确，且不再产生租约
+#   [2] write a fresh lease by hand so the source believes an importer is
+#       reading
+#   [3] before materialising: the snapshot cannot be deleted (proof it is
+#       pinned -- otherwise "deletable afterwards" proves nothing)
+#   [4] materialise: the RPC succeeds, the manifest becomes dense, generation
+#       advances, TTL goes to zero
+#   [5] after materialising: the snapshot can be deleted -- the point of the
+#       feature
+#   [6] import after the source is unloaded: the data is still correct, and
+#       no lease is taken
 #
-# 为什么 [2] 用手写租约而不是真的导入：一个进程只装得下一个 blobstore，源和目标
-# lvstore 无法同时加载。这对本探针无损 —— 快照删除的判据是**租约**
-# （export_pin_state），而不是本进程里的读者数，所以一份租约正是真实 importer
-# 会留下的信号。真实导入放在 [6]，那时源端已经卸载。
+# Why [2] uses a hand-written lease rather than a real import: one process
+# holds one blobstore, so source and destination lvstores cannot be loaded
+# together. That does not weaken this probe -- snapshot delete decides by
+# *lease* (export_pin_state), not by counting readers in this process, so a
+# lease is exactly the signal a real importer would leave. The real import
+# is [6], after the source is unloaded.
 #
-# [5] 和 [6] 合起来才是完整的证明：[5] 说源端确实拿回了空间，[6] 说这不是靠
-# 丢数据换来的。
+# [5] and [6] together are the full proof: [5] says the source got the space
+# back; [6] says that was not by throwing the data away.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -208,7 +217,7 @@ MAT="$(rpc --raw rcow_materialise_export "$(printf '{"export_uuid":"%s","lvs_nam
 info "reply: ${MAT}"
 if printf '%s' "${MAT}" | grep -qiE 'error|refus'; then
 	bad "rcow_materialise_export failed: ${MAT}"
-	echo; echo "===== SUMMARY"; echo "  ${FAILED} 项失败"; exit "${FAILED}"
+	echo; echo "===== SUMMARY"; echo "  ${FAILED} failure(s)"; exit "${FAILED}"
 fi
 ok "rcow_materialise_export succeeded"
 
@@ -282,9 +291,10 @@ fi
 echo
 echo "===== SUMMARY"
 if [ "${FAILED}" = "0" ]; then
-	echo "  源端收回了快照：物化后 export 自持副本、快照可删，"
-	echo "  而 export 依然可被导入，数据正确。"
+	echo "  the source reclaimed the snapshot: after materialising, the"
+	echo "  export holds its own copies, the snapshot can be deleted, and"
+	echo "  the export can still be imported with the right data."
 else
-	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+	echo "  ${FAILED} failure(s) -- see [FAIL] above"
 fi
 exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/probe_materialise.sh
+++ b/CubeS3lvol/test/dataplane/probe_materialise.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# 物化探针：源端能否收回被 export 钉住的快照
+#
+# 这是整条链路的目的所在。ref export 引用源 lvstore 的活对象，所以它钉住快照 ——
+# 只要还有 importer 在续租，快照就删不掉，无论对方是否真的还需要数据。物化是
+# 唯一的出路：源端把数据拷成 export 自有的副本，重新发布 dense manifest（generation+1），
+# 此后 export 不再欠任何人，快照可以删。
+#
+# 判据按因果顺序排列，每一条都不能少：
+#
+#   [2] 手工写一份新鲜租约，让源端相信有 importer 在读
+#   [3] 物化前：快照删不掉（钉住的证据 —— 否则后面的"可删"证明不了任何事）
+#   [4] 物化：RPC 成功，manifest 变成 dense 且 generation 递增、TTL 归零
+#   [5] 物化后：快照可以删掉了 —— 这是整个功能的目的
+#   [6] 源端 unload 之后再导入：数据仍然正确，且不再产生租约
+#
+# 为什么 [2] 用手写租约而不是真的导入：一个进程只装得下一个 blobstore，源和目标
+# lvstore 无法同时加载。这对本探针无损 —— 快照删除的判据是**租约**
+# （export_pin_state），而不是本进程里的读者数，所以一份租约正是真实 importer
+# 会留下的信号。真实导入放在 [6]，那时源端已经卸载。
+#
+# [5] 和 [6] 合起来才是完整的证明：[5] 说源端确实拿回了空间，[6] 说这不是靠
+# 丢数据换来的。
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+GET_MANIFEST="${ROOT}/test/tools/s3_get_manifest.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+SRC_LVS=pmat_src
+DST_LVS=pmat_dst
+SRC_WAL=/tmp/pmat_src_wal.img
+DST_WAL=/tmp/pmat_dst_wal.img
+RPC_SOCK=/tmp/pmat.sock
+TGT_LOG=/tmp/pmat_target.log
+NQN="nqn.2026-09.io.spdk:pmat"
+PORT="4475"
+WORKDIR="$(mktemp -d /tmp/pmat.XXXXXX)"
+FILL_MB=8
+
+TGT_PID=""
+CONNECTED=0
+UUIDS=""
+FAILED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+ok()   { echo "     [PASS] $*"; }
+bad()  { echo "     [FAIL] $*"; FAILED=$((FAILED + 1)); }
+want() { if [ "$2" = "$3" ]; then ok "$1 ($2)"; else bad "$1: got '$2', want '$3'"; fi; }
+mfield() { python3 "${GET_MANIFEST}" -e "${EP}" -b "${BK}" -r "${RG}" -u "$1" \
+	--field "$2" 2>/dev/null; }
+
+cleanup()
+{
+	set +u
+	[ "${CONNECTED}" = "1" ] && nvme disconnect -n "${NQN}" >/dev/null 2>&1
+	[ -n "${TGT_PID}" ] && { kill "${TGT_PID}" 2>/dev/null; sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null; }
+	rcow_load_credentials
+	for p in "${SRC_LVS}" "${DST_LVS}"; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+			-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+			-p "${p}/" >/dev/null 2>&1
+	done
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+			-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+			-p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${SRC_WAL}" "${DST_WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo "===== log: ${TGT_LOG}"
+}
+trap cleanup EXIT
+
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 320M "${SRC_WAL}"
+truncate -s 320M "${DST_WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+for p in "${SRC_LVS}" "${DST_LVS}"; do
+	python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${p}/" >/dev/null 2>&1
+done
+
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"src_wal0","block_size":4096}' \
+	"${SRC_WAL}")" >/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"dst_wal0","block_size":4096}' \
+	"${DST_WAL}")" >/dev/null 2>&1
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"PMAT00000000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose() { raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+	"${NQN}" "$1")" 2>/dev/null | tr -d '[:space:]'; }
+unexpose() { [ -n "$1" ] && raw nvmf_subsystem_remove_ns \
+	"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "$1")" >/dev/null 2>&1; return 0; }
+ctrl_of_nqn() { local c; for c in /sys/class/nvme/nvme*; do
+	[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done; return 1; }
+wait_dev()
+{
+	local nsid="$1" deadline ctrl dev
+	deadline=$(( $(date +%s) + 30 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if ctrl="$(ctrl_of_nqn)"; then
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		fi
+		sleep 0.3
+	done
+	return 1
+}
+
+# One target, two lvstores, both loaded at once. That is what makes the pin
+# observable: the refusal to delete a pinned snapshot is checked against readers
+# in this process, so the importing lvstore has to be one of them.
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"src_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${SRC_LVS}" "${BK}")" >/dev/null || { echo "create src"; exit 1; }
+
+echo
+info "[1] source: write, snapshot, zero-copy export"
+rpc rcow_create_lvol '{"lvol_name":"v","size_gib":1}' >/dev/null || { echo "lvol"; exit 1; }
+NSID_SRC="$(expose "${SRC_LVS}/v")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 2
+DEV="$(wait_dev "${NSID_SRC}")" || { echo "src device"; exit 1; }
+
+PAT="${WORKDIR}/pat.bin"
+dd if=/dev/urandom of="${PAT}" bs=1M count="${FILL_MB}" status=none
+PAT_MD5="$(md5sum "${PAT}" | cut -d' ' -f1)"
+dd if="${PAT}" of="${DEV}" bs=1M count="${FILL_MB}" oflag=direct conv=fsync status=none
+sync
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"v","snapshot_name":"s"}' >/dev/null || exit 1
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 3
+
+EXP="$(rpc rcow_export_snapshot '{"snapshot_name":"s"}' 2>&1 | tr -d '"[:space:]\n')"
+[ -n "${EXP}" ] || { echo "export"; exit 1; }
+UUIDS="${EXP}"
+for _ in $(seq 90); do
+	st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP}")" \
+		2>/dev/null | tr -d '"[:space:]\n')"
+	case "${st}" in *DONE*) break ;; esac
+	sleep 1
+done
+want "the export is a reference one to begin with" "$(mfield "${EXP}" layout)" "ref"
+want "at generation 0" "$(mfield "${EXP}" generation)" "0"
+info "export ${EXP}"
+
+echo
+info "[2] a fresh lease, so the source believes an importer is reading"
+# Written by hand rather than by importing, because one process holds one
+# blobstore -- the destination lvstore cannot be loaded next to the source. That
+# is fine for what is being tested here: the delete path decides by *lease*
+# (export_pin_state), not by counting readers in this process, so a lease is
+# exactly the signal a real importer would leave.
+#
+# The importer side of the same story is [6], after this lvstore is unloaded.
+rcow_load_credentials
+python3 "${ROOT}/test/tools/s3_put_lease.py" "${EP}" "${BK}" "${RG}" \
+	"${SRC_LVS}/meta/exports/${EXP}.lease" 20 0 >"${WORKDIR}/lease.log" 2>&1 \
+	&& ok "an importer's lease was written" \
+	|| bad "could not write the lease: $(tail -1 "${WORKDIR}/lease.log")"
+# The source reads the lease on its own poller; give it a turn before asking.
+sleep 8
+
+echo
+info "[3] before materialising: the snapshot is pinned"
+# Asserted first, and this is not ceremony: without it "deletable afterwards"
+# would prove nothing, since it might have been deletable all along.
+DEL="$(rpc --raw rcow_delete_lvol "$(printf '{"lvol_name":"s","lvs_name":"%s"}' \
+	"${SRC_LVS}")" 2>&1)"
+info "delete reply: ${DEL}"
+sleep 2
+if rpc rcow_get_lvstores 2>/dev/null | grep -q '"s"'; then
+	ok "the snapshot survived: the reference export still pins it"
+else
+	bad "the snapshot was deleted while a reference export names it: ${DEL}"
+fi
+
+echo
+info "[4] materialise it"
+MARK="$(wc -l <"${TGT_LOG}")"
+MAT="$(rpc --raw rcow_materialise_export "$(printf '{"export_uuid":"%s","lvs_name":"%s"}' \
+	"${EXP}" "${SRC_LVS}")" 2>&1)"
+info "reply: ${MAT}"
+if printf '%s' "${MAT}" | grep -qiE 'error|refus'; then
+	bad "rcow_materialise_export failed: ${MAT}"
+	echo; echo "===== SUMMARY"; echo "  ${FAILED} 项失败"; exit "${FAILED}"
+fi
+ok "rcow_materialise_export succeeded"
+
+want "the manifest is now a copy" "$(mfield "${EXP}" layout)" "dense"
+want "at generation 1" "$(mfield "${EXP}" generation)" "1"
+# expires_at was only ever a promise to hold a snapshot for somebody.
+want "with no deadline left" "$(mfield "${EXP}" expires_at)" "0"
+
+echo
+info "[5] after materialising: the snapshot can go"
+# The point of the whole exercise.
+DEL="$(rpc --raw rcow_delete_lvol "$(printf '{"lvol_name":"s","lvs_name":"%s"}' \
+	"${SRC_LVS}")" 2>&1)"
+info "delete reply: ${DEL}"
+for _ in $(seq 60); do
+	rpc rcow_get_lvstores 2>/dev/null | grep -q '"s"' || break
+	sleep 1
+done
+if rpc rcow_get_lvstores 2>/dev/null | grep -q '"s"'; then
+	bad "the snapshot is still there after materialising: ${DEL}"
+else
+	ok "the snapshot was deleted -- the export no longer pins it"
+fi
+
+echo
+info "[6] and an importer reads the copies, with the source gone"
+# The snapshot is deleted and its objects with it, so the reference the manifest
+# used to hold is unresolvable. An import now has to work entirely off the
+# copies -- which is where the write side and the read side meet.
+#
+# Imported after unloading the source rather than alongside it, because one
+# process holds one blobstore. That also makes it the stronger test: the
+# exporting lvstore is not merely quiet, it is gone.
+unexpose "${NSID_SRC}"; sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1 \
+	|| bad "could not unload the source"
+sleep 2
+
+if rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"dst_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+		"${DST_LVS}" "${BK}")" >/dev/null 2>&1; then
+	IMP="$(rpc --raw rcow_import_lvol "$(printf '{"lvol_name":"i","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+		"${EXP}" "${DST_LVS}")" 2>&1)"
+	info "import reply: ${IMP}"
+
+	NSID_DST="$(expose "${DST_LVS}/i")"
+	sleep 2
+	DEV_I="$(wait_dev "${NSID_DST}")"
+	if [ -n "${DEV_I}" ] && [ -b "${DEV_I}" ]; then
+		sync; echo 3 >/proc/sys/vm/drop_caches 2>/dev/null || true
+		want "it reads the right data out of the copies" \
+			"$(dd if="${DEV_I}" bs=1M count="${FILL_MB}" iflag=direct \
+				status=none 2>"${WORKDIR}/read.err" | md5sum \
+				| cut -d' ' -f1)" \
+			"${PAT_MD5}"
+	else
+		bad "the imported volume never became a device"
+	fi
+
+	# A copied export pins nothing, so an import of one takes no lease. Said
+	# explicitly because the absence is the point: this is what "the source
+	# owes nobody anything" looks like from the other side.
+	if tail -n "+${MARK}" "${TGT_LOG}" | grep -q 'renewing .* lease'; then
+		bad "the import took a lease on an export that pins nothing"
+	else
+		ok "and takes no lease, there being nothing left to pin"
+	fi
+else
+	bad "could not create the destination lvstore"
+fi
+
+echo
+echo "===== SUMMARY"
+if [ "${FAILED}" = "0" ]; then
+	echo "  源端收回了快照：物化后 export 自持副本、快照可删，"
+	echo "  而 export 依然可被导入，数据正确。"
+else
+	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+fi
+exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/probe_publish_latency.sh
+++ b/CubeS3lvol/test/dataplane/probe_publish_latency.sh
@@ -1,46 +1,54 @@
 #!/usr/bin/env bash
-# 端到端发布延迟：import -> create_snapshot -> export_snapshot 各步花多久？
+# End-to-end publish latency: how long do import -> create_snapshot ->
+# export_snapshot take on each path?
 #
-# 起因（用户指出，实测确认）：第 1 步让 create_snapshot 变成 O(1)，但真正的
-# 发布链路是 import -> create_snapshot -> export_snapshot。快照 S 拿走了
-# external parent，所以 export 走到 export_build_chain 时命中
-# spdk_blob_is_esnap_clone()，返回 -ENOTSUP，然后**静默退化成拷贝**
-# （export_ref() -> export_copy()）。拷贝要把已分配的字节读出来再上传一遍。
+# Origin (called out by a user, then measured): step 1 made create_snapshot
+# O(1), but the real publish chain is import -> create_snapshot ->
+# export_snapshot. Snapshot S takes the external parent, so export hits
+# spdk_blob_is_esnap_clone() in export_build_chain, gets -ENOTSUP, and
+# **silently falls back to a copy** (export_ref() -> export_copy()). The copy
+# reads the allocated bytes back out and uploads them again.
 #
-# 也就是说 O(1) 只是从一个 RPC 挪到了下一个，端到端仍是 O(size)。
-# 这个探针要把三条路径的耗时和产出 layout 摆在一起：
+# So O(1) only moved from one RPC to the next; end-to-end was still O(size).
+# This probe puts the three paths' timings and resulting layouts side by side:
 #
-#   路径 A  import -> snapshot -> export            （S 是 esnap clone）
-#   路径 B  import -> snapshot -> decouple S -> export （先收敛再发布）
-#   路径 C  import(decouple 完成) -> snapshot -> export （老办法，先物化后快照）
+#   path A  import -> snapshot -> export                 (S is an esnap clone)
+#   path B  import -> snapshot -> decouple S -> export   (converge, then publish)
+#   path C  import (decouple finished) -> snapshot -> export
+#           (the old way: materialise first, then snapshot)
 #
-# 要回答：
-#   1. 路径 A 的 export 是 REF 还是 DENSE？耗时多少？
-#   2. 路径 B 的 export 是 REF 吗？（若是，说明收敛后可零拷贝再发布）
-#   3. 三条路径的端到端总耗时，哪一条真的更快？
-#   4. S3 上各自占多少对象（存储放大）
+# Questions:
+#   1. Is path A's export REF or DENSE, and how long does it take?
+#   2. Is path B's export REF? (If so, a converged snapshot can be
+#      re-published zero-copy.)
+#   3. Which path is actually faster end to end?
+#   4. How many S3 objects does each occupy (storage amplification)?
 #
-# === 上面描述的是 v3 之前的状态。结论已被 manifest v3 推翻（2026-09-02 实测）===
+# === The above was the pre-v3 state. Manifest v3 reversed the conclusion
+#     (measured 2026-09-02). ===
 #
-#   路径          publish      total     layout   export prefix 对象数
-#   A （旧）       1781ms      2292ms     dense    64
-#   A （v3 后）     366ms       800ms     ref       0
-#   B （v3 后）     622ms      7551ms     ref       0
-#   C （v3 后）     620ms      7424ms     ref       0
+#   path           publish      total     layout   export-prefix objects
+#   A (old)        1781ms      2292ms     dense    64
+#   A (after v3)    366ms       800ms     ref       0
+#   B (after v3)    622ms      7551ms     ref       0
+#   C (after v3)    620ms      7424ms     ref       0
 #
-# export_build_chain() 遇到 esnap 已不再返回 -ENOTSUP：它把 esnap id 当作
-# export uuid 读出来，交给 export_ref() 在 import 注册表里找到父 manifest，
-# 由 s3_export_manifest_inherit() 把父的多源表摊平进来。所以路径 A 现在是
-# 零拷贝的，而且比先收敛的 B/C 快近 10 倍 —— 那两条路径付的是 decouple 的
-# 全卷物化钱。这正是设计要的 O(1) publish。
+# export_build_chain() no longer returns -ENOTSUP on an esnap: it reads the
+# esnap id as an export uuid, hands it to export_ref() to find the parent
+# manifest in the import registry, and s3_export_manifest_inherit() flattens
+# the parent's multi-source table in. Path A is therefore zero-copy, and
+# nearly 10x faster than B/C -- those two pay for a full-volume materialise
+# via decouple. That is the O(1) publish the design wanted.
 #
-# 这个探针只打印、不断言，留作性能口径。**layout=ref 的正式回归在
-# run_derived_test.sh 的步骤 [3]**（断言 version=3 且 layout=ref）；这里的数字
-# 是给"发布到底快了多少"这个问题用的。
+# This probe prints; it does not assert. Keep it as a performance yardstick.
+# **The formal layout=ref regression is run_derived_test.sh around step [3]**
+# (asserts version=3 and layout=ref). The numbers here answer "how much
+# faster did publish actually get?".
 #
-# 仍会退化成拷贝的残余情况（见 docs/manifest-v3-format.md 的判定表）：
-# 跨 bucket/endpoint/region、父 manifest 本身是 dense、chunk_size 不一致、
-# 本地快照链深度 > 32、import 注册表缺条目。
+# Residual cases that still fall back to a copy (see the decision table in
+# docs/manifest-v3-format.md): cross bucket/endpoint/region, a parent
+# manifest that is itself dense, mismatched chunk_size, local snapshot chain
+# deeper than 32, a missing import-registry entry.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -241,12 +249,12 @@ rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_g
 info "destination lvstore ready"
 
 # --------------------------------------------------------------------------
-# 计时与观测辅助
+# Timing and observation helpers
 # --------------------------------------------------------------------------
 now_ms() { date +%s%3N; }
 
-# 一个 export 的 layout。只写在 manifest 对象里（s3_export.c:581），没有 RPC
-# 报告它，所以只能把 manifest 读回来。
+# Layout of one export. It lives only in the manifest object (s3_export.c:581);
+# no RPC reports it, so the manifest has to be read back.
 layout_of()
 {
 	[ -n "${1:-}" ] || { echo "no-uuid"; return; }
@@ -254,10 +262,11 @@ layout_of()
 		-r "${RG}" -u "$1" --field layout 2>/dev/null || echo "unreadable"
 }
 
-# 某个 prefix 下的对象数，用来看存储放大。
+# Object count under a prefix, for storage amplification.
 #
-# 用 wc 而不是 `grep -c . || echo 0`：grep 没匹配时退出码非零，那个 fallback
-# 就会往一个已经是 "0" 的值后面再追加一行，得到一个两行的"数字"。
+# Use wc rather than `grep -c . || echo 0`: grep's non-zero exit on no match
+# would append another "0" onto a value that is already "0", producing a
+# two-line "number".
 objects_under()
 {
 	python3 "${PREFIX_RM}" --list -e "${EP}" -b "${BK}" -r "${RG}" -p "$1" \
@@ -291,7 +300,7 @@ print(len(r if isinstance(r,list) else r.get("queue",[])))' 2>/dev/null)" = "0" 
 }
 
 # --------------------------------------------------------------------------
-# [2] 路径 A：import -> snapshot -> export（S 仍是 esnap clone）
+# [2] Path A: import -> snapshot -> export (S is still an esnap clone)
 # --------------------------------------------------------------------------
 echo
 info "[A] import -> snapshot -> export, with S still an esnap clone"
@@ -324,7 +333,7 @@ grep -aE 'external snapshot, whose|exporting by copying|Snapshot chain reaches' 
 rpc --ls rcow_get_lvstores
 
 # --------------------------------------------------------------------------
-# [3] 路径 B：import -> snapshot -> decouple S -> export（先收敛再发布）
+# [3] Path B: import -> snapshot -> decouple S -> export (converge, then publish)
 # --------------------------------------------------------------------------
 echo
 info "[B] import -> snapshot -> decouple the snapshot -> export"
@@ -357,7 +366,7 @@ info "B: layout=${B_LAYOUT}  objects under its export prefix=${B_OBJS}"
 rpc --ls rcow_get_lvstores
 
 # --------------------------------------------------------------------------
-# [4] 路径 C：等 import 的 decouple 自己跑完，再 snapshot -> export
+# [4] Path C: wait for import's own decouple to finish, then snapshot -> export
 # --------------------------------------------------------------------------
 echo
 info "[C] import, let its decouple finish, then snapshot -> export"
@@ -399,10 +408,12 @@ printf '%-46s %9sms %9sms %10s\n' \
 echo
 echo "  export-prefix objects: A=${A_OBJS}  B=${B_OBJS}  C=${C_OBJS}"
 echo
-echo "  怎么读这张表：A 的 layout 应当是 ref，publish 数百毫秒，export prefix"
-echo "  对象数 0。若 A 出现 dense，说明 export_ref() 又退化成了拷贝 —— 查是不是"
-echo "  跨 bucket/endpoint/region、父 manifest 已是 dense、chunk_size 不一致，"
-echo "  或本地快照链深度超过 32。"
+echo "  How to read this table: A's layout should be ref, publish a few hundred"
+echo "  milliseconds, and the export prefix should have 0 objects. If A comes"
+echo "  out dense, export_ref() fell back to a copy again -- check for a cross"
+echo "  bucket/endpoint/region, a parent manifest that is already dense, a"
+echo "  mismatched chunk_size, or a local snapshot chain deeper than 32."
 echo
-echo "  A 比 B/C 快近 10 倍，差的是 decouple 的全卷物化：B/C 用等待换独立性，"
-echo "  A 用一条跨 prefix 的引用换即时发布。"
+echo "  A is nearly 10x faster than B/C; the gap is decouple's full-volume"
+echo "  materialise. B/C trade wait time for independence; A trades a"
+echo "  cross-prefix reference for instant publish."

--- a/CubeS3lvol/test/dataplane/probe_publish_latency.sh
+++ b/CubeS3lvol/test/dataplane/probe_publish_latency.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# 端到端发布延迟：import -> create_snapshot -> export_snapshot 各步花多久？
+#
+# 起因（用户指出，实测确认）：第 1 步让 create_snapshot 变成 O(1)，但真正的
+# 发布链路是 import -> create_snapshot -> export_snapshot。快照 S 拿走了
+# external parent，所以 export 走到 export_build_chain 时命中
+# spdk_blob_is_esnap_clone()，返回 -ENOTSUP，然后**静默退化成拷贝**
+# （export_ref() -> export_copy()）。拷贝要把已分配的字节读出来再上传一遍。
+#
+# 也就是说 O(1) 只是从一个 RPC 挪到了下一个，端到端仍是 O(size)。
+# 这个探针要把三条路径的耗时和产出 layout 摆在一起：
+#
+#   路径 A  import -> snapshot -> export            （S 是 esnap clone）
+#   路径 B  import -> snapshot -> decouple S -> export （先收敛再发布）
+#   路径 C  import(decouple 完成) -> snapshot -> export （老办法，先物化后快照）
+#
+# 要回答：
+#   1. 路径 A 的 export 是 REF 还是 DENSE？耗时多少？
+#   2. 路径 B 的 export 是 REF 吗？（若是，说明收敛后可零拷贝再发布）
+#   3. 三条路径的端到端总耗时，哪一条真的更快？
+#   4. S3 上各自占多少对象（存储放大）
+#
+# === 上面描述的是 v3 之前的状态。结论已被 manifest v3 推翻（2026-09-02 实测）===
+#
+#   路径          publish      total     layout   export prefix 对象数
+#   A （旧）       1781ms      2292ms     dense    64
+#   A （v3 后）     366ms       800ms     ref       0
+#   B （v3 后）     622ms      7551ms     ref       0
+#   C （v3 后）     620ms      7424ms     ref       0
+#
+# export_build_chain() 遇到 esnap 已不再返回 -ENOTSUP：它把 esnap id 当作
+# export uuid 读出来，交给 export_ref() 在 import 注册表里找到父 manifest，
+# 由 s3_export_manifest_inherit() 把父的多源表摊平进来。所以路径 A 现在是
+# 零拷贝的，而且比先收敛的 B/C 快近 10 倍 —— 那两条路径付的是 decouple 的
+# 全卷物化钱。这正是设计要的 O(1) publish。
+#
+# 这个探针只打印、不断言，留作性能口径。**layout=ref 的正式回归在
+# run_derived_test.sh 的步骤 [3]**（断言 version=3 且 layout=ref）；这里的数字
+# 是给"发布到底快了多少"这个问题用的。
+#
+# 仍会退化成拷贝的残余情况（见 docs/manifest-v3-format.md 的判定表）：
+# 跨 bucket/endpoint/region、父 manifest 本身是 dense、chunk_size 不一致、
+# 本地快照链深度 > 32、import 注册表缺条目。
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+SRC_LVS=ppub_src
+DST_LVS=ppub_dst
+SRC_WAL=/tmp/ppub_src_wal.img
+DST_WAL=/tmp/ppub_dst_wal.img
+RPC_SOCK=/tmp/ppub.sock
+TGT_LOG=/tmp/ppub_target.log
+NQN="nqn.2026-08.io.spdk:ppub"
+PORT="4473"
+WORKDIR="$(mktemp -d /tmp/ppub.XXXXXX)"
+FILL_MB=64
+WRITE_MB=4
+
+TGT_PID=""
+CONNECTED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+
+cleanup()
+{
+	set +u
+	[ "${CONNECTED}" = "1" ] && nvme disconnect -n "${NQN}" >/dev/null 2>&1
+	if [ -n "${TGT_PID}" ]; then
+		kill "${TGT_PID}" 2>/dev/null
+		sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null
+	fi
+	rcow_load_credentials
+	for p in "${SRC_LVS}" "${DST_LVS}"; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "${p}/" >/dev/null 2>&1
+	done
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${SRC_WAL}" "${DST_WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo
+	grep -aE 'external snapshot|esnap|not a clone|only a read-only|create snapshot|snapshot/clone|Decoupling|materialised|Deleted lvol' \
+		"${TGT_LOG}" 2>/dev/null | tail -18
+	echo "===== log: ${TGT_LOG}   workdir: ${WORKDIR}"
+}
+trap cleanup EXIT
+
+# --------------------------------------------------------------------------
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 320M "${SRC_WAL}"
+truncate -s 320M "${DST_WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+info "endpoint ${EP}  bucket ${BK}"
+for p in "${SRC_LVS}" "${DST_LVS}"; do
+	python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${p}/" >/dev/null 2>&1
+done
+
+info "starting target"
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config failed"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"src_wal0","block_size":4096}' "${SRC_WAL}")" \
+	>/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"dst_wal0","block_size":4096}' "${DST_WAL}")" \
+	>/dev/null 2>&1
+
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"src_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${SRC_LVS}" "${BK}")" >/dev/null || { echo "create ${SRC_LVS} failed"; exit 1; }
+info "source lvstore ready"
+
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"PPUB00000000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose()
+{
+	raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+		"${NQN}" "$1")" 2>/dev/null | tr -d '[:space:]'
+}
+
+unexpose()
+{
+	local nsid="$1"
+	[ -n "${nsid}" ] && raw nvmf_subsystem_remove_ns \
+		"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "${nsid}")" >/dev/null 2>&1
+	return 0
+}
+
+ctrl_of_nqn()
+{
+	local c
+	for c in /sys/class/nvme/nvme*; do
+		[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done
+	return 1
+}
+
+wait_dev()
+{
+	local nsid="$1" deadline ctrl dev
+	deadline=$(( $(date +%s) + 30 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if ctrl="$(ctrl_of_nqn)"; then
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		fi
+		sleep 0.3
+	done
+	return 1
+}
+
+# Read the first FILL_MB of a volume by name: expose, read, unexpose.
+read_vol()
+{
+	local name="$1" nsid dev md5
+	nsid="$(expose "${DST_LVS}/${name}")"
+	[ -n "${nsid}" ] || { echo "EXPOSE_FAILED"; return 1; }
+	dev="$(wait_dev "${nsid}")" || { unexpose "${nsid}"; echo "NO_DEV"; return 1; }
+	md5="$(dd if="${dev}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+	unexpose "${nsid}"
+	sleep 1
+	printf '%s' "${md5}"
+}
+
+# The ALLOC column of rcow_get_lvstores --ls, for one volume. SIZE prints as
+# two fields ("1.0 GiB"), so ALLOC is $5.
+alloc_of()
+{
+	rpc --ls rcow_get_lvstores 2>/dev/null | awk -v n="$1" '$1 == n { print $5; exit }'
+}
+
+# --------------------------------------------------------------------------
+# [1] source: a volume with known content -> snapshot -> REF export
+# --------------------------------------------------------------------------
+info "[1] source volume, filled"
+rpc rcow_create_lvol '{"lvol_name":"src","size_gib":1}' >/dev/null \
+	|| { echo "create_lvol failed"; exit 1; }
+NSID_SRC="$(expose "${SRC_LVS}/src")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 2
+SRC_DEV="$(wait_dev "${NSID_SRC}")" || { echo "source device never appeared"; exit 1; }
+info "source device ${SRC_DEV}"
+
+PAT="${WORKDIR}/pattern.bin"
+dd if=/dev/urandom of="${PAT}" bs=1M count="${FILL_MB}" status=none
+PAT_MD5="$(md5sum "${PAT}" | cut -d' ' -f1)"
+dd if="${PAT}" of="${SRC_DEV}" bs=1M oflag=direct status=none
+sync
+SRC_READ="$(dd if="${SRC_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+info "pattern ${PAT_MD5}; read back $([ "${SRC_READ}" = "${PAT_MD5}" ] && echo match || echo MISMATCH)"
+
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"src","snapshot_name":"src-snap"}' >/dev/null \
+	|| { echo "snapshot failed"; exit 1; }
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 3
+
+EXP_UUID="$(rpc rcow_export_snapshot '{"snapshot_name":"src-snap"}' 2>&1 | tr -d '"[:space:]\n')"
+UUIDS="${EXP_UUID}"
+[ -n "${EXP_UUID}" ] || { echo "export failed"; exit 1; }
+info "exported as ${EXP_UUID}"
+for _ in $(seq 120); do
+	st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP_UUID}")" 2>/dev/null \
+		| tr -d '"[:space:]\n')"
+	case "${st}" in *DONE*) break ;; esac
+	sleep 1
+done
+info "export status: ${st:-unknown}"
+
+unexpose "${NSID_SRC}"
+sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1 \
+	|| { echo "unload source failed"; exit 1; }
+sleep 2
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"dst_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${DST_LVS}" "${BK}")" >/dev/null || { echo "create ${DST_LVS} failed"; exit 1; }
+info "destination lvstore ready"
+
+# --------------------------------------------------------------------------
+# 计时与观测辅助
+# --------------------------------------------------------------------------
+now_ms() { date +%s%3N; }
+
+# 一个 export 的 layout。只写在 manifest 对象里（s3_export.c:581），没有 RPC
+# 报告它，所以只能把 manifest 读回来。
+layout_of()
+{
+	[ -n "${1:-}" ] || { echo "no-uuid"; return; }
+	python3 "${ROOT}/test/tools/s3_get_manifest.py" -e "${EP}" -b "${BK}" \
+		-r "${RG}" -u "$1" --field layout 2>/dev/null || echo "unreadable"
+}
+
+# 某个 prefix 下的对象数，用来看存储放大。
+#
+# 用 wc 而不是 `grep -c . || echo 0`：grep 没匹配时退出码非零，那个 fallback
+# 就会往一个已经是 "0" 的值后面再追加一行，得到一个两行的"数字"。
+objects_under()
+{
+	python3 "${PREFIX_RM}" --list -e "${EP}" -b "${BK}" -r "${RG}" -p "$1" \
+		2>/dev/null | grep -c . | head -1
+}
+
+wait_export()
+{
+	local u="$1" i st
+	for i in $(seq 600); do
+		st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${u}")" \
+			2>/dev/null | tr -d '"[:space:]\n')"
+		case "${st}" in *DONE*) return 0 ;; *FAIL*|*ERROR*) return 1 ;; esac
+		sleep 0.2
+	done
+	return 1
+}
+
+drain_decouple()
+{
+	local i
+	for i in $(seq 900); do
+		[ "$(rpc rcow_get_decouple 2>/dev/null | python3 -c '
+import json,sys
+try: r=json.load(sys.stdin)
+except Exception: r=[]
+print(len(r if isinstance(r,list) else r.get("queue",[])))' 2>/dev/null)" = "0" ] && return 0
+		sleep 0.2
+	done
+	return 1
+}
+
+# --------------------------------------------------------------------------
+# [2] 路径 A：import -> snapshot -> export（S 仍是 esnap clone）
+# --------------------------------------------------------------------------
+echo
+info "[A] import -> snapshot -> export, with S still an esnap clone"
+T0="$(now_ms)"
+rpc rcow_import_lvol "$(printf '{"lvol_name":"VA","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+	"${EXP_UUID}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "import VA failed"; exit 1; }
+T_IMP="$(now_ms)"
+
+rpc rcow_create_snapshot '{"lvol_name":"VA","snapshot_name":"SA"}' >/dev/null 2>&1 \
+	|| { echo "snapshot SA failed"; exit 1; }
+T_SNAP="$(now_ms)"
+
+UA="$(rpc rcow_export_snapshot '{"snapshot_name":"SA"}' 2>&1 | tr -d '"[:space:]\n')"
+if [ -n "${UA}" ]; then
+	wait_export "${UA}" && T_EXP="$(now_ms)" || { T_EXP="$(now_ms)"; info "export A did not finish"; }
+	UUIDS="${UUIDS} ${UA}"
+else
+	T_EXP="$(now_ms)"
+	info "export A was refused"
+fi
+
+A_IMP=$((T_IMP - T0)); A_SNAP=$((T_SNAP - T_IMP)); A_EXP=$((T_EXP - T_SNAP))
+A_TOTAL=$((T_EXP - T0))
+A_LAYOUT="$(layout_of "${UA}")"
+A_OBJS="$(objects_under "${DST_LVS}/exports/${UA}")"
+info "A: import ${A_IMP}ms  snapshot ${A_SNAP}ms  export ${A_EXP}ms  total ${A_TOTAL}ms"
+info "A: layout=${A_LAYOUT}  objects under its export prefix=${A_OBJS}"
+grep -aE 'external snapshot, whose|exporting by copying|Snapshot chain reaches' \
+	"${TGT_LOG}" | tail -2 | sed 's/^/       /'
+rpc --ls rcow_get_lvstores
+
+# --------------------------------------------------------------------------
+# [3] 路径 B：import -> snapshot -> decouple S -> export（先收敛再发布）
+# --------------------------------------------------------------------------
+echo
+info "[B] import -> snapshot -> decouple the snapshot -> export"
+T0="$(now_ms)"
+rpc rcow_import_lvol "$(printf '{"lvol_name":"VB","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+	"${EXP_UUID}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "import VB failed"; exit 1; }
+rpc rcow_create_snapshot '{"lvol_name":"VB","snapshot_name":"SB"}' >/dev/null 2>&1 \
+	|| { echo "snapshot SB failed"; exit 1; }
+T_SNAP="$(now_ms)"
+
+rpc rcow_decouple_lvol '{"lvol_name":"SB"}' >/dev/null 2>&1 \
+	|| info "decouple SB refused"
+drain_decouple || info "decouple SB did not drain"
+T_DEC="$(now_ms)"
+
+UB="$(rpc rcow_export_snapshot '{"snapshot_name":"SB"}' 2>&1 | tr -d '"[:space:]\n')"
+if [ -n "${UB}" ]; then
+	wait_export "${UB}" && T_EXP="$(now_ms)" || { T_EXP="$(now_ms)"; info "export B did not finish"; }
+	UUIDS="${UUIDS} ${UB}"
+else
+	T_EXP="$(now_ms)"; info "export B was refused"
+fi
+
+B_SNAP=$((T_SNAP - T0)); B_DEC=$((T_DEC - T_SNAP)); B_EXP=$((T_EXP - T_DEC))
+B_TOTAL=$((T_EXP - T0))
+B_LAYOUT="$(layout_of "${UB}")"
+B_OBJS="$(objects_under "${DST_LVS}/exports/${UB}")"
+info "B: import+snapshot ${B_SNAP}ms  decouple ${B_DEC}ms  export ${B_EXP}ms  total ${B_TOTAL}ms"
+info "B: layout=${B_LAYOUT}  objects under its export prefix=${B_OBJS}"
+rpc --ls rcow_get_lvstores
+
+# --------------------------------------------------------------------------
+# [4] 路径 C：等 import 的 decouple 自己跑完，再 snapshot -> export
+# --------------------------------------------------------------------------
+echo
+info "[C] import, let its decouple finish, then snapshot -> export"
+T0="$(now_ms)"
+rpc rcow_import_lvol "$(printf '{"lvol_name":"VC","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+	"${EXP_UUID}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "import VC failed"; exit 1; }
+drain_decouple || info "decouple VC did not drain"
+T_DEC="$(now_ms)"
+
+rpc rcow_create_snapshot '{"lvol_name":"VC","snapshot_name":"SC"}' >/dev/null 2>&1 \
+	|| { echo "snapshot SC failed"; exit 1; }
+T_SNAP="$(now_ms)"
+
+UC="$(rpc rcow_export_snapshot '{"snapshot_name":"SC"}' 2>&1 | tr -d '"[:space:]\n')"
+if [ -n "${UC}" ]; then
+	wait_export "${UC}" && T_EXP="$(now_ms)" || { T_EXP="$(now_ms)"; info "export C did not finish"; }
+	UUIDS="${UUIDS} ${UC}"
+else
+	T_EXP="$(now_ms)"; info "export C was refused"
+fi
+
+C_DEC=$((T_DEC - T0)); C_SNAP=$((T_SNAP - T_DEC)); C_EXP=$((T_EXP - T_SNAP))
+C_TOTAL=$((T_EXP - T0))
+C_LAYOUT="$(layout_of "${UC}")"
+C_OBJS="$(objects_under "${DST_LVS}/exports/${UC}")"
+info "C: import+decouple ${C_DEC}ms  snapshot ${C_SNAP}ms  export ${C_EXP}ms  total ${C_TOTAL}ms"
+info "C: layout=${C_LAYOUT}  objects under its export prefix=${C_OBJS}"
+rpc --ls rcow_get_lvstores
+
+echo
+echo "===== SUMMARY  (source volume was ${FILL_MB} MiB of data)"
+printf '%-46s %10s %10s %10s\n' "path" "publish" "total" "layout"
+printf '%-46s %9sms %9sms %10s\n' \
+	"A  snapshot then export (S is esnap clone)" "${A_EXP}" "${A_TOTAL}" "${A_LAYOUT}"
+printf '%-46s %9sms %9sms %10s\n' \
+	"B  snapshot, decouple it, then export"      "${B_EXP}" "${B_TOTAL}" "${B_LAYOUT}"
+printf '%-46s %9sms %9sms %10s\n' \
+	"C  decouple first, then snapshot+export"    "${C_EXP}" "${C_TOTAL}" "${C_LAYOUT}"
+echo
+echo "  export-prefix objects: A=${A_OBJS}  B=${B_OBJS}  C=${C_OBJS}"
+echo
+echo "  怎么读这张表：A 的 layout 应当是 ref，publish 数百毫秒，export prefix"
+echo "  对象数 0。若 A 出现 dense，说明 export_ref() 又退化成了拷贝 —— 查是不是"
+echo "  跨 bucket/endpoint/region、父 manifest 已是 dense、chunk_size 不一致，"
+echo "  或本地快照链深度超过 32。"
+echo
+echo "  A 比 B/C 快近 10 倍，差的是 decouple 的全卷物化：B/C 用等待换独立性，"
+echo "  A 用一条跨 prefix 的引用换即时发布。"

--- a/CubeS3lvol/test/dataplane/probe_snapshot_decouple.sh
+++ b/CubeS3lvol/test/dataplane/probe_snapshot_decouple.sh
@@ -1,25 +1,36 @@
 #!/usr/bin/env bash
-# Phase 1 第 2 步探针：父快照被物化时，它的 clone 读得对吗？
+# Phase 1 step-2 probe: when a parent snapshot is materialised, do its clones
+# still read correctly?
 #
-# 这是 §7 计划里唯一没有测量支撑的假设，也是第 3 步（decouple 只读快照）的门禁。
-# 上一次把未验证的假设当结论已经付过代价（§9.2），这次先测。
+# This is the only unmeasured assumption in the §7 plan, and the gate for
+# step 3 (decouple a read-only snapshot). Treating an unverified assumption
+# as a conclusion already cost once (§9.2); measure first this time.
 #
-# !! 当初跑它需要两处临时补丁；**补丁现在已经是主干代码**（第 3 步），所以
-#    直接跑即可。原来的补丁自检已经去掉——留着会让它拒绝在正确的代码上运行。
+# !! It originally needed two temporary patches; **those patches are now
+#    on the main line** (step 3), so it can be run as-is. The old patch
+#    self-check was removed -- leaving it would refuse to run on the
+#    correct code.
 #
-#    但那次踩的坑仍然成立，改 deps/spdk 时务必记住：顶层 make **不会**重编
-#    deps/spdk，必须先在 deps/spdk 里 make。第一次跑这个探针时补丁没生效，
-#    结果看起来像"物化只读快照静默无效"这个错误结论（§9.5）。
+#    The pitfall from that first run still holds: when changing deps/spdk,
+#    remember that the top-level make **does not** rebuild deps/spdk; make
+#    inside deps/spdk first. The first time this probe ran the patch was
+#    not in the binary, which looked like "materialising a read-only
+#    snapshot is a silent no-op" -- the wrong conclusion in §9.5.
 #
-#    回归断言版见 test/dataplane/run_snapshot_converge_test.sh。
+#    The asserting regression is test/dataplane/run_snapshot_converge_test.sh.
 #
-# 要回答：
-#   1. decouple 一个只读快照 S 能否真的完成（不只是"没报错"——要验 S 不再是 esnap）
-#   2. S 物化**期间**，clone C 持续读是否始终正确
-#   3. 物化后 S / C / V 三者数据是否都对
-#      （V 也是 S 的 clone：快照后 V 变成 S 的普通 clone）
-#   4. 收敛是否真的达成：放掉源 export 之后三者是否仍可读
-#   5. C 自己写过的 cluster 是否被物化影响（不该）
+# Questions:
+#   1. Does decoupling a read-only snapshot S actually finish (not merely
+#      "no error" -- S must no longer be an esnap)?
+#   2. While S is being materialised, do continuous reads of clone C stay
+#      correct?
+#   3. After materialise, are S / C / V all correct?
+#      (V is also a clone of S: after the snapshot, V becomes an ordinary
+#      clone of S.)
+#   4. Is convergence real: after dropping the source export, can all three
+#      still be read?
+#   5. Are clusters C wrote itself affected by the materialise? (They must
+#      not be.)
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -226,7 +237,8 @@ rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_g
 info "destination lvstore ready"
 
 # --------------------------------------------------------------------------
-# [2] import V -> snapshot S -> clone C；再往 C 写一段，使 C 自己也有 cluster
+# [2] import V -> snapshot S -> clone C; then write a range on C so C owns
+#     some clusters of its own
 # --------------------------------------------------------------------------
 echo
 info "[2] import V, snapshot S, clone C"
@@ -237,7 +249,8 @@ rpc rcow_create_snapshot '{"lvol_name":"V","snapshot_name":"S"}' >/dev/null 2>&1
 rpc rcow_create_clone '{"snapshot_name":"S","clone_name":"C"}' >/dev/null 2>&1 \
 	|| { echo "clone failed"; exit 1; }
 
-# C 写入自己的一段，使它同时拥有"自有 cluster"和"经 S 继承的 cluster"
+# Write a range on C so it has both "its own clusters" and "clusters
+# inherited through S".
 NEW="${WORKDIR}/newdata.bin"
 dd if=/dev/urandom of="${NEW}" bs=1M count="${WRITE_MB}" status=none
 EXPECT="${WORKDIR}/expect_c.bin"
@@ -253,7 +266,7 @@ info "C device ${C_DEV} (kept exposed for the duration)"
 rpc --ls rcow_get_lvstores
 
 # --------------------------------------------------------------------------
-# [3] 后台持续读 C，然后 decouple 只读快照 S
+# [3] background reader on C, then decouple the read-only snapshot S
 # --------------------------------------------------------------------------
 echo
 info "[3] start a reader loop on C, then decouple S"
@@ -293,7 +306,7 @@ if [ "${BAD}" != "0" ]; then
 fi
 
 # --------------------------------------------------------------------------
-# [4] 物化后：三者数据 + S 是否真的脱离了 export
+# [4] after materialise: data of all three, and whether S really left the export
 # --------------------------------------------------------------------------
 echo
 info "[4] after materialisation"
@@ -306,12 +319,12 @@ info "S = ${S_AFTER}  $([ "${S_AFTER}" = "${PAT_MD5}" ] && echo "MATCH ✓" || e
 info "V = ${V_AFTER}  $([ "${V_AFTER}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
 rpc --ls rcow_get_lvstores
 
-# S 若真的脱离了，再次 decouple 必须报 EINVAL（不再是 esnap clone）
+# If S really left, a second decouple must return EINVAL (no longer an esnap clone).
 REDEC="$(rpc rcow_decouple_lvol '{"lvol_name":"S"}' 2>&1)"
-info "decouple S again -> ${REDEC}   (Invalid argument = 已脱离 export，收敛成功)"
+info "decouple S again -> ${REDEC}   (Invalid argument = left the export; converged)"
 
 # --------------------------------------------------------------------------
-# [5] 真正的收敛证明：放掉源 export，三者仍须可读
+# [5] the real convergence proof: drop the source export; all three must still read
 # --------------------------------------------------------------------------
 echo
 info "[5] delete A's objects from S3, reload the lvstore, then re-read"

--- a/CubeS3lvol/test/dataplane/probe_snapshot_decouple.sh
+++ b/CubeS3lvol/test/dataplane/probe_snapshot_decouple.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# Phase 1 第 2 步探针：父快照被物化时，它的 clone 读得对吗？
+#
+# 这是 §7 计划里唯一没有测量支撑的假设，也是第 3 步（decouple 只读快照）的门禁。
+# 上一次把未验证的假设当结论已经付过代价（§9.2），这次先测。
+#
+# !! 当初跑它需要两处临时补丁；**补丁现在已经是主干代码**（第 3 步），所以
+#    直接跑即可。原来的补丁自检已经去掉——留着会让它拒绝在正确的代码上运行。
+#
+#    但那次踩的坑仍然成立，改 deps/spdk 时务必记住：顶层 make **不会**重编
+#    deps/spdk，必须先在 deps/spdk 里 make。第一次跑这个探针时补丁没生效，
+#    结果看起来像"物化只读快照静默无效"这个错误结论（§9.5）。
+#
+#    回归断言版见 test/dataplane/run_snapshot_converge_test.sh。
+#
+# 要回答：
+#   1. decouple 一个只读快照 S 能否真的完成（不只是"没报错"——要验 S 不再是 esnap）
+#   2. S 物化**期间**，clone C 持续读是否始终正确
+#   3. 物化后 S / C / V 三者数据是否都对
+#      （V 也是 S 的 clone：快照后 V 变成 S 的普通 clone）
+#   4. 收敛是否真的达成：放掉源 export 之后三者是否仍可读
+#   5. C 自己写过的 cluster 是否被物化影响（不该）
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+SRC_LVS=psdec_src
+DST_LVS=psdec_dst
+SRC_WAL=/tmp/psdec_src_wal.img
+DST_WAL=/tmp/psdec_dst_wal.img
+RPC_SOCK=/tmp/psdec.sock
+TGT_LOG=/tmp/psdec_target.log
+NQN="nqn.2026-08.io.spdk:psdec"
+PORT="4472"
+WORKDIR="$(mktemp -d /tmp/psdec.XXXXXX)"
+FILL_MB=48
+WRITE_MB=4
+
+TGT_PID=""
+CONNECTED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+
+cleanup()
+{
+	set +u
+	[ "${CONNECTED}" = "1" ] && nvme disconnect -n "${NQN}" >/dev/null 2>&1
+	if [ -n "${TGT_PID}" ]; then
+		kill "${TGT_PID}" 2>/dev/null
+		sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null
+	fi
+	rcow_load_credentials
+	for p in "${SRC_LVS}" "${DST_LVS}"; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "${p}/" >/dev/null 2>&1
+	done
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "$(rcow_s3_buckets|head -1)" \
+			-r "$(rcow_cfg_get region)" -p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${SRC_WAL}" "${DST_WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo
+	grep -aE 'external snapshot|esnap|not a clone|only a read-only|create snapshot|snapshot/clone|Decoupling|materialised|Deleted lvol' \
+		"${TGT_LOG}" 2>/dev/null | tail -18
+	echo "===== log: ${TGT_LOG}   workdir: ${WORKDIR}"
+}
+# The binary has to exist; the md_ro patch check that used to live here is gone,
+# because the patch is upstream of this probe now (step 3).
+if [ ! -x "${TGT_BIN}" ]; then
+	echo "no target binary at ${TGT_BIN}"; exit 1
+fi
+
+trap cleanup EXIT
+
+# --------------------------------------------------------------------------
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${SRC_WAL}" "${DST_WAL}"
+truncate -s 320M "${SRC_WAL}"
+truncate -s 320M "${DST_WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+info "endpoint ${EP}  bucket ${BK}"
+for p in "${SRC_LVS}" "${DST_LVS}"; do
+	python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${p}/" >/dev/null 2>&1
+done
+
+info "starting target"
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config failed"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"src_wal0","block_size":4096}' "${SRC_WAL}")" \
+	>/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"dst_wal0","block_size":4096}' "${DST_WAL}")" \
+	>/dev/null 2>&1
+
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"src_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${SRC_LVS}" "${BK}")" >/dev/null || { echo "create ${SRC_LVS} failed"; exit 1; }
+info "source lvstore ready"
+
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"PSDEC0000000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose()
+{
+	raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+		"${NQN}" "$1")" 2>/dev/null | tr -d '[:space:]'
+}
+
+unexpose()
+{
+	local nsid="$1"
+	[ -n "${nsid}" ] && raw nvmf_subsystem_remove_ns \
+		"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "${nsid}")" >/dev/null 2>&1
+	return 0
+}
+
+ctrl_of_nqn()
+{
+	local c
+	for c in /sys/class/nvme/nvme*; do
+		[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done
+	return 1
+}
+
+wait_dev()
+{
+	local nsid="$1" deadline ctrl dev
+	deadline=$(( $(date +%s) + 30 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if ctrl="$(ctrl_of_nqn)"; then
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		fi
+		sleep 0.3
+	done
+	return 1
+}
+
+# Read the first FILL_MB of a volume by name: expose, read, unexpose.
+read_vol()
+{
+	local name="$1" nsid dev md5
+	nsid="$(expose "${DST_LVS}/${name}")"
+	[ -n "${nsid}" ] || { echo "EXPOSE_FAILED"; return 1; }
+	dev="$(wait_dev "${nsid}")" || { unexpose "${nsid}"; echo "NO_DEV"; return 1; }
+	md5="$(dd if="${dev}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+	unexpose "${nsid}"
+	sleep 1
+	printf '%s' "${md5}"
+}
+
+# The ALLOC column of rcow_get_lvstores --ls, for one volume. SIZE prints as
+# two fields ("1.0 GiB"), so ALLOC is $5.
+alloc_of()
+{
+	rpc --ls rcow_get_lvstores 2>/dev/null | awk -v n="$1" '$1 == n { print $5; exit }'
+}
+
+# --------------------------------------------------------------------------
+# [1] source: a volume with known content -> snapshot -> REF export
+# --------------------------------------------------------------------------
+info "[1] source volume, filled"
+rpc rcow_create_lvol '{"lvol_name":"src","size_gib":1}' >/dev/null \
+	|| { echo "create_lvol failed"; exit 1; }
+NSID_SRC="$(expose "${SRC_LVS}/src")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 2
+SRC_DEV="$(wait_dev "${NSID_SRC}")" || { echo "source device never appeared"; exit 1; }
+info "source device ${SRC_DEV}"
+
+PAT="${WORKDIR}/pattern.bin"
+dd if=/dev/urandom of="${PAT}" bs=1M count="${FILL_MB}" status=none
+PAT_MD5="$(md5sum "${PAT}" | cut -d' ' -f1)"
+dd if="${PAT}" of="${SRC_DEV}" bs=1M oflag=direct status=none
+sync
+SRC_READ="$(dd if="${SRC_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+info "pattern ${PAT_MD5}; read back $([ "${SRC_READ}" = "${PAT_MD5}" ] && echo match || echo MISMATCH)"
+
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"src","snapshot_name":"src-snap"}' >/dev/null \
+	|| { echo "snapshot failed"; exit 1; }
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null
+sleep 3
+
+EXP_UUID="$(rpc rcow_export_snapshot '{"snapshot_name":"src-snap"}' 2>&1 | tr -d '"[:space:]\n')"
+UUIDS="${EXP_UUID}"
+[ -n "${EXP_UUID}" ] || { echo "export failed"; exit 1; }
+info "exported as ${EXP_UUID}"
+for _ in $(seq 120); do
+	st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${EXP_UUID}")" 2>/dev/null \
+		| tr -d '"[:space:]\n')"
+	case "${st}" in *DONE*) break ;; esac
+	sleep 1
+done
+info "export status: ${st:-unknown}"
+
+unexpose "${NSID_SRC}"
+sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" >/dev/null 2>&1 \
+	|| { echo "unload source failed"; exit 1; }
+sleep 2
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"dst_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${DST_LVS}" "${BK}")" >/dev/null || { echo "create ${DST_LVS} failed"; exit 1; }
+info "destination lvstore ready"
+
+# --------------------------------------------------------------------------
+# [2] import V -> snapshot S -> clone C；再往 C 写一段，使 C 自己也有 cluster
+# --------------------------------------------------------------------------
+echo
+info "[2] import V, snapshot S, clone C"
+rpc rcow_import_lvol "$(printf '{"lvol_name":"V","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+	"${EXP_UUID}" "${DST_LVS}")" >/dev/null 2>&1 || { echo "import failed"; exit 1; }
+rpc rcow_create_snapshot '{"lvol_name":"V","snapshot_name":"S"}' >/dev/null 2>&1 \
+	|| { echo "snapshot failed"; exit 1; }
+rpc rcow_create_clone '{"snapshot_name":"S","clone_name":"C"}' >/dev/null 2>&1 \
+	|| { echo "clone failed"; exit 1; }
+
+# C 写入自己的一段，使它同时拥有"自有 cluster"和"经 S 继承的 cluster"
+NEW="${WORKDIR}/newdata.bin"
+dd if=/dev/urandom of="${NEW}" bs=1M count="${WRITE_MB}" status=none
+EXPECT="${WORKDIR}/expect_c.bin"
+cp "${PAT}" "${EXPECT}"
+dd if="${NEW}" of="${EXPECT}" bs=1M conv=notrunc status=none
+EXPECT_MD5="$(md5sum "${EXPECT}" | cut -d' ' -f1)"
+
+NSID_C="$(expose "${DST_LVS}/C")"
+C_DEV="$(wait_dev "${NSID_C}")" || { echo "C never appeared"; exit 1; }
+dd if="${NEW}" of="${C_DEV}" bs=1M oflag=direct status=none
+sync
+info "C device ${C_DEV} (kept exposed for the duration)"
+rpc --ls rcow_get_lvstores
+
+# --------------------------------------------------------------------------
+# [3] 后台持续读 C，然后 decouple 只读快照 S
+# --------------------------------------------------------------------------
+echo
+info "[3] start a reader loop on C, then decouple S"
+READLOG="${WORKDIR}/creads.txt"
+(
+	while [ ! -f "${WORKDIR}/stop" ]; do
+		m="$(dd if="${C_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none 2>/dev/null \
+			| md5sum | cut -d' ' -f1)"
+		echo "${m}" >> "${READLOG}"
+	done
+) &
+READER_PID=$!
+
+DEC_S="$(rpc rcow_decouple_lvol '{"lvol_name":"S"}' 2>&1)"
+info "decouple S -> ${DEC_S}"
+
+for i in $(seq 600); do
+	busy="$(rpc rcow_get_decouple 2>/dev/null | python3 -c '
+import json,sys
+try: rows=json.load(sys.stdin)
+except Exception: rows=[]
+if isinstance(rows, dict): rows=rows.get("queue", [])
+print(len(rows))' 2>/dev/null)"
+	[ "${busy}" = "0" ] && break
+	sleep 1
+done
+info "decouple queue drained after ${i}s"
+
+touch "${WORKDIR}/stop"
+wait "${READER_PID}" 2>/dev/null
+READS="$(wc -l < "${READLOG}" 2>/dev/null || echo 0)"
+BAD="$(grep -cv "^${EXPECT_MD5}$" "${READLOG}" 2>/dev/null || echo 0)"
+info "C was read ${READS} time(s) during the decouple; ${BAD} mismatch(es)"
+if [ "${BAD}" != "0" ]; then
+	info "distinct wrong values:"
+	grep -v "^${EXPECT_MD5}$" "${READLOG}" | sort -u | sed 's/^/       /' | head -5
+fi
+
+# --------------------------------------------------------------------------
+# [4] 物化后：三者数据 + S 是否真的脱离了 export
+# --------------------------------------------------------------------------
+echo
+info "[4] after materialisation"
+C_AFTER="$(dd if="${C_DEV}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+unexpose "${NSID_C}"; sleep 1
+S_AFTER="$(read_vol S)" || true
+V_AFTER="$(read_vol V)" || true
+info "C = ${C_AFTER}  $([ "${C_AFTER}" = "${EXPECT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+info "S = ${S_AFTER}  $([ "${S_AFTER}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+info "V = ${V_AFTER}  $([ "${V_AFTER}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+rpc --ls rcow_get_lvstores
+
+# S 若真的脱离了，再次 decouple 必须报 EINVAL（不再是 esnap clone）
+REDEC="$(rpc rcow_decouple_lvol '{"lvol_name":"S"}' 2>&1)"
+info "decouple S again -> ${REDEC}   (Invalid argument = 已脱离 export，收敛成功)"
+
+# --------------------------------------------------------------------------
+# [5] 真正的收敛证明：放掉源 export，三者仍须可读
+# --------------------------------------------------------------------------
+echo
+info "[5] delete A's objects from S3, reload the lvstore, then re-read"
+# release_export is not usable here: it runs on the *source* lvstore, which was
+# unloaded so the destination could be created. Deleting the source prefix
+# outright is the stronger test anyway -- if the bytes are gone from S3 and the
+# reads still succeed, S really does hold them locally.
+#
+# Unload and re-attach afterwards so nothing can be served from an in-memory
+# chunk cache: the answer has to come from what is actually persisted.
+REL="$(python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${SRC_LVS}/" 2>&1 | tail -1)"
+info "deleted prefix ${SRC_LVS}/ -> ${REL}"
+
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${DST_LVS}")" >/dev/null 2>&1
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${DST_LVS}")" >/dev/null 2>&1 \
+	&& info "unloaded ${DST_LVS}" || info "unload failed"
+sleep 2
+rpc rcow_attach_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"dst_wal0"}' \
+	"${DST_LVS}" "${BK}")" >/dev/null 2>&1 \
+	&& info "re-attached ${DST_LVS}" || { info "RE-ATTACH FAILED"; }
+sleep 2
+rpc --ls rcow_get_lvstores
+
+NSID_C2="$(expose "${DST_LVS}/C")"
+C_DEV2="$(wait_dev "${NSID_C2}")" || C_DEV2=""
+if [ -n "${C_DEV2}" ]; then
+	C_REL="$(dd if="${C_DEV2}" bs=1M count="${FILL_MB}" iflag=direct status=none | md5sum | cut -d' ' -f1)"
+else
+	C_REL="NO_DEV"
+fi
+unexpose "${NSID_C2}"; sleep 1
+S_REL="$(read_vol S)" || true
+V_REL="$(read_vol V)" || true
+info "C = ${C_REL}  $([ "${C_REL}" = "${EXPECT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+info "S = ${S_REL}  $([ "${S_REL}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+info "V = ${V_REL}  $([ "${V_REL}" = "${PAT_MD5}" ] && echo "MATCH ✓" || echo "MISMATCH ✗")"
+
+echo
+echo "===== SUMMARY"
+echo "  pattern (A holds)            : ${PAT_MD5}"
+echo "  expected C (pattern+its write): ${EXPECT_MD5}"
+echo
+echo "  decouple S (read-only snap)  : ${DEC_S}"
+echo "  reads of C during it         : ${READS}, mismatches: ${BAD}"
+echo "  decouple S again             : ${REDEC}"
+echo "  source prefix deleted        : ${REL}"
+echo
+echo "                                 after materialise / after A was erased"
+echo "  C                            : ${C_AFTER:-n/a} / ${C_REL:-n/a}"
+echo "  S                            : ${S_AFTER:-n/a} / ${S_REL:-n/a}"
+echo "  V                            : ${V_AFTER:-n/a} / ${V_REL:-n/a}"

--- a/CubeS3lvol/test/dataplane/probe_src_lease.sh
+++ b/CubeS3lvol/test/dataplane/probe_src_lease.sh
@@ -1,29 +1,38 @@
 #!/usr/bin/env bash
-# 派生 export 自续租探针：发布后无人导入时，它引用的上游还受保护吗
+# Derived-export self-renewal probe: after publish, with nobody importing,
+# is the upstream it names still protected?
 #
-# 修的是 design §6 里 "E pins A while E is alive" 这一条。此前 E 自己不 pin ——
-# 只有 E 的**读者**会为 A 续租。于是存在这样一个窗口：
+# This is design §6, "E pins A while E is alive". Previously E did not pin --
+# only E's *readers* renewed A's lease. That left a window:
 #
-#   B 从 A 导入 → B 发布派生 export E（引用 A 的 prefix）
-#              → 但没有任何节点导入 E
-#              → 没人为 A 续租 → A 的租约陈旧 → A 删掉快照
-#              → E 成为一份看起来有效、实际解析不到任何对象的 manifest
+#   B imports from A -> B publishes derived export E (naming A's prefix)
+#                    -> no node imports E
+#                    -> nobody renews A -> A's lease goes stale -> A deletes
+#                       the snapshot
+#                    -> E is a manifest that looks valid and resolves to
+#                       nothing
 #
-# 现在 E 从发布起就自己为上游续租，直到用户显式 rcow_release_export。
+# E now renews upstream itself from the moment it is published, until the
+# user explicitly rcow_release_export.
 #
-# 判据：
-#   [3] B 发布 E 之后（无任何 import），日志说 E 在为上游续租，且键指向 A
-#   [4] A 的租约对象确实在被刷新，且写者是 E 而不是 vb —— 这是 A 那侧唯一会看的东西
-#   [5] unload 后停止、attach 后恢复 —— 这份义务是对另一个节点的，必须跨重启存活
-#   [6] release_export 之后续租停止 —— 这是设计上唯一的出口
+# Checks:
+#   [3] after B publishes E (with no import), the log says E is renewing
+#       upstream, and the key names A
+#   [4] A's lease object is actually being refreshed, and the writer is E
+#       not vb -- that is the only thing A's side looks at
+#   [5] it stops on unload and resumes on attach -- the duty is to another
+#       node, so it must survive a restart
+#   [6] renewals stop after release_export -- that is the only designed exit
 #
-# [4] 是最要紧的：只看日志说"在续租"不够，得看 S3 上那个对象的 updated_at
-# 真的在往前走，否则一个提交了 PUT 却全部失败的实现也会打出同样的日志。而且必须
-# 看 importer_id：vb 也在为同一个键续租（它读的就是 EXP_A），只是周期长得多，
-# 所以"时间戳动了"本身并不能说明是 E 动的。
+# [4] is the one that matters: a log line saying "renewing" is not enough;
+# updated_at on the S3 object has to actually move, or an implementation
+# whose PUTs all fail would print the same log. importer_id must be checked
+# too: vb also renews the same key (it is reading EXP_A), just on a much
+# longer period, so "the timestamp moved" does not by itself say E moved it.
 #
-# [5] 之所以做成"先停后复"而不是只看"attach 后还在续租"：后者在某个 poller 从未
-# 被停掉的情况下同样会通过，而那是另一个 bug。
+# [5] is stop-then-resume rather than just "still renewing after attach":
+# the latter also passes if some poller was never stopped, which is a
+# different bug.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -365,8 +374,9 @@ fi
 echo
 echo "===== SUMMARY"
 if [ "${FAILED}" = "0" ]; then
-	echo "  未被导入的派生 export 也会为其上游续租，直到 release_export。"
+	echo "  an unimported derived export still renews its upstream until"
+	echo "  release_export."
 else
-	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+	echo "  ${FAILED} failure(s) -- see [FAIL] above"
 fi
 exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/probe_src_lease.sh
+++ b/CubeS3lvol/test/dataplane/probe_src_lease.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# 派生 export 自续租探针：发布后无人导入时，它引用的上游还受保护吗
+#
+# 修的是 design §6 里 "E pins A while E is alive" 这一条。此前 E 自己不 pin ——
+# 只有 E 的**读者**会为 A 续租。于是存在这样一个窗口：
+#
+#   B 从 A 导入 → B 发布派生 export E（引用 A 的 prefix）
+#              → 但没有任何节点导入 E
+#              → 没人为 A 续租 → A 的租约陈旧 → A 删掉快照
+#              → E 成为一份看起来有效、实际解析不到任何对象的 manifest
+#
+# 现在 E 从发布起就自己为上游续租，直到用户显式 rcow_release_export。
+#
+# 判据：
+#   [3] B 发布 E 之后（无任何 import），日志说 E 在为上游续租，且键指向 A
+#   [4] A 的租约对象确实在被刷新，且写者是 E 而不是 vb —— 这是 A 那侧唯一会看的东西
+#   [5] unload 后停止、attach 后恢复 —— 这份义务是对另一个节点的，必须跨重启存活
+#   [6] release_export 之后续租停止 —— 这是设计上唯一的出口
+#
+# [4] 是最要紧的：只看日志说"在续租"不够，得看 S3 上那个对象的 updated_at
+# 真的在往前走，否则一个提交了 PUT 却全部失败的实现也会打出同样的日志。而且必须
+# 看 importer_id：vb 也在为同一个键续租（它读的就是 EXP_A），只是周期长得多，
+# 所以"时间戳动了"本身并不能说明是 E 动的。
+#
+# [5] 之所以做成"先停后复"而不是只看"attach 后还在续租"：后者在某个 poller 从未
+# 被停掉的情况下同样会通过，而那是另一个 bug。
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+GET_MANIFEST="${ROOT}/test/tools/s3_get_manifest.py"
+TGT_BIN="${ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+# shellcheck source=../../scripts/rcow_common.sh
+. "${ROOT}/scripts/rcow_common.sh"
+
+A_LVS=psrc_a
+B_LVS=psrc_b
+A_WAL=/tmp/psrc_a_wal.img
+B_WAL=/tmp/psrc_b_wal.img
+RPC_SOCK=/tmp/psrc.sock
+TGT_LOG=/tmp/psrc_target.log
+NQN="nqn.2026-09.io.spdk:psrc"
+PORT="4476"
+WORKDIR="$(mktemp -d /tmp/psrc.XXXXXX)"
+FILL_MB=8
+HALF_MB=4
+
+TGT_PID=""
+CONNECTED=0
+UUIDS=""
+FAILED=0
+
+rpc() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" "$@"; }
+raw() { python3 "${RPC_PY}" --sock "${RPC_SOCK}" --raw "$1" ${2:+"$2"}; }
+info() { echo "---- $*"; }
+ok()   { echo "     [PASS] $*"; }
+bad()  { echo "     [FAIL] $*"; FAILED=$((FAILED + 1)); }
+want() { if [ "$2" = "$3" ]; then ok "$1 ($2)"; else bad "$1: got '$2', want '$3'"; fi; }
+mfield() { python3 "${GET_MANIFEST}" -e "${EP}" -b "${BK}" -r "${RG}" -u "$1" \
+	--field "$2" 2>/dev/null; }
+
+# One field out of a lease object, or empty if the object is not there.
+#
+# importer_id matters as much as updated_at here, and that is not obvious: the
+# volume B imported and the export B published both renew the *same* key -- vb
+# reads EXP_A, and E references EXP_A's prefix -- so "the timestamp advanced"
+# alone does not say which of the two wrote it. The two identify themselves
+# differently (a bare lvstore name from import_lease_renew(), "export:<uuid>"
+# from export_src_lease_renew()), so the writer is checkable rather than
+# inferred. Without that check this probe would pass on the strength of the
+# importer's renewals, which run at ttl/3 -- 1200 s at the default TTL, i.e.
+# outside every window below, which is precisely the sort of unwritten timing
+# assumption that makes a probe agree with a broken implementation.
+lease_field()
+{
+	python3 - "$1" "$2" <<'PY' 2>/dev/null
+import json, os, sys
+sys.path.insert(0, os.environ["TOOLS"])
+from s3_prefix_rm import Client
+c = Client(os.environ["EP"], os.environ["BK"], os.environ["RG"], False,
+           os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"])
+st, body = c.request("GET", c._base_path() + "/" + sys.argv[1])
+if st == 200:
+    print(json.loads(body).get(sys.argv[2], ""))
+PY
+}
+lease_updated_at() { lease_field "$1" updated_at; }
+
+cleanup()
+{
+	set +u
+	[ "${CONNECTED}" = "1" ] && nvme disconnect -n "${NQN}" >/dev/null 2>&1
+	[ -n "${TGT_PID}" ] && { kill "${TGT_PID}" 2>/dev/null; sleep 2
+		kill -9 "${TGT_PID}" 2>/dev/null; }
+	rcow_load_credentials
+	for p in "${A_LVS}" "${B_LVS}"; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+			-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+			-p "${p}/" >/dev/null 2>&1
+	done
+	for u in ${UUIDS:-}; do
+		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+			-b "$(rcow_s3_buckets|head -1)" -r "$(rcow_cfg_get region)" \
+			-p "exports/${u}" >/dev/null 2>&1
+	done
+	rm -f "${A_WAL}" "${B_WAL}" "${RPC_SOCK}"
+	[ -z "${KEEP:-}" ] && rm -rf "${WORKDIR}"
+	echo "===== log: ${TGT_LOG}"
+}
+trap cleanup EXIT
+
+pkill -9 -f s3lvol_tgt 2>/dev/null
+sleep 2
+rm -f "${RPC_SOCK}" "${A_WAL}" "${B_WAL}"
+truncate -s 320M "${A_WAL}"
+truncate -s 320M "${B_WAL}"
+
+rcow_load_credentials
+EP="$(rcow_cfg_get endpoint)"; BK="$(rcow_s3_buckets|head -1)"; RG="$(rcow_cfg_get region)"
+export EP BK RG
+export TOOLS="${ROOT}/test/tools"
+for p in "${A_LVS}" "${B_LVS}"; do
+	python3 "${PREFIX_RM}" -e "${EP}" -b "${BK}" -r "${RG}" -p "${p}/" >/dev/null 2>&1
+done
+
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" >"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 80); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { echo "target failed to start"; tail -20 "${TGT_LOG}"; exit 1; }
+sleep 1
+
+rpc rcow_add_s3_config "$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+	"${BK}" "${EP}" "${BK}" "${RG}")" >/dev/null || { echo "add_s3_config"; exit 1; }
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"a_wal0","block_size":4096}' \
+	"${A_WAL}")" >/dev/null 2>&1
+raw bdev_aio_create "$(printf '{"filename":"%s","name":"b_wal0","block_size":4096}' \
+	"${B_WAL}")" >/dev/null 2>&1
+raw nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+raw nvmf_create_subsystem "$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"PSRC00000000001"}' \
+	"${NQN}")" >/dev/null 2>&1
+raw nvmf_subsystem_add_listener "$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"127.0.0.1","trsvcid":"%s"}}' \
+	"${NQN}" "${PORT}")" >/dev/null 2>&1
+
+expose() { raw nvmf_subsystem_add_ns "$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+	"${NQN}" "$1")" 2>/dev/null | tr -d '[:space:]'; }
+unexpose() { [ -n "$1" ] && raw nvmf_subsystem_remove_ns \
+	"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "$1")" >/dev/null 2>&1; return 0; }
+ctrl_of_nqn() { local c; for c in /sys/class/nvme/nvme*; do
+	[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && { basename "${c}"; return 0; }
+	done; return 1; }
+wait_dev()
+{
+	local nsid="$1" deadline ctrl dev
+	deadline=$(( $(date +%s) + 30 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if ctrl="$(ctrl_of_nqn)"; then
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		fi
+		sleep 0.3
+	done
+	return 1
+}
+await_export()
+{
+	local u="$1" st=""
+	for _ in $(seq 120); do
+		st="$(rpc rcow_get_snapshot_status "$(printf '{"export_uuid":"%s"}' "${u}")" \
+			2>/dev/null | tr -d '"[:space:]\n')"
+		case "${st}" in *DONE*) return 0 ;; esac
+		sleep 1
+	done
+	return 1
+}
+
+echo
+info "[1] node A: a snapshot, exported by reference"
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"a_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${A_LVS}" "${BK}")" >/dev/null || { echo "create a"; exit 1; }
+rpc rcow_create_lvol '{"lvol_name":"va","size_gib":1}' >/dev/null || exit 1
+NSID="$(expose "${A_LVS}/va")"
+nvme connect -t tcp -a 127.0.0.1 -s "${PORT}" -n "${NQN}" >/dev/null 2>&1
+CONNECTED=1
+sleep 2
+DEV="$(wait_dev "${NSID}")" || { echo "a device"; exit 1; }
+
+dd if=/dev/urandom of="${WORKDIR}/pat.bin" bs=1M count="${FILL_MB}" status=none
+dd if="${WORKDIR}/pat.bin" of="${DEV}" bs=1M count="${FILL_MB}" oflag=direct \
+	conv=fsync status=none
+sync
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${A_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"va","snapshot_name":"sa"}' >/dev/null || exit 1
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${A_LVS}")" >/dev/null
+sleep 3
+EXP_A="$(rpc rcow_export_snapshot '{"snapshot_name":"sa"}' 2>&1 | tr -d '"[:space:]\n')"
+[ -n "${EXP_A}" ] || { echo "export a"; exit 1; }
+UUIDS="${EXP_A}"
+await_export "${EXP_A}" || { echo "export a never done"; exit 1; }
+info "export A = ${EXP_A}"
+
+unexpose "${NSID}"; sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${A_LVS}")" >/dev/null 2>&1
+sleep 2
+
+echo
+info "[2] node B: import it, rewrite half, snapshot, export again"
+rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":4,"wal_bdev":"b_wal0","journal_size_mb":64,"wal_size_mb":128,"force":true}' \
+	"${B_LVS}" "${BK}")" >/dev/null || { echo "create b"; exit 1; }
+rpc rcow_import_lvol "$(printf '{"lvol_name":"vb","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+	"${EXP_A}" "${B_LVS}")" >/dev/null 2>&1 || { echo "import"; exit 1; }
+NSID="$(expose "${B_LVS}/vb")"
+sleep 2
+DEV="$(wait_dev "${NSID}")" || { echo "b device"; exit 1; }
+# Only half, so the derived export still inherits the rest from A -- otherwise B
+# would own every chunk and there would be no upstream reference at all.
+dd if=/dev/urandom of="${WORKDIR}/tail.bin" bs=1M count="${HALF_MB}" status=none
+dd if="${WORKDIR}/tail.bin" of="${DEV}" bs=1M count="${HALF_MB}" seek="${HALF_MB}" \
+	oflag=direct conv=fsync status=none
+sync
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${B_LVS}")" >/dev/null
+rpc rcow_create_snapshot '{"lvol_name":"vb","snapshot_name":"sb"}' >/dev/null || exit 1
+rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${B_LVS}")" >/dev/null
+sleep 3
+
+MARK="$(wc -l <"${TGT_LOG}")"
+EXP_B="$(rpc rcow_export_snapshot '{"snapshot_name":"sb"}' 2>&1 | tr -d '"[:space:]\n')"
+[ -n "${EXP_B}" ] || { echo "export b"; exit 1; }
+UUIDS="${UUIDS} ${EXP_B}"
+await_export "${EXP_B}" || { echo "export b never done"; exit 1; }
+want "B's export is derived (version 3)" "$(mfield "${EXP_B}" version)" "3"
+info "export B = ${EXP_B}"
+
+echo
+info "[3] nobody has imported E, yet it renews upstream"
+sleep 3
+NEW="$(tail -n "+${MARK}" "${TGT_LOG}")"
+if printf '%s' "${NEW}" | grep -q 'renews .* upstream lease'; then
+	ok "$(printf '%s' "${NEW}" | grep -o 'renews .* upstream lease(s).*second(s)' | head -1)"
+else
+	bad "the derived export renews nothing upstream"
+fi
+UP_KEY="${A_LVS}/meta/exports/${EXP_A}.lease"
+if printf '%s' "${NEW}" | grep -q "upstream lease \[0\]: ${UP_KEY}"; then
+	ok "and the key is A's own export lease"
+else
+	bad "the upstream key is not ${UP_KEY}: $(printf '%s' "${NEW}" \
+		| grep -o 'upstream lease \[0\].*' | head -1)"
+fi
+
+echo
+info "[4] A's lease object is really being refreshed, by E and not by vb"
+# The log alone would also be printed by an implementation whose PUTs all fail.
+T1="$(lease_updated_at "${UP_KEY}")"
+if [ -z "${T1}" ]; then
+	bad "no lease object at ${UP_KEY}"
+else
+	ok "the lease exists, updated_at=${T1}"
+	# Decisive, and cheap: vb renews this same key at ttl/3, so a timestamp
+	# that moved does not by itself say the export moved it.
+	want "and it was written by the export, not the import" \
+		"$(lease_field "${UP_KEY}" importer_id)" "export:${EXP_B}"
+	# renew_s is what the upstream turns into its grace period (3x it), and it
+	# must describe the protection wanted rather than how often this node writes.
+	# The two differ here: E writes every 20 s but needs A held until E's own
+	# promise to its readers runs out, ttl/3 = 1200 s at the default 3600 s TTL.
+	#
+	# Reporting the write rate is not a cosmetic error. E and any importer of E
+	# write this same key and the object keeps only the last writer, and E writes
+	# 60x more often -- so a cadence here would set A's grace from E's rate and
+	# then apply it to an importer that speaks every 1200 s. Losing E would make
+	# A's snapshot STALE within a minute, which the pending-delete poller acts on
+	# unattended, under a reader that is still there. Asserted on the number
+	# because the failure it guards needs A, B and C up at once plus a wait past
+	# the grace period, and this is the same fact one GET earlier.
+	RS="$(lease_field "${UP_KEY}" renew_s)"
+	if [ "${RS:-0}" -ge 1200 ] 2>/dev/null; then
+		ok "and asks for protection to E's own deadline, not its write rate "\
+"(renew_s=${RS} => grace ${RS}x3 s)"
+	else
+		bad "renew_s=${RS:-<none>}: E is asking A for a grace period of "\
+"$(( ${RS:-0} * 3 ))s, but an importer of E renews only every 1200s"
+	fi
+	# The renew interval is the floor, 20 s. Wait past one tick.
+	info "waiting for the next renewal (interval is the 20 s floor)"
+	sleep 25
+	T2="$(lease_updated_at "${UP_KEY}")"
+	if [ -n "${T2}" ] && [ "${T2}" -gt "${T1}" ] 2>/dev/null; then
+		ok "and it moved on: ${T1} -> ${T2}"
+	else
+		bad "updated_at did not advance (${T1} -> ${T2:-<gone>}); the PUTs are "\
+"not landing"
+	fi
+fi
+
+echo
+info "[5] a restart resumes it, from the registry rather than the manifest"
+# The obligation is to another node, so it has to outlive this one's uptime: a
+# restart that forgets it hands A permission to delete the snapshot behind chunks
+# E still names. Asserted as stop-then-resume rather than just "still renewing",
+# because the latter also passes if some poller was simply never stopped.
+unexpose "${NSID}"; sleep 2
+rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${B_LVS}")" >/dev/null 2>&1 \
+	&& info "unloaded ${B_LVS}" || bad "could not unload ${B_LVS}"
+sleep 2
+T5="$(lease_updated_at "${UP_KEY}")"
+info "waiting to confirm the renewals stopped with the lvstore"
+sleep 25
+T6="$(lease_updated_at "${UP_KEY}")"
+if [ "${T6:-0}" = "${T5}" ]; then
+	ok "unloaded: the renewals stopped (${T5} unchanged)"
+else
+	bad "still renewing after unload: ${T5} -> ${T6}"
+fi
+
+MARK3="$(wc -l <"${TGT_LOG}")"
+rpc rcow_attach_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"b_wal0"}' \
+	"${B_LVS}" "${BK}")" >/dev/null 2>&1 \
+	&& info "re-attached ${B_LVS}" || { bad "could not re-attach ${B_LVS}"; }
+sleep 3
+NEW3="$(tail -n "+${MARK3}" "${TGT_LOG}")"
+if printf '%s' "${NEW3}" | grep -q "upstream lease \[0\]: ${UP_KEY}"; then
+	ok "the attach read the key back out of the registry"
+else
+	bad "the attach did not resume any upstream lease; a derived export's "\
+"obligation did not survive a restart"
+fi
+# arm() renews immediately, so this catches the resume without a further wait;
+# the second window then proves the poller runs and not merely that one PUT went.
+T7="$(lease_updated_at "${UP_KEY}")"
+if [ -n "${T7}" ] && [ "${T7}" -gt "${T6:-0}" ] 2>/dev/null; then
+	ok "and renewed at once on attach: ${T6} -> ${T7}"
+else
+	bad "no renewal after attach (${T6} -> ${T7:-<gone>})"
+fi
+want "still identifying the export as the writer" \
+	"$(lease_field "${UP_KEY}" importer_id)" "export:${EXP_B}"
+info "waiting to confirm the poller is running, not just the one PUT"
+sleep 25
+T8="$(lease_updated_at "${UP_KEY}")"
+if [ -n "${T8}" ] && [ "${T8}" -gt "${T7:-0}" ] 2>/dev/null; then
+	ok "the resumed poller keeps renewing: ${T7} -> ${T8}"
+else
+	bad "renewals did not continue after the attach (${T7} -> ${T8:-<gone>})"
+fi
+
+echo
+info "[6] release_export is what stops it"
+MARK2="$(wc -l <"${TGT_LOG}")"
+REL="$(rpc --raw rcow_release_export "$(printf '{"export_uuid":"%s","lvs_name":"%s"}' \
+	"${EXP_B}" "${B_LVS}")" 2>&1)"
+info "release reply: ${REL}"
+T3="$(lease_updated_at "${UP_KEY}")"
+sleep 25
+T4="$(lease_updated_at "${UP_KEY}")"
+if [ -z "${T3}" ]; then
+	bad "the lease vanished before the check"
+elif [ "${T4:-0}" = "${T3}" ]; then
+	ok "the upstream lease stopped being renewed (${T3} unchanged)"
+else
+	bad "still renewing after release: ${T3} -> ${T4}"
+fi
+
+echo
+echo "===== SUMMARY"
+if [ "${FAILED}" = "0" ]; then
+	echo "  未被导入的派生 export 也会为其上游续租，直到 release_export。"
+else
+	echo "  ${FAILED} 项失败 —— 见上方 [FAIL]"
+fi
+exit "${FAILED}"

--- a/CubeS3lvol/test/dataplane/run_activation_test.sh
+++ b/CubeS3lvol/test/dataplane/run_activation_test.sh
@@ -314,6 +314,15 @@ RE_NSID="$(jget "${RE_JSON}" nsid)"; RE_SUB="$(jget "${RE_JSON}" subsys)"
 	&& pass "reattached at exactly subsys ${A_SUB} nsid ${A_NSID}" \
 	|| fail "reattached to subsys ${RE_SUB} nsid ${RE_NSID}, wanted ${A_SUB}/${A_NSID}"
 
+# No sleep: Cubelet opens the path get_bdev returns. A same-nsid reactivate
+# used to hand back /dev/nvmeXnY while udev was still replacing the node.
+RE_DEV="$(jget "$("${RPC}" rcow_get_bdev '{"device_name":"disk-a"}')" device_path)"
+if [ -n "${RE_DEV}" ] && [ -b "${RE_DEV}" ]; then
+	pass "get_bdev after same-nsid reactivate is an openable block device (${RE_DEV})"
+else
+	fail "get_bdev after same-nsid reactivate: '${RE_DEV}' is not a block device"
+fi
+
 sleep 2
 nvme ns-rescan "/dev/nvme0" >/dev/null 2>&1 || true
 sleep 1

--- a/CubeS3lvol/test/dataplane/run_agent_template_test.sh
+++ b/CubeS3lvol/test/dataplane/run_agent_template_test.sh
@@ -17,6 +17,7 @@
 #      -> delete the clone (merged into its snapshot) -> export the snapshot
 #    B (destination node):
 #      a fresh s3lvol_tgt process -> import the export -> verify the data
+#      -> delete the import -> import the same uuid again -> verify again
 #
 #  What it proves beyond the single-process suites (run_export_test.sh runs
 #  both sides inside one target):
@@ -28,7 +29,8 @@
 #      then exports that merged state cleanly -- the agent instance is
 #      transient, the image it produced is the asset;
 #    - an import on an unrelated node reads the exact data (file-level md5,
-#      not just a dd of one region) of the source-side snapshot.
+#      not just a dd of one region) of the source-side snapshot;
+#    - B can delete that import and import the same uuid again.
 #
 #  === Why two real processes instead of two lvstores ===
 #
@@ -685,6 +687,93 @@ else
 	info "--- imported ---"; echo "${IMPORTED_MANIFEST}" | sort -u | sed 's/^/       /'
 fi
 check_target "${TGT_B_PID}" "${WORKDIR}/target_b.log" "step 4" || exit 1
+
+# ==========================================================================
+# [4b] B: delete the import and import the same export again
+#
+# Two real processes, only the bucket shared. 11k covers the same pair inside
+# one target; this is the deployment form -- B's lease, imports registry and
+# lvol name must go away with the delete, or the second import fails for a
+# reason that has nothing to do with A's snapshot.
+# ==========================================================================
+echo ""
+echo "[4b] B: delete the import and import the same export again"
+
+B_REIMP_ROUNDS=2
+for round in $(seq 1 "${B_REIMP_ROUNDS}"); do
+	if [ "${MOUNTED_IMPORT}" -eq 1 ]; then
+		unmount_quietly "${MNT_IMPORT}" || {
+			fail "umount import (round ${round})"; exit 1; }
+		MOUNTED_IMPORT=0
+	fi
+	nvme_settle
+	B_NSID="$(nsid_of_sock "${SOCK_B}" "${NQN_B}" "${LVS_B}/${IMPORT_VOL}")"
+	[ -n "${B_NSID}" ] && spdk_b nvmf_subsystem_remove_ns "${NQN_B}" \
+		"${B_NSID}" >/dev/null 2>&1 || true
+	nvme_settle
+
+	if ! rpc_b rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "${IMPORT_VOL}")" \
+			>/dev/null 2>"${WORKDIR}/b_del_${round}.err"; then
+		fail "B delete_lvol (round ${round})"
+		sed 's/^/       /' "${WORKDIR}/b_del_${round}.err"
+		exit 1
+	fi
+	if python3 "${SPDK_RPC_PY}" -s "${SOCK_B}" bdev_get_bdevs \
+			-b "${LVS_B}/${IMPORT_VOL}" >/dev/null 2>&1; then
+		fail "round ${round}: ${IMPORT_VOL} still registered on B after delete"
+		exit 1
+	fi
+	pass "round ${round}: B deleted ${IMPORT_VOL}"
+
+	if ! rpc_b rcow_import_lvol "$(printf '{"lvol_name":"%s","export_uuid":"%s","decouple":true}' \
+			"${IMPORT_VOL}" "${EXP_UUID}")" >/dev/null 2>&1; then
+		fail "B import_lvol (round ${round})"
+		exit 1
+	fi
+	pass "round ${round}: B imported ${IMPORT_VOL} again"
+
+	DECOUPLE_DONE=0
+	for _i in $(seq 120); do
+		n="$(rpc_b rcow_get_decouple '{}' 2>/dev/null || echo '[]')"
+		if [ "$(printf '%s' "${n}" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null)" = "0" ]; then
+			DECOUPLE_DONE=1
+			break
+		fi
+		sleep 1
+	done
+	if [ "${DECOUPLE_DONE}" -eq 1 ]; then
+		pass "round ${round}: B decouple finished"
+	else
+		fail "round ${round}: B decouple did not finish in 120s"
+		exit 1
+	fi
+
+	BEFORE_B_NS="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
+	spdk_b nvmf_subsystem_add_ns "${NQN_B}" \
+		"${LVS_B}/${IMPORT_VOL}" >/dev/null 2>&1 \
+		|| { fail "B add_ns import (round ${round})"; exit 1; }
+	DEV_B="$(wait_new_ns "${BEFORE_B_NS}")"
+	if [ -z "${DEV_B}" ]; then
+		fail "round ${round}: B: no namespace appeared"
+		exit 1
+	fi
+	pass "round ${round}: B import device ${DEV_B}"
+
+	mount "${DEV_B}" "${MNT_IMPORT}" || { fail "mount import (round ${round})"; exit 1; }
+	MOUNTED_IMPORT=1
+	IMPORTED_MANIFEST="$(fs_manifest "${MNT_IMPORT}")"
+	if [ "$(echo "${IMPORTED_MANIFEST}" | sort -u)" = "${EXPECTED}" ]; then
+		pass "round ${round}: reimported data still matches the source snapshot"
+	else
+		fail "round ${round}: reimported data differs from the source snapshot"
+		info "--- expected ---"; echo "${EXPECTED}" | sed 's/^/       /'
+		info "--- imported ---"; echo "${IMPORTED_MANIFEST}" | sort -u | sed 's/^/       /'
+		exit 1
+	fi
+	check_target "${TGT_B_PID}" "${WORKDIR}/target_b.log" "step 4b round ${round}" \
+		|| exit 1
+done
+pass "B imported, deleted and imported the same export again ${B_REIMP_ROUNDS} times"
 
 # ==========================================================================
 # [5] the snapshot exported after the clone was merged into it

--- a/CubeS3lvol/test/dataplane/run_cubecow_client_test.sh
+++ b/CubeS3lvol/test/dataplane/run_cubecow_client_test.sh
@@ -1,0 +1,633 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+#  The cubecow / Cubelet client contract, as one dataplane script.
+#
+#  === Why a new suite rather than another section in export / agent_template ===
+#
+#  Those two already have a thesis. export is "zero-copy across prefixes";
+#  agent_template is "two real s3lvol_tgt processes sharing only the bucket".
+#  Cubelet never calls either of those shapes directly. It talks through cubecow
+#  (`backend.kind=s3`) and always uses the same 11 rcow_* methods in a fixed
+#  order: create/clone → active → get_bdev → (ext4) → umount → snapshot
+#  (inactive) → deactive → delete work volume; Pause exports three snapshots
+#  from one lvstore; restore imports with decouple=true and activates before
+#  any decouple waiter. Stuffing that sequence into export would make a red
+#  run look like a manifest bug; stuffing it into agent_template would make it
+#  look like a two-process state-file bug.
+#
+#  What this suite pins, and the existing ones do not:
+#
+#    [1]  __cbc_probe_* deactive is a no-op: success or a not-found-class
+#         error, no registry entry, and two RPCs on one long-lived
+#         connection stay in order
+#    [2]  create → active → get_bdev returns a path that is a real block
+#         device; mkfs.ext4 + umount + snapshot (snap is never activated) +
+#         delete the work volume, which is Cubelet's metadata/rootfs seal
+#    [3]  deactive then get_bdev is not-found; reactivate still yields a
+#         path that open(2)s, even if the node number changed
+#    [4]  N clones from one template snap, isolated writes, then resize one
+#         clone (sandbox rootfs grow after CreateVolumeFromSnapshot)
+#    [5]  three snapshots exported at once (Pause/Commit: rootfs + memory +
+#         metadata); busy is retried; progress is polled by snapshot_name,
+#         which is what GetVolumeInfo does
+#    [6]  deleting the template snap while clones exist is refused, and the
+#         message must not contain "not found" (cubecow would treat that as
+#         an idempotent success)
+#    [7]  a failed import of a garbage uuid must not leave a named lvol
+#    [8]  import(decouple=true) on a second lvstore → activate + ext4 mount
+#         immediately, without waiting for decouple to finish
+#
+#  Usage:
+#    sudo -E ./test/dataplane/run_cubecow_client_test.sh
+#
+#  Needs root, nvme-cli, e2fsprogs (mkfs.ext4), a readable /data/cubelet/s3.cfg.
+#  Own lvstore / WAL / registries, so a production instance is untouched.
+#
+
+set -u
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SELF_DIR}/../.." && pwd)"
+SCRIPTS="${ROOT}/scripts"
+RPC_PY="${ROOT}/test/tools/s3lvol_rpc.py"
+PREFIX_RM="${ROOT}/test/tools/s3_prefix_rm.py"
+
+export RCOW_LVS_NAME=cbcvs
+export RCOW_WAL_IMG=/data/s3lvol_cbc_wal.img
+export RCOW_WAL_BDEV=cbc_wal0
+export RCOW_CAPACITY_GB=16
+export RCOW_JOURNAL_MB=64
+export RCOW_WAL_MB=256
+export RCOW_TGT_MEM_MB=2048
+export RCOW_RUN_DIR=/var/tmp/rcow_cbcclient
+export RCOW_LOG_DIR=/var/tmp/rcow_cbcclient/log
+export RCOW_ACTIVE_FILE=/var/tmp/rcow_cbcclient/active_lvols
+export RCOW_BSTORE_FILE=/var/tmp/rcow_cbcclient/bstore.json
+export RCOW_S3_CFG="${RCOW_S3_CFG:-/data/cubelet/s3.cfg}"
+
+DST_LVS=cbcimp
+DST_WAL_IMG=/data/s3lvol_cbc_dst.img
+DST_WAL_BDEV=cbc_dst_wal0
+
+N_CLONES=4
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  [PASS] $*"; }
+fail() { FAIL=$((FAIL+1)); echo "  [FAIL] $*"; }
+info() { echo "  ---- $*"; }
+
+STARTED=0
+WORKDIR=""
+EXPORTS=""
+DST_CREATED=0
+MNT=""
+CLONE1_DEV=""
+
+# shellcheck source=../../scripts/rcow_common.sh
+. "${SCRIPTS}/rcow_common.sh"
+
+rpc() { python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" "$@"; }
+
+err_is_not_found()
+{
+	printf '%s' "$1" | grep -qiE 'not found|no such'
+}
+
+err_is_busy()
+{
+	printf '%s' "$1" | grep -qiE 'busy|in use|resource'
+}
+
+err_is_already_exists()
+{
+	printf '%s' "$1" | grep -qiE 'already exists|already exist'
+}
+
+# Activate and echo the host device. Prints nothing on failure -- it runs in a
+# command substitution, so the caller decides what an empty result means.
+resolve()
+{
+	local name="$1" out path
+
+	if ! out="$(rpc rcow_active_bdev "$(printf '{"device_name":"%s"}' "${name}")" 2>&1)"; then
+		echo "  ---- activate ${name} failed: ${out}" >&2
+		return 1
+	fi
+	if ! rcow_verify_active 30 >/dev/null 2>&1; then
+		echo "  ---- ${name}: rcow_verify_active timed out" >&2
+		return 1
+	fi
+	path="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["device_path"])' \
+		"$(rpc rcow_get_bdev "$(printf '{"device_name":"%s"}' "${name}")")" 2>/dev/null)"
+	if [ -z "${path}" ] || [ ! -b "${path}" ]; then
+		echo "  ---- ${name}: device_path '${path}' is not a block device" >&2
+		return 1
+	fi
+	printf '%s' "${path}"
+}
+
+del_vol()
+{
+	rpc rcow_deactive_bdev "$(printf '{"device_name":"%s"}' "$1")" >/dev/null 2>&1
+	rpc rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "$1")" >/dev/null 2>&1
+}
+
+unmount_quietly()
+{
+	local mnt="$1"
+	mountpoint -q "${mnt}" 2>/dev/null || return 0
+	umount "${mnt}" 2>/dev/null && return 0
+	sync
+	sleep 1
+	umount "${mnt}" 2>/dev/null && return 0
+	umount -l "${mnt}" 2>/dev/null
+}
+
+wait_export_done_by_name()
+{
+	local name="$1"
+	local deadline=$(( $(date +%s) + 90 ))
+	local out st
+
+	while :; do
+		if ! out="$(rpc rcow_get_snapshot_status \
+				"$(printf '{"snapshot_name":"%s"}' "${name}")" \
+				2>/dev/null)"; then
+			fail "status of ${name} became unqueryable"
+			return 1
+		fi
+		st="$(printf '%s' "${out}" \
+			| python3 -c 'import json,sys; print(json.load(sys.stdin).get("export_status",""))' \
+				2>/dev/null)"
+		if [ "${st}" = "DONE" ]; then
+			return 0
+		fi
+		if [ "$(date +%s)" -ge "${deadline}" ]; then
+			fail "${name} never reached DONE (last status='${st}')"
+			return 1
+		fi
+		sleep 0.2
+	done
+}
+
+# Cubelet issues three exports against one lvstore. s3lvol drains one at a
+# time and a waiting export has a short window to win, so the first wave is
+# allowed to return busy; the client retries until it has a uuid.
+export_with_retry()
+{
+	local name="$1"
+	local tries=0
+	local out err
+
+	while [ "${tries}" -lt 30 ]; do
+		err=""
+		if out="$(rpc rcow_export_snapshot \
+				"$(printf '{"snapshot_name":"%s"}' "${name}")" 2>"${WORKDIR}/exp.${name}.err")"; then
+			out="$(printf '%s' "${out}" | tr -d '"[:space:]')"
+			if [ -n "${out}" ]; then
+				printf '%s' "${out}"
+				return 0
+			fi
+		fi
+		err="$(cat "${WORKDIR}/exp.${name}.err" 2>/dev/null || true)"
+		if err_is_busy "${err}"; then
+			tries=$((tries + 1))
+			sleep 1
+			continue
+		fi
+		echo "${err}" >&2
+		return 1
+	done
+	echo "export ${name} stayed busy" >&2
+	return 1
+}
+
+cleanup()
+{
+	echo ""
+	echo "=== cleanup"
+
+	[ -n "${MNT}" ] && unmount_quietly "${MNT}"
+
+	if rcow_target_alive; then
+		for n in tpl-work mem-work meta-work \
+			 sb-0 sb-1 sb-2 sb-3 \
+			 tpl-rootfs mem-snap meta-snap \
+			 ghost imp-rootfs; do
+			rpc rcow_deactive_bdev "$(printf '{"device_name":"%s"}' "${n}")" \
+				>/dev/null 2>&1
+		done
+		if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
+			if [ "${DST_CREATED}" -eq 1 ]; then
+				rpc rcow_delete_lvstore \
+					"$(printf '{"lvs_name":"%s"}' "${DST_LVS}")" \
+					>/dev/null 2>&1 || info "delete dst lvstore failed"
+			fi
+			rpc rcow_delete_lvstore \
+				"$(printf '{"lvs_name":"%s"}' "${RCOW_LVS_NAME}")" \
+				>/dev/null 2>&1 || info "delete src lvstore failed"
+		fi
+	fi
+	[ "${STARTED}" -eq 1 ] && "${SCRIPTS}/rcow_stop.sh" --force >/dev/null 2>&1
+
+	if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
+		rcow_load_credentials
+		EP="$(rcow_cfg_get endpoint)"; RG="$(rcow_cfg_get region)"
+		python3 "${PREFIX_RM}" -e "${EP}" -b "${BUCKET}" -r "${RG}" \
+			-p "${RCOW_LVS_NAME}/" 2>&1 | tail -1
+		python3 "${PREFIX_RM}" -e "${EP}" -b "${BUCKET}" -r "${RG}" \
+			-p "${DST_LVS}/" 2>&1 | tail -1
+		for u in ${EXPORTS}; do
+			python3 "${PREFIX_RM}" -e "${EP}" -b "${BUCKET}" -r "${RG}" \
+				-p "exports/${u}" 2>&1 | tail -1
+		done
+		rm -f "${RCOW_WAL_IMG}" "${DST_WAL_IMG}"
+		rm -rf "${RCOW_RUN_DIR}" "${WORKDIR}"
+	else
+		info "state kept: ${RCOW_WAL_IMG}, ${DST_WAL_IMG}, ${RCOW_RUN_DIR}, ${WORKDIR}"
+	fi
+
+	echo ""
+	echo "=== result: ${PASS} passed, ${FAIL} failed ==="
+	[ "${FAIL}" -eq 0 ] || exit 1
+}
+trap cleanup EXIT
+
+# ==========================================================================
+echo "=== [0] preconditions"
+
+[ "$(id -u)" -eq 0 ] || { echo "must run as root" >&2; exit 1; }
+[ -x "${ROOT}/app/s3lvol_tgt/s3lvol_tgt" ] || { echo "target not built" >&2; exit 1; }
+[ -r "${RCOW_S3_CFG}" ] || { echo "no S3 config" >&2; exit 1; }
+command -v nvme >/dev/null || { echo "nvme-cli is required" >&2; exit 1; }
+command -v mkfs.ext4 >/dev/null || { echo "mkfs.ext4 is required" >&2; exit 1; }
+[ -n "$(rcow_target_instances)" ] && { echo "a target is already running" >&2; exit 1; }
+
+"${ROOT}/test/tools/check_binary_fresh.sh" "${RCOW_TGT_BIN}" || exit 1
+
+BUCKET="$(rcow_s3_buckets | head -1)"
+WORKDIR="$(mktemp -d /tmp/rcow_cbc.XXXXXX)"
+MNT="${WORKDIR}/mnt"
+mkdir -p "${MNT}"
+rm -rf "${RCOW_RUN_DIR}"; mkdir -p "${RCOW_RUN_DIR}"
+rm -f "${RCOW_WAL_IMG}" "${DST_WAL_IMG}"
+truncate -s 1G "${RCOW_WAL_IMG}"
+
+"${SCRIPTS}/rcow_start.sh" >"${WORKDIR}/start.log" 2>&1 && STARTED=1 || {
+	fail "rcow_start.sh failed"; tail -20 "${WORKDIR}/start.log"; exit 1; }
+pass "data plane up, lvstore ${RCOW_LVS_NAME} in ${BUCKET}"
+
+# ==========================================================================
+echo ""
+echo "=== [1] cubecow liveness probe and a long-lived connection"
+
+PROBE_OUT="$(rpc rcow_deactive_bdev \
+	'{"device_name":"__cbc_probe_cbcclient"}' 2>&1)"
+PROBE_RC=$?
+if [ "${PROBE_RC}" -eq 0 ]; then
+	pass "probe __cbc_probe_* is a successful no-op"
+elif err_is_not_found "${PROBE_OUT}"; then
+	pass "probe __cbc_probe_* is not-found-class"
+else
+	fail "probe deactive was a hard error: ${PROBE_OUT}"
+	exit 1
+fi
+if rpc rcow_get_bdev '{"device_name":"__cbc_probe_cbcclient"}' >/dev/null 2>&1; then
+	fail "probe name became an active bdev"
+	exit 1
+fi
+pass "probe left no host device"
+
+python3 - "${RCOW_RPC_SOCK}" <<'PY' >"${WORKDIR}/keepalive.out" 2>"${WORKDIR}/keepalive.err"
+import json, socket, sys
+
+sock_path = sys.argv[1]
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(10)
+s.connect(sock_path)
+
+def call(i):
+    req = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "rcow_deactive_bdev",
+        "params": {"device_name": "__cbc_probe_keep"},
+        "id": i,
+    }) + "\n"
+    s.sendall(req.encode())
+    buf = b""
+    while b"\n" not in buf:
+        chunk = s.recv(4096)
+        if not chunk:
+            raise RuntimeError("server closed the connection mid-frame")
+        buf += chunk
+    return json.loads(buf.split(b"\n", 1)[0])
+
+r1 = call(1)
+r2 = call(2)
+if r1.get("id") != 1 or r2.get("id") != 2:
+    raise SystemExit("id mismatch: %r then %r" % (r1.get("id"), r2.get("id")))
+print("ok")
+PY
+if [ "$(cat "${WORKDIR}/keepalive.out" 2>/dev/null)" = "ok" ]; then
+	pass "two RPCs on one connection came back in send order"
+else
+	fail "long-lived connection: $(cat "${WORKDIR}/keepalive.err" 2>/dev/null)"
+	exit 1
+fi
+
+# ==========================================================================
+echo ""
+echo "=== [2] seal path: ext4 volume → umount → inactive snapshot → delete work vol"
+
+rpc rcow_create_lvol '{"lvol_name":"tpl-work","size_gib":1}' >/dev/null || {
+	fail "create tpl-work"; exit 1; }
+TPL_DEV="$(resolve tpl-work)"
+[ -b "${TPL_DEV}" ] || { fail "tpl-work did not become a device"; exit 1; }
+pass "tpl-work is ${TPL_DEV}"
+
+mkfs.ext4 -F -b 4096 "${TPL_DEV}" >/dev/null 2>&1 || {
+	fail "mkfs.ext4 tpl-work"; exit 1; }
+mount "${TPL_DEV}" "${MNT}" || { fail "mount tpl-work"; exit 1; }
+echo "tpl-v1" >"${MNT}/marker.txt"
+sync
+unmount_quietly "${MNT}"
+
+rpc rcow_create_snapshot \
+	'{"lvol_name":"tpl-work","snapshot_name":"tpl-rootfs"}' >/dev/null || {
+	fail "snapshot tpl-rootfs"; exit 1; }
+pass "tpl-rootfs snap created (not activated)"
+
+# Cubelet never activates the sealed package snap for IO.
+if rpc rcow_get_bdev '{"device_name":"tpl-rootfs"}' >/dev/null 2>&1; then
+	fail "inactive snap tpl-rootfs was already a bdev"
+	exit 1
+fi
+pass "sealed snap has no host device"
+
+rpc rcow_deactive_bdev '{"device_name":"tpl-work"}' >/dev/null 2>&1
+rpc rcow_delete_lvol '{"lvol_name":"tpl-work"}' >/dev/null || {
+	fail "delete work volume after seal"; exit 1; }
+pass "work volume deleted; snap remains"
+
+# ==========================================================================
+echo ""
+echo "=== [3] deactive → get_bdev not-found → reactivate still openable"
+
+rpc rcow_create_lvol '{"lvol_name":"mem-work","size_gib":1}' >/dev/null || {
+	fail "create mem-work"; exit 1; }
+MEM_DEV="$(resolve mem-work)"
+[ -b "${MEM_DEV}" ] || { fail "mem-work did not become a device"; exit 1; }
+dd if=/dev/urandom of="${WORKDIR}/mem.pat" bs=1M count=8 status=none
+dd if="${WORKDIR}/mem.pat" of="${MEM_DEV}" bs=1M count=8 oflag=direct status=none
+MEM_MD5="$(md5sum "${WORKDIR}/mem.pat" | cut -d' ' -f1)"
+
+rpc rcow_deactive_bdev '{"device_name":"mem-work"}' >/dev/null || {
+	fail "deactive mem-work"; exit 1; }
+GET_ERR="$(rpc rcow_get_bdev '{"device_name":"mem-work"}' 2>&1)" && {
+	fail "get_bdev after deactive succeeded"; exit 1; }
+if err_is_not_found "${GET_ERR}"; then
+	pass "get_bdev after deactive is not-found-class"
+else
+	fail "get_bdev after deactive: ${GET_ERR}"
+	exit 1
+fi
+
+MEM_DEV2="$(resolve mem-work)"
+[ -b "${MEM_DEV2}" ] || { fail "reactivate did not yield a block device"; exit 1; }
+GOT="$(dd if="${MEM_DEV2}" bs=1M count=8 iflag=direct status=none 2>/dev/null | md5sum | cut -d' ' -f1)"
+if [ "${GOT}" = "${MEM_MD5}" ]; then
+	pass "reactivate path ${MEM_DEV2} (was ${MEM_DEV}) still holds the data"
+else
+	fail "reactivate readback mismatch"
+	exit 1
+fi
+
+rpc rcow_create_snapshot \
+	'{"lvol_name":"mem-work","snapshot_name":"mem-snap"}' >/dev/null || {
+	fail "snapshot mem-snap"; exit 1; }
+rpc rcow_deactive_bdev '{"device_name":"mem-work"}' >/dev/null 2>&1
+rpc rcow_delete_lvol '{"lvol_name":"mem-work"}' >/dev/null || {
+	fail "delete mem-work"; exit 1; }
+
+rpc rcow_create_lvol '{"lvol_name":"meta-work","size_gib":1}' >/dev/null || {
+	fail "create meta-work"; exit 1; }
+META_DEV="$(resolve meta-work)"
+mkfs.ext4 -F -b 4096 "${META_DEV}" >/dev/null 2>&1 || {
+	fail "mkfs.ext4 meta-work"; exit 1; }
+rpc rcow_create_snapshot \
+	'{"lvol_name":"meta-work","snapshot_name":"meta-snap"}' >/dev/null || {
+	fail "snapshot meta-snap"; exit 1; }
+rpc rcow_deactive_bdev '{"device_name":"meta-work"}' >/dev/null 2>&1
+rpc rcow_delete_lvol '{"lvol_name":"meta-work"}' >/dev/null || {
+	fail "delete meta-work"; exit 1; }
+pass "memory and metadata snaps sealed the same way as rootfs"
+
+# ==========================================================================
+echo ""
+echo "=== [4] N clones from one snap, isolation, resize one clone"
+
+for i in $(seq 0 $((N_CLONES - 1))); do
+	rpc rcow_create_clone \
+		"$(printf '{"snapshot_name":"tpl-rootfs","clone_name":"sb-%s"}' "${i}")" \
+		>/dev/null || { fail "clone sb-${i}"; exit 1; }
+	DEV="$(resolve "sb-${i}")"
+	[ -b "${DEV}" ] || { fail "sb-${i} not a block device"; exit 1; }
+	# Unique 1 MiB at 32 MiB so a shared-cluster write would collide.
+	printf 'clone-%s\n' "${i}" | dd of="${DEV}" bs=1M seek=32 count=1 conv=sync \
+		oflag=direct status=none 2>/dev/null
+	eval "SB_${i}_DEV='${DEV}'"
+	[ "${i}" = "1" ] && CLONE1_DEV="${DEV}"
+done
+pass "${N_CLONES} clones of tpl-rootfs activated"
+
+# Resize must apply to the clone, not the snap. Cubelet grows sandbox rootfs
+# after CreateVolumeFromSnapshot.
+if ! rpc rcow_resize_lvol '{"lvol_name":"sb-0","size_gib":2}' >/dev/null; then
+	fail "resize sb-0 after clone"
+	exit 1
+fi
+pass "resized clone sb-0 to 2 GiB"
+
+# The template snap must still mount as the original ext4 image, via a clone
+# that only wrote past the filesystem. Use sb-1 (not resized).
+unmount_quietly "${MNT}"
+mount "${CLONE1_DEV}" "${MNT}" || { fail "mount clone sb-1"; exit 1; }
+if [ "$(cat "${MNT}/marker.txt" 2>/dev/null)" = "tpl-v1" ]; then
+	pass "clone still reads the sealed ext4 marker"
+else
+	fail "clone lost the template filesystem"
+	exit 1
+fi
+unmount_quietly "${MNT}"
+
+# Isolation: each clone's 32 MiB slot is its own.
+for i in $(seq 0 $((N_CLONES - 1))); do
+	eval "DEV=\${SB_${i}_DEV}"
+	got="$(dd if="${DEV}" bs=1M skip=32 count=1 iflag=direct status=none 2>/dev/null \
+		| tr -d '\0' | head -c 16)"
+	echo "${got}" | grep -q "clone-${i}" || {
+		fail "sb-${i} marker missing (got '${got}')"; exit 1; }
+done
+pass "clone writes did not leak across the fan-out"
+
+# ==========================================================================
+echo ""
+echo "=== [5] three snapshots exported in parallel, polled by snapshot_name"
+
+SNAPS="tpl-rootfs mem-snap meta-snap"
+for n in ${SNAPS}; do
+	(
+		if uuid="$(export_with_retry "${n}")"; then
+			printf '%s' "${uuid}" >"${WORKDIR}/export.${n}.uuid"
+		else
+			printf 'FAIL' >"${WORKDIR}/export.${n}.uuid"
+		fi
+	) &
+done
+wait
+
+FAIL_EXPORT=0
+for n in ${SNAPS}; do
+	uuid="$(cat "${WORKDIR}/export.${n}.uuid" 2>/dev/null || true)"
+	if [ -z "${uuid}" ] || [ "${uuid}" = "FAIL" ]; then
+		fail "parallel export of ${n}"
+		FAIL_EXPORT=1
+		continue
+	fi
+	EXPORTS="${EXPORTS} ${uuid}"
+	eval "UUID_$(printf '%s' "${n}" | tr '-' '_')=${uuid}"
+	pass "exported ${n} as ${uuid}"
+done
+[ "${FAIL_EXPORT}" -eq 0 ] || exit 1
+
+for n in ${SNAPS}; do
+	wait_export_done_by_name "${n}" || exit 1
+done
+pass "all three reached DONE when queried by snapshot_name"
+
+# cubecow's RPC doc says the uuid is stable for the snapshot's lifetime.
+# s3lvol only coalesces while an export is still in flight (see
+# run_export_test.sh 11d.3); after DONE a second call mints a new uuid.
+# Cubelet persists the first uuid and polls that, so we do not re-export
+# here -- a new uuid would be a different export, not a retry of this one.
+
+# ==========================================================================
+echo ""
+echo "=== [6] delete of a snap with clones/export: must not vanish, must not look like not-found"
+
+# s3lvol may refuse with EBUSY, or accept the delete as deferred (pending
+# mark, bool_value true, extra field deferred=true). Cubelet's FFI unwraps
+# that as success and would think the template is gone. The load-bearing
+# check is therefore that the snapshot is still queryable, and that any
+# error string does not contain "not found".
+DEL_RAW="$(python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --raw \
+	rcow_delete_lvol '{"lvol_name":"tpl-rootfs"}' 2>&1)" || true
+if err_is_not_found "${DEL_RAW}"; then
+	fail "delete of live template contained not-found: ${DEL_RAW}"
+	exit 1
+fi
+if ! rpc rcow_get_snapshot_status '{"snapshot_name":"tpl-rootfs"}' >/dev/null; then
+	fail "tpl-rootfs vanished after delete RPC"
+	exit 1
+fi
+if printf '%s' "${DEL_RAW}" | grep -q '"deferred"[[:space:]]*:[[:space:]]*true'; then
+	pass "delete deferred; snapshot still queryable"
+elif printf '%s' "${DEL_RAW}" | grep -qiE 'busy|clone|referenced|in use|export'; then
+	pass "delete refused; snapshot still queryable"
+else
+	info "delete reply: ${DEL_RAW}"
+	pass "snapshot still queryable after delete RPC"
+fi
+
+# ==========================================================================
+echo ""
+echo "=== [7] failed import must not leave a named shell lvol"
+
+GHOST_ERR="$(rpc rcow_import_lvol \
+	'{"lvol_name":"ghost","export_uuid":"00000000-0000-0000-0000-ffffffffffff","decouple":true}' \
+	2>&1)" && {
+	fail "import of a garbage uuid succeeded"; exit 1; }
+pass "garbage import refused: $(printf '%s' "${GHOST_ERR}" | head -c 80)"
+
+if rpc rcow_get_bdev '{"device_name":"ghost"}' >/dev/null 2>&1; then
+	fail "ghost became a bdev after a failed import"
+	exit 1
+fi
+# delete of a name that must not exist: cubecow treats not-found as success.
+GHOST_DEL="$(rpc rcow_delete_lvol '{"lvol_name":"ghost"}' 2>&1)" && {
+	fail "ghost existed after failed import (delete succeeded)"
+	exit 1
+}
+if err_is_already_exists "${GHOST_DEL}"; then
+	fail "ghost occupied the namespace after failed import: ${GHOST_DEL}"
+	exit 1
+fi
+if err_is_not_found "${GHOST_DEL}"; then
+	pass "failed import left no ghost lvol"
+else
+	# Some servers refuse delete of a missing name with a different wording.
+	# As long as it is not already-exists, the namespace is free.
+	info "delete ghost: ${GHOST_DEL}"
+	pass "failed import left no ghost lvol (delete was not already-exists)"
+fi
+
+# ==========================================================================
+echo ""
+echo "=== [8] import(decouple=true) then activate immediately (no decouple wait)"
+
+for i in $(seq 0 $((N_CLONES - 1))); do
+	del_vol "sb-${i}"
+done
+rpc rcow_deactive_bdev '{"device_name":"tpl-rootfs"}' >/dev/null 2>&1
+rpc rcow_deactive_bdev '{"device_name":"mem-snap"}' >/dev/null 2>&1
+rpc rcow_deactive_bdev '{"device_name":"meta-snap"}' >/dev/null 2>&1
+
+# One blobstore per node on create: unload the source so the destination
+# lvstore can be created. The export lives in S3.
+rpc rcow_unload_lvstore \
+	"$(printf '{"lvs_name":"%s"}' "${RCOW_LVS_NAME}")" >/dev/null || {
+	fail "unload src lvstore"; exit 1; }
+pass "src lvstore unloaded; exports remain in S3"
+
+truncate -s 1G "${DST_WAL_IMG}"
+python3 "${RCOW_SPDK_RPC_PY}" -s "${RCOW_RPC_SOCK}" bdev_aio_create \
+	"${DST_WAL_IMG}" "${DST_WAL_BDEV}" 4096 >/dev/null || {
+	fail "bdev_aio_create ${DST_WAL_BDEV}"; exit 1; }
+
+S3LVOL_EXTRA_JSON=""
+[ "${S3LVOL_TEST_PATH_STYLE:-0}" -eq 1 ] && S3LVOL_EXTRA_JSON+=',"path_style":true'
+[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_EXTRA_JSON+=',"no_tls":true'
+
+rpc rcow_create_lvstore \
+	"$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":%d,"wal_bdev":"%s","journal_size_mb":%d,"wal_size_mb":%d%s}' \
+		"${DST_LVS}" "${BUCKET}" "${RCOW_CAPACITY_GB}" "${DST_WAL_BDEV}" \
+		"${RCOW_JOURNAL_MB}" "${RCOW_WAL_MB}" "${S3LVOL_EXTRA_JSON}")" >/dev/null || {
+	fail "create dst lvstore"; exit 1; }
+DST_CREATED=1
+pass "dst lvstore ${DST_LVS} created"
+
+# cubecow always sends decouple=true and then ActivateVolume without a waiter.
+if ! rpc rcow_import_lvol \
+	"$(printf '{"lvol_name":"imp-rootfs","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+		"${UUID_tpl_rootfs}" "${DST_LVS}")" >/dev/null; then
+	fail "import imp-rootfs"
+	exit 1
+fi
+pass "import(decouple=true) returned"
+
+IMP_DEV="$(resolve imp-rootfs)"
+[ -b "${IMP_DEV}" ] || { fail "imp-rootfs did not become a device"; exit 1; }
+pass "activated imp-rootfs immediately as ${IMP_DEV}"
+
+unmount_quietly "${MNT}"
+mount "${IMP_DEV}" "${MNT}" || { fail "mount imp-rootfs right after import"; exit 1; }
+if [ "$(cat "${MNT}/marker.txt" 2>/dev/null)" = "tpl-v1" ]; then
+	pass "imported volume mounted ext4 and read the sealed marker without waiting for decouple"
+else
+	fail "imported ext4 did not contain marker.txt"
+	exit 1
+fi
+unmount_quietly "${MNT}"

--- a/CubeS3lvol/test/dataplane/run_decouple_queue_test.sh
+++ b/CubeS3lvol/test/dataplane/run_decouple_queue_test.sh
@@ -26,6 +26,8 @@
 #    src: a small sparse volume -> snapshot -> export
 #    dst: import big (decouple:true)   -- starts materialising, slowly
 #    dst: import small (decouple:true) -- queued behind big
+#    while big is ingesting: partial-write small's first parent-backed cluster
+#         -- must CoW from small's export, never from big's active ingest
 #    while small is queued: snapshot small -> cancels the queued decouple, succeeds
 #    big's decouple must be unaffected, and small must afterwards be undecouplable
 #
@@ -183,6 +185,46 @@ nvme_settle()
 	udevadm settle --timeout=5 >/dev/null 2>&1 || true
 }
 
+ctrl_of_nqn()
+{
+	local c
+
+	for c in /sys/class/nvme/nvme*; do
+		if [ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ]; then
+			printf '/dev/%s' "$(basename "${c}")"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Wait for a 1 GiB namespace on this subsystem. Linux names /dev/nvmeXnY by
+# discovery order, not NVMe nsid, so matching on size is what keeps hold0
+# (4 MiB) and the volumes apart. exclude, if set, is skipped.
+wait_vol_dev()
+{
+	local exclude="${1:-}"
+	local deadline=$(( $(date +%s) + 25 ))
+	local ctrl dev sz
+
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		ctrl="$(ctrl_of_nqn)" || { sleep 0.2; continue; }
+		nvme ns-rescan "${ctrl}" >/dev/null 2>&1 || true
+		nvme_settle
+		for dev in $(ls "${ctrl}"n* 2>/dev/null || true); do
+			[ -b "${dev}" ] || continue
+			[ -n "${exclude}" ] && [ "${dev}" = "${exclude}" ] && continue
+			sz="$(blockdev --getsize64 "${dev}" 2>/dev/null || echo 0)"
+			if [ "${sz}" = "${VOL_BYTES}" ]; then
+				printf '%s' "${dev}"
+				return 0
+			fi
+		done
+		sleep 0.2
+	done
+	return 1
+}
+
 remove_prefix()
 {
 	python3 "${TOOLS_DIR}/s3_prefix_rm.py" -e "${ENDPOINT}" -b "${BUCKET}" \
@@ -322,12 +364,22 @@ ${RPC} nvmf_create_transport -t TCP >/dev/null 2>&1 || true
 ${RPC} nvmf_create_subsystem "${NQN}" -a -s R2X0000000000000001 \
 	>/dev/null 2>&1 || { fail "nvmf_create_subsystem"; exit 1; }
 TRANSPORT_READY=1
+# Keep one namespace alive while the source lvstore is unloaded. Otherwise the
+# kernel is free to tear down the controller before the destination import is
+# exposed, making the cross-volume CoW window impossible to drive from /dev.
+${RPC} bdev_null_create hold0 4 4096 >/dev/null 2>&1 \
+	|| { fail "bdev_null_create (controller hold)"; exit 1; }
+HOLD_NSID=30
+BIG_NSID=1
+SMALL_NSID=2
+VOL_BYTES=$((SMALL_GIB * 1024 * 1024 * 1024))
+${RPC} nvmf_subsystem_add_ns "${NQN}" hold0 -n "${HOLD_NSID}" >/dev/null 2>&1 \
+	|| { fail "nvmf_subsystem_add_ns (controller hold)"; exit 1; }
 ${RPC} nvmf_subsystem_add_ns "${NQN}" "${SRC_LVS}/${BIG_VOL}" \
-	>/dev/null 2>&1 || { fail "nvmf_subsystem_add_ns (big)"; exit 1; }
+	-n "${BIG_NSID}" >/dev/null 2>&1 || { fail "nvmf_subsystem_add_ns (big)"; exit 1; }
 ${RPC} nvmf_subsystem_add_listener "${NQN}" -t tcp -a "${LISTEN_ADDR}" \
 	-s "${LISTEN_PORT}" >/dev/null 2>&1 || { fail "add_listener"; exit 1; }
 
-BEFORE_CONNECT="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
 if ! nvme connect -t tcp -a "${LISTEN_ADDR}" -s "${LISTEN_PORT}" -n "${NQN}" \
 		>"${WORKDIR}/connect.log" 2>&1; then
 	fail "nvme connect"
@@ -335,14 +387,8 @@ if ! nvme connect -t tcp -a "${LISTEN_ADDR}" -s "${LISTEN_PORT}" -n "${NQN}" \
 	exit 1
 fi
 CONNECTED=1
-BIG_DEV=""
-for _ in $(seq 30); do
-	BIG_DEV="$(comm -13 <(echo "${BEFORE_CONNECT}") \
-			<(ls /dev/nvme*n* 2>/dev/null | sort || true) | head -1)"
-	[ -n "${BIG_DEV}" ] && break
-	sleep 0.5
-done
-[ -n "${BIG_DEV}" ] || { fail "no device for big volume"; exit 1; }
+BIG_DEV="$(wait_vol_dev)" \
+	|| { fail "no 1 GiB device for big volume"; exit 1; }
 pass "big volume is ${BIG_DEV}"
 
 info "writing ${BIG_GIB}GiB to ${BIG_VOL} (this is the slow part)"
@@ -368,25 +414,35 @@ raw_rpc rcow_create_lvol "$(printf '{"lvol_name":"%s","size_gib":%d}' \
 	"${SMALL_VOL}" "${SMALL_GIB}")" >/dev/null 2>&1 \
 	|| { fail "create small lvol"; exit 1; }
 ${RPC} nvmf_subsystem_add_ns "${NQN}" "${SRC_LVS}/${SMALL_VOL}" \
-	>/dev/null 2>&1 || { fail "nvmf_subsystem_add_ns (small)"; exit 1; }
-nvme ns-rescan "/dev/$(basename "${BIG_DEV}" | sed 's/n[0-9]*$//')" \
-	>/dev/null 2>&1 || true
-SMALL_DEV=""
-for _ in $(seq 30); do
-	SMALL_DEV="$(comm -13 <(echo "${BEFORE_CONNECT}") \
-			<(ls /dev/nvme*n* 2>/dev/null | sort || true) | grep -v "${BIG_DEV}" \
-			| head -1)"
-	[ -n "${SMALL_DEV}" ] && break
-	sleep 0.5
-done
-[ -n "${SMALL_DEV}" ] || { fail "no device for small volume"; exit 1; }
+	-n "${SMALL_NSID}" >/dev/null 2>&1 || { fail "nvmf_subsystem_add_ns (small)"; exit 1; }
+SMALL_DEV="$(wait_vol_dev "${BIG_DEV}")" \
+	|| { fail "no 1 GiB device for small volume"; exit 1; }
 pass "small volume is ${SMALL_DEV}"
 
 dd if=/dev/urandom of="${WORKDIR}/small.pat" bs=1M count="${SMALL_WRITE_MB}" \
 	status=none
 dd if="${WORKDIR}/small.pat" of="${SMALL_DEV}" bs=1M count="${SMALL_WRITE_MB}" \
 	seek=0 oflag=direct conv=fsync status=none 2>"${WORKDIR}/small_write.err"
+SMALL_SRC_MD5="$(dd if="${SMALL_DEV}" bs=1M count=1 iflag=direct status=none \
+	| md5sum | cut -d' ' -f1)"
+SMALL_PAT_MD5="$(dd if="${WORKDIR}/small.pat" bs=1M count=1 status=none \
+	| md5sum | cut -d' ' -f1)"
+if [ "${SMALL_SRC_MD5}" != "${SMALL_PAT_MD5}" ]; then
+	fail "small source device did not retain the pattern (wrote to the wrong ns?)"
+	exit 1
+fi
+raw_rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" \
+	>/dev/null 2>&1 || { fail "flush after writing small"; exit 1; }
 pass "small volume written (${SMALL_WRITE_MB} MiB sparse)"
+
+# Expected first MiB after the partial write made while this import is queued
+# behind the big decouple. Only the first 4 KiB changes; the rest must still
+# come from the small export's parent cluster.
+dd if=/dev/urandom of="${WORKDIR}/cow.patch" bs=4096 count=1 status=none
+dd if="${WORKDIR}/small.pat" of="${WORKDIR}/cow.expected" bs=1M count=1 status=none
+dd if="${WORKDIR}/cow.patch" of="${WORKDIR}/cow.expected" bs=4096 count=1 \
+	conv=notrunc status=none
+COW_EXPECTED_MD5="$(md5sum "${WORKDIR}/cow.expected" | cut -d' ' -f1)"
 
 raw_rpc rcow_create_snapshot "$(printf '{"lvol_name":"%s","snapshot_name":"%s"}' \
 	"${SMALL_VOL}" "${SMALL_SNAP}")" >/dev/null 2>&1 \
@@ -397,6 +453,11 @@ SMALL_EXP_UUID="$(raw_rpc rcow_export_snapshot \
 [ -n "${SMALL_EXP_UUID}" ] || { fail "export small snapshot"; exit 1; }
 wait_export_done "${SMALL_EXP_UUID}" "small export" || exit 1
 pass "small snapshot exported (${SMALL_EXP_UUID})"
+
+# Drop the source namespaces before unload so their nsids can be reused for the
+# imported volume. hold0 stays, which is what keeps the controller alive.
+${RPC} nvmf_subsystem_remove_ns "${NQN}" "${BIG_NSID}" >/dev/null 2>&1 || true
+${RPC} nvmf_subsystem_remove_ns "${NQN}" "${SMALL_NSID}" >/dev/null 2>&1 || true
 
 # One blobstore per node: the source lvstore has to be unloaded before the
 # destination can be created. Its export lives in S3, so the import below still
@@ -445,9 +506,62 @@ if ! raw_rpc rcow_import_lvol \
 	exit 1
 fi
 pass "small imported, decouple queued behind big"
+if grep -qE "Imported export .* as lvol '${SMALL_IMP}': .* 0 of [0-9]+ chunk" "${TGT_LOG}"; then
+	fail "small import has no parent chunks; the CoW check would be vacuous"
+	exit 1
+fi
 
 # ==========================================================================
-echo "[7] while small is queued: snapshot it (must cancel the decouple and succeed)"
+echo "[7] while big ingests: CoW small must read small's export, not big's"
+# Reuse the source small nsid. hold0 (nsid 30) keeps the controller up across
+# the source unload, so a rescan is enough; reconnecting would also work.
+SMALL_IMP_NSID="${SMALL_NSID}"
+${RPC} nvmf_subsystem_add_ns "${NQN}" "${DST_LVS}/${SMALL_IMP}" \
+	-n "${SMALL_IMP_NSID}" >/dev/null 2>"${WORKDIR}/add_small_imp_ns.err" || {
+	fail "expose imported small"
+	sed 's/^/       /' "${WORKDIR}/add_small_imp_ns.err"
+	exit 1
+}
+SMALL_IMP_DEV="$(wait_vol_dev)" || {
+	fail "imported small 1 GiB device did not appear"
+	exit 1
+}
+BIG_STILL_RUNNING="$(raw_rpc rcow_get_decouple 2>/dev/null | python3 -c "
+import json,sys
+name = sys.argv[1]
+try:
+    rows = json.load(sys.stdin)
+except Exception:
+    rows = []
+print(len([r for r in rows if r.get('lvol_name') == name and not r.get('queued')]))
+" "${BIG_IMP}" 2>/dev/null || echo 0)"
+if [ "${BIG_STILL_RUNNING}" != "1" ]; then
+	fail "big decouple finished before the CoW; the cross-volume window was missed"
+	exit 1
+fi
+pass "imported small is ${SMALL_IMP_DEV}; big ingest still running"
+
+# A 4 KiB overwrite of a parent-backed 1 MiB chunk forces blobstore to preserve
+# the other 1020 KiB through CoW. While the big CopyObject ingest is installed
+# lvstore-wide, the historical bug resolved that read against the big manifest:
+# the write either hung behind ingest slots or the untouched bytes silently
+# came from the wrong export. Bound the write so a regression cannot stall CI.
+if timeout 60 dd if="${WORKDIR}/cow.patch" of="${SMALL_IMP_DEV}" bs=4096 count=1 \
+		oflag=direct conv=fsync status=none 2>"${WORKDIR}/cow_write.err"; then
+	COW_GOT_MD5="$(dd if="${SMALL_IMP_DEV}" bs=1M count=1 iflag=direct \
+		status=none 2>"${WORKDIR}/cow_read.err" | md5sum | cut -d' ' -f1)"
+	if [ "${COW_GOT_MD5}" = "${COW_EXPECTED_MD5}" ]; then
+		pass "queued small CoW preserved bytes from the small export"
+	else
+		fail "queued small CoW used wrong parent bytes (got ${COW_GOT_MD5}, expected ${COW_EXPECTED_MD5})"
+	fi
+else
+	fail "queued small CoW failed or timed out while big ingest was active"
+	sed 's/^/       /' "${WORKDIR}/cow_write.err"
+fi
+
+# ==========================================================================
+echo "[8] while small is queued: snapshot it (must cancel the decouple and succeed)"
 # This used to assert a refusal, and the refusal was correct as far as it went --
 # letting the snapshot through while the decouple stood is what produced the
 # detach failure this test is named for. But refusing makes "import a volume,
@@ -487,7 +601,7 @@ else
 fi
 
 # ==========================================================================
-echo "[8] wait for all decouples to finish"
+echo "[9] wait for all decouples to finish"
 if wait_for_decouple; then
 	pass "all decouples finished"
 else
@@ -495,7 +609,7 @@ else
 fi
 
 # ==========================================================================
-echo "[9] verdict"
+echo "[10] verdict"
 echo "--- relevant log lines:"
 grep -nE 'queued to be decoupled|decouple_start|decouple_finish|Decoupling|blob is not a clone' \
 	"${TGT_LOG}" | tail -40 | sed 's/^/    /' || true

--- a/CubeS3lvol/test/dataplane/run_derived_test.sh
+++ b/CubeS3lvol/test/dataplane/run_derived_test.sh
@@ -1,0 +1,1003 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+#  Handing on an imported volume without copying it (manifest version 3)
+#
+#  === What this is for ===
+#
+#  A volume imported from an export can be snapshotted and exported again. Before
+#  version 3 that second export had to copy: the chunks older than the import live
+#  under the *exporting* node's prefix, and a manifest could name only one. So the
+#  second hop paid for the whole volume even though every byte was already in the
+#  bucket.
+#
+#  Version 3 names a prefix per chunk, so the second export references both its own
+#  objects and the ones it inherited. This test is what says that actually works
+#  end to end, against a real bucket, rather than in a unit test's idea of a
+#  manifest.
+#
+#  === Why three nodes ===
+#
+#      A: writes head+tail, snapshots, exports         -> export A (version 2)
+#  B: imports A without decoupling, rewrites tail,
+#     zeroes the first MiB of the head, snapshots, exports
+#                                                   -> export B (version 3)
+#  C: imports B, reads both halves (zeroed head prefix + A's rest + B's tail)
+#
+#  Two nodes would prove too little. B's manifest can name A's prefix and still be
+#  useless if nothing ever resolves it, so C exists to do the resolving -- from a
+#  third prefix, with A's lvstore unloaded, which is the situation a real handoff
+#  arrives in.
+#
+#  === Why the volume is written in two halves ===
+#
+#  B rewrites only the tail and zeroes the first MiB of the head. That leaves
+#  most of the head resolving to A's prefix, the tail to B's, and the zeroed
+#  prefix a hole -- so what C reads is the only assertion that can separate:
+#
+#    - the right prefix from a wrong one. A wrong prefix does not fail loudly: it
+#      names an object that exists and holds a different chunk, so the read
+#      succeeds and returns plausible bytes.
+#    - the nearer layer winning from the older one winning. A *also* has data at
+#      the tail. If inherit ran before the local walk, or overwrote instead of
+#      skipping, C would read A's tail -- the volume as it was before the import,
+#      with nothing anywhere to say so.
+#    - a local write_zeroes from an untouched hole. inherit fills absent chunks
+#      from the parent; without marking the zero resolved, C would read A's
+#      first MiB instead of zeroes.
+#
+#  A fully overwritten volume would leave B owning every chunk and the inherit path
+#  would not run at all, which is why the overwrite is half and not all.
+#
+#  === What else is checked, and why it is not obvious ===
+#
+#  That B's export is version 3 with layout still ref. A copy would also produce a
+#  perfectly readable export and every data assertion below would still pass -- the
+#  manifest is the only place the difference is visible.
+#
+#  That C renews two leases, one of them A's own export. This is what keeps the
+#  handoff durable: A decides independently whether its snapshot is still needed,
+#  and it consults the lease. Renewing only B's would leave A free to delete the
+#  objects C's head resolves to. It is also why the lease is renewed against A
+#  directly rather than through B -- B may be gone.
+#
+#  Usage:
+#    sudo -E ./test/dataplane/run_derived_test.sh -e <endpoint> -b <bucket> [-r <region>]
+#
+#  Requires: root, nvme-cli, a real bucket with credentials in the environment.
+#
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TOOLS_DIR="${REPO_ROOT}/test/tools"
+
+TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+RPC_SOCK="/var/run/s3lvol_derived.sock"
+
+A_LVS="drva"
+B_LVS="drvb"
+C_LVS="drvc"
+S3_EXPORTS_DIR="exports"
+
+NQN="nqn.2026-09.io.spdk:derived"
+LISTEN_ADDR="127.0.0.1"
+LISTEN_PORT="4473"
+
+CAPACITY_GIB=4
+LVOL_GIB=1
+JOURNAL_MB=64
+WAL_MB=128
+WAL_FILE_MB=$((JOURNAL_MB + WAL_MB + 128))
+
+A_WAL_FILE="${S3LVOL_A_WAL_FILE:-/data/s3lvol_derived_a.img}"
+B_WAL_FILE="${S3LVOL_B_WAL_FILE:-/data/s3lvol_derived_b.img}"
+C_WAL_FILE="${S3LVOL_C_WAL_FILE:-/data/s3lvol_derived_c.img}"
+A_WAL_BDEV="derived_a_wal0"
+B_WAL_BDEV="derived_b_wal0"
+C_WAL_BDEV="derived_c_wal0"
+
+# Two halves, each several chunks wide, starting past the blobstore metadata.
+HALF_MB=8
+HEAD_OFF_MB=8
+TAIL_OFF_MB=$((HEAD_OFF_MB + HALF_MB))
+# First cluster of the head. cluster_size == chunk_size == 1 MiB.
+ZERO_OFF_MB="${HEAD_OFF_MB}"
+ZERO_LEN_MB=1
+HEAD_REST_OFF_MB=$((HEAD_OFF_MB + ZERO_LEN_MB))
+HEAD_REST_MB=$((HALF_MB - ZERO_LEN_MB))
+
+ENDPOINT=""
+BUCKET=""
+REGION="ap-nanjing"
+
+PASS=0
+FAIL=0
+TGT_PID=""
+TGT_LOG=""
+WORKDIR=""
+CONNECTED=0
+TRANSPORT_READY=0
+A_CREATED=0
+B_CREATED=0
+C_CREATED=0
+ANY_CREATED=0
+TEARDOWN_ANOMALY=0
+EXPORT_UUIDS=""
+EXP_A=""
+EXP_B=""
+DID_ZERO=0
+NVME_DEV=""
+CUR_NSID=""
+
+pass() { PASS=$((PASS + 1)); echo "[PASS] $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "[FAIL] $*"; }
+info() { echo "---- $*"; }
+
+# Every value comparison goes through here so the summary cannot disagree with the
+# body, and so a failure prints what it actually got.
+want()
+{
+	if [ "$2" = "$3" ]; then
+		pass "$1 (${2})"
+	else
+		fail "$1: got '${2}', want '${3}'"
+	fi
+}
+
+usage()
+{
+	cat <<EOF
+Usage: $0 -e <endpoint> -b <bucket> [-r <region>]
+
+  -e   S3/COS endpoint host, e.g. cos.ap-nanjing.myqcloud.com
+  -b   bucket (must be a test bucket: a clean run deletes its own prefixes)
+  -r   region (default: ${REGION})
+
+Credentials are read from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
+
+Environment:
+  S3LVOL_KEEP_S3    keep the S3 objects after the run
+  S3LVOL_KEEP_LOGS  keep the target log after a clean run
+EOF
+}
+
+while getopts "e:b:r:h" opt; do
+	case "${opt}" in
+	e) ENDPOINT="${OPTARG}" ;;
+	b) BUCKET="${OPTARG}" ;;
+	r) REGION="${OPTARG}" ;;
+	h) usage; exit 0 ;;
+	*) usage; exit 1 ;;
+	esac
+done
+
+if [ -z "${ENDPOINT}" ] || [ -z "${BUCKET}" ]; then
+	usage
+	exit 1
+fi
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+	echo "AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY must be set" >&2
+	exit 1
+fi
+if [ "$(id -u)" -ne 0 ]; then
+	echo "must run as root (hugepages, nvme connect)" >&2
+	exit 1
+fi
+for tool in nvme dd md5sum python3; do
+	command -v "${tool}" >/dev/null 2>&1 || {
+		echo "${tool} is required" >&2; exit 1; }
+done
+
+WORKDIR="$(mktemp -d /tmp/s3lvol_derived.XXXXXX)"
+TGT_LOG="${WORKDIR}/target.log"
+
+raw_rpc()
+{
+	python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" "$1" "${2:-}"
+}
+
+nvmf_rpc()
+{
+	python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --raw "$1" "${2:-}"
+}
+
+target_alive()
+{
+	[ -n "${TGT_PID}" ] && kill -0 "${TGT_PID}" 2>/dev/null
+}
+
+check_target()
+{
+	local where="$1"
+
+	if ! target_alive; then
+		fail "target died during ${where}"
+		tail -25 "${TGT_LOG}" | sed 's/^/       /'
+		return 1
+	fi
+	if grep -qE 'Assertion|SIGSEGV|panic:' "${TGT_LOG}" 2>/dev/null; then
+		fail "target hit an assertion during ${where}"
+		grep -nE 'Assertion|SIGSEGV|panic:' "${TGT_LOG}" | head -5 | \
+			sed 's/^/       /'
+		return 1
+	fi
+	return 0
+}
+
+export_status_field()
+{
+	local out
+
+	out="$(raw_rpc rcow_get_snapshot_status \
+		"$(printf '{"export_uuid":"%s"}' "$1")" 2>/dev/null)" || return 1
+	printf '%s' "${out}" \
+		| python3 -c "import json,sys; print(json.load(sys.stdin).get('$2',''))" \
+			2>/dev/null
+}
+
+wait_export_done()
+{
+	local uuid="$1" where="$2"
+	local deadline=$(( $(date +%s) + 120 ))
+	local st
+
+	while :; do
+		if ! st="$(export_status_field "${uuid}" export_status)"; then
+			fail "export ${uuid} finished without a manifest (${where})"
+			return 1
+		fi
+		[ "${st}" = "DONE" ] && return 0
+		if [ "$(date +%s)" -ge "${deadline}" ]; then
+			fail "export ${uuid} never reached DONE (${where}, last '${st}')"
+			return 1
+		fi
+		sleep 0.3
+	done
+}
+
+wait_for_decouple()
+{
+	local deadline=$(( $(date +%s) + 900 ))
+
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if raw_rpc rcow_get_decouple "" 2>/dev/null |
+		   python3 -c 'import json,sys; raise SystemExit(0 if not json.load(sys.stdin) else 1)'; then
+			return 0
+		fi
+		sleep 1
+	done
+	return 1
+}
+
+# Read a member out of the published manifest. This is the only way to tell a
+# referenced export from a copied one, so it comes from S3 rather than from any
+# RPC the writing node offers -- what the importer will see is what is asserted.
+manifest_field()
+{
+	python3 "${TOOLS_DIR}/s3_get_manifest.py" -e "${ENDPOINT}" -b "${BUCKET}" \
+		-r "${REGION}" -u "$1" --field "$2" 2>/dev/null
+}
+
+nvme_settle()
+{
+	udevadm settle --timeout=5 >/dev/null 2>&1 || true
+}
+
+expose()
+{
+	nvmf_rpc nvmf_subsystem_add_ns \
+		"$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+			"${NQN}" "$1")" 2>/dev/null | tr -d '[:space:]'
+}
+
+unexpose()
+{
+	local nsid="$1"
+	[ -n "${nsid}" ] && nvmf_rpc nvmf_subsystem_remove_ns \
+		"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "${nsid}")" \
+		>/dev/null 2>&1
+	nvme_settle
+	return 0
+}
+
+ctrl_of_nqn()
+{
+	local c
+	for c in /sys/class/nvme/nvme*; do
+		[ "$(cat "${c}/subsysnqn" 2>/dev/null)" = "${NQN}" ] && \
+			{ basename "${c}"; return 0; }
+	done
+	return 1
+}
+
+wait_dev()
+{
+	local nsid="$1" deadline ctrl dev
+	deadline=$(( $(date +%s) + 30 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if ctrl="$(ctrl_of_nqn)"; then
+			nvme ns-rescan "/dev/${ctrl}" >/dev/null 2>&1 || true
+			dev="/dev/${ctrl}n${nsid}"
+			[ -b "${dev}" ] && { printf '%s' "${dev}"; return 0; }
+		fi
+		sleep 0.3
+	done
+	return 1
+}
+
+# Expose a volume and hand back its device, or fail and print nothing. Runs in a
+# command substitution, so anything it did to PASS/FAIL would be lost with the
+# subshell -- the caller decides what an empty answer means.
+attach()
+{
+	local bdev="$1" nsid dev
+
+	nsid="$(expose "${bdev}")"
+	if [ -z "${nsid}" ]; then
+		echo "---- could not expose ${bdev}" >&2
+		return 1
+	fi
+	CUR_NSID="${nsid}"
+	nvme_settle
+	if ! dev="$(wait_dev "${nsid}")"; then
+		echo "---- ${bdev}: nsid ${nsid} never became a device" >&2
+		return 1
+	fi
+	NVME_DEV="${dev}"
+	printf '%s' "${dev}"
+}
+
+# Refuses a target that is not already a block device: writing to a path that has
+# not appeared yet creates a regular file where the device belongs, which outlives
+# the run and breaks every later one for a reason that looks like a discovery
+# timeout.
+write_at()
+{
+	local dev="$1" file="$2" off_mb="$3"
+
+	if [ -z "${dev}" ] || [ ! -b "${dev}" ]; then
+		fail "refusing to write to '${dev}': not a block device"
+		return 1
+	fi
+	dd if="${file}" of="${dev}" bs=1M count="${HALF_MB}" seek="${off_mb}" \
+		oflag=direct conv=fsync status=none 2>"${WORKDIR}/write.err"
+}
+
+read_md5_at()
+{
+	local dev="$1" off_mb="$2"
+
+	read_md5_range "${dev}" "${off_mb}" "${HALF_MB}"
+}
+
+read_md5_range()
+{
+	local dev="$1" off_mb="$2" count_mb="$3"
+
+	dd if="${dev}" bs=1M count="${count_mb}" skip="${off_mb}" \
+		iflag=direct status=none 2>/dev/null | md5sum | cut -d' ' -f1
+}
+
+md5_of() { md5sum "$1" | cut -d' ' -f1; }
+
+md5_of_range()
+{
+	local file="$1" skip_mb="$2" count_mb="$3"
+
+	dd if="${file}" bs=1M skip="${skip_mb}" count="${count_mb}" \
+		status=none 2>/dev/null | md5sum | cut -d' ' -f1
+}
+
+md5_of_zeroes()
+{
+	dd if=/dev/zero bs=1M count="$1" status=none 2>/dev/null | md5sum | cut -d' ' -f1
+}
+
+drop_caches() { sync; echo 3 >/proc/sys/vm/drop_caches 2>/dev/null || true; }
+
+create_lvstore()
+{
+	local lvs="$1" wal="$2"
+
+	raw_rpc rcow_create_lvstore \
+		"$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":%d,"wal_bdev":"%s","journal_size_mb":%d,"wal_size_mb":%d}' \
+			"${lvs}" "${BUCKET}" "${CAPACITY_GIB}" "${wal}" \
+			"${JOURNAL_MB}" "${WAL_MB}")" \
+		>"${WORKDIR}/${lvs}_create.json" 2>"${WORKDIR}/${lvs}_create.err"
+}
+
+remove_prefix()
+{
+	python3 "${TOOLS_DIR}/s3_prefix_rm.py" -e "${ENDPOINT}" -b "${BUCKET}" \
+		-r "${REGION}" -p "$1"
+}
+
+cleanup()
+{
+	local rc=$?
+
+	echo
+	echo "=== cleanup ==="
+
+	if [ "${CONNECTED}" -eq 1 ]; then
+		nvme_settle
+		nvme disconnect -n "${NQN}" >/dev/null 2>&1 && \
+			info "nvme disconnected" || info "nvme disconnect failed"
+		CONNECTED=0
+	fi
+
+	if target_alive; then
+		if [ "${TRANSPORT_READY}" -eq 1 ]; then
+			nvmf_rpc nvmf_delete_subsystem \
+				"$(printf '{"nqn":"%s"}' "${NQN}")" >/dev/null 2>&1 || true
+		fi
+
+		for pair in "${C_LVS}:${C_CREATED}" "${B_LVS}:${B_CREATED}" \
+			    "${A_LVS}:${A_CREATED}"; do
+			[ "${pair#*:}" -eq 1 ] || continue
+			raw_rpc rcow_unload_lvstore \
+				"$(printf '{"lvs_name":"%s"}' "${pair%%:*}")" \
+				>/dev/null 2>&1 || TEARDOWN_ANOMALY=1
+		done
+
+		kill -TERM "${TGT_PID}" 2>/dev/null
+		for _ in $(seq 50); do
+			kill -0 "${TGT_PID}" 2>/dev/null || break
+			sleep 0.1
+		done
+		if kill -0 "${TGT_PID}" 2>/dev/null; then
+			info "target ignored SIGTERM: it is stuck, not slow"
+			TEARDOWN_ANOMALY=1
+			kill -KILL "${TGT_PID}" 2>/dev/null
+		else
+			info "target stopped cleanly"
+		fi
+	fi
+
+	# Swept whether or not the run passed, which is deliberate and differs from
+	# the older suites here.
+	#
+	# Those gate the sweep on FAIL being zero, to leave state behind to look at.
+	# The cost is worse than the benefit: this suite's prefixes are reused by
+	# name, so one failed run poisons every later one, and the second run's
+	# output is then a mixture of a real defect and the leftovers of the first.
+	# Measured, in run_pending_delete_test: the same single failure reads as 14
+	# broken checks on a dirty bucket and 1 on a clean one, and the difference
+	# cost a wrong attribution.
+	#
+	# S3LVOL_KEEP_S3 is the documented way to keep the objects and still works,
+	# so nothing is lost -- it is just no longer the accidental default of any
+	# run that happened to fail.
+	if [ "${ANY_CREATED}" -eq 1 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
+		for prefix in "${A_LVS}/" "${B_LVS}/" "${C_LVS}/"; do
+			remove_prefix "${prefix}" >>"${WORKDIR}/s3_rm.log" 2>&1 || \
+				info "sweep of ${prefix} failed"
+		done
+		# exports/ is bucket-level and shared with anything else running, so
+		# only this run's manifests go, by uuid.
+		for u in ${EXPORT_UUIDS}; do
+			remove_prefix "${S3_EXPORTS_DIR}/${u}" \
+				>>"${WORKDIR}/s3_rm.log" 2>&1 || true
+		done
+		info "S3 prefixes swept"
+	elif [ -n "${S3LVOL_KEEP_S3:-}" ]; then
+		info "S3 kept: ${A_LVS}/ ${B_LVS}/ ${C_LVS}/ and exports/"
+	fi
+
+	rm -f "${A_WAL_FILE}" "${B_WAL_FILE}" "${C_WAL_FILE}"
+
+	if [ "${FAIL}" -eq 0 ] && [ "${rc}" -eq 0 ] && \
+	   [ "${TEARDOWN_ANOMALY}" -eq 0 ] && [ -z "${S3LVOL_KEEP_LOGS:-}" ]; then
+		rm -rf "${WORKDIR}"
+	else
+		info "log and workdir kept: ${WORKDIR}"
+	fi
+
+	if [ "${TEARDOWN_ANOMALY}" -eq 1 ]; then
+		info "teardown was not clean"
+	fi
+
+	echo
+	echo "=== result: ${PASS} passed, ${FAIL} failed ==="
+	[ "${FAIL}" -eq 0 ] || exit 1
+	exit "${rc}"
+}
+trap cleanup EXIT
+
+# ==========================================================================
+echo "=== [0] preconditions"
+
+[ -x "${TGT_BIN}" ] || { echo "target not built: ${TGT_BIN}" >&2; exit 1; }
+if pgrep -f 's3lvol_tgt' >/dev/null 2>&1; then
+	echo "a target is already running" >&2
+	exit 1
+fi
+
+"${TOOLS_DIR}/check_binary_fresh.sh" "${TGT_BIN}" || {
+	echo "target binary is older than the source it was built from" >&2
+	exit 1; }
+pass "target binary is newer than the tree"
+
+rm -f "${RPC_SOCK}"
+for f in "${A_WAL_FILE}" "${B_WAL_FILE}" "${C_WAL_FILE}"; do
+	rm -f "${f}"
+	truncate -s "${WAL_FILE_MB}M" "${f}" || {
+		echo "could not create ${f}" >&2; exit 1; }
+done
+
+# Anything this run's prefixes still hold is from an earlier run that did not get
+# to sweep. Removed before starting rather than after failing, so a run always
+# begins from the same state no matter how the previous one ended.
+for prefix in "${A_LVS}/" "${B_LVS}/" "${C_LVS}/"; do
+	remove_prefix "${prefix}" >>"${WORKDIR}/s3_pre.log" 2>&1 || true
+done
+pass "stale prefixes from earlier runs removed"
+
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	"${TGT_BIN}" -m 0x3 --no-huge -s 2048 -r "${RPC_SOCK}" \
+	>"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+for _ in $(seq 120); do [ -S "${RPC_SOCK}" ] && break; sleep 0.25; done
+[ -S "${RPC_SOCK}" ] || { fail "target never opened its RPC socket"
+	tail -20 "${TGT_LOG}" | sed 's/^/       /'; exit 1; }
+sleep 1
+pass "target started"
+
+raw_rpc rcow_add_s3_config \
+	"$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"}' \
+		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}")" >/dev/null || {
+	fail "rcow_add_s3_config"; exit 1; }
+pass "S3 namespace registered"
+
+for pair in "${A_WAL_FILE}:${A_WAL_BDEV}" "${B_WAL_FILE}:${B_WAL_BDEV}" \
+	    "${C_WAL_FILE}:${C_WAL_BDEV}"; do
+	nvmf_rpc bdev_aio_create \
+		"$(printf '{"filename":"%s","name":"%s","block_size":4096}' \
+			"${pair%%:*}" "${pair#*:}")" >/dev/null 2>&1
+done
+
+nvmf_rpc nvmf_create_transport '{"trtype":"TCP"}' >/dev/null 2>&1
+nvmf_rpc nvmf_create_subsystem \
+	"$(printf '{"nqn":"%s","allow_any_host":true,"serial_number":"DERIVED00000001"}' \
+		"${NQN}")" >/dev/null 2>&1
+nvmf_rpc nvmf_subsystem_add_listener \
+	"$(printf '{"nqn":"%s","listen_address":{"trtype":"TCP","adrfam":"IPv4","traddr":"%s","trsvcid":"%s"}}' \
+		"${NQN}" "${LISTEN_ADDR}" "${LISTEN_PORT}")" >/dev/null 2>&1
+TRANSPORT_READY=1
+pass "nvmf transport and subsystem ready"
+
+# ==========================================================================
+echo
+echo "=== [1] node A: two halves, a snapshot, and a zero-copy export"
+
+create_lvstore "${A_LVS}" "${A_WAL_BDEV}" || {
+	fail "create lvstore ${A_LVS}"
+	sed 's/^/       /' "${WORKDIR}/${A_LVS}_create.err"; exit 1; }
+A_CREATED=1; ANY_CREATED=1
+pass "lvstore ${A_LVS} created"
+
+raw_rpc rcow_create_lvol \
+	"$(printf '{"lvol_name":"va","size_gib":%d}' "${LVOL_GIB}")" >/dev/null || {
+	fail "create va"; exit 1; }
+
+nvme connect -t tcp -a "${LISTEN_ADDR}" -s "${LISTEN_PORT}" -n "${NQN}" \
+	>/dev/null 2>&1
+CONNECTED=1
+sleep 2
+
+DEV="$(attach "${A_LVS}/va")"
+[ -b "${DEV}" ] || { fail "va did not become a device"; exit 1; }
+pass "va attached at ${DEV}"
+
+HEAD="${WORKDIR}/head.bin"
+TAIL_A="${WORKDIR}/tail_a.bin"
+TAIL_B="${WORKDIR}/tail_b.bin"
+dd if=/dev/urandom of="${HEAD}"   bs=1M count="${HALF_MB}" status=none
+dd if=/dev/urandom of="${TAIL_A}" bs=1M count="${HALF_MB}" status=none
+dd if=/dev/urandom of="${TAIL_B}" bs=1M count="${HALF_MB}" status=none
+HEAD_MD5="$(md5_of "${HEAD}")"
+TAILA_MD5="$(md5_of "${TAIL_A}")"
+TAILB_MD5="$(md5_of "${TAIL_B}")"
+
+write_at "${DEV}" "${HEAD}"   "${HEAD_OFF_MB}" || exit 1
+write_at "${DEV}" "${TAIL_A}" "${TAIL_OFF_MB}" || exit 1
+sync
+drop_caches
+want "A reads back the head it wrote" \
+	"$(read_md5_at "${DEV}" "${HEAD_OFF_MB}")" "${HEAD_MD5}"
+want "A reads back the tail it wrote" \
+	"$(read_md5_at "${DEV}" "${TAIL_OFF_MB}")" "${TAILA_MD5}"
+
+raw_rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${A_LVS}")" \
+	>/dev/null 2>&1 || info "flush of ${A_LVS} failed"
+raw_rpc rcow_create_snapshot '{"lvol_name":"va","snapshot_name":"sa"}' \
+	>/dev/null || { fail "snapshot sa"; exit 1; }
+raw_rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${A_LVS}")" \
+	>/dev/null 2>&1 || true
+pass "sa taken and flushed"
+
+EXP_A="$(raw_rpc rcow_export_snapshot '{"snapshot_name":"sa"}' 2>/dev/null \
+	| tr -d '"[:space:]')"
+[ -n "${EXP_A}" ] || { fail "export of sa"; exit 1; }
+EXPORT_UUIDS="${EXPORT_UUIDS} ${EXP_A}"
+wait_export_done "${EXP_A}" "node A" || exit 1
+pass "sa exported as ${EXP_A}"
+
+# A single-source export is written as version 2, so the version alone tells the
+# two apart later without having to reason about the source table.
+want "A's export is version 2" "$(manifest_field "${EXP_A}" version)" "2"
+
+check_target "node A" || exit 1
+
+unexpose "${CUR_NSID}"
+raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${A_LVS}")" \
+	>/dev/null 2>&1 || { fail "unload ${A_LVS}"; exit 1; }
+A_CREATED=0
+sleep 2
+pass "A unloaded -- everything it holds is now only in the bucket"
+
+# ==========================================================================
+echo
+echo "=== [2] node B: import A, rewrite the tail, zero the first MiB of the head"
+
+create_lvstore "${B_LVS}" "${B_WAL_BDEV}" || {
+	fail "create lvstore ${B_LVS}"
+	sed 's/^/       /' "${WORKDIR}/${B_LVS}_create.err"; exit 1; }
+B_CREATED=1
+pass "lvstore ${B_LVS} created"
+
+# decouple:false is the whole point: vb stays an esnap clone, so the head remains
+# A's objects and only the tail becomes B's. Decoupled, B would own every chunk
+# and there would be nothing to inherit.
+raw_rpc rcow_import_lvol \
+	"$(printf '{"lvol_name":"vb","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+		"${EXP_A}" "${B_LVS}")" >"${WORKDIR}/import_b.json" 2>&1 || {
+	fail "import into B"; sed 's/^/       /' "${WORKDIR}/import_b.json"; exit 1; }
+pass "A imported into B without decoupling"
+
+DEV="$(attach "${B_LVS}/vb")"
+[ -b "${DEV}" ] || { fail "vb did not become a device"; exit 1; }
+drop_caches
+
+# If this is wrong nothing after it means anything, so it is checked before the
+# rewrite rather than inferred from the end result.
+want "B reads A's head through the export" \
+	"$(read_md5_at "${DEV}" "${HEAD_OFF_MB}")" "${HEAD_MD5}"
+want "B reads A's tail through the export" \
+	"$(read_md5_at "${DEV}" "${TAIL_OFF_MB}")" "${TAILA_MD5}"
+
+write_at "${DEV}" "${TAIL_B}" "${TAIL_OFF_MB}" || exit 1
+sync
+drop_caches
+want "B's rewritten tail reads back" \
+	"$(read_md5_at "${DEV}" "${TAIL_OFF_MB}")" "${TAILB_MD5}"
+want "and B's head is untouched" \
+	"$(read_md5_at "${DEV}" "${HEAD_OFF_MB}")" "${HEAD_MD5}"
+
+HEAD_REST_MD5="$(md5_of_range "${HEAD}" "${ZERO_LEN_MB}" "${HEAD_REST_MB}")"
+ZERO_MD5="$(md5_of_zeroes "${ZERO_LEN_MB}")"
+
+if command -v blkdiscard >/dev/null 2>&1; then
+	if blkdiscard -z -o $((ZERO_OFF_MB * 1024 * 1024)) \
+		-l $((ZERO_LEN_MB * 1024 * 1024)) "${DEV}"; then
+		DID_ZERO=1
+		sync
+		drop_caches
+		want "B's first MiB of the head is now zeroes" \
+			"$(read_md5_range "${DEV}" "${ZERO_OFF_MB}" "${ZERO_LEN_MB}")" \
+			"${ZERO_MD5}"
+		want "and the rest of B's head is still A's" \
+			"$(read_md5_range "${DEV}" "${HEAD_REST_OFF_MB}" "${HEAD_REST_MB}")" \
+			"${HEAD_REST_MD5}"
+	else
+		fail "blkdiscard -z on the first MiB of B's head"
+	fi
+else
+	info "blkdiscard not available, skipping the local-zero inherit check"
+fi
+
+raw_rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${B_LVS}")" \
+	>/dev/null 2>&1 || info "flush of ${B_LVS} failed"
+raw_rpc rcow_create_snapshot '{"lvol_name":"vb","snapshot_name":"sb"}' \
+	>/dev/null || { fail "snapshot sb on an imported volume"; exit 1; }
+raw_rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${B_LVS}")" \
+	>/dev/null 2>&1 || true
+pass "sb taken on the imported volume"
+
+EXP_B="$(raw_rpc rcow_export_snapshot '{"snapshot_name":"sb"}' 2>/dev/null \
+	| tr -d '"[:space:]')"
+[ -n "${EXP_B}" ] || { fail "export of sb"; exit 1; }
+EXPORT_UUIDS="${EXPORT_UUIDS} ${EXP_B}"
+wait_export_done "${EXP_B}" "node B" || exit 1
+pass "sb exported as ${EXP_B}"
+
+check_target "node B" || exit 1
+
+# ==========================================================================
+echo
+echo "=== [3] was B's export derived, or copied?"
+
+# A copy would produce an export that reads perfectly and passes every data check
+# in [4]. The manifest is the only place the difference shows.
+want "B's export is version 3" "$(manifest_field "${EXP_B}" version)" "3"
+want "with layout still ref, so nothing was copied" \
+	"$(manifest_field "${EXP_B}" layout)" "ref"
+
+SRCS="$(manifest_field "${EXP_B}" srcs)"
+info "srcs: ${SRCS}"
+if printf '%s' "${SRCS}" | grep -q "${A_LVS}"; then
+	pass "its source table names A's prefix (${A_LVS})"
+else
+	fail "its source table does not name A's prefix: ${SRCS}"
+fi
+# The lease is renewed against whatever export uuid the entry names, so this is
+# not cosmetic: the wrong uuid here renews a lease nobody consults.
+if printf '%s' "${SRCS}" | grep -q "${EXP_A}"; then
+	pass "attributed to A's own export, which is what a lease renews"
+else
+	fail "no reference to A's export ${EXP_A} in: ${SRCS}"
+fi
+
+unexpose "${CUR_NSID}"
+raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${B_LVS}")" \
+	>/dev/null 2>&1 || { fail "unload ${B_LVS}"; exit 1; }
+B_CREATED=0
+sleep 2
+pass "B unloaded -- A and B are both gone now"
+
+# ==========================================================================
+echo
+echo "=== [4] node C: import the derived export and read both halves"
+
+create_lvstore "${C_LVS}" "${C_WAL_BDEV}" || {
+	fail "create lvstore ${C_LVS}"
+	sed 's/^/       /' "${WORKDIR}/${C_LVS}_create.err"; exit 1; }
+C_CREATED=1
+pass "lvstore ${C_LVS} created"
+
+raw_rpc rcow_import_lvol \
+	"$(printf '{"lvol_name":"vc","export_uuid":"%s","lvs_name":"%s","decouple":false}' \
+		"${EXP_B}" "${C_LVS}")" >"${WORKDIR}/import_c.json" 2>&1 || {
+	fail "import into C"; sed 's/^/       /' "${WORKDIR}/import_c.json"; exit 1; }
+pass "B's derived export imported into C"
+
+DEV="$(attach "${C_LVS}/vc")"
+[ -b "${DEV}" ] || { fail "vc did not become a device"; exit 1; }
+drop_caches
+
+# The two halves together are the assertion. The head can only come from A's
+# prefix and the tail only from B's, so this is what separates a right prefix from
+# a wrong one that still returns bytes -- and, since A also has data at the tail,
+# what proves the nearer layer wins. The first MiB of the head is the local-zero
+# case: inherit must not put A's object back.
+if [ "${DID_ZERO}" -eq 1 ]; then
+	want "C reads zeroes where B zeroed the head" \
+		"$(read_md5_range "${DEV}" "${ZERO_OFF_MB}" "${ZERO_LEN_MB}")" \
+		"${ZERO_MD5}"
+	want "C reads the rest of the head from A's prefix" \
+		"$(read_md5_range "${DEV}" "${HEAD_REST_OFF_MB}" "${HEAD_REST_MB}")" \
+		"${HEAD_REST_MD5}"
+else
+	want "C reads the head from A's prefix, with both A and B unloaded" \
+		"$(read_md5_at "${DEV}" "${HEAD_OFF_MB}")" "${HEAD_MD5}"
+fi
+want "C reads the tail as B rewrote it, not as A had it" \
+	"$(read_md5_at "${DEV}" "${TAIL_OFF_MB}")" "${TAILB_MD5}"
+
+if [ "$(read_md5_at "${DEV}" "${TAIL_OFF_MB}")" = "${TAILA_MD5}" ]; then
+	fail "C read A's tail: the inherited layer overwrote the local one"
+fi
+
+check_target "node C" || exit 1
+
+# ==========================================================================
+echo
+echo "=== [5] C renews a lease per prefix, not one per import"
+
+# A's snapshot is protected only by A's own lease. Renewing B's alone would leave
+# A free to delete the objects C's head resolves to, and C would start reading
+# 404s some time later -- a failure that would surface nowhere near here.
+#
+# The pattern is anchored on "export <uuid> lease", which is what an *importer*
+# logs. An export that references other prefixes renews on its own behalf too and
+# logs "export <uuid> upstream lease [i]", so a pattern starting at "lease [" also
+# counts the line B printed back in [2] -- this counted three for a while, and the
+# third one was neither C's nor wrong.
+sleep 3
+LEASES="$(grep -aoE "export [0-9a-f-]+ lease \[[0-9]+\]: [^ ]+" "${TGT_LOG}" | tail -8)"
+info "leases: $(printf '%s' "${LEASES}" | tr '\n' ' ')"
+want "C renews two leases" \
+	"$(printf '%s\n' "${LEASES}" | grep -c 'lease \[' || true)" "2"
+
+if printf '%s' "${LEASES}" | grep -q "${A_LVS}/meta/exports/${EXP_A}.lease"; then
+	pass "one is A's own export, so A will refuse to delete its snapshot"
+else
+	fail "A's lease ${A_LVS}/meta/exports/${EXP_A}.lease is not renewed"
+fi
+if printf '%s' "${LEASES}" | grep -q "${B_LVS}/meta/exports/${EXP_B}.lease"; then
+	pass "the other is B's"
+else
+	fail "B's lease is not renewed"
+fi
+
+check_target "leases" || exit 1
+
+# ==========================================================================
+echo
+echo "=== [6] converge B's snapshot and redirect its published export"
+
+# Keep C's old generation in its imports registry. After B rewrites the manifest
+# and A's objects disappear, C must encounter a 404, refetch generation 1 and
+# continue against B's local objects.
+unexpose "${CUR_NSID}"
+raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${C_LVS}")" \
+	>/dev/null 2>&1 || { fail "unload ${C_LVS} before convergence"; exit 1; }
+C_CREATED=0
+
+raw_rpc rcow_attach_lvstore \
+	"$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"%s"}' \
+		"${B_LVS}" "${BUCKET}" "${B_WAL_BDEV}")" \
+	>/dev/null 2>"${WORKDIR}/attach_b.err" || {
+	fail "re-attach ${B_LVS}"; sed 's/^/       /' "${WORKDIR}/attach_b.err"; exit 1; }
+B_CREATED=1
+pass "B re-attached with its reference snapshot and export"
+
+raw_rpc rcow_decouple_lvol "$(printf '{"lvol_name":"%s"}' "sb")" \
+	>/dev/null 2>"${WORKDIR}/decouple_sb.err" || {
+	fail "start decoupling sb"; sed 's/^/       /' "${WORKDIR}/decouple_sb.err"; exit 1; }
+if wait_for_decouple; then
+	pass "sb decoupled and its export rewrite completed"
+else
+	fail "sb decouple/export rewrite did not finish"
+	exit 1
+fi
+
+want "B's export generation advanced after convergence" \
+	"$(manifest_field "${EXP_B}" generation)" "1"
+want "B's converged export remains zero-copy ref" \
+	"$(manifest_field "${EXP_B}" layout)" "ref"
+SRCS="$(manifest_field "${EXP_B}" srcs)"
+info "converged srcs: ${SRCS}"
+if printf '%s' "${SRCS}" | grep -q "${A_LVS}"; then
+	fail "converged export still references A: ${SRCS}"
+else
+	pass "converged export no longer references A"
+fi
+if printf '%s' "$(manifest_field "${EXP_B}" source)" | grep -q "${B_LVS}"; then
+	pass "converged export references B's local objects"
+else
+	fail "converged export's primary source does not name B"
+fi
+if grep -q "export ${EXP_B} now references local snapshot 'sb' at generation 1" \
+	"${TGT_LOG}"; then
+	pass "B logged the automatic manifest redirection"
+else
+	fail "automatic manifest redirection was not logged"
+fi
+
+raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${B_LVS}")" \
+	>/dev/null 2>&1 || { fail "unload ${B_LVS} after convergence"; exit 1; }
+B_CREATED=0
+
+remove_prefix "${A_LVS}/" >"${WORKDIR}/remove_a.log" 2>&1 || {
+	fail "remove A's source objects"; exit 1; }
+pass "A's source prefix removed after B converged"
+
+raw_rpc rcow_attach_lvstore \
+	"$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"%s"}' \
+		"${C_LVS}" "${BUCKET}" "${C_WAL_BDEV}")" \
+	>/dev/null 2>"${WORKDIR}/reattach_c.err" || {
+	fail "re-attach ${C_LVS}"; sed 's/^/       /' "${WORKDIR}/reattach_c.err"; exit 1; }
+C_CREATED=1
+DEV="$(attach "${C_LVS}/vc")"
+[ -b "${DEV}" ] || { fail "vc did not return after C re-attached"; exit 1; }
+drop_caches
+if [ "${DID_ZERO}" -eq 1 ]; then
+	want "C refetches the rewritten manifest and still reads the zeroed prefix" \
+		"$(read_md5_range "${DEV}" "${ZERO_OFF_MB}" "${ZERO_LEN_MB}")" \
+		"${ZERO_MD5}"
+	want "C still reads the rest of the head after refetch" \
+		"$(read_md5_range "${DEV}" "${HEAD_REST_OFF_MB}" "${HEAD_REST_MB}")" \
+		"${HEAD_REST_MD5}"
+else
+	want "C refetches the rewritten manifest and still reads the head" \
+		"$(read_md5_at "${DEV}" "${HEAD_OFF_MB}")" "${HEAD_MD5}"
+fi
+want "C still reads B's tail with A gone" \
+	"$(read_md5_at "${DEV}" "${TAIL_OFF_MB}")" "${TAILB_MD5}"
+if grep -q "export ${EXP_B}: now reading generation 1" "${TGT_LOG}"; then
+	pass "C switched from its cached manifest to generation 1"
+else
+	fail "C did not log a manifest refetch to generation 1"
+fi
+
+check_target "automatic export convergence" || exit 1
+
+# ==========================================================================
+echo
+echo "=== [7] persist the refetched generation, then derive and decouple"
+
+unexpose "${CUR_NSID}"
+raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${C_LVS}")" \
+	>/dev/null 2>&1 || { fail "unload ${C_LVS} after refetch persist"; exit 1; }
+C_CREATED=0
+raw_rpc rcow_attach_lvstore \
+	"$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"%s"}' \
+		"${C_LVS}" "${BUCKET}" "${C_WAL_BDEV}")" \
+	>/dev/null 2>"${WORKDIR}/restart_c.err" || {
+	fail "re-attach ${C_LVS} after refetch persist"
+	sed 's/^/       /' "${WORKDIR}/restart_c.err"; exit 1; }
+C_CREATED=1
+DEV="$(attach "${C_LVS}/vc")"
+[ -b "${DEV}" ] || { fail "vc did not return after refetch persist"; exit 1; }
+drop_caches
+if [ "${DID_ZERO}" -eq 1 ]; then
+	want "C still reads zeroes after restart on the persisted generation" \
+		"$(read_md5_range "${DEV}" "${ZERO_OFF_MB}" "${ZERO_LEN_MB}")" \
+		"${ZERO_MD5}"
+	want "C still reads the rest of the head after restart" \
+		"$(read_md5_range "${DEV}" "${HEAD_REST_OFF_MB}" "${HEAD_REST_MB}")" \
+		"${HEAD_REST_MD5}"
+else
+	want "C still reads the head after restart on the persisted generation" \
+		"$(read_md5_at "${DEV}" "${HEAD_OFF_MB}")" "${HEAD_MD5}"
+fi
+want "C still reads B's tail after restart" \
+	"$(read_md5_at "${DEV}" "${TAIL_OFF_MB}")" "${TAILB_MD5}"
+
+# C's data plane has generation 1. Derive and same-bucket decouple used to
+# read imp->m, which stayed on generation 0 and named A's objects -- already
+# deleted. Restart used the persisted registry copy of the same stale
+# generation.
+raw_rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${C_LVS}")" \
+	>/dev/null 2>&1 || true
+raw_rpc rcow_create_snapshot '{"lvol_name":"vc","snapshot_name":"sc"}' \
+	>/dev/null || { fail "snapshot sc after refetch"; exit 1; }
+EXP_C="$(raw_rpc rcow_export_snapshot '{"snapshot_name":"sc"}' 2>/dev/null \
+	| tr -d '"[:space:]')"
+[ -n "${EXP_C}" ] || { fail "export of sc"; exit 1; }
+EXPORT_UUIDS="${EXPORT_UUIDS} ${EXP_C}"
+wait_export_done "${EXP_C}" "node C after refetch" || exit 1
+pass "sc exported as ${EXP_C}"
+
+SRCS="$(manifest_field "${EXP_C}" srcs)"
+info "derived-after-refetch srcs: ${SRCS}"
+if printf '%s' "${SRCS}" | grep -q "${A_LVS}"; then
+	fail "derived export after refetch still names A's prefix: ${SRCS}"
+else
+	pass "derived export after refetch does not name A's deleted prefix"
+fi
+
+raw_rpc rcow_decouple_lvol '{"lvol_name":"sc"}' \
+	>/dev/null 2>"${WORKDIR}/decouple_sc.err" || {
+	fail "decouple sc after refetch"
+	sed 's/^/       /' "${WORKDIR}/decouple_sc.err"; exit 1; }
+if wait_for_decouple; then
+	pass "sc decoupled against the refetched generation"
+else
+	fail "sc decouple after refetch did not finish"
+	exit 1
+fi
+drop_caches
+if [ "${DID_ZERO}" -eq 1 ]; then
+	want "C still reads zeroes after decouple" \
+		"$(read_md5_range "${DEV}" "${ZERO_OFF_MB}" "${ZERO_LEN_MB}")" \
+		"${ZERO_MD5}"
+	want "C still reads the rest of the head after decouple" \
+		"$(read_md5_range "${DEV}" "${HEAD_REST_OFF_MB}" "${HEAD_REST_MB}")" \
+		"${HEAD_REST_MD5}"
+else
+	want "C still reads the head after decouple" \
+		"$(read_md5_at "${DEV}" "${HEAD_OFF_MB}")" "${HEAD_MD5}"
+fi
+want "C still reads B's tail after decouple" \
+	"$(read_md5_at "${DEV}" "${TAIL_OFF_MB}")" "${TAILB_MD5}"
+
+check_target "derive/decouple after refetch" || exit 1
+
+echo
+echo "=== all steps done"

--- a/CubeS3lvol/test/dataplane/run_export_test.sh
+++ b/CubeS3lvol/test/dataplane/run_export_test.sh
@@ -238,6 +238,33 @@ check_deletable()
 	fi
 }
 
+# Lease-aware: a 404 recorded before expires_at does not unpin, and the lease
+# poller is floored at 20s. Poll until the field matches rather than sleeping
+# a TTL-sized margin.
+wait_deletable()
+{
+	local uuid="$1"
+	local want="$2"
+	local where="$3"
+	local deadline=$(( $(date +%s) + 90 ))
+	local got
+
+	while :; do
+		if ! got="$(export_status_field "${uuid}" deletable)"; then
+			fail "cannot read deletable: export ${uuid} does not exist (${where})"
+			return 1
+		fi
+		if [ "${got}" = "${want}" ]; then
+			return 0
+		fi
+		if [ "$(date +%s)" -ge "${deadline}" ]; then
+			fail "deletable=${got}, expected ${want} for ${uuid} (${where})"
+			return 1
+		fi
+		sleep 1
+	done
+}
+
 now_ns()
 {
 	date +%s%N
@@ -851,14 +878,40 @@ SNAP_DEL2="$(snapshot_status_field "${EXPORT_SNAP_NAME}" deletable)" \
 	&& pass "both forms agree that it is not deletable" \
 	|| fail "the snapshot form says deletable='${SNAP_DEL2}', expected NO"
 
-if raw_rpc rcow_delete_lvol \
-		"$(printf '{"lvol_name":"%s"}' "${EXPORT_SNAP_NAME}")" \
-		>/dev/null 2>&1; then
-	fail "deleting the snapshot behind a live export succeeded"
-	exit 1
-else
+# The delete does not go through -- deletable said NO and the delete path agrees
+# -- but how that is reported depends on whether the export's liveness can be
+# decided. An export this fresh has not had its first lease check answered yet,
+# so the target assumes an importer may arrive, records the intent, and reports
+# it as deferred: the delete completes by itself once the lease goes stale, with
+# no release_export and no retry. Only an export known to have no lease at all
+# (the pre-lease case, where a TTL is the sole signal) is refused outright.
+#
+# Either way the snapshot must still be here, which is the property this step
+# exists for.
+# --raw, not raw_rpc: that helper unwraps the {bool_value, string_value}
+# envelope, which is what hides the deferred flag this has to look at.
+DEL_OUT="$(python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --raw \
+	rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "${EXPORT_SNAP_NAME}")" 2>&1)"
+if echo "${DEL_OUT}" | grep -q '"deferred": *true'; then
+	pass "rcow_delete_lvol defers it (the export still pins it)"
+elif echo "${DEL_OUT}" | grep -q '"bool_value": *false'; then
 	pass "rcow_delete_lvol refuses it too (deletable agrees with the delete path)"
+else
+	fail "deleting the snapshot behind a live export was accepted outright: ${DEL_OUT}"
+	exit 1
 fi
+
+if snapshot_status_field "${EXPORT_SNAP_NAME}" export_status >/dev/null 2>&1; then
+	pass "the exported snapshot is still there"
+else
+	fail "the snapshot behind a live export is gone"
+	exit 1
+fi
+
+# Withdraw the intent, or the poller would delete this snapshot as soon as the
+# export stops pinning it -- the rest of this suite still needs it.
+raw_rpc rcow_cancel_pending_delete \
+	"$(printf '{"lvol_name":"%s"}' "${EXPORT_SNAP_NAME}")" >/dev/null 2>&1
 check_target "step 3, deletable" || exit 1
 
 # An uuid nobody exported is refused rather than described: the reply carries
@@ -1979,9 +2032,11 @@ wait_export_done "${TTL_U}" "step 11d.4" || exit 1
 
 check_deletable "${TTL_U}" NO "step 11d.4, within TTL"
 
-# 3 s ttl plus margin; the poll that does the work is once a second.
-sleep 5
-
+# 3 s ttl plus margin is not the unpin: a miss from before expires_at must be
+# followed by a poll at or after the deadline, at the 20s lease cadence.
+wait_deletable "${TTL_U}" YES "step 11d.4, after TTL" || {
+	check_target "step 11d.4" || exit 1
+}
 ST_TTL="$(export_status_field "${TTL_U}" export_status)"
 [ "${ST_TTL}" = "DONE" ] \
 	&& pass "the expired export still reports DONE" \

--- a/CubeS3lvol/test/dataplane/run_export_test.sh
+++ b/CubeS3lvol/test/dataplane/run_export_test.sh
@@ -3991,6 +3991,405 @@ done
 check_target "step 11j" || exit 1
 
 # ==========================================================================
+# [11k] import, delete, import the same export again (decouple:true)
+#
+# A destination node that resumes a sandbox and later tears it down does this:
+# import the export, delete the volume, import the same uuid again. Every
+# earlier step either keeps the imported volume or deletes it as cleanup and
+# never comes back. The field report is that repeating that pair on the
+# destination is what breaks -- leftover registry, lease, or name -- so the
+# same export is imported, deleted and imported again here, three times, with
+# decouple:true.
+# ==========================================================================
+echo
+echo "[11k] importing, deleting and re-importing the same export"
+
+REIMP_SRC="${SRC_VOL}-reimp"
+REIMP_SNAP="${REIMP_SRC}-snap"
+REIMP_DST="${DST_VOL}-reimp"
+REIMP_ROUNDS=3
+
+if ! raw_rpc rcow_create_lvol "$(printf '{"lvol_name":"%s","size_gib":%d}' \
+		"${REIMP_SRC}" "${LVOL_GIB}")" \
+		>/dev/null 2>"${WORKDIR}/reimp_lvol.err"; then
+	fail "rcow_create_lvol (${REIMP_SRC})"
+	sed 's/^/       /' "${WORKDIR}/reimp_lvol.err"
+	exit 1
+fi
+
+BEFORE_REIMP_SRC_NS="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
+${RPC} nvmf_subsystem_add_ns "${NQN}" "${SRC_LVS}/${REIMP_SRC}" \
+	>/dev/null 2>&1 || { fail "nvmf_subsystem_add_ns (${REIMP_SRC})"; exit 1; }
+REIMP_SRC_DEV="$(wait_for_new_ns "${BEFORE_REIMP_SRC_NS}")"
+if [ -z "${REIMP_SRC_DEV}" ]; then
+	fail "no namespace for ${REIMP_SRC}"
+	exit 1
+fi
+write_pattern "${REIMP_SRC_DEV}" "${WORKDIR}/REIMP.bin"
+REIMP_HASH="$(md5_of "${WORKDIR}/REIMP.bin")"
+
+if ! raw_rpc rcow_create_snapshot "$(printf '{"lvol_name":"%s","snapshot_name":"%s"}' \
+		"${REIMP_SRC}" "${REIMP_SNAP}")" \
+		>/dev/null 2>"${WORKDIR}/reimp_snap.err"; then
+	fail "rcow_create_snapshot (${REIMP_SNAP})"
+	sed 's/^/       /' "${WORKDIR}/reimp_snap.err"
+	exit 1
+fi
+
+nvme_settle
+REIMP_SRC_NSID="$(nsid_of "${SRC_LVS}/${REIMP_SRC}")"
+[ -n "${REIMP_SRC_NSID}" ] && ${RPC} nvmf_subsystem_remove_ns "${NQN}" \
+	"${REIMP_SRC_NSID}" >/dev/null 2>&1 || true
+
+REIMP_UUID="$(raw_rpc rcow_export_snapshot \
+	"$(printf '{"snapshot_name":"%s"}' "${REIMP_SNAP}")" 2>/dev/null \
+	| tr -d '"[:space:]')"
+if [ -z "${REIMP_UUID}" ]; then
+	fail "rcow_export_snapshot (step 11k)"
+	exit 1
+fi
+wait_export_done "${REIMP_UUID}" "step 11k" || exit 1
+pass "export ${REIMP_UUID} ready for repeated import"
+
+if ! raw_rpc rcow_attach_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"%s"}' \
+		"${DST_LVS}" "${BUCKET}" "${DST_WAL_BDEV}")" \
+		>/dev/null 2>"${WORKDIR}/reimp_attach.err"; then
+	fail "rcow_attach_lvstore (destination, for step 11k)"
+	sed 's/^/       /' "${WORKDIR}/reimp_attach.err"
+	exit 1
+fi
+DST_CREATED=1
+
+for round in $(seq 1 "${REIMP_ROUNDS}"); do
+	if ! raw_rpc rcow_import_lvol "$(printf '{"lvol_name":"%s","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+			"${REIMP_DST}" "${REIMP_UUID}" "${DST_LVS}")" \
+			>/dev/null 2>"${WORKDIR}/reimp_import_${round}.err"; then
+		fail "rcow_import_lvol (round ${round} of ${REIMP_ROUNDS})"
+		sed 's/^/       /' "${WORKDIR}/reimp_import_${round}.err"
+		check_target "step 11k, import round ${round}" || exit 1
+		exit 1
+	fi
+	pass "round ${round}: imported ${REIMP_DST}"
+
+	if wait_for_decouple; then
+		pass "round ${round}: decouple finished"
+	else
+		fail "round ${round}: decouple did not finish in 120s"
+		sed 's/^/       /' "${WORKDIR}/decouple_progress.json" 2>/dev/null | head -3
+		check_target "step 11k, decouple round ${round}" || exit 1
+		exit 1
+	fi
+
+	BEFORE_REIMP_NS="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
+	${RPC} nvmf_subsystem_add_ns "${NQN}" "${DST_LVS}/${REIMP_DST}" \
+		>/dev/null 2>&1 || {
+		fail "nvmf_subsystem_add_ns (${REIMP_DST}, round ${round})"
+		exit 1; }
+	REIMP_DEV="$(wait_for_new_ns "${BEFORE_REIMP_NS}")"
+	if [ -z "${REIMP_DEV}" ]; then
+		fail "round ${round}: no namespace for ${REIMP_DST}"
+		exit 1
+	fi
+
+	REIMP_GOT="$(read_md5 "${REIMP_DEV}" "${WORKDIR}/reimp_got_${round}.bin")"
+	if [ "${REIMP_GOT}" = "${REIMP_HASH}" ]; then
+		pass "round ${round}: the imported volume reads the exported data"
+	else
+		fail "round ${round}: imported data mismatch (${REIMP_GOT} != ${REIMP_HASH})"
+		exit 1
+	fi
+
+	nvme_settle
+	REIMP_NSID="$(nsid_of "${DST_LVS}/${REIMP_DST}")"
+	[ -n "${REIMP_NSID}" ] && ${RPC} nvmf_subsystem_remove_ns "${NQN}" \
+		"${REIMP_NSID}" >/dev/null 2>&1 || true
+	if ! raw_rpc rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "${REIMP_DST}")" \
+			>/dev/null 2>"${WORKDIR}/reimp_del_${round}.err"; then
+		fail "rcow_delete_lvol (${REIMP_DST}, round ${round})"
+		sed 's/^/       /' "${WORKDIR}/reimp_del_${round}.err"
+		exit 1
+	fi
+
+	if ${RPC} bdev_get_bdevs -b "${DST_LVS}/${REIMP_DST}" \
+			>/dev/null 2>"${WORKDIR}/reimp_bdev_${round}.err"; then
+		fail "round ${round}: ${REIMP_DST} is still registered after delete"
+		exit 1
+	fi
+	pass "round ${round}: deleted, name is free"
+
+	if raw_rpc rcow_get_imports "$(printf '{"lvs_name":"%s"}' "${DST_LVS}")" \
+			>"${WORKDIR}/reimp_imports_${round}.json" 2>/dev/null && \
+	   grep -q "${REIMP_UUID}" "${WORKDIR}/reimp_imports_${round}.json"; then
+		fail "round ${round}: the registry still lists the export after delete"
+	else
+		pass "round ${round}: the registry no longer lists the export"
+	fi
+	check_target "step 11k, round ${round}" || exit 1
+done
+pass "the same export was imported, deleted and imported again ${REIMP_ROUNDS} times"
+
+raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${DST_LVS}")" \
+	>/dev/null 2>&1 || fail "rcow_unload_lvstore (destination, after step 11k)"
+DST_CREATED=0
+
+REIMP_RELEASED=0
+for _ in $(seq 40); do
+	if raw_rpc rcow_release_export "$(printf '{"export_uuid":"%s","lvs_name":"%s"}' \
+			"${REIMP_UUID}" "${SRC_LVS}")" \
+			>/dev/null 2>"${WORKDIR}/reimp_release.err"; then
+		REIMP_RELEASED=1
+		break
+	fi
+	sleep 0.5
+done
+if [ "${REIMP_RELEASED}" = "1" ]; then
+	pass "the reimport export was released"
+else
+	fail "rcow_release_export (step 11k)"
+	sed 's/^/       /' "${WORKDIR}/reimp_release.err" 2>/dev/null
+fi
+
+for vol in "${REIMP_SRC}" "${REIMP_SNAP}"; do
+	raw_rpc rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "${vol}")" \
+		>/dev/null 2>&1 || fail "rcow_delete_lvol (${vol})"
+done
+
+check_target "step 11k" || exit 1
+
+# ==========================================================================
+# [11l] delete the import *while its decouple is still running*
+#
+# 11k waits for the copy to finish, which is not what a caller that treats
+# rcow_import_lvol's reply as "the volume is fully local" does. Import with
+# decouple:true starts the copy in the background and answers at once; a
+# delete that lands in that window is deferred (the volume is still there,
+# action_in_progress is set), so a same-name import of the same uuid fails
+# until the pending delete actually completes. That is the field report;
+# 11k cannot see it.
+# ==========================================================================
+echo
+echo "[11l] deleting an import whose decouple is still running"
+
+BUSY_SRC="${SRC_VOL}-busy"
+BUSY_SNAP="${BUSY_SRC}-snap"
+BUSY_DST="${DST_VOL}-busy"
+# Enough allocated clusters that the copy is still on the list when delete
+# runs. 8 MiB (11k) finishes in tens of milliseconds and misses the window.
+BUSY_LEN_MB=64
+
+if ! raw_rpc rcow_create_lvol "$(printf '{"lvol_name":"%s","size_gib":%d}' \
+		"${BUSY_SRC}" "${LVOL_GIB}")" \
+		>/dev/null 2>"${WORKDIR}/busy_lvol.err"; then
+	fail "rcow_create_lvol (${BUSY_SRC})"
+	sed 's/^/       /' "${WORKDIR}/busy_lvol.err"
+	exit 1
+fi
+
+BEFORE_BUSY_SRC_NS="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
+${RPC} nvmf_subsystem_add_ns "${NQN}" "${SRC_LVS}/${BUSY_SRC}" \
+	>/dev/null 2>&1 || { fail "nvmf_subsystem_add_ns (${BUSY_SRC})"; exit 1; }
+BUSY_SRC_DEV="$(wait_for_new_ns "${BEFORE_BUSY_SRC_NS}")"
+if [ -z "${BUSY_SRC_DEV}" ]; then
+	fail "no namespace for ${BUSY_SRC}"
+	exit 1
+fi
+write_pattern_at "${BUSY_SRC_DEV}" "${WORKDIR}/BUSY.bin" "${IO_OFF_MB}" "${BUSY_LEN_MB}"
+BUSY_HASH="$(md5_of "${WORKDIR}/BUSY.bin")"
+
+if ! raw_rpc rcow_create_snapshot "$(printf '{"lvol_name":"%s","snapshot_name":"%s"}' \
+		"${BUSY_SRC}" "${BUSY_SNAP}")" \
+		>/dev/null 2>"${WORKDIR}/busy_snap.err"; then
+	fail "rcow_create_snapshot (${BUSY_SNAP})"
+	sed 's/^/       /' "${WORKDIR}/busy_snap.err"
+	exit 1
+fi
+
+nvme_settle
+BUSY_SRC_NSID="$(nsid_of "${SRC_LVS}/${BUSY_SRC}")"
+[ -n "${BUSY_SRC_NSID}" ] && ${RPC} nvmf_subsystem_remove_ns "${NQN}" \
+	"${BUSY_SRC_NSID}" >/dev/null 2>&1 || true
+
+BUSY_UUID="$(raw_rpc rcow_export_snapshot \
+	"$(printf '{"snapshot_name":"%s"}' "${BUSY_SNAP}")" 2>/dev/null \
+	| tr -d '"[:space:]')"
+if [ -z "${BUSY_UUID}" ]; then
+	fail "rcow_export_snapshot (step 11l)"
+	exit 1
+fi
+wait_export_done "${BUSY_UUID}" "step 11l" || exit 1
+pass "export ${BUSY_UUID} ready (${BUSY_LEN_MB} MiB to copy)"
+
+if ! raw_rpc rcow_attach_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"%s"}' \
+		"${DST_LVS}" "${BUCKET}" "${DST_WAL_BDEV}")" \
+		>/dev/null 2>"${WORKDIR}/busy_attach.err"; then
+	fail "rcow_attach_lvstore (destination, for step 11l)"
+	sed 's/^/       /' "${WORKDIR}/busy_attach.err"
+	exit 1
+fi
+DST_CREATED=1
+
+if ! raw_rpc rcow_import_lvol "$(printf '{"lvol_name":"%s","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+		"${BUSY_DST}" "${BUSY_UUID}" "${DST_LVS}")" \
+		>/dev/null 2>"${WORKDIR}/busy_import.err"; then
+	fail "rcow_import_lvol (${BUSY_DST})"
+	sed 's/^/       /' "${WORKDIR}/busy_import.err"
+	exit 1
+fi
+pass "imported ${BUSY_DST} with decouple:true (not waiting)"
+
+# The window this step exists to hit. An empty list here means the copy already
+# finished and a delete would go through for the wrong reason.
+raw_rpc rcow_get_decouple "" >"${WORKDIR}/busy_decouple.json" 2>/dev/null || true
+if python3 -c "
+import json, sys
+sys.exit(0 if len(json.load(open(sys.argv[1]))) > 0 else 1)
+" "${WORKDIR}/busy_decouple.json"; then
+	pass "the decouple is still running"
+else
+	fail "the decouple had already finished; ${BUSY_LEN_MB} MiB was not enough to catch the window"
+	sed 's/^/       /' "${WORKDIR}/busy_decouple.json" 2>/dev/null | head -3
+	exit 1
+fi
+
+# --raw, because the unwrapped reply is just the name and hides deferred.
+BUSY_DEL="$(python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --raw \
+	rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "${BUSY_DST}")" 2>&1)"
+if echo "${BUSY_DEL}" | grep -q '"deferred": *true'; then
+	pass "delete while decouple is running was deferred"
+else
+	fail "delete while decouple is running was not deferred: ${BUSY_DEL}"
+	exit 1
+fi
+
+if ${RPC} bdev_get_bdevs -b "${DST_LVS}/${BUSY_DST}" \
+		>/dev/null 2>"${WORKDIR}/busy_still.err"; then
+	pass "the volume is still registered (the delete has not run yet)"
+else
+	fail "the volume vanished on a deferred delete"
+	exit 1
+fi
+
+if raw_rpc rcow_get_pending_deletes "$(printf '{"lvs_name":"%s"}' "${DST_LVS}")" \
+		>"${WORKDIR}/busy_pending.json" 2>/dev/null && \
+   python3 -c "
+import json, sys
+name, reason = sys.argv[1], sys.argv[2]
+try:
+    q = json.load(open(sys.argv[3]))
+except Exception:
+    sys.exit(1)
+sys.exit(0 if any(e.get('lvol_name') == name and e.get('reason') == reason for e in q) else 1)
+" "${BUSY_DST}" "decouple" "${WORKDIR}/busy_pending.json"; then
+	pass "the pending-delete queue names it as reason=decouple"
+else
+	fail "the deferred delete is not queued as decouple: $(cat "${WORKDIR}/busy_pending.json" 2>/dev/null)"
+fi
+
+if raw_rpc rcow_import_lvol "$(printf '{"lvol_name":"%s","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+		"${BUSY_DST}" "${BUSY_UUID}" "${DST_LVS}")" \
+		>/dev/null 2>"${WORKDIR}/busy_reimp_early.err"; then
+	fail "a same-name import succeeded while the deferred delete had not run"
+	exit 1
+else
+	pass "same-name import refused while the volume is still there"
+fi
+
+if wait_for_decouple; then
+	pass "the decouple finished (the pending delete can now complete)"
+else
+	fail "the decouple did not finish in 120s"
+	exit 1
+fi
+
+# The poller ticks once a minute; --retry-pending is the same destroy once
+# deletable is YES, without waiting for that tick.
+python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --retry-pending \
+	>/dev/null 2>"${WORKDIR}/busy_retry.err" || true
+BUSY_GONE=0
+for _ in $(seq 90); do
+	if ! ${RPC} bdev_get_bdevs -b "${DST_LVS}/${BUSY_DST}" \
+			>/dev/null 2>/dev/null; then
+		BUSY_GONE=1
+		break
+	fi
+	sleep 1
+done
+if [ "${BUSY_GONE}" = "1" ]; then
+	pass "the pending delete completed; the name is free"
+else
+	fail "the volume was still registered 90s after the decouple finished"
+	exit 1
+fi
+
+if ! raw_rpc rcow_import_lvol "$(printf '{"lvol_name":"%s","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+		"${BUSY_DST}" "${BUSY_UUID}" "${DST_LVS}")" \
+		>/dev/null 2>"${WORKDIR}/busy_reimp.err"; then
+	fail "rcow_import_lvol after the pending delete completed"
+	sed 's/^/       /' "${WORKDIR}/busy_reimp.err"
+	exit 1
+fi
+pass "imported ${BUSY_DST} again once the name was free"
+
+if wait_for_decouple; then
+	pass "the second decouple finished"
+else
+	fail "the second decouple did not finish in 120s"
+	exit 1
+fi
+
+BEFORE_BUSY_NS="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
+${RPC} nvmf_subsystem_add_ns "${NQN}" "${DST_LVS}/${BUSY_DST}" \
+	>/dev/null 2>&1 || { fail "nvmf_subsystem_add_ns (${BUSY_DST})"; exit 1; }
+BUSY_DEV="$(wait_for_new_ns "${BEFORE_BUSY_NS}")"
+if [ -z "${BUSY_DEV}" ]; then
+	fail "no namespace for the reimported volume"
+	exit 1
+fi
+BUSY_GOT="$(read_md5_at "${BUSY_DEV}" "${WORKDIR}/busy_got.bin" \
+	"${IO_OFF_MB}" "${BUSY_LEN_MB}")"
+if [ "${BUSY_GOT}" = "${BUSY_HASH}" ]; then
+	pass "the reimported volume reads the exported data"
+else
+	fail "reimported data mismatch (${BUSY_GOT} != ${BUSY_HASH})"
+	exit 1
+fi
+
+nvme_settle
+BUSY_NSID="$(nsid_of "${DST_LVS}/${BUSY_DST}")"
+[ -n "${BUSY_NSID}" ] && ${RPC} nvmf_subsystem_remove_ns "${NQN}" \
+	"${BUSY_NSID}" >/dev/null 2>&1 || true
+raw_rpc rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "${BUSY_DST}")" \
+	>/dev/null 2>&1 || fail "rcow_delete_lvol (${BUSY_DST})"
+
+raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${DST_LVS}")" \
+	>/dev/null 2>&1 || fail "rcow_unload_lvstore (destination, after step 11l)"
+DST_CREATED=0
+
+BUSY_RELEASED=0
+for _ in $(seq 40); do
+	if raw_rpc rcow_release_export "$(printf '{"export_uuid":"%s","lvs_name":"%s"}' \
+			"${BUSY_UUID}" "${SRC_LVS}")" \
+			>/dev/null 2>"${WORKDIR}/busy_release.err"; then
+		BUSY_RELEASED=1
+		break
+	fi
+	sleep 0.5
+done
+if [ "${BUSY_RELEASED}" = "1" ]; then
+	pass "the in-flight-delete export was released"
+else
+	fail "rcow_release_export (step 11l)"
+	sed 's/^/       /' "${WORKDIR}/busy_release.err" 2>/dev/null
+fi
+
+for vol in "${BUSY_SRC}" "${BUSY_SNAP}"; do
+	raw_rpc rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "${vol}")" \
+		>/dev/null 2>&1 || fail "rcow_delete_lvol (${vol})"
+done
+
+check_target "step 11l" || exit 1
+
+# ==========================================================================
 # [12] target log
 # ==========================================================================
 echo
@@ -4076,7 +4475,7 @@ fi
 # provokes on purpose to prove deletable agrees with the delete path. It is an
 # expected refusal like the ones beside it, not a fault.
 LOG_ERRORS="$(grep -inE 'error|failed' "${TGT_LOG}" 2>/dev/null | \
-	grep -viE 'already|not found|read-only|is not a snapshot|meta/owner|still the parent|imports.json|is the snapshot behind export' | \
+	grep -viE 'already|not found|read-only|is not a snapshot|meta/owner|still the parent|imports.json|is the snapshot behind export|cannot be deleted yet|in progress on lvol' | \
 	grep -viE 'response status=404' || true)"
 # The 404 a reread already dealt with is not an unexpected error either.
 if [ -n "${LOG_ERRORS}" ] && [ -n "${REREAD_UUIDS}" ]; then

--- a/CubeS3lvol/test/dataplane/run_pending_delete_test.sh
+++ b/CubeS3lvol/test/dataplane/run_pending_delete_test.sh
@@ -26,6 +26,19 @@
 #    4. an unmarked snapshot is never deleted by --retry-pending, however
 #       deletable it is
 #
+#  Step [10] covers the other half of the registry leak: a lease-aware export
+#  nobody imported, past its TTL, with no pending delete. The snapshot stays;
+#  the export must not.
+#
+#  Step [11] delays the pending-delete registry HEAD and GET around unload. A
+#  late callback must not use a freed wrapper, and must not restore marks until
+#  a later attach's own load (a same-name replacement has a new uuid and is
+#  ignored).
+#
+#  Step [12] writes a lease after the first 404 and before the deadline. The
+#  reaper must not treat that historical miss as "nobody imported" once the
+#  TTL lapses.
+#
 #  === Why an export is used as the blocker ===
 #
 #  It is the one blocker a test can raise and drop on demand: rcow_export_snapshot
@@ -110,6 +123,53 @@ lvol_exists()
 	[ -n "$(lvol_field "$1" name)" ]
 }
 
+pendel_ns()
+{
+	python3 -c '
+import json, sys
+try:
+    print(json.load(open(sys.argv[1]))[sys.argv[2]]["ns_name"])
+except Exception:
+    print("")
+' "${RCOW_BSTORE_FILE}" "${RCOW_LVS_NAME}" 2>/dev/null
+}
+
+pendel_attach()
+{
+	local ns="${LVS_NS:-$(pendel_ns)}"
+
+	[ -n "${ns}" ] || ns="${BUCKET}"
+	rpc rcow_attach_lvstore \
+		"$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"%s"}' \
+		   "${RCOW_LVS_NAME}" "${ns}" "${RCOW_WAL_BDEV}")"
+}
+
+pendel_unload()
+{
+	rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${RCOW_LVS_NAME}")"
+}
+
+pending_load_parked()
+{
+	rpc rcow_pending_load_hold '{}' 2>/dev/null | python3 -c '
+import json, sys
+try:
+    print(int(json.load(sys.stdin).get("parked", 0)))
+except Exception:
+    print(0)
+'
+}
+
+wait_pending_parked()
+{
+	local want="$1"
+	for _ in $(seq 30); do
+		[ "$(pending_load_parked)" = "${want}" ] && return 0
+		sleep 1
+	done
+	return 1
+}
+
 resolve()
 {
 	local name="$1"
@@ -150,6 +210,15 @@ except Exception:
 		rcow_load_credentials
 		python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "${BUCKET}" \
 			-r "$(rcow_cfg_get region)" -p "${RCOW_LVS_NAME}/" 2>&1 | tail -1
+		# Manifests live at the bucket root (exports/<uuid>.json), outside
+		# this lvstore's prefix, so the sweep above does not reach them. The
+		# reaper deletes the ones whose snapshot went; anything a failed
+		# step left behind is cleaned here.
+		for u in ${EXPORT_UUIDS_SEEN:-}; do
+			python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" \
+				-b "${BUCKET}" -r "$(rcow_cfg_get region)" \
+				-p "exports/${u}" >/dev/null 2>&1
+		done
 		rm -f "${RCOW_WAL_IMG}"
 		rm -rf "${RCOW_RUN_DIR}" "${WORKDIR}"
 	elif [ -n "${WORKDIR}" ]; then
@@ -213,6 +282,7 @@ rpc rcow_deactive_bdev "$(printf '{"device_name":"%s"}' "${VOL}")" >/dev/null 2>
 EXPORT_UUID="$(rpc rcow_export_snapshot '{"snapshot_name":"pinned0"}' \
 	2>/dev/null | tr -d ' \t\r\n"')"
 if [ -n "${EXPORT_UUID}" ]; then
+	EXPORT_UUIDS_SEEN="${EXPORT_UUIDS_SEEN:-} ${EXPORT_UUID}"
 	pass "pinned0 exported (${EXPORT_UUID}), so a delete of it must be refused"
 else
 	fail "rcow_export_snapshot did not return a uuid"
@@ -231,14 +301,47 @@ except Exception:
 	sleep 1
 done
 
+exports_has()
+{
+	local uuid="$1"
+
+	rpc rcow_get_exports 2>/dev/null | python3 -c '
+import json, sys
+want = sys.argv[1]
+try:
+    for e in json.load(sys.stdin):
+        if e.get("export_uuid") == want:
+            print(e.get("snapshot", ""))
+            sys.exit(0)
+except Exception:
+    pass
+sys.exit(1)
+' "${uuid}"
+}
+
+if SNAP="$(exports_has "${EXPORT_UUID}")" && [ "${SNAP}" = "pinned0" ]; then
+	pass "rcow_get_exports lists pinned0 as ${EXPORT_UUID}"
+else
+	fail "rcow_get_exports does not list the new export"
+fi
+
 # ==========================================================================
 echo ""
-echo "=== [2] the refused delete is recorded, and the snapshot survives"
+echo "=== [2] the blocked delete is recorded, and the snapshot survives"
 
-if rpc rcow_delete_lvol '{"lvol_name":"pinned0"}' >/dev/null 2>&1; then
-	fail "delete of the exported pinned0 was accepted"
-else
+# The delete does not happen; how it is reported depends on whether this export's
+# liveness can be decided yet (see step 6). Deferred while an importer may still
+# arrive, refused once the export is known to have no lease at all. What has to
+# hold either way -- and what the rest of this suite is built on -- is that the
+# snapshot is still here and the intent was recorded.
+DEL_OUT="$(python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --raw \
+	rcow_delete_lvol '{"lvol_name":"pinned0"}' 2>&1)"
+if echo "${DEL_OUT}" | grep -q '"deferred": *true'; then
+	pass "delete of pinned0 deferred while the export pins it"
+elif echo "${DEL_OUT}" | grep -q '"bool_value": *false'; then
 	pass "delete of pinned0 refused while the export pins it"
+else
+	fail "delete of the exported pinned0 was carried out: ${DEL_OUT}"
 fi
 
 lvol_exists pinned0 && pass "pinned0 still exists after the refusal" \
@@ -282,6 +385,12 @@ echo "=== [4] once the export is released, --retry-pending completes the delete"
 
 rpc rcow_release_export "$(printf '{"export_uuid":"%s"}' "${EXPORT_UUID}")" \
 	>/dev/null 2>&1 && pass "export released" || fail "rcow_release_export failed"
+
+if exports_has "${EXPORT_UUID}" >/dev/null; then
+	fail "rcow_get_exports still lists the released export"
+else
+	pass "rcow_get_exports no longer lists the released export"
+fi
 
 for _ in $(seq 30); do
 	[ "$(lvol_field pinned0 deletable)" = "YES" ] && break
@@ -360,13 +469,16 @@ fi
 
 # ==========================================================================
 echo ""
-echo "=== [6] an unload drops that lvstore's marks"
+echo "=== [6] an unload keeps the intent, and a re-attach restores it"
 #
-# The marks are scoped to the lvstore, not to the process: past a teardown they
-# name lvols that no longer exist, and the lvstore attached next can give the
-# same names to different objects. This is the step that would have caught the
-# marks surviving an unload because the uuid was read off a pointer the unload
-# had already cleared.
+# The queue is persisted to <prefix>/meta/pending-deletes.json, so a delete that
+# is waiting for its blocker is not forgotten by a restart -- the caller was told
+# it needed to do nothing else. What makes that safe is the uuid: a restored
+# entry names the lvol it was recorded for and can never match a later object
+# that happens to reuse the name.
+#
+# This step used to assert the opposite (the mark dropped on unload), which was
+# correct while the queue lived only in memory.
 
 # A fresh blocked delete to leave a mark behind.
 rpc rcow_active_bdev "$(printf '{"device_name":"%s"}' "${VOL}")" >/dev/null 2>&1
@@ -379,6 +491,7 @@ rpc rcow_deactive_bdev "$(printf '{"device_name":"%s"}' "${VOL}")" >/dev/null 2>
 EXP2="$(rpc rcow_export_snapshot '{"snapshot_name":"marked1"}' 2>/dev/null | \
 	tr -d ' \t\r\n"')"
 [ -n "${EXP2}" ] && pass "marked1 exported (${EXP2})" || fail "export of marked1 failed"
+EXPORT_UUIDS_SEEN="${EXPORT_UUIDS_SEEN:-} ${EXP2}"
 for _ in $(seq 30); do
 	[ "$(rpc rcow_get_snapshot_status '{"snapshot_name":"marked1"}' 2>/dev/null | \
 		python3 -c 'import json,sys
@@ -394,16 +507,16 @@ rpc rcow_delete_lvol '{"lvol_name":"marked1"}' >/dev/null 2>&1
 	&& pass "marked1 is marked after the refused delete" \
 	|| fail "marked1 was not marked (got '$(lvol_field marked1 delete_pending)')"
 
-# Release the export first: the mark has to be dropped by the unload, not by the
-# blocker still being there.
+# Release the export first, so the restored intent is one that can actually be
+# completed after the re-attach rather than one still sitting behind its blocker.
 rpc rcow_release_export "$(printf '{"export_uuid":"%s"}' "${EXP2}")" >/dev/null 2>&1
 for _ in $(seq 30); do
 	[ "$(lvol_field marked1 deletable)" = "YES" ] && break
 	sleep 1
 done
 [ "$(lvol_field marked1 deletable)" = "YES" ] \
-	&& pass "marked1 is deletable again (so only the unload can clear the mark)" \
-	|| info "marked1 not deletable; the next assertion is weaker but still valid"
+	&& pass "marked1 is deletable again" \
+	|| info "marked1 not deletable; the next assertions are weaker but still valid"
 
 echo "  ---- unload and re-attach ${RCOW_LVS_NAME}"
 rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${RCOW_LVS_NAME}")" \
@@ -431,14 +544,659 @@ fi
 lvol_exists marked1 && pass "marked1 came back with the lvstore" \
 	|| fail "marked1 did not survive the re-attach"
 
-[ "$(lvol_field marked1 delete_pending)" = "false" ] \
-	&& pass "the mark did not survive the unload" \
-	|| fail "the mark survived the unload (delete_pending='$(lvol_field marked1 delete_pending)')"
+for _ in $(seq 30); do
+	[ "$(lvol_field marked1 delete_pending)" = "true" ] && break
+	sleep 1
+done
+[ "$(lvol_field marked1 delete_pending)" = "true" ] \
+	&& pass "the intent survived the unload (restored from S3)" \
+	|| fail "the intent was lost across the unload (delete_pending='$(lvol_field marked1 delete_pending)')"
 
+# The restored entry has to name the same object and carry an export blocker.
+#
+# Which one depends on whether the export's first lease check has been answered
+# by now: nothing imported this export, so once it has, the entry is the "legacy"
+# case (no lease at all, only a TTL speaks, never completed unattended). Until
+# then the target assumes an importer may arrive and reports it as
+# self-completing. Both are accepted here -- the timing of one S3 HEAD is not
+# what this step is about -- and the retry below works either way.
+if rpc rcow_get_pending_deletes 2>/dev/null | \
+	python3 -c 'import json,sys
+try:
+    q = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+for e in q:
+    if e.get("lvol_name") == "marked1":
+        sys.exit(0 if e.get("reason") in ("export", "export_legacy") else 1)
+sys.exit(1)'; then
+	pass "rcow_get_pending_deletes reports marked1 as blocked by its export"
+else
+	fail "the restored entry is not the one that was recorded: $(rpc rcow_get_pending_deletes 2>&1 | head -c 200)"
+fi
+
+# And the retry finishes it, which is what the restored intent was for: the
+# export is already released, so nothing blocks the delete any more.
 python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --retry-pending \
 	>"${WORKDIR}/retry-after-unload.log" 2>&1
-if grep -q "no pending snapshot deletes to retry" "${WORKDIR}/retry-after-unload.log"; then
-	pass "--retry-pending has nothing to do after the re-attach"
+if grep -q "deleted marked1" "${WORKDIR}/retry-after-unload.log"; then
+	pass "--retry-pending completed the delete the restart could have lost"
 else
-	fail "--retry-pending acted on a mark that should have been dropped: $(cat "${WORKDIR}/retry-after-unload.log")"
+	fail "--retry-pending did not act on the restored intent: $(cat "${WORKDIR}/retry-after-unload.log")"
 fi
+
+lvol_exists marked1 && fail "marked1 is still there after the retry" \
+	|| pass "marked1 is gone"
+
+# ==========================================================================
+echo ""
+echo "=== [7] a blocker that clears on its own is completed without any retry"
+#
+# The other half of the queue: clone_count and decouple resolve with no decision
+# to make, so rcow_delete_lvol accepts the intent (deferred) and the poller
+# completes it once the blocker goes. This is the path that removes the manual
+# retry entirely.
+
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"defsnap"}' "${VOL}")" \
+	>/dev/null && pass "defsnap taken" || fail "could not take defsnap"
+
+# A second clone is what makes it undeletable: blobstore can merge a snapshot
+# into one clone, not two.
+rpc rcow_create_clone '{"snapshot_name":"defsnap","clone_name":"defclone"}' \
+	>/dev/null && pass "defclone created (defsnap now has two clones)" \
+	|| fail "could not clone defsnap"
+
+# The extra field, not the envelope: every existing caller still reads the name
+# off stdout, so the deferral is only visible with --raw.
+DEF_RAW="$(python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --raw \
+	rcow_delete_lvol '{"lvol_name":"defsnap"}' 2>&1)"
+if echo "${DEF_RAW}" | grep -q '"deferred": *true'; then
+	pass "rcow_delete_lvol reported the delete as deferred"
+else
+	fail "the delete was not reported as deferred: ${DEF_RAW}"
+fi
+
+PLAIN="$(rpc rcow_delete_lvol '{"lvol_name":"defsnap"}' 2>&1)"
+[ "${PLAIN}" = "defsnap" ] \
+	&& pass "the plain answer is unchanged for callers that just read the name" \
+	|| fail "the plain answer changed shape: '${PLAIN}'"
+
+lvol_exists defsnap && pass "defsnap is still there (the intent was queued, not executed)" \
+	|| fail "defsnap was deleted while it still had two clones"
+
+if rpc rcow_get_pending_deletes 2>/dev/null | \
+	python3 -c 'import json,sys
+try:
+    q = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+for e in q:
+    if e.get("lvol_name") == "defsnap":
+        sys.exit(0 if e.get("reason") == "clone_count" and e.get("deferred") else 1)
+sys.exit(1)'; then
+	pass "the queue reports defsnap as clone_count and self-completing"
+else
+	fail "defsnap is not queued as expected: $(rpc rcow_get_pending_deletes 2>&1 | head -c 200)"
+fi
+
+# Asking twice must not enqueue twice.
+rpc rcow_delete_lvol '{"lvol_name":"defsnap"}' >/dev/null 2>&1
+N_DEF="$(rpc rcow_get_pending_deletes 2>/dev/null | python3 -c 'import json,sys
+try:
+    print(sum(1 for e in json.load(sys.stdin) if e.get("lvol_name") == "defsnap"))
+except Exception:
+    print(-1)')"
+[ "${N_DEF}" = "1" ] \
+	&& pass "asking again did not enqueue a second time" \
+	|| fail "the queue has ${N_DEF} entries for defsnap"
+
+# Now clear the blocker. One clone left means blobstore can merge, so the delete
+# the poller retries will go through.
+rpc rcow_delete_lvol '{"lvol_name":"defclone"}' >/dev/null 2>&1 \
+	&& pass "defclone deleted (defsnap now has one clone)" \
+	|| fail "could not delete defclone"
+
+# The poller runs once a minute, so this is the one place the test has to wait.
+info "waiting for the poller to complete the deferred delete (up to 120s)"
+for _ in $(seq 120); do
+	lvol_exists defsnap || break
+	sleep 1
+done
+
+if lvol_exists defsnap; then
+	fail "defsnap was still there after 120s; the poller did not complete it"
+else
+	pass "the poller completed the delete once the blocker cleared"
+fi
+
+if rpc rcow_get_pending_deletes 2>/dev/null | grep -q defsnap; then
+	fail "the queue still lists defsnap after the delete completed"
+else
+	pass "the completed entry left the queue"
+fi
+
+grep -q "pending delete of 'defsnap' completed" "${RCOW_LOG}" \
+	&& pass "the log names the queue as what finished it" \
+	|| info "no completion line in the log (the delete still happened)"
+
+# ==========================================================================
+echo ""
+echo "=== [8] an intent can be withdrawn"
+
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"cansnap"}' "${VOL}")" \
+	>/dev/null && pass "cansnap taken" || fail "could not take cansnap"
+rpc rcow_create_clone '{"snapshot_name":"cansnap","clone_name":"canclone"}' \
+	>/dev/null && pass "canclone created" || fail "could not clone cansnap"
+
+rpc rcow_delete_lvol '{"lvol_name":"cansnap"}' >/dev/null 2>&1
+[ "$(lvol_field cansnap delete_pending)" = "true" ] \
+	&& pass "cansnap is queued" || fail "cansnap was not queued"
+
+rpc rcow_cancel_pending_delete '{"lvol_name":"cansnap"}' >/dev/null 2>&1 \
+	&& pass "the intent was withdrawn" || fail "cancel failed"
+
+[ "$(lvol_field cansnap delete_pending)" = "false" ] \
+	&& pass "cansnap is no longer queued" \
+	|| fail "cansnap is still queued after the cancel"
+
+# Idempotent: cancelling what is not queued leaves the caller in the state they
+# asked for, so it succeeds rather than making them handle a race.
+rpc rcow_cancel_pending_delete '{"lvol_name":"cansnap"}' >/dev/null 2>&1 \
+	&& pass "cancelling an entry that is not queued succeeds" \
+	|| fail "the second cancel failed"
+
+# Withdrawing the intent must not have touched the snapshot, and must stop the
+# poller from acting on it once the blocker clears.
+rpc rcow_delete_lvol '{"lvol_name":"canclone"}' >/dev/null 2>&1
+sleep 3
+lvol_exists cansnap \
+	&& pass "cansnap survived: a withdrawn intent is not completed" \
+	|| fail "cansnap was deleted after its intent was withdrawn"
+
+# ==========================================================================
+echo ""
+echo "=== [9] an export whose importer stopped renewing is completed, and the"
+echo "        dead export is then reaped"
+#
+# The cross-node case, and the one the deployment actually runs: the control
+# plane deletes the snapshot and never calls rcow_release_export. For that to
+# reclaim anything, two things have to happen by themselves.
+#
+#   1. The delete has to complete once the importer is gone. An importer renews
+#      a lease object while it still reads the export; when it stops, the lease
+#      goes stale, and a stale lease is *evidence* nobody is reading -- unlike a
+#      TTL, which lapses on its own whether or not somebody is. So the poller
+#      finishes the delete on that basis.
+#   2. The export entry has to go, or the registry grows without bound until it
+#      crosses S3LVOL_MAX_EXPORTS and the lvstore stops being attachable. Once
+#      the snapshot is gone the export can never be imported by anyone, so the
+#      reaper releases it: manifest deleted, entry dropped.
+#
+# The importer here is s3_put_lease.py rather than a second target: what the
+# source side consumes is the lease object, and writing it directly is what lets
+# this control the timing (a real importer's cadence comes from the TTL).
+
+LEASE_TTL=30       # importer renews every ttl/3 = 10 s, source's grace is 3x that
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"leased"}' "${VOL}")" \
+	>/dev/null && pass "leased taken" || fail "could not take leased"
+
+LEASE_UU="$(rpc rcow_export_snapshot \
+	"$(printf '{"snapshot_name":"leased","ttl_sec":%d}' "${LEASE_TTL}")" \
+	2>/dev/null | tr -d ' \t\r\n"')"
+[ -n "${LEASE_UU}" ] && pass "leased exported (${LEASE_UU})" \
+	|| fail "export of leased failed"
+EXPORT_UUIDS_SEEN="${EXPORT_UUIDS_SEEN:-} ${LEASE_UU}"
+for _ in $(seq 60); do
+	[ "$(rpc rcow_get_snapshot_status '{"snapshot_name":"leased"}' 2>/dev/null | \
+		python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("export_status",""))
+except Exception:
+    print("")')" = "DONE" ] && break
+	sleep 1
+done
+
+# One renewal is enough: the source caches what it reads, and the point is that a
+# lease exists and then stops advancing.
+#
+# The credentials have to be in the environment for this: everything else here
+# talks to the target over RPC, so nothing has loaded them yet.
+rcow_load_credentials
+if python3 "${ROOT}/test/tools/s3_put_lease.py" \
+		"$(rcow_cfg_get endpoint)" "${BUCKET}" "$(rcow_cfg_get region)" \
+		"${RCOW_LVS_NAME}/meta/exports/${LEASE_UU}.lease" 10 0 \
+		>"${WORKDIR}/put_lease.log" 2>&1; then
+	pass "an importer's lease was written for the export"
+else
+	fail "could not write the lease object: $(tail -1 "${WORKDIR}/put_lease.log")"
+fi
+
+# Wait for the source to read it, so the delete below sees a *fresh* lease rather
+# than the "not checked yet" state.
+info "waiting for the source to pick the lease up"
+for _ in $(seq 40); do
+	[ "$(rpc rcow_get_pending_deletes 2>/dev/null | wc -c)" -gt 0 ] && break
+	sleep 1
+done
+sleep "$((LEASE_TTL / 3 + 3))"
+
+# A fresh lease must still record the intent -- that is what makes the delete
+# happen later without anyone asking again.
+DEL_OUT="$(python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --raw \
+	rcow_delete_lvol '{"lvol_name":"leased"}' 2>&1)"
+lvol_exists leased \
+	&& pass "leased was not deleted while its importer holds the lease" \
+	|| fail "leased was deleted with a fresh lease on its export"
+[ "$(lvol_field leased delete_pending)" = "true" ] \
+	&& pass "the delete was recorded even though the lease is fresh" \
+	|| fail "no intent was recorded for leased: ${DEL_OUT}"
+
+if echo "${DEL_OUT}" | grep -q '"deferred": *true'; then
+	pass "and it was reported as self-completing"
+else
+	info "reported as a refusal (${DEL_OUT}); the poller decides either way"
+fi
+
+# Now stop renewing: nothing writes the lease again, and nothing releases the
+# export. Everything from here has to happen on its own.
+#
+# The wait covers the grace period plus one poll. Grace is 3x the renew_s in the
+# lease, floored at S3LVOL_LEASE_MIN_GRACE_SEC -- the lease above says 10, so the
+# floor decides and it is 60 s, not 30. The source then has to notice, which it
+# does at its own poll cadence (also floored, at S3LVOL_LEASE_RENEW_MIN_SEC).
+info "letting the lease go stale (grace is the 60 s floor, not 3x10) and waiting"
+for _ in $(seq 180); do
+	lvol_exists leased || break
+	sleep 1
+done
+if lvol_exists leased; then
+	fail "leased was still there after 180 s; the stale lease did not complete it"
+else
+	pass "the poller completed the delete once the lease went stale"
+fi
+
+# And the export it left behind: unreachable for ever (its manifest names chunks
+# the snapshot owned), so the reaper drops it.
+info "waiting for the reaper to collect the dead export"
+for _ in $(seq 150); do
+	rpc rcow_get_snapshot_status \
+		"$(printf '{"export_uuid":"%s"}' "${LEASE_UU}")" >/dev/null 2>&1 || break
+	sleep 1
+done
+if rpc rcow_get_snapshot_status \
+		"$(printf '{"export_uuid":"%s"}' "${LEASE_UU}")" >/dev/null 2>&1; then
+	fail "the export entry outlived the snapshot it referenced"
+else
+	pass "the dead export was reaped from the registry"
+fi
+
+if python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "${BUCKET}" \
+		-r "$(rcow_cfg_get region)" -p "exports/${LEASE_UU}.json" \
+		--list 2>/dev/null | grep -q .; then
+	fail "the reaped export's manifest is still in the bucket"
+else
+	pass "and its manifest is gone from the bucket"
+fi
+
+grep -q "reaped" "${RCOW_LOG}" \
+	&& pass "the log names the reaper" \
+	|| info "no reaper line in the log (the entry went all the same)"
+
+# ==========================================================================
+echo ""
+echo "=== [10] an export nobody imported is reaped past the deadline,"
+echo "         without deleting its snapshot"
+#
+# The production leak the lease-stale path in [9] does not cover: a reference
+# export, never imported, TTL elapsed, snapshot still here because nobody
+# recorded a pending delete (the control plane treated an earlier refusal as
+# success and stopped tracking it). The lease HEAD is a permanent 404. The
+# watch has to stop and the registry entry has to go; the snapshot stays.
+
+UNIMP_TTL=20
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"unimported"}' "${VOL}")" \
+	>/dev/null && pass "unimported taken" || fail "could not take unimported"
+
+UNIMP_UU="$(rpc rcow_export_snapshot \
+	"$(printf '{"snapshot_name":"unimported","ttl_sec":%d}' "${UNIMP_TTL}")" \
+	2>/dev/null | tr -d ' \t\r\n"')"
+[ -n "${UNIMP_UU}" ] && pass "unimported exported (${UNIMP_UU})" \
+	|| fail "export of unimported failed"
+EXPORT_UUIDS_SEEN="${EXPORT_UUIDS_SEEN:-} ${UNIMP_UU}"
+
+unimported_status()
+{
+	rpc rcow_get_snapshot_status '{"snapshot_name":"unimported"}' \
+		2>/dev/null | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("export_status",""))
+except Exception:
+    print("")'
+}
+
+for _ in $(seq 60); do
+	[ "$(unimported_status)" = "DONE" ] && break
+	sleep 1
+done
+[ "$(unimported_status)" = "DONE" ] \
+	&& pass "unimported export is DONE" \
+	|| fail "unimported export did not reach DONE"
+
+# The first lease check is immediate and 404s, but the deadline has not passed,
+# so the entry must stay: the TTL is still a promise to an importer that may
+# not have started yet.
+sleep 3
+if rpc rcow_get_snapshot_status \
+		"$(printf '{"export_uuid":"%s"}' "${UNIMP_UU}")" >/dev/null 2>&1; then
+	pass "the export is still in the registry before the deadline"
+else
+	fail "the export was reaped before the deadline"
+fi
+if SNAP="$(exports_has "${UNIMP_UU}")" && [ "${SNAP}" = "unimported" ]; then
+	pass "rcow_get_exports lists the unimported export before the deadline"
+else
+	fail "rcow_get_exports does not list the unimported export"
+fi
+lvol_exists unimported \
+	&& pass "the snapshot is still there before the deadline" \
+	|| fail "the snapshot disappeared before the deadline"
+
+# Do not ask to delete it. That is the production path: delete_pending stays
+# false, and --retry-pending would not see this snapshot.
+[ "$(lvol_field unimported delete_pending)" = "false" ] \
+	&& pass "no pending delete was recorded" \
+	|| fail "unimported was queued without anyone asking"
+
+info "waiting for the deadline (${UNIMP_TTL}s) and the reaper"
+for _ in $(seq 150); do
+	rpc rcow_get_snapshot_status \
+		"$(printf '{"export_uuid":"%s"}' "${UNIMP_UU}")" >/dev/null 2>&1 || break
+	sleep 1
+done
+if rpc rcow_get_snapshot_status \
+		"$(printf '{"export_uuid":"%s"}' "${UNIMP_UU}")" >/dev/null 2>&1; then
+	fail "the unimported export outlived its deadline"
+else
+	pass "the unimported export was reaped past the deadline"
+fi
+if exports_has "${UNIMP_UU}" >/dev/null; then
+	fail "rcow_get_exports still lists the reaped export"
+else
+	pass "rcow_get_exports no longer lists the reaped export"
+fi
+
+lvol_exists unimported \
+	&& pass "the snapshot was left in place" \
+	|| fail "the snapshot was deleted along with the export"
+[ "$(lvol_field unimported delete_pending)" = "false" ] \
+	&& pass "still no pending delete" \
+	|| fail "a pending delete appeared on its own"
+[ "$(unimported_status)" = "NONE" ] \
+	&& pass "the snapshot's export_status is NONE" \
+	|| fail "export_status after reap: $(unimported_status)"
+
+if python3 "${PREFIX_RM}" -e "$(rcow_cfg_get endpoint)" -b "${BUCKET}" \
+		-r "$(rcow_cfg_get region)" -p "exports/${UNIMP_UU}.json" \
+		--list 2>/dev/null | grep -q .; then
+	fail "the reaped export's manifest is still in the bucket"
+else
+	pass "and its manifest is gone from the bucket"
+fi
+
+grep -q "stopping the watch" "${RCOW_LOG}" \
+	&& pass "the log stopped the lease watch" \
+	|| info "no stop-watch line (the poller may have been torn down by the reaper)"
+grep -q "nobody imported it past the deadline" "${RCOW_LOG}" \
+	&& pass "the log names the absent-lease reaper" \
+	|| fail "the reaper did not log the absent-lease path"
+
+# ==========================================================================
+echo ""
+echo "=== [11] a late registry load cannot use a freed lvstore"
+#
+# Attach starts HEAD then GET without waiting. The wrappers used to live in
+# the load ctx; unload freed them while CRT still owed a callback. Now the ctx
+# holds a uuid and an extra client ref, and the callback re-resolves. Parking
+# each stage lets this script unload first.
+
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"loadhold"}' "${VOL}")" \
+	>/dev/null && pass "loadhold taken" || fail "could not take loadhold"
+rpc rcow_create_clone '{"snapshot_name":"loadhold","clone_name":"loadholdc"}' \
+	>/dev/null && pass "loadholdc created" || fail "could not create loadholdc"
+rpc rcow_delete_lvol '{"lvol_name":"loadhold"}' >/dev/null 2>&1
+[ "$(lvol_field loadhold delete_pending)" = "true" ] \
+	&& pass "loadhold is marked" \
+	|| fail "loadhold was not marked (got '$(lvol_field loadhold delete_pending)')"
+
+# Give the registry PUT a moment so the next attach has something to HEAD.
+sleep 2
+
+LVS_NS="$(pendel_ns)"
+[ -n "${LVS_NS}" ] || LVS_NS="${BUCKET}"
+
+rpc rcow_pending_load_hold '{"stage":"head"}' >/dev/null \
+	&& pass "HEAD completions will park" \
+	|| fail "rcow_pending_load_hold head failed"
+
+pendel_unload >/dev/null 2>&1 && pass "unloaded before the held attach" \
+	|| fail "unload before held attach failed"
+
+if pendel_attach >/dev/null 2>&1; then
+	pass "attached with HEAD parked"
+else
+	fail "attach with HEAD parked failed"
+fi
+
+if wait_pending_parked 1; then
+	pass "the registry HEAD is parked"
+else
+	fail "HEAD did not park (parked=$(pending_load_parked))"
+fi
+[ "$(lvol_field loadhold delete_pending)" = "true" ] \
+	&& fail "HEAD-parked attach already restored the mark" \
+	|| pass "the mark is not restored while HEAD is parked"
+
+pendel_unload >/dev/null 2>&1 && pass "unloaded while HEAD is parked" \
+	|| fail "unload while HEAD parked failed"
+
+REL="$(rpc rcow_pending_load_hold '{"release":true}' 2>/dev/null | python3 -c '
+import json,sys
+try:
+    print(int(json.load(sys.stdin).get("released", 0)))
+except Exception:
+    print(0)
+')"
+[ "${REL}" = "1" ] \
+	&& pass "late HEAD was released after unload" \
+	|| fail "expected one parked HEAD, released ${REL}"
+
+if rpc rcow_get_pending_deletes >/dev/null 2>&1; then
+	pass "the target survived the late HEAD"
+else
+	fail "the target did not answer after the late HEAD"
+fi
+
+if pendel_attach >/dev/null 2>&1; then
+	pass "re-attached after the dropped HEAD"
+else
+	fail "re-attach after dropped HEAD failed"
+fi
+for _ in $(seq 30); do
+	[ "$(lvol_field loadhold delete_pending)" = "true" ] && break
+	sleep 1
+done
+[ "$(lvol_field loadhold delete_pending)" = "true" ] \
+	&& pass "a new load restored the mark after the dropped HEAD" \
+	|| fail "the mark did not come back after the new attach"
+
+rpc rcow_pending_load_hold '{"stage":"get"}' >/dev/null \
+	&& pass "GET completions will park" \
+	|| fail "rcow_pending_load_hold get failed"
+
+pendel_unload >/dev/null 2>&1 && pass "unloaded before the GET-held attach" \
+	|| fail "unload before GET-held attach failed"
+
+if pendel_attach >/dev/null 2>&1; then
+	pass "attached with GET parked"
+else
+	fail "attach with GET parked failed"
+fi
+
+if wait_pending_parked 1; then
+	pass "the registry GET is parked"
+else
+	fail "GET did not park (parked=$(pending_load_parked))"
+fi
+[ "$(lvol_field loadhold delete_pending)" = "true" ] \
+	&& fail "GET-parked attach already restored the mark" \
+	|| pass "the mark is not restored while GET is parked"
+
+pendel_unload >/dev/null 2>&1 && pass "unloaded while GET is parked" \
+	|| fail "unload while GET parked failed"
+
+REL="$(rpc rcow_pending_load_hold '{"release":true}' 2>/dev/null | python3 -c '
+import json,sys
+try:
+    print(int(json.load(sys.stdin).get("released", 0)))
+except Exception:
+    print(0)
+')"
+[ "${REL}" = "1" ] \
+	&& pass "late GET was released after unload" \
+	|| fail "expected one parked GET, released ${REL}"
+
+if rpc rcow_get_pending_deletes >/dev/null 2>&1; then
+	pass "the target survived the late GET"
+else
+	fail "the target did not answer after the late GET"
+fi
+
+# Same uuid re-attach after a dropped GET is a new load, not the parked
+# callback filling a wrapper that no longer exists. A same-name store with a
+# different uuid would also miss pending_lvs_by_uuid and stay empty.
+rpc rcow_pending_load_hold '{"stage":"none"}' >/dev/null 2>&1
+
+if pendel_attach >/dev/null 2>&1; then
+	pass "re-attached after the dropped GET"
+else
+	fail "re-attach after dropped GET failed"
+fi
+for _ in $(seq 30); do
+	[ "$(lvol_field loadhold delete_pending)" = "true" ] && break
+	sleep 1
+done
+[ "$(lvol_field loadhold delete_pending)" = "true" ] \
+	&& pass "a new load restored the mark after the dropped GET" \
+	|| fail "the mark did not come back after the GET-dropped attach"
+
+# ==========================================================================
+echo ""
+echo "=== [12] a 404 before the deadline does not reap a late importer"
+#
+# The first lease HEAD is immediate and 404s. An importer can still PUT before
+# expires_at. Combining that historical miss with "now past the deadline"
+# would delete the manifest under a live import. The miss has to be observed
+# on a check submitted after the deadline.
+
+LATE_TTL=20
+rpc rcow_create_snapshot \
+	"$(printf '{"lvol_name":"%s","snapshot_name":"lateimp"}' "${VOL}")" \
+	>/dev/null && pass "lateimp taken" || fail "could not take lateimp"
+
+LATE_UU="$(rpc rcow_export_snapshot \
+	"$(printf '{"snapshot_name":"lateimp","ttl_sec":%d}' "${LATE_TTL}")" \
+	2>/dev/null | tr -d ' \t\r\n"')"
+[ -n "${LATE_UU}" ] && pass "lateimp exported (${LATE_UU})" \
+	|| fail "export of lateimp failed"
+EXPORT_UUIDS_SEEN="${EXPORT_UUIDS_SEEN:-} ${LATE_UU}"
+
+for _ in $(seq 60); do
+	[ "$(rpc rcow_get_snapshot_status '{"snapshot_name":"lateimp"}' 2>/dev/null | \
+		python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("export_status",""))
+except Exception:
+    print("")')" = "DONE" ] && break
+	sleep 1
+done
+[ "$(rpc rcow_get_snapshot_status '{"snapshot_name":"lateimp"}' 2>/dev/null | \
+	python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("export_status",""))
+except Exception:
+    print("")')" = "DONE" ] \
+	&& pass "lateimp export is DONE" || fail "lateimp export did not reach DONE"
+
+export_lease_absent()
+{
+	rpc rcow_get_exports 2>/dev/null | python3 -c '
+import json, sys
+want = sys.argv[1]
+try:
+    for e in json.load(sys.stdin):
+        if e.get("export_uuid") == want:
+            print("true" if e.get("lease_absent") else "false")
+            sys.exit(0)
+except Exception:
+    pass
+print("missing")
+' "${1}"
+}
+
+for _ in $(seq 30); do
+	[ "$(export_lease_absent "${LATE_UU}")" = "true" ] && break
+	sleep 1
+done
+[ "$(export_lease_absent "${LATE_UU}")" = "true" ] \
+	&& pass "the first lease check missed (404 before the deadline)" \
+	|| fail "lease_absent never became true (got '$(export_lease_absent "${LATE_UU}")')"
+
+rcow_load_credentials
+if python3 "${ROOT}/test/tools/s3_put_lease.py" \
+		"$(rcow_cfg_get endpoint)" "${BUCKET}" "$(rcow_cfg_get region)" \
+		"${RCOW_LVS_NAME}/meta/exports/${LATE_UU}.lease" 20 0 \
+		>"${WORKDIR}/put_late_lease.log" 2>&1; then
+	pass "a lease was written after that 404, still inside the TTL"
+else
+	fail "could not write the late lease: $(tail -1 "${WORKDIR}/put_late_lease.log")"
+fi
+
+# Past the deadline and at least one reaper tick (60 s). The old 404 must not
+# be enough to drop the entry; the live lease must.
+info "waiting past the deadline (${LATE_TTL}s) and a reaper tick"
+survived=0
+for _ in $(seq 90); do
+	if ! rpc rcow_get_snapshot_status \
+			"$(printf '{"export_uuid":"%s"}' "${LATE_UU}")" \
+			>/dev/null 2>&1; then
+		survived=0
+		break
+	fi
+	survived=1
+	sleep 1
+done
+if [ "${survived}" = "1" ] && rpc rcow_get_snapshot_status \
+		"$(printf '{"export_uuid":"%s"}' "${LATE_UU}")" >/dev/null 2>&1; then
+	pass "the export was not reaped after a pre-deadline 404 plus expiry"
+else
+	fail "the export was reaped despite a lease PUT after the 404"
+fi
+lvol_exists lateimp \
+	&& pass "the snapshot was left in place" \
+	|| fail "the snapshot was deleted with the late importer's lease"
+
+if SNAP="$(exports_has "${LATE_UU}")" && [ "${SNAP}" = "lateimp" ]; then
+	pass "rcow_get_exports still lists the late-imported export"
+else
+	fail "rcow_get_exports lost the export after the historical 404"
+fi
+
+rpc rcow_release_export "$(printf '{"export_uuid":"%s"}' "${LATE_UU}")" \
+	>/dev/null 2>&1 \
+	&& pass "lateimp export released" \
+	|| fail "could not release the lateimp export"

--- a/CubeS3lvol/test/dataplane/run_selfimport_test.sh
+++ b/CubeS3lvol/test/dataplane/run_selfimport_test.sh
@@ -114,6 +114,56 @@ wait_export_done()
 	done
 }
 
+# A lease-aware export stays pinned until a lease HEAD submitted at or after
+# expires_at misses. The poller is floored at S3LVOL_LEASE_RENEW_MIN_SEC (20s),
+# so ttl_sec=2 plus a few seconds of sleep is not enough for the pin to lift.
+wait_export_deletable()
+{
+	local uuid="$1"
+	local deadline=$(( $(date +%s) + 90 ))
+	local out got
+
+	while :; do
+		if ! out="$(rpc rcow_get_snapshot_status \
+				"$(printf '{"export_uuid":"%s"}' "${uuid}")" \
+				2>/dev/null)"; then
+			fail "export ${uuid} vanished while waiting for it to unpin"
+			return 1
+		fi
+		got="$(printf '%s' "${out}" \
+			| python3 -c 'import json,sys; print(json.load(sys.stdin).get("deletable",""))' \
+				2>/dev/null)"
+		if [ "${got}" = "YES" ]; then
+			return 0
+		fi
+		if [ "$(date +%s)" -ge "${deadline}" ]; then
+			fail "export ${uuid} still deletable=${got:-?} after 90s"
+			return 1
+		fi
+		sleep 1
+	done
+}
+
+# True once the named lvol is no longer in the store. A deferred delete reports
+# success while the snapshot is still there; the negatives below need it gone.
+wait_lvol_gone()
+{
+	local name="$1"
+	local deadline=$(( $(date +%s) + 30 ))
+
+	while :; do
+		if ! rpc rcow_get_snapshot_status \
+			"$(printf '{"snapshot_name":"%s"}' "${name}")" \
+			>/dev/null 2>&1; then
+			return 0
+		fi
+		if [ "$(date +%s)" -ge "${deadline}" ]; then
+			return 1
+		fi
+		sleep 0.5
+	done
+}
+
 # The import reply carries a third field saying which implementation ran. Read from
 # the reply rather than guessed from side effects.
 import_mode()
@@ -343,11 +393,25 @@ fi
 # snapshot with a clone is undeletable -- which is not true and briefly became a bug
 # when the pre-flight check in s3lvol_lvol_destroy refused at one clone as well.
 # run_snapdelete_test.sh covers the one-clone case that must succeed.
-if rpc rcow_delete_lvol '{"lvol_name":"snap0"}' >/dev/null 2>&1; then
-	fail "snap0 was deleted while both vol0 and c_local clone it"
+#
+# The delete is *deferred* rather than refused: an extra clone goes away on its
+# own, so the intent is recorded and completed when it does
+# (docs/pending-delete-design.md). What has to hold here is that snap0 survives.
+DEL_OUT="$(python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --raw \
+	rcow_delete_lvol '{"lvol_name":"snap0"}' 2>&1)"
+if echo "${DEL_OUT}" | grep -q '"deferred": *true'; then
+	pass "and deleting snap0 is deferred while it has two clones"
+elif rpc rcow_get_lvol '{"lvol_name":"snap0"}' >/dev/null 2>&1 ||
+     rpc --ls rcow_get_lvstores 2>/dev/null | grep -q '^snap0 '; then
+	pass "and snap0 was not deleted while it has two clones"
 else
-	pass "and snap0 cannot be deleted while it has two clones"
+	fail "snap0 was deleted while both vol0 and c_local clone it"
 fi
+
+# Withdraw it: later steps still expect snap0, and the poller would remove it as
+# soon as one of the clones goes.
+python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" \
+	rcow_cancel_pending_delete '{"lvol_name":"snap0"}' >/dev/null 2>&1
 
 # ==========================================================================
 echo ""
@@ -370,24 +434,25 @@ rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${RCOW_LVS_NAME}")" >/dev/
 # The layout cannot be chosen over RPC either -- the decoders take snapshot_name,
 # export_id and ttl_sec, and same-bucket always means REF.
 #
-# What does work is the TTL. s3lvol_export_pinning() reports an expired export as
-# not pinning, which is exactly so that this delete can proceed, and import does not
-# reject an expired manifest. So: export with a two-second TTL, let it lapse, then
-# delete. The manifest is still in the bucket because nothing released it.
+# What does work is waiting out the pin. s3lvol_export_pinning() reports a
+# lease-aware export as not pinning only after a lease HEAD submitted at or after
+# expires_at misses -- ttl_sec=2 is the deadline, not the wait. Import does not
+# reject an expired manifest. The snapshot is then actually gone, not merely
+# queued as a deferred delete.
 U2="$(rpc rcow_export_snapshot '{"snapshot_name":"snap_gone","ttl_sec":2}' | tr -d '"')"
 EXPORTS="${EXPORTS} ${U2}"
 [ -n "${U2}" ] && pass "exported snap_gone as ${U2} with a 2s TTL" \
 	|| { fail "export of snap_gone failed"; exit 1; }
 wait_export_done "${U2}" || exit 1
-
-sleep 4
+wait_export_deletable "${U2}" || exit 1
 
 # tmp1 clones snap_gone, so it has to go first -- and deactivated, not just deleted.
 del_vol tmp1
-if rpc rcow_delete_lvol '{"lvol_name":"snap_gone"}' >/dev/null 2>&1; then
-	pass "with the export expired, the source snapshot could be deleted"
+if rpc rcow_delete_lvol '{"lvol_name":"snap_gone"}' >/dev/null 2>&1 \
+	&& wait_lvol_gone snap_gone; then
+	pass "with the export unpinned, the source snapshot could be deleted"
 else
-	fail "could not delete snap_gone even after its export expired"
+	fail "could not delete snap_gone even after its export unpinned"
 	grep "snap_gone" "${RCOW_LOG}" | tail -2 | sed 's/^/       /'
 fi
 
@@ -418,16 +483,18 @@ sync
 rpc rcow_create_snapshot '{"lvol_name":"tmp2","snapshot_name":"snap_dup"}' >/dev/null
 rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${RCOW_LVS_NAME}")" >/dev/null 2>&1
 # Two-second TTL for the same reason as step [3]: the export would otherwise pin
-# snap_dup and the replacement below could not happen.
+# snap_dup and the replacement below could not happen. Wait for the pin to lift,
+# not merely for the deadline to pass.
 U3="$(rpc rcow_export_snapshot '{"snapshot_name":"snap_dup","ttl_sec":2}' | tr -d '"')"
 wait_export_done "${U3}" || exit 1
-sleep 4
+wait_export_deletable "${U3}" || exit 1
 EXPORTS="${EXPORTS} ${U3}"
 pass "exported snap_dup as ${U3}"
 
 # Replace it: same name, different blob, different content.
 del_vol tmp2
 rpc rcow_delete_lvol '{"lvol_name":"snap_dup"}' >/dev/null 2>&1
+wait_lvol_gone snap_dup || fail "snap_dup was still present after its export unpinned"
 rpc rcow_create_lvol '{"lvol_name":"tmp3","size_gib":1}' >/dev/null 2>&1
 T="$(resolve tmp3)"
 [ -b "${T}" ] || { fail "tmp3 did not become a device"; exit 1; }
@@ -503,13 +570,14 @@ rpc rcow_create_snapshot '{"lvol_name":"tmp4","snapshot_name":"snap_rw"}' >/dev/
 rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${RCOW_LVS_NAME}")" >/dev/null 2>&1
 U4="$(rpc rcow_export_snapshot '{"snapshot_name":"snap_rw","ttl_sec":2}' | tr -d '"')"
 wait_export_done "${U4}" || exit 1
-sleep 4
+wait_export_deletable "${U4}" || exit 1
 EXPORTS="${EXPORTS} ${U4}"
 
 # Replace the snapshot with a *writable* lvol of the same name.
 del_vol tmp4
 rpc rcow_delete_lvol '{"lvol_name":"snap_rw"}' >/dev/null 2>&1
-if rpc rcow_create_lvol '{"lvol_name":"snap_rw","size_gib":1}' >/dev/null 2>&1; then
+if wait_lvol_gone snap_rw \
+	&& rpc rcow_create_lvol '{"lvol_name":"snap_rw","size_gib":1}' >/dev/null 2>&1; then
 	pass "created a writable lvol named snap_rw"
 else
 	fail "could not create a writable snap_rw"

--- a/CubeS3lvol/test/dataplane/run_snapdelete_test.sh
+++ b/CubeS3lvol/test/dataplane/run_snapdelete_test.sh
@@ -337,25 +337,43 @@ rpc rcow_create_clone '{"snapshot_name":"sx","clone_name":"cx"}' >/dev/null 2>&1
 # `if rpc rcow_get_bdev '{"device_name":"cx"}'`, which fails for a volume that was
 # never activated -- so the whole two-clone case silently skipped and the one
 # assertion the pre-flight check exists for was never run.
-# The reason is checked in the target log, not in the RPC reply. The reply carries
-# only strerror(-EBUSY) -- "Device or resource busy" -- which is what a dozen other
-# refusals would also say, so matching on it would accept the wrong cause. The log
-# is where the clone count appears.
-LOG_BEFORE="$(grep -c 'is a snapshot with' "${RCOW_LOG}" 2>/dev/null || echo 0)"
+#
+# Two clones is no longer an error, it is a *deferral*: blobstore still cannot
+# merge into two, so the delete does not happen now, but the extra clone is
+# something that goes away on its own and the delete completes when it does (see
+# docs/pending-delete-design.md). So the RPC answers success with deferred:true,
+# and what has to be asserted is that sx is still there and the reason was
+# recorded -- not that the call failed.
+#
+# The reason is checked in the target log, not in the RPC reply: the reply says
+# only that the delete was queued, while the log is where the clone count appears.
+if OUT="$(python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" --raw \
+		rcow_delete_lvol '{"lvol_name":"sx"}' 2>&1)"; then
+	if echo "${OUT}" | grep -q '"deferred": *true'; then
+		pass "sx was not deleted; the delete was deferred until a clone goes"
+	else
+		fail "sx was deleted despite having two clones (${VOL} and cx)"
+		info "blobstore cannot merge into two clones, so this had to be deferred"
+	fi
+else
+	fail "the delete of sx was refused outright rather than deferred: \
+$(echo "${OUT}" | tr -d '\n' | head -c 120)"
+fi
 
-if OUT="$(rpc rcow_delete_lvol '{"lvol_name":"sx"}' 2>&1)"; then
-	fail "sx was deleted despite having two clones (${VOL} and cx)"
-	info "blobstore cannot merge into two clones, so this had to be refused"
-elif [ "$(grep -c 'is a snapshot with 2 clones' "${RCOW_LOG}" 2>/dev/null || echo 0)" \
+if [ "$(grep -c 'is a snapshot with 2 clones' "${RCOW_LOG}" 2>/dev/null || echo 0)" \
 		-gt 0 ]; then
-	pass "sx refused by the pre-flight check, which names the clone count"
+	pass "the pre-flight check named the clone count"
 elif [ "$(grep -c 'more than one clone' "${RCOW_LOG}" 2>/dev/null || echo 0)" -gt 0 ]; then
 	fail "the refusal came from blobstore, i.e. too late: the bdev is already gone"
 	info "the pre-flight check in s3lvol_lvol_destroy should have caught this"
 else
-	fail "sx refused, but nothing in the log says why: \
-$(echo "${OUT}" | tr -d '\n' | head -c 120)"
+	fail "sx was not deleted, but nothing in the log says why"
 fi
+
+# Withdraw the intent again: the rest of this script expects sx to stay put, and
+# the poller would otherwise delete it as soon as cx is gone.
+python3 "${RPC_PY}" --sock "${RCOW_RPC_SOCK}" \
+	rcow_cancel_pending_delete '{"lvol_name":"sx"}' >/dev/null 2>&1
 
 # The refusal must have happened before any teardown: same data, and the volume is
 # still writable. A late refusal would have unregistered the bdev already.

--- a/CubeS3lvol/test/dataplane/run_snapshot_cancel_test.sh
+++ b/CubeS3lvol/test/dataplane/run_snapshot_cancel_test.sh
@@ -2,35 +2,33 @@
 # Copyright (c) 2026 Tencent Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-#  Regression test for issue 2: snapshotting an esnap clone whose decouple is
-#  queued must not leave a decouple that cannot detach.
+#  Snapshotting an imported volume whose decouple is *running* must cancel that
+#  decouple and succeed.
 #
-#  The field failure it pins down (64-node): a decouple that is queued behind a
-#  slow full-volume materialisation does not hold action_in_progress, so a
-#  snapshot of the volume was allowed -- and snapshotting an esnap clone moves
-#  the external snapshot identity onto the new snapshot (spdk_bs_create_snapshot
-#  clears it on the origin). The queued decouple then materialised everything
-#  and failed its detach with "blob is not a clone of an external snapshot".
+#  The companion of run_decouple_queue_test.sh, which covers the queued case.
+#  This one covers the common one: s3lvol_lvol_decouple() starts immediately
+#  unless another decouple is in the way, so an ordinary "import, then snapshot"
+#  meets a decouple that is already materialising -- and trips the
+#  action_in_progress branch of derive_check rather than the decouple_pending one.
+#  Both had to give way; a queue only exercises one of them.
 #
-#  This test reproduces the queue window and asserts the fix. The fix was first a
-#  refusal, and is now a cancellation: refusing was correct about the hazard but
-#  made "import a volume, then snapshot it" impossible, since decouple defaults to
-#  true and is started before the import replies. So create_snapshot cancels the
-#  decouple and proceeds, which removes the hazard by removing the decouple. What
-#  is asserted either way is that no decouple ever materialises everything and then
-#  fails to detach.
+#  What must hold afterwards:
+#    - the snapshot exists, and the reply says decouple_cancelled
+#    - the decouple stopped part-way and said so, without the detach failure of
+#      docs/import-reference-snapshot-design.md 9.2
+#    - clusters materialised before the cancellation are kept, and they belong to
+#      the snapshot (a volume hands its clusters over when snapshotted)
+#    - the snapshot reads the source's bytes, and so does the volume
+#    - the volume can no longer be decoupled: the snapshot holds the parent now
 #
 #  Scenario:
-#    src: a big volume written full -> snapshot -> export  (the decouple of its
-#         import takes minutes, which is the queue window)
-#    src: a small sparse volume -> snapshot -> export
-#    dst: import big (decouple:true)   -- starts materialising, slowly
-#    dst: import small (decouple:true) -- queued behind big
-#    while small is queued: snapshot small -> cancels the queued decouple, succeeds
-#    big's decouple must be unaffected, and small must afterwards be undecouplable
+#    src: a volume written full -> snapshot -> export  (a slow decouple, so the
+#         cancellation lands in the middle of one rather than after it)
+#    dst: import it with decouple:true, assert the decouple is actually running
+#    dst: snapshot the import -> must cancel and succeed
 #
 #  Usage:
-#    sudo -E ./test/dataplane/repro_issue2.sh -e <endpoint> -b <bucket> [-r <region>]
+#    sudo -E ./test/dataplane/run_snapshot_cancel_test.sh -e <endpoint> -b <bucket> [-r <region>]
 #
 #  Credentials from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
 #  Needs root, nvme-cli, a writable /data.
@@ -43,38 +41,33 @@ TOOLS_DIR="${REPO_ROOT}/test/tools"
 
 TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
 RPC_PY="${SPDK_ROOT:-${REPO_ROOT}/deps/spdk}/scripts/rpc.py"
-RPC="${RPC_PY} -s /var/run/s3lvol.sock"
-RPC_SOCK="/var/run/s3lvol.sock"
+RPC="${RPC_PY} -s /var/run/s3lvol_sc.sock"
+RPC_SOCK="/var/run/s3lvol_sc.sock"
 
 S3_EXPORTS_DIR="exports"
 
-SRC_LVS="r2src"
-DST_LVS="r2dst"
+SRC_LVS="scsrc"
+DST_LVS="scdst"
 
 BIG_VOL="big0"
-SMALL_VOL="small0"
 BIG_SNAP="big0-snap"
-SMALL_SNAP="small0-snap"
 BIG_IMP="big0-imp"
-SMALL_IMP="small0-imp"
-SMALL_IMP_SNAP="small0-imp-snap"
+BIG_IMP_SNAP="big0-imp-snap"
 
 CAPACITY_GIB=8
-BIG_GIB=1          # full volume: written end to end
-SMALL_GIB=1        # sparse: only SMALL_WRITE_MB written
-SMALL_WRITE_MB=16
+BIG_GIB=1          # written end to end, so its decouple is slow enough to catch
 JOURNAL_MB=64
 WAL_MB=128
 WAL_FILE_MB=$((JOURNAL_MB + WAL_MB + 128))
 
-SRC_WAL_FILE="/data/r2_src.img"
-DST_WAL_FILE="/data/r2_dst.img"
-SRC_WAL_BDEV="r2_src_wal0"
-DST_WAL_BDEV="r2_dst_wal0"
+SRC_WAL_FILE="/data/sc_src.img"
+DST_WAL_FILE="/data/sc_dst.img"
+SRC_WAL_BDEV="sc_src_wal0"
+DST_WAL_BDEV="sc_dst_wal0"
 
-NQN="nqn.2026-08.io.spdk:r2"
+NQN="nqn.2026-08.io.spdk:sc"
 LISTEN_ADDR="127.0.0.1"
-LISTEN_PORT="4420"
+LISTEN_PORT="4421"
 
 ENDPOINT=""
 BUCKET=""
@@ -92,7 +85,6 @@ CONNECTED=0
 TRANSPORT_READY=0
 TEARDOWN_ANOMALY=0
 BIG_EXP_UUID=""
-SMALL_EXP_UUID=""
 
 pass() { PASS=$((PASS + 1)); echo "[PASS] $*"; }
 fail() { FAIL=$((FAIL + 1)); echo "[FAIL] $*"; }
@@ -206,6 +198,72 @@ sys.exit(0 if len(json.load(open(sys.argv[1]))) == 0 else 1)
 		sleep 1
 	done
 	return 1
+}
+
+remove_ns()
+{
+	python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --raw \
+		nvmf_subsystem_remove_ns \
+		"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "$1")" >/dev/null 2>&1 || true
+}
+
+# md5 of the first BIG_GIB of one volume, by name.
+#
+# Exposed and withdrawn around each read rather than kept: the namespaces are all
+# on one subsystem, so a volume added while connected shows up as another
+# /dev/nvmeXnY, and the set difference is how it is found -- the same way the
+# source device is located above.
+read_vol_md5()
+{
+	local name="$1" before dev nsid _i
+
+	before="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
+
+	# --raw, because for nvmf_subsystem_add_ns the result *is* the nsid, and
+	# SPDK's own rpc.py prints nothing for it -- which is fine for the callers
+	# that only check the exit code, but this one has to give the namespace back
+	# afterwards.
+	nsid="$(python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --raw \
+		nvmf_subsystem_add_ns \
+		"$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+			"${NQN}" "${DST_LVS}/${name}")" \
+		2>"${WORKDIR}/addns_${name}.err" | tr -d '[:space:]')"
+	if [ -z "${nsid}" ]; then
+		{
+			echo "add_ns for ${DST_LVS}/${name} produced no nsid"
+			echo "stderr:"; sed 's/^/  /' "${WORKDIR}/addns_${name}.err"
+			echo "devices: $(ls /dev/nvme*n* 2>/dev/null | tr '\n' ' ')"
+		} >>"${WORKDIR}/read_vol_diag.txt" 2>&1
+		return 1
+	fi
+
+	dev=""
+	for _i in $(seq 40); do
+		dev="$(comm -13 <(echo "${before}") \
+			<(ls /dev/nvme*n* 2>/dev/null | sort || true) | head -1)"
+		[ -n "${dev}" ] && [ -b "${dev}" ] && break
+		dev=""
+		sleep 0.5
+	done
+	if [ -z "${dev}" ]; then
+		{
+			echo "no new device for ${name} (nsid ${nsid})"
+			echo "before: ${before}"
+			echo "after:  $(ls /dev/nvme*n* 2>/dev/null | tr '\n' ' ')"
+			echo "controllers:"
+			for c in /sys/class/nvme/nvme*; do
+				[ -e "${c}/subsysnqn" ] && echo "  $(basename "${c}") $(cat "${c}/subsysnqn")"
+			done
+		} >>"${WORKDIR}/read_vol_diag.txt" 2>&1
+		remove_ns "${nsid}"
+		return 1
+	fi
+
+	dd if="${dev}" bs=1M count=$((BIG_GIB * 1024)) iflag=direct status=none \
+		| md5sum | cut -d' ' -f1
+	remove_ns "${nsid}"
+	sleep 1
+	return 0
 }
 
 cleanup()
@@ -352,6 +410,18 @@ dd if="${WORKDIR}/big.pat" of="${BIG_DEV}" bs=1M count=$((BIG_GIB * 1024)) \
 	oflag=direct conv=fsync status=none 2>"${WORKDIR}/big_write.err"
 pass "big volume written full"
 
+# What every later read is compared against. Taken from the device rather than the
+# pattern file so that a source-side write bug fails here rather than looking like
+# a decouple bug three steps later.
+SRC_MD5="$(dd if="${BIG_DEV}" bs=1M count=$((BIG_GIB * 1024)) iflag=direct \
+	status=none | md5sum | cut -d' ' -f1)"
+info "source content ${SRC_MD5}"
+if [ "${SRC_MD5}" = "$(md5sum "${WORKDIR}/big.pat" | cut -d' ' -f1)" ]; then
+	pass "source reads back what was written"
+else
+	fail "source does not read back what was written"
+fi
+
 raw_rpc rcow_create_snapshot "$(printf '{"lvol_name":"%s","snapshot_name":"%s"}' \
 	"${BIG_VOL}" "${BIG_SNAP}")" >/dev/null 2>&1 \
 	|| { fail "snapshot big"; exit 1; }
@@ -363,168 +433,152 @@ wait_export_done "${BIG_EXP_UUID}" "big export" || exit 1
 pass "big snapshot exported (${BIG_EXP_UUID})"
 
 # ==========================================================================
-echo "[3] source small volume, sparse"
-raw_rpc rcow_create_lvol "$(printf '{"lvol_name":"%s","size_gib":%d}' \
-	"${SMALL_VOL}" "${SMALL_GIB}")" >/dev/null 2>&1 \
-	|| { fail "create small lvol"; exit 1; }
-${RPC} nvmf_subsystem_add_ns "${NQN}" "${SRC_LVS}/${SMALL_VOL}" \
-	>/dev/null 2>&1 || { fail "nvmf_subsystem_add_ns (small)"; exit 1; }
-nvme ns-rescan "/dev/$(basename "${BIG_DEV}" | sed 's/n[0-9]*$//')" \
-	>/dev/null 2>&1 || true
-SMALL_DEV=""
-for _ in $(seq 30); do
-	SMALL_DEV="$(comm -13 <(echo "${BEFORE_CONNECT}") \
-			<(ls /dev/nvme*n* 2>/dev/null | sort || true) | grep -v "${BIG_DEV}" \
-			| head -1)"
-	[ -n "${SMALL_DEV}" ] && break
-	sleep 0.5
-done
-[ -n "${SMALL_DEV}" ] || { fail "no device for small volume"; exit 1; }
-pass "small volume is ${SMALL_DEV}"
-
-dd if=/dev/urandom of="${WORKDIR}/small.pat" bs=1M count="${SMALL_WRITE_MB}" \
-	status=none
-dd if="${WORKDIR}/small.pat" of="${SMALL_DEV}" bs=1M count="${SMALL_WRITE_MB}" \
-	seek=0 oflag=direct conv=fsync status=none 2>"${WORKDIR}/small_write.err"
-pass "small volume written (${SMALL_WRITE_MB} MiB sparse)"
-
-raw_rpc rcow_create_snapshot "$(printf '{"lvol_name":"%s","snapshot_name":"%s"}' \
-	"${SMALL_VOL}" "${SMALL_SNAP}")" >/dev/null 2>&1 \
-	|| { fail "snapshot small"; exit 1; }
-SMALL_EXP_UUID="$(raw_rpc rcow_export_snapshot \
-	"$(printf '{"snapshot_name":"%s"}' "${SMALL_SNAP}")" \
-	2>"${WORKDIR}/small_exp.err" | tr -d ' \t\r\n')"
-[ -n "${SMALL_EXP_UUID}" ] || { fail "export small snapshot"; exit 1; }
-wait_export_done "${SMALL_EXP_UUID}" "small export" || exit 1
-pass "small snapshot exported (${SMALL_EXP_UUID})"
-
-# One blobstore per node: the source lvstore has to be unloaded before the
-# destination can be created. Its export lives in S3, so the import below still
-# reads through it.
+echo "[3] destination lvstore"
+# One blobstore per node: the source has to be unloaded before the destination can
+# be created. Its export lives in S3, so the import below still reads through it --
+# and the device the source was read from is gone from here on, which is why
+# SRC_MD5 was taken while it was still attached.
+nvme_settle
+remove_ns 1
 raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" \
 	>/dev/null 2>"${WORKDIR}/unload_src.err" \
 	|| { fail "unload src lvstore"; sed 's/^/       /' "${WORKDIR}/unload_src.err"; exit 1; }
 SRC_CREATED=0
-pass "src lvstore unloaded (exports remain in S3)"
+pass "src lvstore unloaded (its export remains in S3)"
 
-# ==========================================================================
-echo "[4] destination lvstore"
-# The namespace was registered for the source; one registration per bucket.
-raw_rpc rcow_create_lvstore \
-	"$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":%d,"wal_bdev":"%s","journal_size_mb":%d,"wal_size_mb":%d}' \
-		"${DST_LVS}" "${BUCKET}" "${CAPACITY_GIB}" "${DST_WAL_BDEV}" \
-		"${JOURNAL_MB}" "${WAL_MB}")" \
-	>"${WORKDIR}/dst_lvs.json" 2>"${WORKDIR}/dst_lvs.err" \
-	|| { fail "dst create_lvstore"; sed 's/^/       /' "${WORKDIR}/dst_lvs.err"; exit 1; }
+if ! raw_rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":%d,"wal_bdev":"%s","journal_size_mb":%d,"wal_size_mb":%d,"force":true}' \
+	"${DST_LVS}" "${BUCKET}" "${CAPACITY_GIB}" "${DST_WAL_BDEV}" "${JOURNAL_MB}" "${WAL_MB}")" \
+	>/dev/null; then
+	fail "could not create ${DST_LVS}"
+	exit 1
+fi
 DST_CREATED=1
-pass "dst lvstore ${DST_LVS} created"
+pass "destination lvstore ready"
 
 # ==========================================================================
-echo "[5] import big with decouple:true (starts materialising)"
-if ! raw_rpc rcow_import_lvol \
-		"$(printf '{"lvol_name":"%s","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
-			"${BIG_IMP}" "${BIG_EXP_UUID}" "${DST_LVS}")" \
-		>"${WORKDIR}/import_big.json" 2>"${WORKDIR}/import_big.err"; then
-	fail "import big"
-	sed 's/^/       /' "${WORKDIR}/import_big.err"
+echo "[4] import with decouple:true, and catch it while it runs"
+if ! raw_rpc rcow_import_lvol "$(printf '{"lvol_name":"%s","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+	"${BIG_IMP}" "${BIG_EXP_UUID}" "${DST_LVS}")" >/dev/null; then
+	fail "import of ${BIG_IMP} failed"
 	exit 1
 fi
-pass "big imported, decoupling in background"
 
-# Give the big decouple a moment to grab the queue.
-sleep 3
-
-# ==========================================================================
-echo "[6] import small with decouple:true (queued behind big)"
-if ! raw_rpc rcow_import_lvol \
-		"$(printf '{"lvol_name":"%s","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
-			"${SMALL_IMP}" "${SMALL_EXP_UUID}" "${DST_LVS}")" \
-		>"${WORKDIR}/import_small.json" 2>"${WORKDIR}/import_small.err"; then
-	fail "import small"
-	sed 's/^/       /' "${WORKDIR}/import_small.err"
+# It must be *running*, not queued -- that is the branch this test exists for.
+# decouple_start() is called before the import replies, so this should already
+# hold; asserted rather than assumed, because a queued one would quietly turn this
+# into a duplicate of run_decouple_queue_test.sh.
+if ! grep -qE "Decoupling lvol '${BIG_IMP}'" "${TGT_LOG}"; then
+	fail "${BIG_IMP} is not materialising -- this test needs a running decouple"
 	exit 1
 fi
-pass "small imported, decouple queued behind big"
+pass "${BIG_IMP} imported, decouple running"
+
+# Let it get somewhere, so the cancellation has clusters to keep.
+sleep 5
 
 # ==========================================================================
-echo "[7] while small is queued: snapshot it (must cancel the decouple and succeed)"
-# This used to assert a refusal, and the refusal was correct as far as it went --
-# letting the snapshot through while the decouple stood is what produced the
-# detach failure this test is named for. But refusing makes "import a volume,
-# then snapshot it" impossible, because decouple defaults to true and starts
-# before the import replies. So the decouple is cancelled instead, and the
-# snapshot proceeds; the hazard is gone because there is no longer a decouple to
-# fail. See docs/import-reference-snapshot-design.md §3.1 and §9.2.
+echo "[5] snapshot the importing volume (must cancel the running decouple)"
 raw_rpc rcow_create_snapshot "$(printf '{"lvol_name":"%s","snapshot_name":"%s"}' \
-	"${SMALL_IMP}" "${SMALL_IMP_SNAP}")" \
-	>"${WORKDIR}/snap_small.json" 2>"${WORKDIR}/snap_small.err"
+	"${BIG_IMP}" "${BIG_IMP_SNAP}")" \
+	>"${WORKDIR}/snap.json" 2>"${WORKDIR}/snap.err"
 SNAP_RC=$?
 if [ "${SNAP_RC}" -eq 0 ]; then
-	pass "snapshot of queued small succeeded (rc=0)"
+	pass "snapshot succeeded while a decouple was running (rc=0)"
 else
-	fail "snapshot of queued small refused (rc=${SNAP_RC}) -- it must cancel the queued decouple instead"
-	sed 's/^/    /' "${WORKDIR}/snap_small.err" 2>/dev/null | tail -5
+	fail "snapshot refused (rc=${SNAP_RC}) -- it must cancel the running decouple"
+	sed 's/^/    /' "${WORKDIR}/snap.err" 2>/dev/null | tail -5
 fi
 
-# The reply has to say the decouple was dropped: the caller asked for one, by
-# default, and is not getting it.
-if grep -q 'decouple_cancelled' "${WORKDIR}/snap_small.json" 2>/dev/null; then
+if grep -q 'decouple_cancelled' "${WORKDIR}/snap.json" 2>/dev/null; then
 	pass "reply reports decouple_cancelled"
 else
-	fail "reply does not report decouple_cancelled: $(tr -d '\n' < "${WORKDIR}/snap_small.json" 2>/dev/null | head -c 200)"
+	fail "reply does not report decouple_cancelled"
+	tr -d '\n' < "${WORKDIR}/snap.json" 2>/dev/null | head -c 200 | sed 's/^/    /'
 fi
 
-# Cancelled from the queue, so it must say so -- and must not have started.
-if grep -qE "'${SMALL_IMP}' was waiting to be decoupled .* is being snapshotted" "${TGT_LOG}"; then
-	pass "queued decouple of ${SMALL_IMP} was dequeued for the snapshot"
+if grep -qE "Cancelling the decouple of lvol '${BIG_IMP}'" "${TGT_LOG}"; then
+	pass "cancellation logged with its progress"
 else
-	fail "no dequeue-for-snapshot line for ${SMALL_IMP} in the log"
-fi
-if grep -qE "Decoupling lvol '${SMALL_IMP}'" "${TGT_LOG}"; then
-	fail "${SMALL_IMP} started materialising -- a queued cancel must stop it before that"
-else
-	pass "${SMALL_IMP} never started materialising"
+	fail "no cancellation line for ${BIG_IMP} in the log"
 fi
 
 # ==========================================================================
-echo "[8] wait for all decouples to finish"
+echo "[6] the decouple must stop, part-way, without a detach failure"
 if wait_for_decouple; then
-	pass "all decouples finished"
+	pass "no decouple left running"
 else
-	fail "decouple did not finish in time"
+	fail "decouple still running after the cancellation"
+fi
+
+if grep -qE "Decoupling lvol '${BIG_IMP}' from export .* was cancelled after" "${TGT_LOG}"; then
+	pass "decouple reported itself cancelled"
+else
+	fail "no 'was cancelled after' line -- the abort path did not run"
+fi
+
+# The regression this whole family of tests is about.
+if grep -qE 'blob is not a clone of an external snapshot' "${TGT_LOG}"; then
+	fail "detach failure present -- cancelling did not prevent the 9.2 hazard"
+else
+	pass "no detach failure"
+fi
+
+# The old failure message must not be reused for a cancellation: it says the
+# volume can be decoupled again, which is exactly what [8] shows to be false.
+if grep -qE "Decoupling lvol '${BIG_IMP}'.*can be decoupled again" "${TGT_LOG}"; then
+	fail "cancellation logged with the misleading 'can be decoupled again' message"
+else
+	pass "cancellation did not claim the volume can be decoupled again"
 fi
 
 # ==========================================================================
-echo "[9] verdict"
-echo "--- relevant log lines:"
-grep -nE 'queued to be decoupled|decouple_start|decouple_finish|Decoupling|blob is not a clone' \
-	"${TGT_LOG}" | tail -40 | sed 's/^/    /' || true
-
-# The point of the whole test. Whether the snapshot is refused or the decouple is
-# cancelled, what must never appear is a decouple that materialised everything and
-# then could not detach.
-if grep -qE 'blob is not a clone of an external snapshot' "${TGT_LOG}"; then
-	fail "decouple detach failed -- the fix did not hold"
+echo "[7] clusters copied before the cancellation are kept, and belong to the snapshot"
+raw_rpc rcow_get_lvstores "" >"${WORKDIR}/lvs.json" 2>/dev/null || true
+SNAP_ALLOC="$(python3 -c "
+import json, sys
+try:
+    rows = json.load(open(sys.argv[1]))
+except Exception:
+    print(-1); raise SystemExit
+for lvs in (rows if isinstance(rows, list) else rows.get('lvstores', [])):
+    for l in lvs.get('lvols', []):
+        if l.get('name') == sys.argv[2]:
+            print(l.get('allocated_clusters', -1)); raise SystemExit
+print(-1)
+" "${WORKDIR}/lvs.json" "${BIG_IMP_SNAP}" 2>/dev/null || echo -1)"
+if [ "${SNAP_ALLOC}" -gt 0 ] 2>/dev/null; then
+	pass "snapshot owns ${SNAP_ALLOC} materialised cluster(s) -- the partial copy was kept"
 else
-	pass "no detach failure: every decouple detached cleanly"
+	info "snapshot allocated clusters reported as '${SNAP_ALLOC}'"
+	info "(0 would mean the cancellation beat the first cluster; the 5 s wait should prevent that)"
+	fail "snapshot owns no clusters -- the partial copy was discarded, or never started"
 fi
 
-# big was never snapshotted, so its decouple must still have run to completion --
-# cancelling one volume's decouple must not disturb another's.
-if grep -qE "'${BIG_IMP}' no longer reads export" "${TGT_LOG}"; then
-	pass "${BIG_IMP} decoupled cleanly, unaffected by the cancellation"
+# ==========================================================================
+echo "[8] the volume can no longer be decoupled: its snapshot holds the parent"
+if raw_rpc rcow_decouple_lvol "$(printf '{"lvol_name":"%s"}' "${BIG_IMP}")" \
+	>/dev/null 2>"${WORKDIR}/redecouple.err"; then
+	fail "${BIG_IMP} accepted a decouple after being snapshotted"
 else
-	fail "${BIG_IMP} did not finish its decouple"
+	pass "${BIG_IMP} refuses a further decouple (it reads its snapshot, not the export)"
 fi
 
-# small's decouple was cancelled, so it must still read the export -- and asking
-# again must be refused, because the snapshot now owns the external parent.
-raw_rpc rcow_decouple_lvol "$(printf '{"lvol_name":"%s"}' "${SMALL_IMP}")" \
-	>/dev/null 2>"${WORKDIR}/redecouple.err"
-if [ $? -ne 0 ]; then
-	pass "${SMALL_IMP} can no longer be decoupled (its snapshot holds the parent)"
+# ==========================================================================
+echo "[9] data: the snapshot and the volume both read the source's bytes"
+SNAP_MD5="$(read_vol_md5 "${BIG_IMP_SNAP}")" || SNAP_MD5="unreadable"
+VOL_MD5="$(read_vol_md5 "${BIG_IMP}")" || VOL_MD5="unreadable"
+info "source   ${SRC_MD5}"
+info "snapshot ${SNAP_MD5}"
+info "volume   ${VOL_MD5}"
+if [ "${SNAP_MD5}" = "${SRC_MD5}" ]; then
+	pass "snapshot reads the source's bytes"
 else
-	fail "${SMALL_IMP} accepted a decouple after being snapshotted -- it has no external parent to clear"
+	fail "snapshot content differs from the source"
+fi
+if [ "${VOL_MD5}" = "${SRC_MD5}" ]; then
+	pass "volume still reads the source's bytes"
+else
+	fail "volume content differs from the source"
 fi
 
 check_target "step 9" || exit 1

--- a/CubeS3lvol/test/dataplane/run_snapshot_converge_test.sh
+++ b/CubeS3lvol/test/dataplane/run_snapshot_converge_test.sh
@@ -1,0 +1,689 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+#  A reference chain must be able to stop depending on its source export.
+#
+#  Snapshotting an imported volume moves the external snapshot onto the snapshot
+#  (measured, docs/import-reference-snapshot-design.md 9.2). That left nothing to
+#  decouple: the volume no longer reads the export, and a read-only snapshot could
+#  not be materialised -- so the chain referenced its source until it was deleted,
+#  which ties the data's survival to the importer's uptime, since a lease going
+#  stale is what licenses an unattended delete on the source.
+#
+#  Decoupling a snapshot is what closes that. This asserts it end to end, and the
+#  assertion that matters is the last one: the source's objects are deleted from S3
+#  and the lvstore is unloaded and re-attached before the final read, so a pass
+#  cannot come from a cache.
+#
+#  Scenario:
+#    src: a volume written full -> snapshot -> export
+#    dst: import it, snapshot it (which cancels the import's decouple), clone the
+#         snapshot, write to the clone
+#    dst: decouple the snapshot, while a reader loops on the clone
+#    then: erase the source prefix, reload, and read everything back
+#
+#  Usage:
+#    sudo -E ./test/dataplane/run_snapshot_converge_test.sh -e <endpoint> -b <bucket> [-r <region>]
+#
+#  Credentials from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
+#  Needs root, nvme-cli, a writable /data.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TOOLS_DIR="${REPO_ROOT}/test/tools"
+
+TGT_BIN="${REPO_ROOT}/app/s3lvol_tgt/s3lvol_tgt"
+RPC_PY="${SPDK_ROOT:-${REPO_ROOT}/deps/spdk}/scripts/rpc.py"
+RPC="${RPC_PY} -s /var/run/s3lvol_cv.sock"
+RPC_SOCK="/var/run/s3lvol_cv.sock"
+
+S3_EXPORTS_DIR="exports"
+
+SRC_LVS="cvsrc"
+DST_LVS="cvdst"
+
+BIG_VOL="big0"
+BIG_SNAP="big0-snap"
+BIG_IMP="big0-imp"
+BIG_IMP_SNAP="big0-imp-snap"
+BIG_IMP_CLONE="big0-imp-clone"
+
+CAPACITY_GIB=8
+BIG_GIB=1          # written end to end, so its decouple is slow enough to catch
+CLONE_WRITE_MB=32  # the clone's own clusters, so its writes are covered too
+JOURNAL_MB=64
+WAL_MB=128
+WAL_FILE_MB=$((JOURNAL_MB + WAL_MB + 128))
+
+SRC_WAL_FILE="/data/cv_src.img"
+DST_WAL_FILE="/data/cv_dst.img"
+SRC_WAL_BDEV="cv_src_wal0"
+DST_WAL_BDEV="cv_dst_wal0"
+
+NQN="nqn.2026-08.io.spdk:cv"
+LISTEN_ADDR="127.0.0.1"
+LISTEN_PORT="4422"
+
+ENDPOINT=""
+BUCKET=""
+REGION="ap-nanjing"
+
+PASS=0
+FAIL=0
+TGT_PID=""
+TGT_LOG=""
+WORKDIR=""
+SRC_CREATED=0
+DST_CREATED=0
+WAL_FILES_CREATED=0
+CONNECTED=0
+TRANSPORT_READY=0
+TEARDOWN_ANOMALY=0
+CLONE_NSID=""
+READER_PID=""
+BIG_EXP_UUID=""
+
+pass() { PASS=$((PASS + 1)); echo "[PASS] $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "[FAIL] $*"; }
+info() { echo "---- $*"; }
+
+usage()
+{
+	cat <<EOF
+Usage: $0 -e <endpoint> -b <bucket> [-r <region>]
+
+  -e   S3/COS endpoint host
+  -b   bucket (a test bucket: a clean run deletes its own prefixes)
+  -r   region (default: ${REGION})
+EOF
+}
+
+while getopts "e:b:r:h" opt; do
+	case "${opt}" in
+	e) ENDPOINT="${OPTARG}" ;;
+	b) BUCKET="${OPTARG}" ;;
+	r) REGION="${OPTARG}" ;;
+	h) usage; exit 0 ;;
+	*) usage; exit 1 ;;
+	esac
+done
+[ -n "${ENDPOINT}" ] && [ -n "${BUCKET}" ] || { usage; exit 1; }
+[ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ] || {
+	echo "AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY must be set" >&2; exit 1; }
+[ "$(id -u)" -eq 0 ] || { echo "must run as root" >&2; exit 1; }
+for tool in nvme dd md5sum python3; do
+	command -v "${tool}" >/dev/null 2>&1 || {
+		echo "${tool} is required" >&2; exit 1; }
+done
+
+WORKDIR="$(mktemp -d /tmp/r2.XXXXXX)"
+TGT_LOG="${WORKDIR}/target.log"
+
+raw_rpc()
+{
+	python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" "$1" "${2:-}"
+}
+
+wait_export_done()
+{
+	local uuid="$1" where="$2"
+	local deadline=$(( $(date +%s) + 120 ))
+	local out st
+
+	while :; do
+		if ! out="$(raw_rpc rcow_get_snapshot_status \
+				"$(printf '{"export_uuid":"%s"}' "${uuid}")" 2>/dev/null)"; then
+			fail "export ${uuid} finished without a manifest (${where})"
+			return 1
+		fi
+		st="$(printf '%s' "${out}" \
+			| python3 -c 'import json,sys; print(json.load(sys.stdin).get("export_status",""))' \
+				2>/dev/null)"
+		if [ "${st}" = "DONE" ]; then
+			return 0
+		fi
+		if [ "$(date +%s)" -ge "${deadline}" ]; then
+			fail "export ${uuid} never reached DONE (${where})"
+			return 1
+		fi
+		sleep 0.2
+	done
+}
+
+target_alive()
+{
+	[ -n "${TGT_PID}" ] && kill -0 "${TGT_PID}" 2>/dev/null
+}
+
+check_target()
+{
+	local where="$1"
+
+	if ! target_alive; then
+		fail "target died during ${where}"
+		tail -25 "${TGT_LOG}" | sed 's/^/       /'
+		return 1
+	fi
+	return 0
+}
+
+nvme_settle()
+{
+	udevadm settle --timeout=5 >/dev/null 2>&1 || true
+}
+
+remove_prefix()
+{
+	python3 "${TOOLS_DIR}/s3_prefix_rm.py" -e "${ENDPOINT}" -b "${BUCKET}" \
+		-r "${REGION}" -p "$1"
+}
+
+# Decouple is considered done when the decouple list is empty.
+wait_for_decouple()
+{
+	local _i
+	for _i in $(seq 600); do
+		if ! raw_rpc rcow_get_decouple "" >"${WORKDIR}/decouple.json" 2>/dev/null; then
+			return 1
+		fi
+		if python3 -c "
+import json, sys
+sys.exit(0 if len(json.load(open(sys.argv[1]))) == 0 else 1)
+" "${WORKDIR}/decouple.json"; then
+			return 0
+		fi
+		sleep 1
+	done
+	return 1
+}
+
+remove_ns()
+{
+	python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --raw \
+		nvmf_subsystem_remove_ns \
+		"$(printf '{"nqn":"%s","nsid":%s}' "${NQN}" "$1")" >/dev/null 2>&1 || true
+}
+
+# md5 of the first BIG_GIB of one volume, by name.
+#
+# Exposed and withdrawn around each read rather than kept: the namespaces are all
+# on one subsystem, so a volume added while connected shows up as another
+# /dev/nvmeXnY, and the set difference is how it is found -- the same way the
+# source device is located above.
+read_vol_md5()
+{
+	local name="$1" before dev nsid _i
+
+	before="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
+
+	# --raw, because for nvmf_subsystem_add_ns the result *is* the nsid, and
+	# SPDK's own rpc.py prints nothing for it -- which is fine for the callers
+	# that only check the exit code, but this one has to give the namespace back
+	# afterwards.
+	nsid="$(python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --raw \
+		nvmf_subsystem_add_ns \
+		"$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+			"${NQN}" "${DST_LVS}/${name}")" \
+		2>"${WORKDIR}/addns_${name}.err" | tr -d '[:space:]')"
+	if [ -z "${nsid}" ]; then
+		{
+			echo "add_ns for ${DST_LVS}/${name} produced no nsid"
+			echo "stderr:"; sed 's/^/  /' "${WORKDIR}/addns_${name}.err"
+			echo "devices: $(ls /dev/nvme*n* 2>/dev/null | tr '\n' ' ')"
+		} >>"${WORKDIR}/read_vol_diag.txt" 2>&1
+		return 1
+	fi
+
+	dev=""
+	for _i in $(seq 40); do
+		dev="$(comm -13 <(echo "${before}") \
+			<(ls /dev/nvme*n* 2>/dev/null | sort || true) | head -1)"
+		[ -n "${dev}" ] && [ -b "${dev}" ] && break
+		dev=""
+		sleep 0.5
+	done
+	if [ -z "${dev}" ]; then
+		{
+			echo "no new device for ${name} (nsid ${nsid})"
+			echo "before: ${before}"
+			echo "after:  $(ls /dev/nvme*n* 2>/dev/null | tr '\n' ' ')"
+			echo "controllers:"
+			for c in /sys/class/nvme/nvme*; do
+				[ -e "${c}/subsysnqn" ] && echo "  $(basename "${c}") $(cat "${c}/subsysnqn")"
+			done
+		} >>"${WORKDIR}/read_vol_diag.txt" 2>&1
+		remove_ns "${nsid}"
+		return 1
+	fi
+
+	dd if="${dev}" bs=1M count=$((BIG_GIB * 1024)) iflag=direct status=none \
+		| md5sum | cut -d' ' -f1
+	remove_ns "${nsid}"
+	sleep 1
+	return 0
+}
+
+cleanup()
+{
+	local rc=$?
+
+	echo
+	echo "=== cleanup ==="
+
+	# The reader loops on a device that is about to be taken away, so it has to
+	# stop before the namespace goes -- including when the run exits early.
+	if [ -n "${READER_PID}" ]; then
+		touch "${WORKDIR}/reader_stop" 2>/dev/null || true
+		wait "${READER_PID}" 2>/dev/null || true
+		READER_PID=""
+	fi
+	if [ -n "${CLONE_NSID}" ]; then
+		remove_ns "${CLONE_NSID}"
+		CLONE_NSID=""
+	fi
+
+	if [ "${CONNECTED}" -eq 1 ]; then
+		nvme_settle
+		nvme disconnect -n "${NQN}" >/dev/null 2>&1 || true
+		CONNECTED=0
+	fi
+
+	if target_alive; then
+		if [ "${TRANSPORT_READY}" -eq 1 ]; then
+			${RPC} nvmf_delete_subsystem "${NQN}" >/dev/null 2>&1 || true
+		fi
+		for lvs in "${DST_LVS}" "${SRC_LVS}"; do
+			raw_rpc rcow_delete_lvstore \
+				"$(printf '{"lvs_name":"%s"}' "${lvs}")" >/dev/null 2>&1 || true
+		done
+		kill -TERM "${TGT_PID}" 2>/dev/null
+		for _ in $(seq 50); do
+			kill -0 "${TGT_PID}" 2>/dev/null || break
+			sleep 0.1
+		done
+		kill -KILL "${TGT_PID}" 2>/dev/null
+	fi
+
+	if [ "${FAIL}" -eq 0 ] && [ -z "${S3LVOL_KEEP_S3:-}" ]; then
+		for prefix in "${SRC_LVS}/" "${DST_LVS}/" "${S3_EXPORTS_DIR}/"; do
+			remove_prefix "${prefix}" >"${WORKDIR}/s3_rm.log" 2>&1 || true
+		done
+	fi
+	if [ "${WAL_FILES_CREATED}" -eq 1 ]; then
+		rm -f "${SRC_WAL_FILE}" "${DST_WAL_FILE}"
+	fi
+
+	echo "--- target log: ${TGT_LOG}"
+	echo
+	echo "=== result: ${PASS} passed, ${FAIL} failed ==="
+	[ "${FAIL}" -eq 0 ] || exit 1
+}
+trap cleanup EXIT
+
+# ==========================================================================
+echo "[0] preconditions"
+[ -x "${TGT_BIN}" ] || { echo "target not built" >&2; exit 1; }
+if pgrep -x s3lvol_tgt >/dev/null 2>&1; then
+	echo "another s3lvol_tgt is running; stop it first" >&2
+	exit 1
+fi
+pass "preconditions"
+
+# ==========================================================================
+echo "[1] starting the target"
+rm -f "${SRC_WAL_FILE}" "${DST_WAL_FILE}"
+truncate -s "${WAL_FILE_MB}M" "${SRC_WAL_FILE}"
+truncate -s "${WAL_FILE_MB}M" "${DST_WAL_FILE}"
+WAL_FILES_CREATED=1
+
+"${TGT_BIN}" -m "${S3LVOL_TGT_CPUMASK:-0x3}" --no-huge -s 2048 -r "${RPC_SOCK}" \
+	>"${TGT_LOG}" 2>&1 &
+TGT_PID=$!
+
+for _ in $(seq 80); do
+	[ -e "${RPC_SOCK}" ] && break
+	kill -0 "${TGT_PID}" 2>/dev/null || { echo "target died on start" >&2; exit 1; }
+	sleep 0.1
+done
+[ -e "${RPC_SOCK}" ] || { echo "target never opened ${RPC_SOCK}" >&2; exit 1; }
+sleep 1
+pass "target is up (pid ${TGT_PID})"
+
+${RPC} bdev_aio_create "${SRC_WAL_FILE}" "${SRC_WAL_BDEV}" 4096 >/dev/null 2>&1 || {
+	fail "bdev_aio_create (source)"; exit 1; }
+${RPC} bdev_aio_create "${DST_WAL_FILE}" "${DST_WAL_BDEV}" 4096 >/dev/null 2>&1 || {
+	fail "bdev_aio_create (destination)"; exit 1; }
+pass "two local devices attached"
+
+# ==========================================================================
+echo "[2] source lvstore + big volume, written full"
+S3LVOL_EXTRA_JSON=""
+[ "${S3LVOL_TEST_PATH_STYLE:-0}" -eq 1 ] && S3LVOL_EXTRA_JSON+=',"path_style":true'
+[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_EXTRA_JSON+=',"no_tls":true'
+# The same flags in the form s3_prefix_rm.py takes, for count_objects and
+# remove_prefix. run_all.sh sets this for a full-suite run; a direct run
+# generates it here so only PATH_STYLE / NO_TLS need to be set.
+if [ -z "${S3LVOL_TEST_S3FLAGS:-}" ]; then
+	S3LVOL_TEST_S3FLAGS=""
+	[ "${S3LVOL_TEST_PATH_STYLE:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --path-style"
+	[ "${S3LVOL_TEST_NO_TLS:-0}" -eq 1 ] && S3LVOL_TEST_S3FLAGS+=" --no-tls"
+fi
+raw_rpc rcow_add_s3_config \
+	"$(printf '{"namespace":"%s","endpoint":"%s","bucket":"%s","region":"%s"%s}' \
+		"${BUCKET}" "${ENDPOINT}" "${BUCKET}" "${REGION}" "${S3LVOL_EXTRA_JSON}")" >/dev/null 2>&1 \
+	|| { fail "add_s3_config"; exit 1; }
+raw_rpc rcow_create_lvstore \
+	"$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":%d,"wal_bdev":"%s","journal_size_mb":%d,"wal_size_mb":%d}' \
+		"${SRC_LVS}" "${BUCKET}" "${CAPACITY_GIB}" "${SRC_WAL_BDEV}" \
+		"${JOURNAL_MB}" "${WAL_MB}")" \
+	>"${WORKDIR}/src_lvs.json" 2>"${WORKDIR}/src_lvs.err" \
+	|| { fail "src create_lvstore"; sed 's/^/       /' "${WORKDIR}/src_lvs.err"; exit 1; }
+SRC_CREATED=1
+pass "src lvstore ${SRC_LVS} created"
+
+raw_rpc rcow_create_lvol "$(printf '{"lvol_name":"%s","size_gib":%d}' \
+	"${BIG_VOL}" "${BIG_GIB}")" >/dev/null 2>&1 \
+	|| { fail "create big lvol"; exit 1; }
+
+${RPC} nvmf_create_transport -t TCP >/dev/null 2>&1 || true
+${RPC} nvmf_create_subsystem "${NQN}" -a -s R2X0000000000000001 \
+	>/dev/null 2>&1 || { fail "nvmf_create_subsystem"; exit 1; }
+TRANSPORT_READY=1
+${RPC} nvmf_subsystem_add_ns "${NQN}" "${SRC_LVS}/${BIG_VOL}" \
+	>/dev/null 2>&1 || { fail "nvmf_subsystem_add_ns (big)"; exit 1; }
+${RPC} nvmf_subsystem_add_listener "${NQN}" -t tcp -a "${LISTEN_ADDR}" \
+	-s "${LISTEN_PORT}" >/dev/null 2>&1 || { fail "add_listener"; exit 1; }
+
+BEFORE_CONNECT="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
+if ! nvme connect -t tcp -a "${LISTEN_ADDR}" -s "${LISTEN_PORT}" -n "${NQN}" \
+		>"${WORKDIR}/connect.log" 2>&1; then
+	fail "nvme connect"
+	sed 's/^/       /' "${WORKDIR}/connect.log"
+	exit 1
+fi
+CONNECTED=1
+BIG_DEV=""
+for _ in $(seq 30); do
+	BIG_DEV="$(comm -13 <(echo "${BEFORE_CONNECT}") \
+			<(ls /dev/nvme*n* 2>/dev/null | sort || true) | head -1)"
+	[ -n "${BIG_DEV}" ] && break
+	sleep 0.5
+done
+[ -n "${BIG_DEV}" ] || { fail "no device for big volume"; exit 1; }
+pass "big volume is ${BIG_DEV}"
+
+info "writing ${BIG_GIB}GiB to ${BIG_VOL} (this is the slow part)"
+dd if=/dev/urandom of="${WORKDIR}/big.pat" bs=1M count=$((BIG_GIB * 1024)) \
+	status=none
+dd if="${WORKDIR}/big.pat" of="${BIG_DEV}" bs=1M count=$((BIG_GIB * 1024)) \
+	oflag=direct conv=fsync status=none 2>"${WORKDIR}/big_write.err"
+pass "big volume written full"
+
+# What every later read is compared against. Taken from the device rather than the
+# pattern file so that a source-side write bug fails here rather than looking like
+# a decouple bug three steps later.
+SRC_MD5="$(dd if="${BIG_DEV}" bs=1M count=$((BIG_GIB * 1024)) iflag=direct \
+	status=none | md5sum | cut -d' ' -f1)"
+info "source content ${SRC_MD5}"
+if [ "${SRC_MD5}" = "$(md5sum "${WORKDIR}/big.pat" | cut -d' ' -f1)" ]; then
+	pass "source reads back what was written"
+else
+	fail "source does not read back what was written"
+fi
+
+raw_rpc rcow_create_snapshot "$(printf '{"lvol_name":"%s","snapshot_name":"%s"}' \
+	"${BIG_VOL}" "${BIG_SNAP}")" >/dev/null 2>&1 \
+	|| { fail "snapshot big"; exit 1; }
+BIG_EXP_UUID="$(raw_rpc rcow_export_snapshot \
+	"$(printf '{"snapshot_name":"%s"}' "${BIG_SNAP}")" \
+	2>"${WORKDIR}/big_exp.err" | tr -d ' \t\r\n')"
+[ -n "${BIG_EXP_UUID}" ] || { fail "export big snapshot"; exit 1; }
+wait_export_done "${BIG_EXP_UUID}" "big export" || exit 1
+pass "big snapshot exported (${BIG_EXP_UUID})"
+
+# ==========================================================================
+echo "[3] destination lvstore"
+# One blobstore per node: the source has to be unloaded before the destination can
+# be created. Its export lives in S3, so the import below still reads through it --
+# and the device the source was read from is gone from here on, which is why
+# SRC_MD5 was taken while it was still attached.
+nvme_settle
+remove_ns 1
+raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${SRC_LVS}")" \
+	>/dev/null 2>"${WORKDIR}/unload_src.err" \
+	|| { fail "unload src lvstore"; sed 's/^/       /' "${WORKDIR}/unload_src.err"; exit 1; }
+SRC_CREATED=0
+pass "src lvstore unloaded (its export remains in S3)"
+
+if ! raw_rpc rcow_create_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","capacity_gib":%d,"wal_bdev":"%s","journal_size_mb":%d,"wal_size_mb":%d,"force":true}' \
+	"${DST_LVS}" "${BUCKET}" "${CAPACITY_GIB}" "${DST_WAL_BDEV}" "${JOURNAL_MB}" "${WAL_MB}")" \
+	>/dev/null; then
+	fail "could not create ${DST_LVS}"
+	exit 1
+fi
+DST_CREATED=1
+pass "destination lvstore ready"
+
+# ==========================================================================
+echo "[4] import with decouple:true, and catch it while it runs"
+if ! raw_rpc rcow_import_lvol "$(printf '{"lvol_name":"%s","export_uuid":"%s","lvs_name":"%s","decouple":true}' \
+	"${BIG_IMP}" "${BIG_EXP_UUID}" "${DST_LVS}")" >/dev/null; then
+	fail "import of ${BIG_IMP} failed"
+	exit 1
+fi
+
+# It must be *running*, not queued -- that is the branch this test exists for.
+# decouple_start() is called before the import replies, so this should already
+# hold; asserted rather than assumed, because a queued one would quietly turn this
+# into a duplicate of run_decouple_queue_test.sh.
+if ! grep -qE "Decoupling lvol '${BIG_IMP}'" "${TGT_LOG}"; then
+	fail "${BIG_IMP} is not materialising -- this test needs a running decouple"
+	exit 1
+fi
+pass "${BIG_IMP} imported, decouple running"
+
+# Let it get somewhere, so the cancellation has clusters to keep.
+sleep 5
+
+# ==========================================================================
+echo "[5] snapshot it, clone the snapshot, write to the clone"
+raw_rpc rcow_create_snapshot "$(printf '{"lvol_name":"%s","snapshot_name":"%s"}' \
+	"${BIG_IMP}" "${BIG_IMP_SNAP}")" >/dev/null 2>"${WORKDIR}/snap.err" \
+	|| { fail "snapshot ${BIG_IMP}"; sed 's/^/    /' "${WORKDIR}/snap.err"; exit 1; }
+pass "snapshot ${BIG_IMP_SNAP} taken (its decouple was cancelled)"
+
+raw_rpc rcow_create_clone "$(printf '{"snapshot_name":"%s","clone_name":"%s"}' \
+	"${BIG_IMP_SNAP}" "${BIG_IMP_CLONE}")" >/dev/null 2>"${WORKDIR}/clone.err" \
+	|| { fail "clone ${BIG_IMP_SNAP}"; sed 's/^/    /' "${WORKDIR}/clone.err"; exit 1; }
+pass "clone ${BIG_IMP_CLONE} created"
+
+# The clone is kept exposed: it is the reader that has to stay correct while its
+# parent is materialised, and giving it clusters of its own means the test also
+# covers "the clone's own writes are not disturbed".
+CLONE_BEFORE="$(ls /dev/nvme*n* 2>/dev/null | sort || true)"
+CLONE_NSID="$(python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --raw \
+	nvmf_subsystem_add_ns \
+	"$(printf '{"nqn":"%s","namespace":{"bdev_name":"%s"}}' \
+		"${NQN}" "${DST_LVS}/${BIG_IMP_CLONE}")" 2>/dev/null | tr -d '[:space:]')"
+CLONE_DEV=""
+for _i in $(seq 40); do
+	CLONE_DEV="$(comm -13 <(echo "${CLONE_BEFORE}") \
+		<(ls /dev/nvme*n* 2>/dev/null | sort || true) | head -1)"
+	[ -n "${CLONE_DEV}" ] && [ -b "${CLONE_DEV}" ] && break
+	CLONE_DEV=""
+	sleep 0.5
+done
+[ -n "${CLONE_DEV}" ] || { fail "no device for the clone"; exit 1; }
+
+dd if=/dev/urandom of="${WORKDIR}/clone.pat" bs=1M count="${CLONE_WRITE_MB}" status=none
+dd if="${WORKDIR}/clone.pat" of="${CLONE_DEV}" bs=1M count="${CLONE_WRITE_MB}" \
+	oflag=direct conv=fsync status=none
+# What the clone must read from here on: its own write over the inherited content.
+cp "${WORKDIR}/big.pat" "${WORKDIR}/clone_expect.bin"
+dd if="${WORKDIR}/clone.pat" of="${WORKDIR}/clone_expect.bin" bs=1M conv=notrunc status=none
+CLONE_MD5="$(md5sum "${WORKDIR}/clone_expect.bin" | cut -d' ' -f1)"
+ACTUAL="$(dd if="${CLONE_DEV}" bs=1M count=$((BIG_GIB * 1024)) iflag=direct \
+	status=none | md5sum | cut -d' ' -f1)"
+if [ "${ACTUAL}" = "${CLONE_MD5}" ]; then
+	pass "clone reads its own write over the inherited content"
+else
+	fail "clone content wrong before the decouple even started"
+fi
+
+# ==========================================================================
+echo "[6] decouple the snapshot, with a reader looping on the clone"
+: >"${WORKDIR}/clone_reads.txt"
+rm -f "${WORKDIR}/reader_stop"
+# Small reads at scattered offsets rather than whole-volume ones: a full 1 GiB
+# md5 takes long enough that a materialisation of the same size only fits two of
+# them, which is too few to call the window covered. Each read is checked against
+# the same offset of the expected image, so a cluster caught mid-migration shows
+# up as a mismatch on that offset.
+(
+	off=0
+	while [ ! -f "${WORKDIR}/reader_stop" ]; do
+		got="$(dd if="${CLONE_DEV}" bs=1M skip="${off}" count=4 iflag=direct \
+			status=none 2>/dev/null | md5sum | cut -d' ' -f1)"
+		want="$(dd if="${WORKDIR}/clone_expect.bin" bs=1M skip="${off}" count=4 \
+			status=none 2>/dev/null | md5sum | cut -d' ' -f1)"
+		if [ "${got}" = "${want}" ]; then
+			echo "ok ${off}" >>"${WORKDIR}/clone_reads.txt"
+		else
+			echo "BAD ${off} got=${got} want=${want}" >>"${WORKDIR}/clone_reads.txt"
+		fi
+		off=$(( (off + 4) % (BIG_GIB * 1024) ))
+	done
+) &
+READER_PID=$!
+
+if raw_rpc rcow_decouple_lvol "$(printf '{"lvol_name":"%s"}' "${BIG_IMP_SNAP}")" \
+	>/dev/null 2>"${WORKDIR}/dec.err"; then
+	pass "decouple of the read-only snapshot was accepted"
+else
+	fail "decouple of ${BIG_IMP_SNAP} refused"
+	sed 's/^/    /' "${WORKDIR}/dec.err" 2>/dev/null | tail -3
+fi
+
+if wait_for_decouple; then
+	pass "decouple finished"
+else
+	fail "decouple did not finish in time"
+fi
+
+touch "${WORKDIR}/reader_stop"
+wait "${READER_PID}" 2>/dev/null
+# wc, not `grep -c ... || echo 0`: grep exits non-zero when it matches nothing,
+# and the fallback then appends to an already-empty value, producing a two-line
+# "number" that fails the comparison with a baffling message.
+READS="$(wc -l < "${WORKDIR}/clone_reads.txt" 2>/dev/null | tr -d ' ')"
+READS="${READS:-0}"
+BAD="$(grep -c '^BAD ' "${WORKDIR}/clone_reads.txt" 2>/dev/null | head -1)"
+BAD="${BAD:-0}"
+if [ "${READS}" -gt 0 ] && [ "${BAD}" -eq 0 ]; then
+	pass "clone read correctly ${READS} time(s) while its parent materialised"
+else
+	fail "clone misread ${BAD} of ${READS} read(s) during the materialisation"
+	grep '^BAD ' "${WORKDIR}/clone_reads.txt" 2>/dev/null | head -3 | sed 's/^/    /'
+fi
+
+if grep -qE "'${BIG_IMP_SNAP}' no longer reads export" "${TGT_LOG}"; then
+	pass "snapshot reports it no longer reads the export"
+else
+	fail "no 'no longer reads export' line for ${BIG_IMP_SNAP}"
+fi
+
+# ==========================================================================
+echo "[7] the parent is really gone, not merely unrefused"
+# A second decouple must now fail: EINVAL means the blob is no longer an esnap
+# clone, which is the only direct evidence that clear_external_parent ran.
+if raw_rpc rcow_decouple_lvol "$(printf '{"lvol_name":"%s"}' "${BIG_IMP_SNAP}")" \
+	>/dev/null 2>&1; then
+	fail "a second decouple was accepted -- the external parent was not cleared"
+else
+	pass "second decouple refused: the snapshot is no longer an esnap clone"
+fi
+
+raw_rpc rcow_get_lvstores "" >"${WORKDIR}/lvs.json" 2>/dev/null || true
+SNAP_ALLOC="$(python3 -c "
+import json, sys
+try:
+    rows = json.load(open(sys.argv[1]))
+except Exception:
+    print(-1); raise SystemExit
+for lvs in (rows if isinstance(rows, list) else rows.get('lvstores', [])):
+    for l in lvs.get('lvols', []):
+        if l.get('name') == sys.argv[2]:
+            print(l.get('allocated_clusters', -1)); raise SystemExit
+print(-1)
+" "${WORKDIR}/lvs.json" "${BIG_IMP_SNAP}" 2>/dev/null || echo -1)"
+if [ "${SNAP_ALLOC}" -gt 0 ] 2>/dev/null; then
+	pass "snapshot now owns ${SNAP_ALLOC} cluster(s) of its own"
+else
+	fail "snapshot owns no clusters after being decoupled (reported '${SNAP_ALLOC}')"
+fi
+
+# ==========================================================================
+echo "[8] erase the source and reload: the bytes must be local now"
+# The whole point. release_export cannot be used -- it runs on the source
+# lvstore, which was unloaded so this one could exist -- and deleting the prefix
+# is the stronger statement anyway: if the objects are gone from S3 and the reads
+# still work, the data is really here. Unload and re-attach so that nothing can
+# be answered out of memory.
+nvme_settle
+remove_ns "${CLONE_NSID}"
+CLONE_NSID=""
+
+python3 "${TOOLS_DIR}/s3_prefix_rm.py" -e "${ENDPOINT}" -b "${BUCKET}" \
+	-r "${REGION}" -p "${SRC_LVS}/" >"${WORKDIR}/prefix_rm.log" 2>&1
+info "$(tail -1 "${WORKDIR}/prefix_rm.log")"
+if grep -qE '[1-9][0-9]* deleted' "${WORKDIR}/prefix_rm.log"; then
+	pass "source prefix erased from S3"
+else
+	fail "source prefix was not erased -- the check below would prove nothing"
+fi
+
+raw_rpc rcow_flush_lvstore "$(printf '{"lvs_name":"%s"}' "${DST_LVS}")" >/dev/null 2>&1
+raw_rpc rcow_unload_lvstore "$(printf '{"lvs_name":"%s"}' "${DST_LVS}")" \
+	>/dev/null 2>"${WORKDIR}/unload_dst.err" \
+	|| { fail "unload ${DST_LVS}"; sed 's/^/    /' "${WORKDIR}/unload_dst.err"; exit 1; }
+DST_CREATED=0
+sleep 2
+raw_rpc rcow_attach_lvstore "$(printf '{"lvs_name":"%s","namespace":"%s","wal_bdev":"%s"}' \
+	"${DST_LVS}" "${BUCKET}" "${DST_WAL_BDEV}")" \
+	>/dev/null 2>"${WORKDIR}/attach_dst.err" \
+	|| { fail "re-attach ${DST_LVS}"; sed 's/^/    /' "${WORKDIR}/attach_dst.err"; exit 1; }
+DST_CREATED=1
+sleep 2
+pass "${DST_LVS} unloaded and re-attached with the source gone"
+
+SNAP_MD5="$(read_vol_md5 "${BIG_IMP_SNAP}")" || SNAP_MD5="unreadable"
+VOL_MD5="$(read_vol_md5 "${BIG_IMP}")" || VOL_MD5="unreadable"
+CLONE_NOW="$(read_vol_md5 "${BIG_IMP_CLONE}")" || CLONE_NOW="unreadable"
+info "source was      ${SRC_MD5}"
+info "snapshot        ${SNAP_MD5}"
+info "volume          ${VOL_MD5}"
+info "clone (expects ${CLONE_MD5})"
+info "clone           ${CLONE_NOW}"
+
+if [ "${SNAP_MD5}" = "${SRC_MD5}" ]; then
+	pass "snapshot still reads correctly with its source erased"
+else
+	fail "snapshot content wrong after the source was erased"
+fi
+if [ "${VOL_MD5}" = "${SRC_MD5}" ]; then
+	pass "volume still reads correctly with its source erased"
+else
+	fail "volume content wrong after the source was erased"
+fi
+if [ "${CLONE_NOW}" = "${CLONE_MD5}" ]; then
+	pass "clone still reads its own write with its source erased"
+else
+	fail "clone content wrong after the source was erased"
+fi
+
+check_target "step 8" || exit 1
+
+echo "--- log kept at: ${TGT_LOG}"

--- a/CubeS3lvol/test/dataplane/run_snapshot_test.sh
+++ b/CubeS3lvol/test/dataplane/run_snapshot_test.sh
@@ -847,15 +847,29 @@ if ! ${RPC} nvmf_subsystem_remove_ns "${NQN}" "${SNAP_NSID}" \
 fi
 pass "snapshot namespace removed, so the bdev is no longer claimed"
 
-# The exit status is the answer: the RPC replies with {bool_value, string_value}
-# whether it worked or not, and s3lvol_rpc.py turns bool_value:false into exit 1
-# with the reason on stderr.
-if raw_rpc rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "${SNAP_NAME}")" \
+# Two clones (the writable volume and the clone taken in step 8) is not an error
+# but a deferral: blobstore cannot merge a snapshot into two clones, so the delete
+# does not happen now, yet the extra clone is something that goes away on its own
+# and the delete completes when it does. The RPC therefore answers success with
+# deferred:true (docs/pending-delete-design.md), and what matters here is that the
+# snapshot is still present afterwards.
+if python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" --raw \
+		rcow_delete_lvol "$(printf '{"lvol_name":"%s"}' "${SNAP_NAME}")" \
 		>"${WORKDIR}/del_snap.json" 2>"${WORKDIR}/del_snap.err"; then
-	fail "deleting a snapshot with a live clone succeeded"
+	if grep -q '"deferred": *true' "${WORKDIR}/del_snap.json"; then
+		pass "deleting the snapshot was deferred while the clone needs it"
+	else
+		fail "deleting a snapshot with a live clone succeeded"
+	fi
 else
 	pass "deleting the snapshot was refused: $(cat "${WORKDIR}/del_snap.err")"
 fi
+
+# The intent has to go, or the poller would delete the snapshot as soon as the
+# clone is removed -- later steps still expect it.
+python3 "${TOOLS_DIR}/s3lvol_rpc.py" --sock "${RPC_SOCK}" \
+	rcow_cancel_pending_delete "$(printf '{"lvol_name":"%s"}' "${SNAP_NAME}")" \
+	>/dev/null 2>&1
 check_target "step 9" || exit 1
 
 # ==========================================================================

--- a/CubeS3lvol/test/integration/Makefile
+++ b/CubeS3lvol/test/integration/Makefile
@@ -72,7 +72,8 @@ MODULE_DIR   = ../../module/bdev/s3lvol
 
 APPS = s3_client_test s3_spawner_test s3_thread_bounce_test s3_bs_dev_test \
        s3_journal_test s3_wal_test s3_cache_test s3_flush_test s3_export_test \
-       s3_statefile_test s3_local_dev_test s3_checkpoint_test
+       s3_statefile_test s3_local_dev_test s3_checkpoint_test s3_lease_term_test \
+       s3_pending_persist_test
 
 # (a) minimal library set for the stubbed path
 STUB_SRCS      = spdk_thread_stub.c
@@ -140,6 +141,14 @@ s3_bs_dev_test: s3_bs_dev_test.c $(S3BSDEV_DIR)/libs3bsdev.a
 	    -Wl,--start-group $(BLOB_SPDK_LIBS) -Wl,--end-group \
 	    $(BLOB_DPDK_ARGS) \
 	    $(SYS_LIBS) $(TEST_SYS_LIBS) -o $@
+
+# Lease-miss-after-deadline predicate. Header-only, no S3, no SPDK.
+s3_lease_term_test: s3_lease_term_test.c $(MODULE_DIR)/export_lease_term.h
+	$(CC) $(COMMON_CFLAGS) -I$(MODULE_DIR) s3_lease_term_test.c -o $@
+
+# Pending-delete registry PUT coalescing. Header-only, no S3, no SPDK.
+s3_pending_persist_test: s3_pending_persist_test.c $(MODULE_DIR)/pending_persist_ctl.h
+	$(CC) $(COMMON_CFLAGS) -I$(MODULE_DIR) s3_pending_persist_test.c -o $@
 
 # chunk map persistence check: no S3, but it does need the bdev layer.
 #
@@ -276,7 +285,7 @@ s3_checkpoint_test: s3_checkpoint_test.c $(S3BSDEV_DIR)/libs3bsdev.a
 # Run only the tests that need no S3 credentials
 check: s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test s3_cache_test \
        s3_flush_test s3_export_test s3_statefile_test s3_local_dev_test \
-       s3_checkpoint_test
+       s3_checkpoint_test s3_lease_term_test s3_pending_persist_test
 	./s3_spawner_test
 	./s3_thread_bounce_test
 	./s3_journal_test
@@ -287,6 +296,8 @@ check: s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test s3_cach
 	./s3_statefile_test
 	./s3_local_dev_test
 	./s3_checkpoint_test
+	./s3_lease_term_test
+	./s3_pending_persist_test
 
 .PHONY: $(S3BSDEV_DIR)/libs3bsdev.a
 $(S3BSDEV_DIR)/libs3bsdev.a:

--- a/CubeS3lvol/test/integration/Makefile
+++ b/CubeS3lvol/test/integration/Makefile
@@ -73,7 +73,7 @@ MODULE_DIR   = ../../module/bdev/s3lvol
 APPS = s3_client_test s3_spawner_test s3_thread_bounce_test s3_bs_dev_test \
        s3_journal_test s3_wal_test s3_cache_test s3_flush_test s3_export_test \
        s3_statefile_test s3_local_dev_test s3_checkpoint_test s3_export_swap_test \
-       s3_lease_term_test s3_pending_persist_test
+       s3_copy_xml_test s3_lease_term_test s3_pending_persist_test
 
 # (a) minimal library set for the stubbed path
 STUB_SRCS      = spdk_thread_stub.c
@@ -154,6 +154,10 @@ s3_export_swap_test: s3_export_swap_test.c $(S3BSDEV_DIR)/libs3bsdev.a
 	    -Wl,--start-group $(BLOB_SPDK_LIBS) -Wl,--end-group \
 	    $(BLOB_DPDK_ARGS) \
 	    $(SYS_LIBS) $(TEST_SYS_LIBS) -o $@
+
+# CopyObject XML delimiter / truncation. Header-only, no S3, no SPDK.
+s3_copy_xml_test: s3_copy_xml_test.c $(S3BSDEV_DIR)/s3_copy_xml.h
+	$(CC) $(COMMON_CFLAGS) -I$(S3BSDEV_DIR) s3_copy_xml_test.c -o $@
 
 # Lease-miss-after-deadline predicate. Header-only, no S3, no SPDK.
 s3_lease_term_test: s3_lease_term_test.c $(MODULE_DIR)/export_lease_term.h
@@ -298,7 +302,7 @@ s3_checkpoint_test: s3_checkpoint_test.c $(S3BSDEV_DIR)/libs3bsdev.a
 # Run only the tests that need no S3 credentials
 check: s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test s3_cache_test \
        s3_flush_test s3_export_test s3_statefile_test s3_local_dev_test \
-       s3_checkpoint_test s3_export_swap_test s3_lease_term_test \
+       s3_checkpoint_test s3_export_swap_test s3_copy_xml_test s3_lease_term_test \
        s3_pending_persist_test
 	./s3_spawner_test
 	./s3_thread_bounce_test
@@ -311,6 +315,7 @@ check: s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test s3_cach
 	./s3_local_dev_test
 	./s3_checkpoint_test
 	./s3_export_swap_test
+	./s3_copy_xml_test
 	./s3_lease_term_test
 	./s3_pending_persist_test
 

--- a/CubeS3lvol/test/integration/Makefile
+++ b/CubeS3lvol/test/integration/Makefile
@@ -72,8 +72,8 @@ MODULE_DIR   = ../../module/bdev/s3lvol
 
 APPS = s3_client_test s3_spawner_test s3_thread_bounce_test s3_bs_dev_test \
        s3_journal_test s3_wal_test s3_cache_test s3_flush_test s3_export_test \
-       s3_statefile_test s3_local_dev_test s3_checkpoint_test s3_lease_term_test \
-       s3_pending_persist_test
+       s3_statefile_test s3_local_dev_test s3_checkpoint_test s3_export_swap_test \
+       s3_lease_term_test s3_pending_persist_test
 
 # (a) minimal library set for the stubbed path
 STUB_SRCS      = spdk_thread_stub.c
@@ -136,6 +136,19 @@ s3_thread_bounce_test: s3_thread_bounce_test.c $(S3BSDEV_DIR)/libs3bsdev.a
 # so the stub is not linked.
 s3_bs_dev_test: s3_bs_dev_test.c $(S3BSDEV_DIR)/libs3bsdev.a
 	$(CC) $(COMMON_CFLAGS) s3_bs_dev_test.c \
+	    $(S3BSDEV_DIR)/libs3bsdev.a \
+	    $(AWS_LIBS) \
+	    -Wl,--start-group $(BLOB_SPDK_LIBS) -Wl,--end-group \
+	    $(BLOB_DPDK_ARGS) \
+	    $(SYS_LIBS) $(TEST_SYS_LIBS) -o $@
+
+# Swapping an imported export's manifest. Same link as s3_bs_dev_test -- it uses
+# struct spdk_bs_dev -- and a real thread, because the whole point of the swap is
+# what it does about the *other* threads: the old manifest is released after
+# spdk_for_each_channel() has been round them, and only a real thread can be
+# driven far enough to observe that. No S3: swapping is pure memory.
+s3_export_swap_test: s3_export_swap_test.c $(S3BSDEV_DIR)/libs3bsdev.a
+	$(CC) $(COMMON_CFLAGS) s3_export_swap_test.c \
 	    $(S3BSDEV_DIR)/libs3bsdev.a \
 	    $(AWS_LIBS) \
 	    -Wl,--start-group $(BLOB_SPDK_LIBS) -Wl,--end-group \
@@ -285,7 +298,8 @@ s3_checkpoint_test: s3_checkpoint_test.c $(S3BSDEV_DIR)/libs3bsdev.a
 # Run only the tests that need no S3 credentials
 check: s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test s3_cache_test \
        s3_flush_test s3_export_test s3_statefile_test s3_local_dev_test \
-       s3_checkpoint_test s3_lease_term_test s3_pending_persist_test
+       s3_checkpoint_test s3_export_swap_test s3_lease_term_test \
+       s3_pending_persist_test
 	./s3_spawner_test
 	./s3_thread_bounce_test
 	./s3_journal_test
@@ -296,6 +310,7 @@ check: s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test s3_cach
 	./s3_statefile_test
 	./s3_local_dev_test
 	./s3_checkpoint_test
+	./s3_export_swap_test
 	./s3_lease_term_test
 	./s3_pending_persist_test
 

--- a/CubeS3lvol/test/integration/s3_client_test.c
+++ b/CubeS3lvol/test/integration/s3_client_test.c
@@ -484,6 +484,12 @@ main(int argc, char **argv)
 		s3_client_put(client2);   /* drop the extra reference */
 	}
 
+	/* An explicit extra ref must not destroy the pooled client on the
+	 * matching put -- the same contract the pending-delete load uses so a
+	 * HEAD/GET can outlive the lvstore that started it. */
+	s3_client_get(client);
+	s3_client_put(client);
+
 	/* ---------- 3. prepare data and keys ---------- */
 	uint8_t *wbuf = malloc(TEST_OBJECT_SIZE);
 	uint8_t *rbuf = malloc(TEST_OBJECT_SIZE);

--- a/CubeS3lvol/test/integration/s3_copy_xml_test.c
+++ b/CubeS3lvol/test/integration/s3_copy_xml_test.c
@@ -1,0 +1,159 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+/*
+ * CopyObject XML helpers: delimiter bounds, truncated bodies, fragmented
+ * callbacks. No S3, no SPDK -- the arithmetic is the defect.
+ */
+
+#include "s3_copy_xml.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_pass, g_fail;
+
+static void
+check_true(const char *what, bool ok)
+{
+	if (ok) {
+		g_pass++;
+		printf("\t[PASS] %s\n", what);
+	} else {
+		g_fail++;
+		printf("\t[FAIL] %s\n", what);
+	}
+}
+
+static void
+check_int(const char *what, int got, int want)
+{
+	if (got == want) {
+		g_pass++;
+		printf("\t[PASS] %s (got %d, want %d)\n", what, got, want);
+	} else {
+		g_fail++;
+		printf("\t[FAIL] %s (got %d, want %d)\n", what, got, want);
+	}
+}
+
+static void
+check_size(const char *what, size_t got, size_t want)
+{
+	if (got == want) {
+		g_pass++;
+		printf("\t[PASS] %s (got %zu, want %zu)\n", what, got, want);
+	} else {
+		g_fail++;
+		printf("\t[FAIL] %s (got %zu, want %zu)\n", what, got, want);
+	}
+}
+
+int
+main(void)
+{
+	char buf[S3_COPY_XML_MAX];
+	char *asan;
+	const char *ok =
+		"<?xml version=\"1.0\"?><CopyObjectResult><ETag>\"a\"</ETag></CopyObjectResult>";
+	const char *err =
+		"<?xml version=\"1.0\"?><Error><Code>InternalError</Code></Error>";
+	const char *attrs = "<CopyObjectResult xmlns=\"s3\"><ETag>e</ETag></CopyObjectResult>";
+	size_t i;
+	size_t used;
+	bool truncated;
+
+	printf("[1] opening-tag delimiter must sit inside the buffer\n");
+	check_true("CopyObjectResult",
+		   s3_xml_has_open_tag(ok, strlen(ok), "CopyObjectResult"));
+	check_true("Error", s3_xml_has_open_tag(err, strlen(err), "Error"));
+	check_true("tag with attributes",
+		   s3_xml_has_open_tag(attrs, strlen(attrs), "CopyObjectResult"));
+	check_true("empty is not a tag",
+		   !s3_xml_has_open_tag("", 0, "CopyObjectResult"));
+	check_true("NULL xml", !s3_xml_has_open_tag(NULL, 8, "Error"));
+	check_true("too short for <Error>",
+		   !s3_xml_has_open_tag("<Error", strlen("<Error"), "Error"));
+	check_true("<Error> complete",
+		   s3_xml_has_open_tag("<Error>", strlen("<Error>"), "Error"));
+	check_true("self-closing",
+		   s3_xml_has_open_tag("<Error/>", strlen("<Error/>"), "Error"));
+
+	/* ASan-reproduced case: 8192 bytes ending in "<Error" with no delimiter.
+	 * The old loop allowed i + 1 + nlen == len and read xml[len]. */
+	asan = malloc(S3_COPY_XML_MAX);
+	if (!asan) {
+		fprintf(stderr, "malloc failed\n");
+		return 1;
+	}
+	memset(asan, 'x', S3_COPY_XML_MAX);
+	memcpy(asan + S3_COPY_XML_MAX - 6, "<Error", 6);
+	check_true("8192-byte body ending in <Error is not a tag",
+		   !s3_xml_has_open_tag(asan, S3_COPY_XML_MAX, "Error"));
+	check_true("8192-byte body ending in <Error is not CopyObjectResult",
+		   !s3_xml_has_open_tag(asan, S3_COPY_XML_MAX, "CopyObjectResult"));
+	check_int("that truncated body is -EIO",
+		  s3_copy_xml_status(asan, S3_COPY_XML_MAX, true), -EIO);
+
+	memcpy(asan + S3_COPY_XML_MAX - 7, "<Error>", 7);
+	check_true("8192-byte body ending in <Error> is a tag",
+		   s3_xml_has_open_tag(asan, S3_COPY_XML_MAX, "Error"));
+	check_int("complete Error at the last byte is -EIO",
+		  s3_copy_xml_status(asan, S3_COPY_XML_MAX, false), -EIO);
+	free(asan);
+
+	printf("[2] incomplete XML is not success\n");
+	check_int("empty body", s3_copy_xml_status("", 0, false), -EIO);
+	check_int("garbage", s3_copy_xml_status("not xml", 7, false), -EIO);
+	check_int("partial CopyObjectResult",
+		  s3_copy_xml_status("<CopyObjectResult",
+				     strlen("<CopyObjectResult"), false), -EIO);
+	check_int("complete result",
+		  s3_copy_xml_status(ok, strlen(ok), false), 0);
+	check_int("Error body", s3_copy_xml_status(err, strlen(err), false), -EIO);
+	check_true("Errorish is not Error",
+		   !s3_xml_has_open_tag("<Errorish><Code>x</Code></Errorish>",
+				       strlen("<Errorish><Code>x</Code></Errorish>"),
+				       "Error"));
+	check_int("Errorish is not an Error body",
+		  s3_copy_xml_status("<Errorish><Code>x</Code></Errorish>",
+				     strlen("<Errorish><Code>x</Code></Errorish>"),
+				     false), -EIO);
+	check_int("CopyObjectResult wins when Error is also present",
+		  s3_copy_xml_status("<CopyObjectResult/><Error><Code>x</Code></Error>",
+				     strlen("<CopyObjectResult/><Error><Code>x</Code></Error>"),
+				     false), 0);
+	check_int("truncated without a tag",
+		  s3_copy_xml_status("xxxx", 4, true), -EIO);
+	check_int("truncated after a complete result tag is still success",
+		  s3_copy_xml_status(ok, strlen(ok), true), 0);
+
+	printf("[3] callback fragments assemble, overflow is truncated\n");
+	memset(buf, 0, sizeof(buf));
+	used = 0;
+	truncated = false;
+	for (i = 0; i < strlen(ok); i++) {
+		used = s3_copy_xml_append(buf, sizeof(buf), used, ok + i, 1,
+					  &truncated);
+	}
+	check_size("one-byte fragments fill the document", used, strlen(ok));
+	check_true("one-byte fragments were not truncated", !truncated);
+	check_int("assembled CopyObjectResult",
+		  s3_copy_xml_status(buf, used, truncated), 0);
+
+	used = 0;
+	truncated = false;
+	used = s3_copy_xml_append(buf, 8, used, "abcdefghijkl", 12, &truncated);
+	check_size("overflow keeps the cap", used, 8);
+	check_true("overflow sets truncated", truncated);
+	check_int("truncated prefix without a tag",
+		  s3_copy_xml_status(buf, used, truncated), -EIO);
+
+	truncated = false;
+	used = s3_copy_xml_append(buf, 8, 8, "more", 4, &truncated);
+	check_size("append into a full buffer stays full", used, 8);
+	check_true("append into a full buffer is truncated", truncated);
+
+	printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+	return g_fail ? 1 : 0;
+}

--- a/CubeS3lvol/test/integration/s3_export_swap_test.c
+++ b/CubeS3lvol/test/integration/s3_export_swap_test.c
@@ -1,0 +1,397 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+/*
+ *   Swapping the manifest under an imported export
+ *
+ *   === What this is for ===
+ *
+ *   A ref export names the *source's* live objects. When the source materialises
+ *   it -- rewrites the manifest as dense, holding its own copies -- those objects
+ *   stop existing, and an importer still holding the old manifest reads 404s. Its
+ *   way out is to refetch and carry on against the new manifest, which is what
+ *   s3_export_bs_dev_swap_manifest() does and what `generation` distinguishes.
+ *   A GET that left before that swap can still 404; the refetch then sees
+ *   -EALREADY, which must retry against the installed generation rather than
+ *   report the snapshot as deleted.
+ *
+ *   === Why this needs real SPDK threads ===
+ *
+ *   The whole of s3_export_bs_dev.c is lock free *because* the manifest never
+ *   changes: blobstore makes a channel per thread that touches the clone, and
+ *   every one of them reads dev->m with no serialisation. The swap is the one
+ *   operation that has to consider the others, and it does so with a grace period
+ *   -- spdk_for_each_channel() -- rather than a lock.
+ *
+ *   A test without threads would exercise the validation and none of that. So
+ *   this brings up spdk_thread and drives the iteration, which is also the only
+ *   way to observe the property that matters: the old manifest is released after
+ *   the grace period, not before. Checked by refcount, because "released too
+ *   early" is otherwise a use-after-free that shows up somewhere else entirely.
+ *
+ *   No S3 and no network: swapping is pure memory. The manifests are built in
+ *   process and the device never reads.
+ */
+
+#include "spdk/stdinc.h"
+#include "spdk/env.h"
+#include "spdk/log.h"
+#include "spdk/thread.h"
+#include "spdk/blob.h"
+
+#include "s3lvol/s3_export.h"
+#include "s3lvol/s3_client.h"
+#include "s3lvol/s3_spawner.h"
+
+#define CHUNK_SIZE (1024 * 1024)
+#define NUM_CHUNKS 8
+#define TEST_UUID  "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+#define OTHER_UUID "01234567-89ab-cdef-0123-456789abcdef"
+
+static int g_pass, g_fail;
+
+static void
+check_true(const char *what, bool ok, const char *detail)
+{
+	if (ok) {
+		g_pass++;
+		printf("\t[PASS] %s%s%s\n", what, detail ? " " : "",
+		       detail ? detail : "");
+	} else {
+		g_fail++;
+		printf("\t[FAIL] %s%s%s\n", what, detail ? " " : "",
+		       detail ? detail : "");
+	}
+}
+
+static void
+check_int(const char *what, int got, int want)
+{
+	if (got == want) {
+		g_pass++;
+		printf("\t[PASS] %s (got %d, want %d)\n", what, got, want);
+	} else {
+		g_fail++;
+		printf("\t[FAIL] %s (got %d, want %d)\n", what, got, want);
+	}
+}
+
+static void
+check_u32(const char *what, uint32_t got, uint32_t want)
+{
+	if (got == want) {
+		g_pass++;
+		printf("\t[PASS] %s (got %u, want %u)\n", what, got, want);
+	} else {
+		g_fail++;
+		printf("\t[FAIL] %s (got %u, want %u)\n", what, got, want);
+	}
+}
+
+/* A manifest of the given identity and version, with one chunk so that a ref
+ * layout is well formed. */
+static struct s3_export_manifest *
+make_manifest(const char *uuid, uint32_t generation, uint64_t size_bytes,
+	      enum s3_export_layout layout)
+{
+	struct s3_export_manifest *m = NULL;
+	struct spdk_uuid u;
+	uint8_t raw[16];
+
+	if (s3_export_manifest_create(uuid, size_bytes, CHUNK_SIZE, layout, &m) != 0) {
+		return NULL;
+	}
+	m->generation = generation;
+	snprintf(m->src.prefix, sizeof(m->src.prefix), "srclvs");
+
+	memset(raw, (int)(0x10 + generation), sizeof(raw));
+	memcpy(&u, raw, sizeof(u) < sizeof(raw) ? sizeof(u) : sizeof(raw));
+
+	if (layout == S3_EXPORT_LAYOUT_REF) {
+		s3_export_manifest_set_ref(m, 0, &u, CHUNK_SIZE);
+	} else {
+		s3_export_manifest_set_present(m, 0);
+	}
+	s3_export_manifest_seal(m);
+	return m;
+}
+
+struct swap_result {
+	bool done;
+	int  status;
+};
+
+static void
+swap_done(void *cb_arg, int status)
+{
+	struct swap_result *r = cb_arg;
+
+	r->status = status;
+	r->done = true;
+}
+
+/* The grace period only completes when the thread runs, so every swap has to be
+ * polled to conclusion. */
+static bool
+poll_until(struct spdk_thread *thread, struct swap_result *r)
+{
+	time_t deadline = time(NULL) + 10;
+
+	while (!r->done && time(NULL) < deadline) {
+		spdk_thread_poll(thread, 0, 0);
+		if (!r->done) {
+			usleep(1000);
+		}
+	}
+	return r->done;
+}
+
+int
+main(void)
+{
+	struct spdk_env_opts opts;
+	struct spdk_thread *thread = NULL;
+	struct spdk_bs_dev *bs_dev = NULL;
+	struct s3_export_manifest *m1 = NULL, *m2 = NULL, *bad = NULL;
+	struct s3_client *client = NULL;
+	struct swap_result r;
+	uint64_t size_bytes = (uint64_t)NUM_CHUNKS * CHUNK_SIZE;
+	struct s3_target target = {0};
+	cpu_set_t allowed;
+	int rc;
+
+	spdk_log_set_print_level(SPDK_LOG_NOTICE);
+	spdk_log_open(NULL);
+	printf("=== s3lvol export manifest swap test ===\n");
+
+	printf("\n[1] SPDK env and a real thread\n");
+	opts.opts_size = sizeof(opts);
+	spdk_env_opts_init(&opts);
+	opts.name = "s3_export_swap_test";
+	opts.no_huge = true;
+	opts.mem_size = 64;
+	if (spdk_env_init(&opts) < 0) {
+		fprintf(stderr, "spdk_env_init failed; skipping\n");
+		spdk_log_close();
+		return 77;
+	}
+	check_true("spdk_env_init", true, "no_huge=true");
+
+	rc = spdk_thread_lib_init(NULL, 0);
+	check_int("spdk_thread_lib_init", rc, 0);
+	if (rc != 0) {
+		goto out_env;
+	}
+	thread = spdk_thread_create("swap_test", NULL);
+	check_true("spdk_thread_create", thread != NULL, NULL);
+	if (!thread) {
+		goto out_lib;
+	}
+	spdk_set_thread(thread);
+
+	/* The device holds a client reference and releases it from destroy(), so a
+	 * real one is needed even though nothing here reads: a client cannot be
+	 * created without the spawner and CRT, and skipping them would mean
+	 * skipping destroy() and the reference accounting around it -- which is
+	 * half of what this test is checking. No credentials and no endpoint that
+	 * has to exist; the client is never asked to do anything. */
+	CPU_ZERO(&allowed);
+	sched_getaffinity(0, sizeof(allowed), &allowed);
+	rc = s3_spawner_start(&allowed);
+	check_int("s3_spawner_start", rc, 0);
+	if (rc != 0) {
+		goto out_thread;
+	}
+	rc = s3_crt_global_init(2);
+	check_int("s3_crt_global_init", rc, 0);
+	if (rc != 0) {
+		goto out_spawner;
+	}
+
+	target.endpoint = "127.0.0.1:1";
+	target.bucket   = "swaptest";
+	target.region   = "test";
+	target.auth_mode = S3_AUTH_ENV;
+	rc = s3_client_get_or_create(&target, &client);
+	check_int("an S3 client for the device to hold", rc, 0);
+	if (rc != 0 || !client) {
+		goto out_crt;
+	}
+
+	printf("\n[2] a device built on generation 1\n");
+	m1 = make_manifest(TEST_UUID, 1, size_bytes, S3_EXPORT_LAYOUT_REF);
+	check_true("the first manifest is built", m1 != NULL, NULL);
+	if (!m1) {
+		goto out_client;
+	}
+	rc = s3_export_bs_dev_create(client, m1, &bs_dev);
+	check_int("the device is created", rc, 0);
+	if (rc != 0) {
+		goto out_client;
+	}
+	/* create() took its own reference, so the caller's still stands. */
+	check_u32("the device holds a reference", m1->refcnt, 2);
+	check_true("and sized itself from the manifest",
+		   bs_dev->blockcnt == size_bytes / 4096, NULL);
+
+	printf("\n[3] what must be refused\n");
+
+	/* A different export entirely. Nothing else would catch it -- the geometry
+	 * matches -- and adopting it points the clone at another volume. */
+	bad = make_manifest(OTHER_UUID, 9, size_bytes, S3_EXPORT_LAYOUT_REF);
+	if (bad) {
+		check_int("a manifest for another export is refused",
+			  s3_export_bs_dev_swap_manifest(bs_dev, bad, NULL, NULL),
+			  -EINVAL);
+		s3_export_manifest_unref(bad);
+	}
+
+	/* blobstore has been serving blockcnt from the old size since create. */
+	bad = make_manifest(TEST_UUID, 9, size_bytes * 2, S3_EXPORT_LAYOUT_REF);
+	if (bad) {
+		check_int("a manifest of a different size is refused",
+			  s3_export_bs_dev_swap_manifest(bs_dev, bad, NULL, NULL),
+			  -EINVAL);
+		s3_export_manifest_unref(bad);
+	}
+
+	/* The ordinary answer to "has the source rewritten it yet?" -- distinct
+	 * from success, because a caller that retries needs to tell them apart. */
+	bad = make_manifest(TEST_UUID, 1, size_bytes, S3_EXPORT_LAYOUT_REF);
+	if (bad) {
+		check_int("the same generation is -EALREADY",
+			  s3_export_bs_dev_swap_manifest(bs_dev, bad, NULL, NULL),
+			  -EALREADY);
+		s3_export_manifest_unref(bad);
+	}
+	bad = make_manifest(TEST_UUID, 0, size_bytes, S3_EXPORT_LAYOUT_REF);
+	if (bad) {
+		check_int("an older generation too",
+			  s3_export_bs_dev_swap_manifest(bs_dev, bad, NULL, NULL),
+			  -EALREADY);
+		s3_export_manifest_unref(bad);
+	}
+
+	check_u32("none of them disturbed the device's reference", m1->refcnt, 2);
+
+	{
+		struct s3_export_manifest *cs = NULL;
+
+		if (s3_export_manifest_create(TEST_UUID, size_bytes, CHUNK_SIZE * 2,
+					       S3_EXPORT_LAYOUT_DENSE, &cs) == 0) {
+			cs->generation = 9;
+			s3_export_manifest_set_present(cs, 0);
+			s3_export_manifest_seal(cs);
+			check_int("a different chunk size is refused",
+				  s3_export_bs_dev_swap_manifest(bs_dev, cs, NULL, NULL),
+				  -EINVAL);
+			s3_export_manifest_unref(cs);
+		}
+	}
+
+	printf("\n[4] a newer generation, materialised\n");
+	/* What the source actually publishes when it materialises: same export,
+	 * same size, higher generation, and dense because it now holds copies. */
+	m2 = make_manifest(TEST_UUID, 2, size_bytes, S3_EXPORT_LAYOUT_DENSE);
+	check_true("the second manifest is built", m2 != NULL, NULL);
+	if (!m2) {
+		goto out_dev;
+	}
+
+	memset(&r, 0, sizeof(r));
+	rc = s3_export_bs_dev_swap_manifest(bs_dev, m2, swap_done, &r);
+	check_int("the swap is accepted", rc, 0);
+
+	/* Before the thread runs. The pointer is already the new manifest -- reads
+	 * issued now resolve against it -- but the old one must still be alive,
+	 * because a reader on another thread could have loaded it a moment ago. */
+	check_u32("the new manifest is referenced immediately", m2->refcnt, 2);
+	check_u32("and the old one is still held across the grace period",
+		  m1->refcnt, 2);
+	check_true("the callback has not run yet", !r.done, NULL);
+
+	check_true("it completes once the thread runs", poll_until(thread, &r), NULL);
+	check_int("with success", r.status, 0);
+
+	/* Only now: the device's reference was handed to the swap and released on
+	 * the far side of the iteration. Releasing it any earlier is a
+	 * use-after-free for any reader that had just loaded the pointer. */
+	check_u32("the old manifest is released after the grace period",
+		  m1->refcnt, 1);
+
+	printf("\n[5] and the device is on the new manifest\n");
+	/* Asserted through behaviour rather than by reaching into the struct: the
+	 * only way a second swap can answer -EALREADY at generation 2 is if the
+	 * device is reading generation 2. */
+	bad = make_manifest(TEST_UUID, 2, size_bytes, S3_EXPORT_LAYOUT_DENSE);
+	if (bad) {
+		rc = s3_export_bs_dev_swap_manifest(bs_dev, bad, NULL, NULL);
+		check_int("generation 2 is now the current one", rc, -EALREADY);
+		/* A GET that still used generation 1's keys can 404 after the
+		 * swap above. Its refetch then GETs generation 2 and swap
+		 * returns this same -EALREADY. That is "already current", not
+		 * "the source deleted the snapshot": retrying against the
+		 * installed keys is what makes the read succeed. */
+		check_true("a late 404 after the swap retries, not data loss",
+			   s3_export_bs_dev_refetch_already_current(rc), NULL);
+		s3_export_manifest_unref(bad);
+	}
+	check_true("a refused manifest still gives up",
+		   !s3_export_bs_dev_refetch_already_current(-EINVAL), NULL);
+
+	/* A second swap has to work as well as the first: materialisation is not
+	 * necessarily the last rewrite an export ever sees. */
+	bad = make_manifest(TEST_UUID, 3, size_bytes, S3_EXPORT_LAYOUT_DENSE);
+	if (bad) {
+		memset(&r, 0, sizeof(r));
+		check_int("a third generation is accepted",
+			  s3_export_bs_dev_swap_manifest(bs_dev, bad, swap_done, &r),
+			  0);
+		check_true("and completes", poll_until(thread, &r), NULL);
+		check_u32("releasing generation 2", m2->refcnt, 1);
+		s3_export_manifest_unref(bad);
+	}
+
+out_dev:
+	bs_dev->destroy(bs_dev);
+	/* destroy() is asynchronous: the device frees itself from the unregister
+	 * callback, which needs the thread. It also consumes the client reference
+	 * this test handed to create(), which is why none is released below. */
+	for (rc = 0; rc < 100; rc++) {
+		spdk_thread_poll(thread, 0, 0);
+	}
+	check_u32("destroy released the manifest the device was on",
+		  m2 ? m2->refcnt : 0, 1);
+	bs_dev = NULL;
+	client = NULL;
+
+out_client:
+	/* Only reached with a client still owned here if create() never ran or
+	 * failed, in which case the move did not happen. */
+	if (client) {
+		s3_client_put(client);
+	}
+	s3_export_manifest_unref(m1);
+	s3_export_manifest_unref(m2);
+
+out_crt:
+	s3_crt_global_fini();
+
+out_spawner:
+	s3_spawner_stop();
+
+out_thread:
+	spdk_thread_exit(thread);
+	while (!spdk_thread_is_exited(thread)) {
+		spdk_thread_poll(thread, 0, 0);
+	}
+	spdk_thread_destroy(thread);
+	spdk_set_thread(NULL);
+
+out_lib:
+	spdk_thread_lib_fini();
+
+out_env:
+	printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+	spdk_log_close();
+	return g_fail == 0 ? 0 : 1;
+}

--- a/CubeS3lvol/test/integration/s3_export_test.c
+++ b/CubeS3lvol/test/integration/s3_export_test.c
@@ -34,15 +34,25 @@
 #include "spdk/log.h"
 
 #include "s3lvol/s3_export.h"
+/* For s3_chunk_data_key(), which is how the read path turns a ref into the key it
+ * GETs -- case [13] composes one the same way to check the prefix ends up in it. */
+#include "s3lvol/s3_chunk_map.h"
 
 #define CHUNK_SIZE (1024 * 1024)
 
-/* So that the "a newer version is refused" case follows S3_EXPORT_VERSION
- * instead of having to be edited every time it is bumped -- which is exactly
- * what went wrong the first time it was. */
+/* The version a freshly written manifest carries, which is what the strings these
+ * cases patch actually contain.
+ *
+ * Deliberately not S3_EXPORT_VERSION any more: a manifest is written at the oldest
+ * version that can describe it, so serialize() emits 2 for the single-source
+ * exports every one of these cases builds. Tying this to S3_EXPORT_VERSION made
+ * the substitutions silently match nothing the moment the constant moved to 3, and
+ * check_rejected() then reported "could not build the case" rather than passing
+ * vacuously -- which is the only reason it was noticed. */
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x)  STRINGIFY_(x)
-#define VERSION_FIELD "\"version\":" STRINGIFY(S3_EXPORT_VERSION)
+#define WRITTEN_VERSION 2
+#define VERSION_FIELD "\"version\":" STRINGIFY(WRITTEN_VERSION)
 
 static int g_pass;
 static int g_fail;
@@ -143,7 +153,12 @@ test_geometry(void)
 		check_u64("num_chunks", m->num_chunks, 64);
 		check_u64("size_bytes", m->size_bytes, 64ULL * CHUNK_SIZE);
 		check_u64("block_size", m->block_size, 4096);
-		check_u64("version", m->version, S3_EXPORT_VERSION);
+		/* 2, not S3_EXPORT_VERSION: a manifest is created at the oldest
+		 * version that can describe it, and is only raised to 3 by
+		 * serialize() if it ends up with more than one source. Writing 3
+		 * unconditionally would make every ordinary export unreadable to
+		 * binaries that have not been upgraded, for no gain. */
+		check_u64("a fresh manifest is written as version 2", m->version, 2);
 		check_u64("a fresh manifest has no chunks", m->present_chunks, 0);
 		check_str("the uuid is kept verbatim", m->uuid_str, TEST_UUID);
 		s3_export_manifest_unref(m);
@@ -398,8 +413,16 @@ test_rejections(void)
 	 * unrelated object, which is worse than failing. */
 	check_rejected("an unknown layout is refused", json,
 		       "\"layout\":\"dense\"", "\"layout\":\"uuid\"");
+	/* Above the accepted range: a future layout read as this one would resolve
+	 * every chunk somewhere unrelated. */
 	check_rejected("a newer version is refused", json,
 		       VERSION_FIELD, "\"version\":999");
+	/* Below it. Version 1's ref entries are 24 bytes against version 2's 16, so
+	 * reading one as the other names a different object for every chunk past the
+	 * first and returns plausible data from the wrong place -- which is why 1 is
+	 * refused rather than merely deprecated. */
+	check_rejected("version 1 is refused", json,
+		       VERSION_FIELD, "\"version\":1");
 
 	check_rejected("a block size other than 4 KiB is refused", json,
 		       "\"block_size\":4096", "\"block_size\":512");
@@ -955,6 +978,679 @@ test_captured_manifest(void)
 	s3_export_manifest_unref(m);
 }
 
+/* ==========================================================================
+ * [12] A version 2 ref manifest, read by a binary that can write version 3
+ *
+ * The compatibility direction that matters. Version 3 appends src_idx to the crc,
+ * so a reader that stages the crc by S3_EXPORT_VERSION rather than by the
+ * manifest's own version recomputes every version 2 ref manifest with a stage it
+ * does not carry, and reports corruption on all of them -- including the ones the
+ * same binary wrote before it was upgraded.
+ *
+ * Dense manifests would not have caught it: the extra stage only exists for ref.
+ * The manifest below is built by the writer, so its crc is genuine rather than
+ * asserted, and parse then has to agree with it.
+ * ========================================================================== */
+
+static void
+test_v2_ref_compat(void)
+{
+	struct s3_export_manifest *m = NULL;
+	struct s3_export_manifest *parsed = NULL;
+	struct spdk_uuid u = {0};
+	char *json = NULL;
+	size_t len = 0;
+	int rc;
+
+	printf("\n[12] a version 2 ref manifest read by a version 3 binary\n");
+
+	rc = s3_export_manifest_create(TEST_UUID, 8 * CHUNK_SIZE, CHUNK_SIZE,
+				       S3_EXPORT_LAYOUT_REF, &m);
+	check_int("a ref manifest is created", rc, 0);
+	if (rc != 0) {
+		return;
+	}
+
+	/* One whole chunk and one partial, so the crc covers both the ref table and
+	 * the partial-length exceptions -- the two stages version 2 has. */
+	fill_uuid(&u, 0x11);
+	s3_export_manifest_set_ref(m, 1, &u, CHUNK_SIZE);
+	fill_uuid(&u, 0x22);
+	s3_export_manifest_set_ref(m, 5, &u, CHUNK_SIZE / 2);
+
+	check_u64("written as version 2", m->version, 2);
+	check_u64("with one source", m->num_srcs, 1);
+	check_true("and no per-chunk source table", m->src_idx == NULL, NULL);
+
+	/* serialize() does not seal, and pack_all_refs() sizes its buffer from
+	 * present_chunks, so an unsealed manifest asserts rather than producing a
+	 * short one. Every other caller seals too. */
+	s3_export_manifest_seal(m);
+
+	rc = s3_export_manifest_serialize(m, &json, &len);
+	check_int("it serializes", rc, 0);
+	if (rc != 0) {
+		s3_export_manifest_unref(m);
+		return;
+	}
+	check_true("the json says version 2", strstr(json, "\"version\":2") != NULL,
+		   json);
+	check_true("and carries no source table",
+		   strstr(json, "\"srcs\"") == NULL, json);
+
+	rc = s3_export_manifest_parse(json, len, &parsed);
+	check_int("a version 2 ref manifest parses", rc, 0);
+	if (rc == 0) {
+		/* The assertion this case exists for: the crc has to verify, which it
+		 * only does if seal() staged it the way version 2 wrote it. */
+		check_u64("its crc verifies", parsed->crc32c, m->crc32c);
+		check_u64("version is kept, not overwritten", parsed->version, 2);
+		check_u64("a source table was synthesised", parsed->num_srcs, 1);
+		check_str("naming its own prefix", parsed->srcs[0].prefix,
+			  m->src.prefix);
+		check_true("with src_idx still absent", parsed->src_idx == NULL, NULL);
+		check_u64("present chunks survive", parsed->present_chunks, 2);
+		s3_export_manifest_unref(parsed);
+	}
+
+	free(json);
+	s3_export_manifest_unref(m);
+}
+
+/* ==========================================================================
+ * [13] A version 3 manifest: chunks from more than one prefix
+ *
+ * The format the whole v3 step exists for. What is asserted is that a round trip
+ * preserves which prefix each chunk resolves against -- because getting that wrong
+ * does not fail, it reads another chunk's object and returns bytes that look
+ * perfectly good.
+ * ========================================================================== */
+
+static void
+test_v3_multi_source(void)
+{
+	struct s3_export_manifest *m = NULL, *parsed = NULL;
+	struct spdk_uuid u;
+	uint8_t own = 0xff, parent = 0xff;
+	char *json = NULL;
+	size_t len = 0;
+	int rc;
+
+	printf("\n[13] a version 3 manifest with two sources\n");
+
+	rc = s3_export_manifest_create(TEST_UUID, 8 * CHUNK_SIZE, CHUNK_SIZE,
+				       S3_EXPORT_LAYOUT_REF, &m);
+	check_int("a ref manifest is created", rc, 0);
+	if (rc != 0) {
+		return;
+	}
+	/* The manifest's own prefix. Set directly, as every other case here does --
+	 * there is no setter, and add_src() below has to agree with it. */
+	snprintf(m->src.prefix, sizeof(m->src.prefix), "lvs-b");
+	snprintf(m->src.lvs_name, sizeof(m->src.lvs_name), "lvs-b");
+
+	/* Entry 0 is this export's own prefix and must already be there. */
+	rc = s3_export_manifest_add_src(m, "lvs-b", NULL, NULL, &own);
+	check_int("adding its own prefix succeeds", rc, 0);
+	check_u64("and resolves to entry 0", own, 0);
+	check_u64("without growing the table", m->num_srcs, 1);
+
+	rc = s3_export_manifest_add_src(m, "lvs-a", "exp-a-uuid", "snap-a-uuid",
+					&parent);
+	check_int("adding a parent prefix succeeds", rc, 0);
+	check_u64("as entry 1", parent, 1);
+	check_u64("the table has two entries", m->num_srcs, 2);
+
+	/* Idempotent: a derived export names the same parent for every chunk it
+	 * inherited, so the writer must be able to ask per chunk. */
+	rc = s3_export_manifest_add_src(m, "lvs-a", NULL, NULL, &parent);
+	check_int("asking again succeeds", rc, 0);
+	check_u64("gives the same index", parent, 1);
+	check_u64("and does not grow the table", m->num_srcs, 2);
+
+	/* Two chunks of its own, two inherited. */
+	fill_uuid(&u, 0x11);
+	s3_export_manifest_set_ref(m, 0, &u, CHUNK_SIZE);
+	fill_uuid(&u, 0x22);
+	s3_export_manifest_set_ref(m, 1, &u, CHUNK_SIZE / 2);
+	fill_uuid(&u, 0x33);
+	s3_export_manifest_set_ref(m, 4, &u, CHUNK_SIZE);
+	check_int("chunk 4 takes the parent source",
+		  s3_export_manifest_set_chunk_src(m, 4, parent), 0);
+	fill_uuid(&u, 0x44);
+	s3_export_manifest_set_ref(m, 7, &u, CHUNK_SIZE);
+	check_int("chunk 7 takes the parent source",
+		  s3_export_manifest_set_chunk_src(m, 7, parent), 0);
+
+	check_int("a source nobody added is refused",
+		  s3_export_manifest_set_chunk_src(m, 2, 9), -EINVAL);
+
+	check_str("chunk 0 resolves to its own prefix",
+		  s3_export_manifest_chunk_prefix(m, 0), "lvs-b");
+	check_str("chunk 4 resolves to the parent",
+		  s3_export_manifest_chunk_prefix(m, 4), "lvs-a");
+
+	s3_export_manifest_seal(m);
+	rc = s3_export_manifest_serialize(m, &json, &len);
+	check_int("it serializes", rc, 0);
+	if (rc != 0) {
+		s3_export_manifest_unref(m);
+		return;
+	}
+	/* Raised by serialize, not by create: the version follows the source count. */
+	check_u64("serializing raised it to version 3", m->version, 3);
+	check_true("the json says version 3", strstr(json, "\"version\":3") != NULL,
+		   json);
+	check_true("it carries a source table", strstr(json, "\"srcs\"") != NULL, json);
+	check_true("and per-chunk indices", strstr(json, "\"src_idx\"") != NULL, json);
+	/* Entry 0 is never written: it mirrors "source", and a second copy would be a
+	 * second place for the same prefix to be wrong. So the table starts at the
+	 * parent, and "lvs-b" appears only inside "source". */
+	check_true("the source table starts at entry 1",
+		   strstr(json, "\"srcs\":[{\"prefix\":\"lvs-a\"") != NULL, json);
+	check_true("entry 0 is not repeated in it",
+		   strstr(json, "{\"prefix\":\"lvs-b\"") == NULL, json);
+
+	rc = s3_export_manifest_parse(json, len, &parsed);
+	check_int("it parses back", rc, 0);
+	if (rc == 0) {
+		check_u64("as version 3", parsed->version, 3);
+		check_u64("with both sources", parsed->num_srcs, 2);
+		check_str("entry 0 synthesised from source", parsed->srcs[0].prefix,
+			  "lvs-b");
+		check_str("entry 1 read from the wire", parsed->srcs[1].prefix, "lvs-a");
+		check_str("with its export uuid", parsed->srcs[1].export_uuid,
+			  "exp-a-uuid");
+		check_str("and its snapshot uuid", parsed->srcs[1].snapshot_uuid,
+			  "snap-a-uuid");
+		check_u64("the crc verifies", parsed->crc32c, m->crc32c);
+
+		check_str("chunk 0 still resolves to its own prefix",
+			  s3_export_manifest_chunk_prefix(parsed, 0), "lvs-b");
+		check_str("chunk 1 too",
+			  s3_export_manifest_chunk_prefix(parsed, 1), "lvs-b");
+		check_str("chunk 4 still resolves to the parent",
+			  s3_export_manifest_chunk_prefix(parsed, 4), "lvs-a");
+		check_str("chunk 7 too",
+			  s3_export_manifest_chunk_prefix(parsed, 7), "lvs-a");
+
+		/* The keys themselves, composed the way export_chunk_key() composes
+		 * them. Worth asserting separately from the prefix: this is the value a
+		 * GET is issued against, and if two chunks from different sources came
+		 * out under one prefix the read would still succeed -- on another
+		 * chunk's object. */
+		{
+			const struct s3_export_ref *r0, *r4;
+			char k0[512], k4[512];
+
+			r0 = s3_export_manifest_get_ref(parsed, 0);
+			r4 = s3_export_manifest_get_ref(parsed, 4);
+			check_true("both chunks have refs", r0 && r4, NULL);
+			if (r0 && r4) {
+				s3_chunk_data_key(s3_export_manifest_chunk_prefix(parsed, 0),
+						  &r0->uuid, k0, sizeof(k0));
+				s3_chunk_data_key(s3_export_manifest_chunk_prefix(parsed, 4),
+						  &r4->uuid, k4, sizeof(k4));
+				check_true("chunk 0's key is under its own prefix",
+					   strncmp(k0, "lvs-b/", 6) == 0, k0);
+				check_true("chunk 4's key is under the parent's prefix",
+					   strncmp(k4, "lvs-a/", 6) == 0, k4);
+			}
+		}
+		s3_export_manifest_unref(parsed);
+	}
+
+	/* A source table without indices, or indices without a table, describes
+	 * chunks nobody can resolve; both halves have to arrive. */
+	check_rejected("a source table without indices is refused", json,
+		       "\"src_idx\"", "\"src_idx_unused\"");
+
+	free(json);
+	s3_export_manifest_unref(m);
+}
+
+/* ==========================================================================
+ * [14] The source limit
+ *
+ * Reaching it must be reported, not wrapped: a 17th source silently becoming
+ * source 1 would resolve those chunks against the wrong prefix.
+ * ========================================================================== */
+
+static void
+test_src_limit(void)
+{
+	struct s3_export_manifest *m = NULL;
+	char prefix[32];
+	uint8_t idx = 0;
+	int rc, i;
+
+	printf("\n[14] the source limit\n");
+
+	rc = s3_export_manifest_create(TEST_UUID, 8 * CHUNK_SIZE, CHUNK_SIZE,
+				       S3_EXPORT_LAYOUT_REF, &m);
+	if (rc != 0) {
+		check_int("a ref manifest is created", rc, 0);
+		return;
+	}
+	snprintf(m->src.prefix, sizeof(m->src.prefix), "lvs0");
+	rc = s3_export_manifest_add_src(m, "lvs0", NULL, NULL, &idx);
+	check_int("entry 0 is its own prefix", rc, 0);
+
+	/* Entry 0 exists already, so MAX_SOURCES-1 more fit. */
+	for (i = 1; i < S3_EXPORT_MAX_SOURCES; i++) {
+		snprintf(prefix, sizeof(prefix), "lvs%d", i);
+		rc = s3_export_manifest_add_src(m, prefix, NULL, NULL, &idx);
+		if (rc != 0) {
+			break;
+		}
+	}
+	check_int("filling the table succeeds", rc, 0);
+	check_u64("it holds exactly the limit", m->num_srcs, S3_EXPORT_MAX_SOURCES);
+
+	rc = s3_export_manifest_add_src(m, "one-too-many", NULL, NULL, &idx);
+	check_int("one more is refused with -E2BIG", rc, -E2BIG);
+	check_u64("and the table is unchanged", m->num_srcs, S3_EXPORT_MAX_SOURCES);
+
+	s3_export_manifest_unref(m);
+}
+
+/* ==========================================================================
+ * [15] Inheriting from the export a volume reads through
+ *
+ * The write side of a handoff that is itself derived from an import. What has to
+ * come out right is not just "the chunks are there": each one has to be recorded
+ * against the prefix that really holds it, and against the export whose lease
+ * protects it -- which for a parent that was itself derived is the grandparent's,
+ * not the parent's. Getting either wrong produces a manifest that reads fine on
+ * the machine that wrote it and fails, or serves another volume's data, elsewhere.
+ * ========================================================================== */
+
+/* A ref manifest standing in for one published by another node. */
+static struct s3_export_manifest *
+make_parent(const char *uuid, const char *prefix, const char *snap_uuid,
+	    uint64_t chunks)
+{
+	struct s3_export_manifest *p = NULL;
+	uint8_t idx;
+	int rc;
+
+	rc = s3_export_manifest_create(uuid, chunks * CHUNK_SIZE, CHUNK_SIZE,
+				       S3_EXPORT_LAYOUT_REF, &p);
+	if (rc != 0) {
+		return NULL;
+	}
+	snprintf(p->src.prefix, sizeof(p->src.prefix), "%s", prefix);
+	snprintf(p->src.lvs_name, sizeof(p->src.lvs_name), "%s", prefix);
+	snprintf(p->src.snapshot_uuid, sizeof(p->src.snapshot_uuid), "%s", snap_uuid);
+	snprintf(p->src.bucket, sizeof(p->src.bucket), "bkt");
+	snprintf(p->src.endpoint, sizeof(p->src.endpoint), "ep");
+	if (s3_export_manifest_add_src(p, prefix, NULL, NULL, &idx) != 0) {
+		s3_export_manifest_unref(p);
+		return NULL;
+	}
+	return p;
+}
+
+static void
+test_inherit(void)
+{
+	struct s3_export_manifest *p = NULL, *g = NULL, *c = NULL;
+	uint64_t named = 0, bytes = 0;
+	struct spdk_uuid u;
+	uint8_t idx;
+	int rc;
+
+	printf("\n[15] inheriting from the export a volume reads through\n");
+
+	/* The parent: 8 chunks, owning 0,1,2 and 5, with the rest holes. */
+	p = make_parent("11111111-1111-1111-1111-111111111111", "lvs-p",
+			"snap-p-uuid", 8);
+	c = make_parent("22222222-2222-2222-2222-222222222222", "lvs-c",
+			"snap-c-uuid", 8);
+	check_true("the manifests are built", p && c, NULL);
+	if (!p || !c) {
+		goto out;
+	}
+
+	fill_uuid(&u, 0xA0);
+	s3_export_manifest_set_ref(p, 0, &u, CHUNK_SIZE);
+	fill_uuid(&u, 0xA1);
+	s3_export_manifest_set_ref(p, 1, &u, CHUNK_SIZE);
+	fill_uuid(&u, 0xA2);
+	s3_export_manifest_set_ref(p, 2, &u, CHUNK_SIZE / 4);
+	fill_uuid(&u, 0xA5);
+	s3_export_manifest_set_ref(p, 5, &u, CHUNK_SIZE);
+
+	/* The child wrote chunk 1 since the import, and chunk 6 which the parent
+	 * never had. */
+	fill_uuid(&u, 0xB1);
+	s3_export_manifest_set_ref(c, 1, &u, CHUNK_SIZE);
+	fill_uuid(&u, 0xB6);
+	s3_export_manifest_set_ref(c, 6, &u, CHUNK_SIZE);
+
+	rc = s3_export_manifest_inherit(c, p, &named, &bytes);
+	check_int("inheriting succeeds", rc, 0);
+	/* 0, 2 and 5. Not 1 -- the child rewrote it -- and not the holes. */
+	check_u64("it names the parent's chunks the child lacks", named, 3);
+	check_u64("and their bytes", bytes, CHUNK_SIZE + CHUNK_SIZE / 4 + CHUNK_SIZE);
+
+	/* Sealed first because present_chunks is derived there, not maintained by
+	 * set_ref -- the same reason the writer seals before serializing. */
+	s3_export_manifest_seal(c);
+	check_u64("the child now has five chunks", c->present_chunks, 5);
+	check_true("a hole in the parent stays a hole",
+		   !s3_export_manifest_is_present(c, 3), NULL);
+
+	/* The ordering rule, which is the one that silently serves stale data when
+	 * broken: the chunk the child rewrote must still be the child's. */
+	check_str("the rewritten chunk stays under the child's prefix",
+		  s3_export_manifest_chunk_prefix(c, 1), "lvs-c");
+	check_true("and keeps the child's object",
+		   s3_export_manifest_get_ref(c, 1)->uuid.u.raw[0] == 0xB1, NULL);
+
+	check_str("an inherited chunk moves to the parent's prefix",
+		  s3_export_manifest_chunk_prefix(c, 0), "lvs-p");
+	check_true("carrying the parent's object",
+		   s3_export_manifest_get_ref(c, 0)->uuid.u.raw[0] == 0xA0, NULL);
+	check_u64("and its partial length",
+		  s3_export_manifest_get_ref(c, 2)->valid_bytes, CHUNK_SIZE / 4);
+
+	/* The lease. An importer of the child must renew against the parent's own
+	 * export, because that is the node holding these objects. */
+	check_u64("one prefix was added", c->num_srcs, 2);
+	check_str("named as the parent's prefix", c->srcs[1].prefix, "lvs-p");
+	check_str("governed by the parent's export",
+		  c->srcs[1].export_uuid, "11111111-1111-1111-1111-111111111111");
+	check_str("and its snapshot", c->srcs[1].snapshot_uuid, "snap-p-uuid");
+
+	/* Transitivity. A grandchild inheriting from the child must end up pointing
+	 * at lvs-p directly for those chunks -- not at lvs-c, which does not have
+	 * them -- and must renew the *parent's* lease, not the child's. This is what
+	 * lets the middle node be shut down. */
+	g = make_parent("33333333-3333-3333-3333-333333333333", "lvs-g",
+			"snap-g-uuid", 8);
+	check_true("a grandchild is built", g != NULL, NULL);
+	if (!g) {
+		goto out;
+	}
+	rc = s3_export_manifest_inherit(g, c, &named, &bytes);
+	check_int("it inherits from the child", rc, 0);
+	check_u64("taking everything the child had", named, 5);
+
+	check_str("a chunk the child owned comes from the child",
+		  s3_export_manifest_chunk_prefix(g, 1), "lvs-c");
+	check_str("a chunk the child inherited comes from the grandparent, not the "
+		  "child", s3_export_manifest_chunk_prefix(g, 0), "lvs-p");
+	check_u64("so the grandchild names three prefixes", g->num_srcs, 3);
+
+	/* Which is the point: no entry anywhere refers to a manifest, so nothing has
+	 * to be fetched to resolve a chunk and no node in the history has to be
+	 * running. */
+	for (idx = 1; idx < g->num_srcs; idx++) {
+		const char *pfx = g->srcs[idx].prefix;
+		const char *want = (strcmp(pfx, "lvs-p") == 0)
+				   ? "11111111-1111-1111-1111-111111111111"
+				   : "22222222-2222-2222-2222-222222222222";
+
+		check_str("each prefix is governed by the export that holds it",
+			  g->srcs[idx].export_uuid, want);
+	}
+
+	/* A local write_zeroes leaves present clear -- that is also how an
+	 * untouched hole is spelled -- so inherit used to restore the parent's
+	 * object. resolved is what the walk sets for that case. */
+	{
+		struct s3_export_manifest *z;
+
+		z = make_parent("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "lvs-z",
+				"snap-z-uuid", 8);
+		check_true("a child with a local zero is built", z != NULL, NULL);
+		if (z) {
+			fill_uuid(&u, 0xB1);
+			s3_export_manifest_set_ref(z, 1, &u, CHUNK_SIZE);
+			s3_export_manifest_set_resolved(z, 0);
+
+			rc = s3_export_manifest_inherit(z, p, &named, &bytes);
+			check_int("inherit still succeeds after a local zero", rc, 0);
+			/* 2 and 5. Not 0 -- zeroed -- and not 1 -- rewritten. */
+			check_u64("the zeroed chunk is not inherited", named, 2);
+			check_true("and stays a hole on the child",
+				   !s3_export_manifest_is_present(z, 0), NULL);
+			check_true("while the parent's other objects still are",
+				   s3_export_manifest_is_present(z, 2) &&
+				   s3_export_manifest_is_present(z, 5), NULL);
+			check_true("and the walk's resolved bit is what blocked it",
+				   s3_export_manifest_is_resolved(z, 0), NULL);
+
+			s3_export_manifest_seal(z);
+			{
+				char *json = NULL;
+				size_t len = 0;
+
+				rc = s3_export_manifest_serialize(z, &json, &len);
+				check_int("the hole serializes", rc, 0);
+				if (rc == 0 && json) {
+					struct s3_export_manifest *parsed = NULL;
+
+					rc = s3_export_manifest_parse(json, len, &parsed);
+					check_int("and parses", rc, 0);
+					if (rc == 0) {
+						check_true("the wire form has no object at 0",
+							   !s3_export_manifest_is_present(
+								   parsed, 0), NULL);
+						check_true("resolved does not travel",
+							   !s3_export_manifest_is_resolved(
+								   parsed, 0), NULL);
+						s3_export_manifest_unref(parsed);
+					}
+					free(json);
+				}
+			}
+			s3_export_manifest_unref(z);
+		}
+	}
+
+	/* A parent shorter than the child: the volume grew after the import, so the
+	 * chunks past its end were never the parent's to describe. */
+	{
+		struct s3_export_manifest *small, *big;
+
+		small = make_parent("44444444-4444-4444-4444-444444444444", "lvs-s",
+				    "snap-s-uuid", 2);
+		big   = make_parent("55555555-5555-5555-5555-555555555555", "lvs-t",
+				    "snap-t-uuid", 8);
+		if (small && big) {
+			fill_uuid(&u, 0xC0);
+			s3_export_manifest_set_ref(small, 0, &u, CHUNK_SIZE);
+			fill_uuid(&u, 0xC1);
+			s3_export_manifest_set_ref(small, 1, &u, CHUNK_SIZE);
+
+			rc = s3_export_manifest_inherit(big, small, &named, NULL);
+			check_int("a shorter parent is accepted", rc, 0);
+			check_u64("contributing only what it covers", named, 2);
+			check_true("and nothing past its end",
+				   !s3_export_manifest_is_present(big, 2), NULL);
+		}
+		s3_export_manifest_unref(small);
+		s3_export_manifest_unref(big);
+	}
+
+	/* More distinct prefixes than a manifest can name. This is the degradation
+	 * path, and what it has to do is *stop*: -E2BIG travels back to the writer,
+	 * which exports by copying instead. Copying can express any history in one
+	 * prefix, so nothing is lost but the speed.
+	 *
+	 * Asserted on inherit() rather than only on add_src() -- case [14] already
+	 * covers the table filling up -- because a limit that is enforced but not
+	 * propagated is the dangerous shape: the writer would carry on and publish a
+	 * manifest missing exactly the chunks that did not fit, which reads as
+	 * zeroes on the importer. */
+	{
+		struct s3_export_manifest *wide = NULL, *heir = NULL;
+		char pfx[32];
+		uint8_t widx;
+		uint64_t k;
+
+		/* A parent that has been handed on until its table is full, with a
+		 * chunk under each prefix so every one of them has to be carried. */
+		wide = make_parent("88888888-8888-8888-8888-888888888888", "lvs-w",
+				   "snap-w-uuid", S3_EXPORT_MAX_SOURCES + 4);
+		heir = make_parent("99999999-9999-9999-9999-999999999999", "lvs-h",
+				   "snap-h-uuid", S3_EXPORT_MAX_SOURCES + 4);
+		if (wide && heir) {
+			for (k = 0; k < S3_EXPORT_MAX_SOURCES; k++) {
+				fill_uuid(&u, (uint8_t)(0xD0 + k));
+				s3_export_manifest_set_ref(wide, k, &u, CHUNK_SIZE);
+				if (k == 0) {
+					continue;
+				}
+				snprintf(pfx, sizeof(pfx), "lvs-w%u", (unsigned)k);
+				rc = s3_export_manifest_add_src(wide, pfx, "e", "s",
+								&widx);
+				if (rc != 0) {
+					break;
+				}
+				rc = s3_export_manifest_set_chunk_src(wide, k, widx);
+				if (rc != 0) {
+					break;
+				}
+			}
+			check_int("a parent can be built at the source limit", rc, 0);
+			check_u64("with a full table", wide->num_srcs,
+				  S3_EXPORT_MAX_SOURCES);
+
+			/* The heir already holds its own prefix at entry 0, so the
+			 * parent's own prefix plus its 15 others need one slot more
+			 * than remain. */
+			rc = s3_export_manifest_inherit(heir, wide, NULL, NULL);
+			check_int("inheriting more prefixes than fit gives -E2BIG",
+				  rc, -E2BIG);
+			check_u64("having filled the table and stopped there",
+				  heir->num_srcs, S3_EXPORT_MAX_SOURCES);
+		}
+		s3_export_manifest_unref(wide);
+		s3_export_manifest_unref(heir);
+	}
+
+	/* Different chunk sizes make chunk indices incomparable, so there is nothing
+	 * to carry across without re-cutting the data. */
+	{
+		struct s3_export_manifest *other = NULL;
+
+		rc = s3_export_manifest_create("66666666-6666-6666-6666-666666666666",
+					       8 * CHUNK_SIZE * 2, CHUNK_SIZE * 2,
+					       S3_EXPORT_LAYOUT_REF, &other);
+		if (rc == 0) {
+			check_int("a parent of another chunk size is refused",
+				  s3_export_manifest_inherit(c, other, NULL, NULL),
+				  -EINVAL);
+			s3_export_manifest_unref(other);
+		}
+	}
+
+	/* A copied export keys its objects exports/<uuid>/chunk-N, which a source
+	 * entry -- a bare prefix -- cannot address. */
+	{
+		struct s3_export_manifest *dense = NULL;
+
+		rc = s3_export_manifest_create("77777777-7777-7777-7777-777777777777",
+					       8 * CHUNK_SIZE, CHUNK_SIZE,
+					       S3_EXPORT_LAYOUT_DENSE, &dense);
+		if (rc == 0) {
+			check_int("a copied parent is refused",
+				  s3_export_manifest_inherit(c, dense, NULL, NULL),
+				  -EINVAL);
+			s3_export_manifest_unref(dense);
+		}
+	}
+
+	/* Where a reference cannot be expressed at all, and the writer has to copy.
+	 *
+	 * A source entry is a bare prefix sharing endpoint, bucket and region with
+	 * `source`, so a parent reachable any other way cannot be named. Nothing
+	 * here can be reached by the end-to-end suite -- it would need a second
+	 * bucket -- and the failure it prevents is the quiet kind: a manifest naming
+	 * a prefix in the wrong bucket resolves to whatever happens to be at that
+	 * key there, which on a shared endpoint is another volume's data. */
+	{
+		struct s3_export_source dst;
+		struct s3_export_manifest *dense = NULL;
+
+		memset(&dst, 0, sizeof(dst));
+		snprintf(dst.bucket, sizeof(dst.bucket), "bkt");
+		snprintf(dst.endpoint, sizeof(dst.endpoint), "ep");
+
+		/* p was built by make_parent() with bucket "bkt", endpoint "ep" and
+		 * an empty region, so it matches and is inheritable. */
+		check_int("a parent in the same place is inheritable",
+			  s3_export_manifest_inheritable(p, &dst, "test"), 0);
+
+		snprintf(dst.bucket, sizeof(dst.bucket), "other-bucket");
+		check_int("a parent in another bucket is refused with -ENOTSUP",
+			  s3_export_manifest_inheritable(p, &dst, "test"), -ENOTSUP);
+
+		snprintf(dst.bucket, sizeof(dst.bucket), "bkt");
+		snprintf(dst.endpoint, sizeof(dst.endpoint), "other-endpoint");
+		check_int("a parent behind another endpoint is refused",
+			  s3_export_manifest_inheritable(p, &dst, "test"), -ENOTSUP);
+
+		/* Region carries no address by itself, but the client is built per
+		 * endpoint/bucket/region, so a manifest that changed it silently would
+		 * be resolved by a client the importer never meant to use. */
+		snprintf(dst.endpoint, sizeof(dst.endpoint), "ep");
+		snprintf(dst.region, sizeof(dst.region), "elsewhere");
+		check_int("and so is one in another region",
+			  s3_export_manifest_inheritable(p, &dst, "test"), -ENOTSUP);
+
+		/* A copied export keys its objects exports/<uuid>/chunk-N, which a
+		 * bare prefix cannot address however reachable the bucket is. */
+		dst.region[0] = '\0';
+		rc = s3_export_manifest_create("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					       8 * CHUNK_SIZE, CHUNK_SIZE,
+					       S3_EXPORT_LAYOUT_DENSE, &dense);
+		if (rc == 0) {
+			snprintf(dense->src.bucket, sizeof(dense->src.bucket), "bkt");
+			snprintf(dense->src.endpoint, sizeof(dense->src.endpoint), "ep");
+			check_int("a copied parent is refused even in the right bucket",
+				  s3_export_manifest_inheritable(dense, &dst, "test"),
+				  -ENOTSUP);
+			s3_export_manifest_unref(dense);
+		}
+	}
+
+	/* And the whole thing has to survive the wire, since that is the only way the
+	 * importing node ever sees it. */
+	{
+		char *json = NULL;
+		size_t len = 0;
+		struct s3_export_manifest *parsed = NULL;
+
+		s3_export_manifest_seal(g);
+		rc = s3_export_manifest_serialize(g, &json, &len);
+		check_int("the grandchild serializes", rc, 0);
+		if (rc == 0) {
+			rc = s3_export_manifest_parse(json, len, &parsed);
+			check_int("and parses back", rc, 0);
+			if (rc == 0) {
+				check_u64("with its three sources", parsed->num_srcs, 3);
+				check_str("chunk 0 still points past the middleman",
+					  s3_export_manifest_chunk_prefix(parsed, 0),
+					  "lvs-p");
+				check_str("and chunk 1 at the middleman",
+					  s3_export_manifest_chunk_prefix(parsed, 1),
+					  "lvs-c");
+				s3_export_manifest_unref(parsed);
+			}
+			free(json);
+		}
+	}
+
+out:
+	s3_export_manifest_unref(g);
+	s3_export_manifest_unref(c);
+	s3_export_manifest_unref(p);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -980,6 +1676,10 @@ main(int argc, char **argv)
 	test_ref_crc();
 	test_ref_all_full();
 	test_captured_manifest();
+	test_v2_ref_compat();
+	test_v3_multi_source();
+	test_src_limit();
+	test_inherit();
 
 	printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
 	spdk_log_close();

--- a/CubeS3lvol/test/integration/s3_lease_term_test.c
+++ b/CubeS3lvol/test/integration/s3_lease_term_test.c
@@ -1,0 +1,55 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+/*
+ * A historical lease 404 must not confirm "gone" once the deadline passes.
+ * Both orders: the reaper looking first, and a post-deadline HEAD completing
+ * first. No S3, no SPDK.
+ */
+
+#include "export_lease_term.h"
+
+#include <stdio.h>
+#include <stdbool.h>
+
+static int g_pass, g_fail;
+
+static void
+check_true(const char *what, bool ok)
+{
+	if (ok) {
+		g_pass++;
+		printf("\t[PASS] %s\n", what);
+	} else {
+		g_fail++;
+		printf("\t[FAIL] %s\n", what);
+	}
+}
+
+int
+main(void)
+{
+	const uint64_t expires = 100;
+
+	printf("[1] a 404 from before the deadline is not terminal after it\n");
+	check_true("reaper first: expired, last miss at 50",
+		   !export_lease_miss_confirms_gone(true, 50, expires, 200));
+	check_true("still inside the TTL",
+		   !export_lease_miss_confirms_gone(true, 50, expires, 90));
+
+	printf("[2] a miss submitted at or after the deadline is terminal\n");
+	check_true("HEAD first: miss submitted at 150, now 200",
+		   export_lease_miss_confirms_gone(true, 150, expires, 200));
+	check_true("miss submitted on the deadline",
+		   export_lease_miss_confirms_gone(true, 100, expires, 100));
+
+	printf("[3] no miss, or no deadline, never confirms gone\n");
+	check_true("lease present",
+		   !export_lease_miss_confirms_gone(false, 150, expires, 200));
+	check_true("no expires_at",
+		   !export_lease_miss_confirms_gone(true, 150, 0, 200));
+	check_true("absent_at unset",
+		   !export_lease_miss_confirms_gone(true, 0, expires, 200));
+
+	printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+	return g_fail ? 1 : 0;
+}

--- a/CubeS3lvol/test/integration/s3_pending_persist_test.c
+++ b/CubeS3lvol/test/integration/s3_pending_persist_test.c
@@ -1,0 +1,72 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+/*
+ *   Last-mutation-wins for pending-delete registry PUTs
+ *
+ *   The production path only has one PUT in flight. These sequences are what
+ *   used to complete in reverse order when each mutation submitted its own.
+ */
+
+#include <stdio.h>
+
+#include "pending_persist_ctl.h"
+
+static int g_pass, g_fail;
+
+static void
+check_true(const char *what, bool ok)
+{
+	if (ok) {
+		g_pass++;
+		printf("\t[PASS] %s\n", what);
+	} else {
+		g_fail++;
+		printf("\t[FAIL] %s\n", what);
+	}
+}
+
+int
+main(void)
+{
+	struct pending_persist_ctl c;
+	int puts;
+
+	printf("=== pending-delete registry persist coalescing ===\n");
+
+	printf("\n[1] set then set: second waits, one resubmit\n");
+	c = (struct pending_persist_ctl){0};
+	puts = 0;
+	check_true("first set submits", pending_persist_begin(&c));
+	puts++;
+	check_true("second set coalesces", !pending_persist_begin(&c));
+	check_true("completion asks for a follow-up", pending_persist_end(&c));
+	check_true("pending_persist begin submits PUT #2",
+		   pending_persist_begin(&c));
+	puts++;
+	check_true("second completion is idle", !pending_persist_end(&c));
+	check_true("two PUTs, latest state twice", puts == 2);
+
+	printf("\n[2] set then clear: cancel is what lands\n");
+	c = (struct pending_persist_ctl){0};
+	check_true("set submits", pending_persist_begin(&c));
+	check_true("clear coalesces", !pending_persist_begin(&c));
+	check_true("completion asks for a follow-up", pending_persist_end(&c));
+	check_true("begin submits the clear", pending_persist_begin(&c));
+	check_true("then idle", !pending_persist_end(&c));
+
+	printf("\n[3] clear then set: re-queue is what lands\n");
+	c = (struct pending_persist_ctl){0};
+	check_true("clear submits", pending_persist_begin(&c));
+	check_true("set coalesces", !pending_persist_begin(&c));
+	check_true("completion asks for a follow-up", pending_persist_end(&c));
+	check_true("begin submits the set", pending_persist_begin(&c));
+	check_true("then idle", !pending_persist_end(&c));
+
+	printf("\n[4] a lone mutation is one PUT\n");
+	c = (struct pending_persist_ctl){0};
+	check_true("submits", pending_persist_begin(&c));
+	check_true("completes without a follow-up", !pending_persist_end(&c));
+
+	printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+	return g_fail == 0 ? 0 : 1;
+}

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -245,6 +245,7 @@ S3_ARGS=(-e "${ENDPOINT}" -b "${BUCKET}" -r "${REGION}")
 if [ "${MODE}" = list ]; then
 	echo "offline integration: spawner thread_bounce journal wal cache flush export"
 	echo "                     statefile local_dev checkpoint export_swap"
+	echo "                     copy_xml lease_term pending_persist"
 	echo "with S3:             s3_client_test s3_bs_dev_test"
 	echo "dataplane:           dataplane recovery snapshot export srcdel selfimport"
 	echo "                     derived decouple_queue snapshot_cancel snapshot_converge"
@@ -322,7 +323,7 @@ echo "--- integration (no S3, no root)"
 for t in s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test \
 	 s3_cache_test s3_flush_test s3_export_test s3_statefile_test \
 	 s3_local_dev_test s3_checkpoint_test s3_export_swap_test \
-	 s3_lease_term_test s3_pending_persist_test; do
+	 s3_copy_xml_test s3_lease_term_test s3_pending_persist_test; do
 	run_suite "${t}" "./test/integration/${t}"
 done
 echo ""

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -76,8 +76,8 @@ done
 # Tally
 #
 # Assertion counts come from the suites' own summary lines, which are not in one
-# format: the older tests print Chinese, s3_flush_test omits the "result:"
-# prefix, and the scripts use the English form. All three are parsed rather than
+# format: s3_flush_test omits the "result:" prefix, and the scripts use the
+# English "result: N passed, M failed" form. Both are parsed rather than
 # unified, because rewriting eight suites' output to tidy up a report is a poor
 # trade -- and a suite whose line cannot be parsed is reported as such instead of
 # being counted as zero.

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -246,7 +246,9 @@ if [ "${MODE}" = list ]; then
 	echo "offline integration: spawner thread_bounce journal wal cache flush export"
 	echo "                     statefile local_dev checkpoint"
 	echo "with S3:             s3_client_test s3_bs_dev_test"
-	echo "dataplane:           dataplane recovery snapshot export selfimport decouple_queue snapdelete fs guards activation control"
+	echo "dataplane:           dataplane recovery snapshot export srcdel selfimport"
+	echo "                     decouple_queue agent_template snapdelete pending_delete"
+	echo "                     fs guards activation control"
 	echo ""
 	echo "root:        $([ "${HAVE_ROOT}" -eq 1 ] && echo yes || echo no)"
 	echo "credentials: $([ "${HAVE_CREDS}" -eq 1 ] && echo yes || echo no)"
@@ -318,7 +320,8 @@ echo ""
 echo "--- integration (no S3, no root)"
 for t in s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test \
 	 s3_cache_test s3_flush_test s3_export_test s3_statefile_test \
-	 s3_local_dev_test s3_checkpoint_test; do
+	 s3_local_dev_test s3_checkpoint_test s3_lease_term_test \
+	 s3_pending_persist_test; do
 	run_suite "${t}" "./test/integration/${t}"
 done
 echo ""
@@ -463,9 +466,10 @@ else
 		# Snapshot deletion semantics; next to the suites that build clone chains.
 		run_suite run_snapdelete_test.sh \
 			./test/dataplane/run_snapdelete_test.sh
-		# Pending-delete marks: refused -> marked -> skipped while blocked ->
-		# retried once clear. Right after snapdelete: same delete path, but the
-		# question is what a *refused* delete leaves behind.
+		# Deletes that could not be carried out when asked for: the intent, the
+		# deferral, the poller that completes them, and cancelling. Directly
+		# after snapdelete, whose refusals are what this queue is built on.
+		# Slowest part is one wait for the 60 s poller.
 		run_suite run_pending_delete_test.sh \
 			./test/dataplane/run_pending_delete_test.sh
 		# Mounts a real filesystem, so it goes after the block-level suites:

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -248,7 +248,7 @@ if [ "${MODE}" = list ]; then
 	echo "with S3:             s3_client_test s3_bs_dev_test"
 	echo "dataplane:           dataplane recovery snapshot export srcdel selfimport"
 	echo "                     derived decouple_queue snapshot_cancel snapshot_converge"
-	echo "                     agent_template snapdelete pending_delete"
+	echo "                     agent_template cubecow_client snapdelete pending_delete"
 	echo "                     fs guards activation control"
 	echo ""
 	echo "root:        $([ "${HAVE_ROOT}" -eq 1 ] && echo yes || echo no)"
@@ -425,7 +425,7 @@ if [ "${MODE}" != all ]; then
 	echo "--- dataplane: skipped, $([ "${MODE}" = offline ] && echo --offline || echo --no-dataplane)"
 	for t in dataplane recovery snapshot export srcdel selfimport derived \
 		 decouple_queue snapshot_cancel snapshot_converge agent_template \
-		 snapdelete pending_delete fs guards activation control; do
+		 cubecow_client snapdelete pending_delete fs guards activation control; do
 		report_skip "run_${t}_test.sh" "not requested" 1
 	done
 else
@@ -434,7 +434,7 @@ else
 		echo "--- dataplane"
 		for t in dataplane recovery snapshot export srcdel selfimport derived \
 			 decouple_queue snapshot_cancel snapshot_converge agent_template \
-			 snapdelete pending_delete fs guards activation control; do
+			 cubecow_client snapdelete pending_delete fs guards activation control; do
 			report_skip "run_${t}_test.sh" "${BLOCKER}"
 		done
 	else
@@ -486,6 +486,13 @@ else
 		# the bucket is shared); consumes export manifests like export does.
 		run_suite run_agent_template_test.sh \
 			./test/dataplane/run_agent_template_test.sh "${S3_ARGS[@]}"
+		# cubecow/Cubelet client contract: the 11 rcow_* methods in the
+		# order Cubelet actually issues them (seal, clone fan-out, parallel
+		# export, import then activate without waiting for decouple). Next
+		# to agent_template because that suite is the two-process deployment
+		# form of a similar chain; this one is the single-client RPC form.
+		run_suite run_cubecow_client_test.sh \
+			./test/dataplane/run_cubecow_client_test.sh
 		# Snapshot deletion semantics; next to the suites that build clone chains.
 		run_suite run_snapdelete_test.sh \
 			./test/dataplane/run_snapdelete_test.sh

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -244,10 +244,11 @@ S3_ARGS=(-e "${ENDPOINT}" -b "${BUCKET}" -r "${REGION}")
 
 if [ "${MODE}" = list ]; then
 	echo "offline integration: spawner thread_bounce journal wal cache flush export"
-	echo "                     statefile local_dev checkpoint"
+	echo "                     statefile local_dev checkpoint export_swap"
 	echo "with S3:             s3_client_test s3_bs_dev_test"
 	echo "dataplane:           dataplane recovery snapshot export srcdel selfimport"
-	echo "                     decouple_queue agent_template snapdelete pending_delete"
+	echo "                     derived decouple_queue snapshot_cancel snapshot_converge"
+	echo "                     agent_template snapdelete pending_delete"
 	echo "                     fs guards activation control"
 	echo ""
 	echo "root:        $([ "${HAVE_ROOT}" -eq 1 ] && echo yes || echo no)"
@@ -320,8 +321,8 @@ echo ""
 echo "--- integration (no S3, no root)"
 for t in s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test \
 	 s3_cache_test s3_flush_test s3_export_test s3_statefile_test \
-	 s3_local_dev_test s3_checkpoint_test s3_lease_term_test \
-	 s3_pending_persist_test; do
+	 s3_local_dev_test s3_checkpoint_test s3_export_swap_test \
+	 s3_lease_term_test s3_pending_persist_test; do
 	run_suite "${t}" "./test/integration/${t}"
 done
 echo ""
@@ -422,14 +423,18 @@ else:
 
 if [ "${MODE}" != all ]; then
 	echo "--- dataplane: skipped, $([ "${MODE}" = offline ] && echo --offline || echo --no-dataplane)"
-	for t in dataplane recovery snapshot export selfimport decouple_queue snapdelete fs guards activation control; do
+	for t in dataplane recovery snapshot export srcdel selfimport derived \
+		 decouple_queue snapshot_cancel snapshot_converge agent_template \
+		 snapdelete pending_delete fs guards activation control; do
 		report_skip "run_${t}_test.sh" "not requested" 1
 	done
 else
 	BLOCKER="$(dataplane_blocker)"
 	if [ -n "${BLOCKER}" ]; then
 		echo "--- dataplane"
-		for t in dataplane recovery snapshot export selfimport decouple_queue snapdelete fs guards activation control; do
+		for t in dataplane recovery snapshot export srcdel selfimport derived \
+			 decouple_queue snapshot_cancel snapshot_converge agent_template \
+			 snapdelete pending_delete fs guards activation control; do
 			report_skip "run_${t}_test.sh" "${BLOCKER}"
 		done
 	else
@@ -453,12 +458,30 @@ else
 		# Next to export, whose manifests it consumes.
 		run_suite run_selfimport_test.sh \
 			./test/dataplane/run_selfimport_test.sh
-		# A queued decouple must not be snapshotable: snapshotting an esnap
-		# clone moves its external snapshot onto the new snapshot, and the
-		# queued decouple then fails its detach. Regression for the 64-node
-		# failure; consumes export manifests like export does.
+		# Handing on an imported volume without copying it: three lvstores in
+		# turn, so that what the last one reads has to resolve against two
+		# prefixes at once. Next to selfimport because it is the other half of
+		# the same question -- selfimport is an import that comes home, this is
+		# one that keeps travelling.
+		run_suite run_derived_test.sh \
+			./test/dataplane/run_derived_test.sh "${S3_ARGS[@]}"
+		# Snapshotting a volume whose decouple is *queued* must cancel that
+		# decouple rather than leave one that materialises everything and then
+		# cannot detach. Regression for the 64-node failure; consumes export
+		# manifests like export does.
 		run_suite run_decouple_queue_test.sh \
 			./test/dataplane/run_decouple_queue_test.sh "${S3_ARGS[@]}"
+		# The same, for a decouple that is *running* -- the common case, since a
+		# decouple starts unless another is in the way, so it is the branch an
+		# ordinary "import, then snapshot" trips.
+		run_suite run_snapshot_cancel_test.sh \
+			./test/dataplane/run_snapshot_cancel_test.sh "${S3_ARGS[@]}"
+		# And that such a chain can then stop depending on its source: the
+		# snapshot is decoupled, and the final read happens after the source
+		# prefix is deleted and the lvstore re-attached, so a pass cannot come
+		# from a cache.
+		run_suite run_snapshot_converge_test.sh \
+			./test/dataplane/run_snapshot_converge_test.sh "${S3_ARGS[@]}"
 		# The agent-template chain across two real s3lvol_tgt processes (only
 		# the bucket is shared); consumes export manifests like export does.
 		run_suite run_agent_template_test.sh \

--- a/CubeS3lvol/test/tools/s3_get_manifest.py
+++ b/CubeS3lvol/test/tools/s3_get_manifest.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Fetch an export manifest and print one field of it.
+
+Why this exists: `layout` is only ever written into the manifest object
+(s3_export.c:581). No RPC reports it -- rcow_get_lvstores describes lvols, not
+exports -- so the only way to find out whether an export came out zero-copy or
+copied is to read the manifest back out of S3. A test that wants to assert "this
+export referenced the source rather than duplicating it" has nowhere else to look.
+
+The S3 client is borrowed from s3_prefix_rm.py, which already implements SigV4
+against the same endpoints; duplicating that signing code here would be a second
+thing to keep correct.
+
+Usage:
+    s3_get_manifest.py -e <endpoint> -b <bucket> -r <region> -u <export-uuid>
+                       [-p <prefix>] [--field layout] [--raw]
+
+  -p        prefix the manifest lives under; default "exports" (the bucket-level
+            directory), which is where a same-bucket export writes it
+  --field   member to print; default "layout". "." prints the whole object
+  --raw     print the manifest verbatim, ignoring --field
+
+Exits non-zero if the object cannot be read, so a caller can tell "absent" from
+"present but says something unexpected".
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from s3_prefix_rm import Client  # noqa: E402  (path set above)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("-e", "--endpoint", required=True)
+    p.add_argument("-b", "--bucket", required=True)
+    p.add_argument("-r", "--region", default="ap-nanjing")
+    p.add_argument("-u", "--uuid", required=True, help="export uuid")
+    p.add_argument("-p", "--prefix", default="exports",
+                   help='prefix holding <uuid>.json (default: "%(default)s")')
+    p.add_argument("--field", default="layout",
+                   help='manifest member to print, or "." for all')
+    p.add_argument("--raw", action="store_true")
+    p.add_argument("--path-style", action="store_true")
+    p.add_argument("--no-tls", action="store_true")
+    args = p.parse_args()
+
+    ak = os.environ.get("AWS_ACCESS_KEY_ID", "")
+    sk = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+    if not ak or not sk:
+        print("AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are not set",
+              file=sys.stderr)
+        return 2
+
+    s3 = Client(args.endpoint, args.bucket, args.region, args.path_style, ak, sk,
+            args.no_tls)
+    key = "%s/%s.json" % (args.prefix.rstrip("/"), args.uuid)
+
+    # _base_path() is empty for virtual-hosted addressing and "/<bucket>" for
+    # path style; the signature covers it either way, so it cannot be skipped.
+    status, body = s3.request("GET", s3._base_path() + "/" + key)
+    if status != 200:
+        print("GET %s -> HTTP %s" % (key, status), file=sys.stderr)
+        return 1
+
+    text = body.decode("utf-8", "replace") if isinstance(body, bytes) else body
+    if args.raw:
+        print(text)
+        return 0
+
+    try:
+        m = json.loads(text)
+    except Exception as exc:
+        print("manifest is not JSON: %s" % exc, file=sys.stderr)
+        return 1
+
+    if args.field == ".":
+        print(json.dumps(m, indent=2, sort_keys=True))
+        return 0
+
+    if args.field not in m:
+        print("manifest has no member %r (has: %s)"
+              % (args.field, ", ".join(sorted(m))), file=sys.stderr)
+        return 1
+
+    print(m[args.field])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CubeS3lvol/test/tools/s3_put_lease.py
+++ b/CubeS3lvol/test/tools/s3_put_lease.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# 探针工具：往 S3 写一个 export lease 对象，模拟另一节点的 importer 续约。
+# 复用 s3_prefix_rm.py 的 stdlib SigV4 签名（测试机没有 boto3）。
+import datetime
+import hashlib
+import hmac
+import http.client
+import json
+import os
+import sys
+import time
+
+ap = sys.argv
+if len(ap) < 6:
+    sys.exit("usage: put_lease.py <endpoint> <bucket> <region> <key> <renew_s> [age_s]")
+endpoint, bucket, region, key, renew_s = ap[1], ap[2], ap[3], ap[4], int(ap[5])
+age = int(ap[6]) if len(ap) > 6 else 0
+
+ak = os.environ["AWS_ACCESS_KEY_ID"]
+sk = os.environ["AWS_SECRET_ACCESS_KEY"]
+host = "%s.%s" % (bucket, endpoint)
+
+body = json.dumps({"importer_id": "probe",
+                   "updated_at": int(time.time()) - age,
+                   "renew_s": renew_s}).encode()
+payload_sha = hashlib.sha256(body).hexdigest()
+
+now = datetime.datetime.now(datetime.timezone.utc)
+amzdate = now.strftime("%Y%m%dT%H%M%SZ")
+datestamp = now.strftime("%Y%m%d")
+path = "/" + key
+
+canonical_headers = ("host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n"
+                     % (host, payload_sha, amzdate))
+signed_headers = "host;x-amz-content-sha256;x-amz-date"
+canonical_request = "\n".join(["PUT", path, "", canonical_headers,
+                               signed_headers, payload_sha])
+scope = "%s/%s/s3/aws4_request" % (datestamp, region)
+to_sign = "\n".join(["AWS4-HMAC-SHA256", amzdate, scope,
+                     hashlib.sha256(canonical_request.encode()).hexdigest()])
+
+
+def sign(k, m):
+    return hmac.new(k, m.encode(), hashlib.sha256).digest()
+
+
+k = sign(("AWS4" + sk).encode(), datestamp)
+k = sign(k, region)
+k = sign(k, "s3")
+k = sign(k, "aws4_request")
+signature = hmac.new(k, to_sign.encode(), hashlib.sha256).hexdigest()
+auth = ("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s"
+        % (ak, scope, signed_headers, signature))
+
+conn = http.client.HTTPSConnection(host, timeout=60)
+conn.request("PUT", path, body=body, headers={
+    "Host": host, "x-amz-date": amzdate,
+    "x-amz-content-sha256": payload_sha,
+    "Authorization": auth, "Content-Length": str(len(body)),
+})
+r = conn.getresponse()
+print("PUT %s -> HTTP %d" % (key, r.status))
+r.read()
+conn.close()
+sys.exit(0 if r.status in (200, 204) else 1)

--- a/CubeS3lvol/test/tools/s3_put_lease.py
+++ b/CubeS3lvol/test/tools/s3_put_lease.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# 探针工具：往 S3 写一个 export lease 对象，模拟另一节点的 importer 续约。
-# 复用 s3_prefix_rm.py 的 stdlib SigV4 签名（测试机没有 boto3）。
+# Probe helper: PUT an export lease object on S3, as if another node's
+# importer were renewing. Reuses s3_prefix_rm.py's stdlib SigV4 signing
+# (no boto3 on the test hosts).
 import datetime
 import hashlib
 import hmac

--- a/CubeS3lvol/test/tools/s3lvol_rpc.py
+++ b/CubeS3lvol/test/tools/s3lvol_rpc.py
@@ -47,7 +47,7 @@
 #
 #  Printing string_value *verbatim* is what makes the unwrapping transparent: the
 #  RPCs with more than a name to report put a serialised JSON document in there
-#  (rcow_get_bdev, rcow_get_decouple, rcow_get_imports, rcow_active_bdev), so
+#  (rcow_get_bdev, rcow_get_decouple, rcow_get_exports, rcow_get_imports, rcow_active_bdev), so
 #  stdout ends up carrying exactly the object or array those RPCs used to return,
 #  and callers that parse it need no change at all.
 #
@@ -74,16 +74,14 @@
 #  again is reported and does not stop the others. Exit status is 0 only if
 #  every marked-and-deletable snapshot went.
 #
-#  What this is not:
+#  A ~60s poller already completes leased exports, extra clones, and finished
+#  decouples. This command is for lease-less exports, failed destroys, and not
+#  waiting out the poller. Marks are persisted to
+#  <prefix>/meta/pending-deletes.json; a crash before that PUT forgets the
+#  intent. Withdraw a mark with rcow_cancel_pending_delete (idempotent;
+#  lvol_name required, lvs_name optional). If the poller has already submitted
+#  destroy, cancel only drops the mark and the snapshot may still go away.
 #
-#    * There is no automatic retry. Nothing on the target polls the marks; this
-#      command is the only thing that acts on them, and it has to be run.
-#    * The marks live in the target's memory only. A restart loses them, and a
-#      delete refused before the restart is then indistinguishable from one that
-#      was never asked for.
-#    * There is no way to cancel a mark other than completing the delete. A
-#      refused delete stays recorded for as long as the target runs and its
-#      lvstore stays attached (an unload drops that lvstore's marks).
 #    * The cluster deployment does not run this: Cubelet's own delete path
 #      (S3Cow.DeleteByKind) still treats a refused snapshot delete as success.
 #      This is an operator tool for the node, not a fix for that.
@@ -190,13 +188,25 @@ def _send(sock_path, timeout, method, params=None, raw=False):
 
     result = resp.get("result")
 
-    # The envelope, recognised by its exact shape: an object with those two keys
-    # and nothing else. Being that strict matters -- an RPC that happened to
-    # report a bool_value among other fields would otherwise have the rest of its
-    # answer thrown away.
+    # The envelope, recognised by its shape. The two mandatory keys, plus at most
+    # the ones listed here.
+    #
+    # Being this specific matters in both directions. rcow_delete_lvol adds
+    # "deferred" to say the delete was accepted as an intent rather than carried
+    # out, and every caller that reads the name off stdout has to keep working --
+    # so an unknown extra field cannot simply disqualify the envelope. But
+    # rcow_import_lvol answers {bool_value, string_value, mode} and its callers
+    # parse "mode" out of the whole object, so unwrapping *anything* with those
+    # two keys would throw the rest of its answer away. Hence a whitelist: new
+    # RPCs that carry real payload alongside the envelope keep arriving whole.
+    #
+    # --raw shows the whole object either way.
+    _ENVELOPE_EXTRA = {"deferred"}
     if (not raw and isinstance(result, dict)
-            and set(result) == {"bool_value", "string_value"}
-            and isinstance(result["bool_value"], bool)):
+            and {"bool_value", "string_value"} <= set(result)
+            and set(result) - {"bool_value", "string_value"} <= _ENVELOPE_EXTRA
+            and isinstance(result["bool_value"], bool)
+            and isinstance(result["string_value"], str)):
         text = result["string_value"]
         if result["bool_value"]:
             return True, text, True

--- a/docs/guide/cross-node-snapshot.md
+++ b/docs/guide/cross-node-snapshot.md
@@ -314,7 +314,13 @@ Create from the **template** (`Sandbox.create(template=tpl-…)`).
 
    A different refusal: when the volume is still an **active** NVMe-oF namespace, the delete is refused at the RPC layer (with a hint to run `rcow_deactive_bdev` first). That path does **not** record a mark — it is a precondition the caller can fix immediately, not a blocker to wait out.
 
-   Once the blocker clears (the export is released or expires, the extra clone is deleted, decouple finishes, or the volume is deactivated), you must **retry by hand** on that node:
+   A ~60s poller then completes the delete once the blocker is gone for **leased** exports (the importer stops renewing), extra clones, a finished decouple, or an export that was still publishing. It will **not** auto-complete a **lease-less** export: TTL expiry is not evidence that nobody is reading, so that case waits for a human (or `--retry-pending`). An asynchronously failed destroy is also left for an explicit retry.
+
+   Marks are persisted to `<prefix>/meta/pending-deletes.json` and restored on attach. The delete RPC returns **before** that PUT; a crash in that window forgets the intent and the delete has to be asked for again. When the blocker is one the poller can finish on its own, the reply is still success, with **`deferred: true`**. A lease-less export still returns EBUSY; the mark is recorded in both cases. Withdraw the intent with `rcow_cancel_pending_delete` (`lvol_name` required, `lvs_name` optional); it is idempotent. If the poller has already submitted destroy, cancel only drops the mark and the snapshot may still go away.
+
+   A snapshot of a volume that is still decoupling from an import keeps that external parent; `rcow_create_snapshot` then returns **`decouple_cancelled: true`**.
+
+   `--retry-pending` is still the operator tool for lease-less exports, failed destroys, and not waiting for the poller:
 
    ```sh
    # from the CubeS3lvol directory
@@ -322,7 +328,7 @@ Create from the **template** (`Sandbox.create(template=tpl-…)`).
    test/tools/s3lvol_rpc.py --retry-pending   # retry every marked snapshot that is deletable now
    ```
 
-   Limits of this mechanism: marks live **only in the s3lvol_tgt process memory** and are lost on restart or lvstore unload; there is **no automatic retry** (no background poller) and **no way to cancel** a recorded mark. The cluster delete path (Cubelet `S3Cow.DeleteByKind`) currently treats a refused snapshot delete as success and does not run `--retry-pending`, so leftover objects must be handled on the node as above. See [Retrying a refused snapshot delete](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeS3lvol/README.md#retrying-a-refused-snapshot-delete---retry-pending) in `CubeS3lvol/README.md`.
+   The cluster delete path (Cubelet `S3Cow.DeleteByKind`) currently treats a refused snapshot delete as success and does not run `--retry-pending`, so leftover objects on that path must be handled on the node as above. See [Retrying a refused snapshot delete](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeS3lvol/README.md#retrying-a-refused-snapshot-delete---retry-pending) in `CubeS3lvol/README.md`.
 
 2. **DB / filesystem layout changed vs pre-0.7.0; migration is tested from 0.6.0 only.** Table and on-disk layout differ from versions before 0.7.0. The new release adapts older data for cleanup, but that path is **tested against 0.6.0**. If adaptation fails, delete leftover snapshot files and the matching DB rows by hand.
 

--- a/docs/zh/guide/cross-node-snapshot.md
+++ b/docs/zh/guide/cross-node-snapshot.md
@@ -360,8 +360,21 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
    `rcow_deactive_bdev`），这一路径**不会**记录标记——它是调用方自己可以立即纠正的前置条件，而不是需要
    等待的阻塞原因。
 
-   阻塞原因解除后（导出被释放或过期、多余 clone 被删除、decouple 结束、卷被 deactivate），需要在该节点上
-   **手动重试**：
+   之后约 60 秒一次的 poller 会在阻塞消失后自动完成删除，覆盖：**带 lease 的 export**（importer 停止续约、
+   lease 变 stale）、多余 clone、已经结束的 decouple、以及仍在 publish 的 export。**没有 lease 的
+   export 不会自动删**：TTL 到期只说明时间过了，不能证明没有人在读，这类标记要等人工（或 `--retry-pending`）
+   决定。异步 destroy 已经失败的，也不会每分钟重试。
+
+   标记会写入 `<prefix>/meta/pending-deletes.json`，下次 attach 时恢复。删除 RPC **先返回、再 PUT**；若在
+   窗口内崩溃，意图会丢失，需要再发一次删除。poller 能自行完成的阻塞会返回成功，并带 **`deferred: true`**。
+   **没有 lease 的 export 仍返回 EBUSY**，标记两种情况都会记下。
+   用 `rcow_cancel_pending_delete` 撤回意图（必填 `lvol_name`，可选 `lvs_name` 消歧义），该 RPC 幂等。
+   若 poller 已经提交了 destroy，cancel 只丢掉标记，快照仍可能被删掉。
+
+   对仍在从 import decouple 的卷做快照会保留外部 parent，`rcow_create_snapshot` 此时返回
+   **`decouple_cancelled: true`**。
+
+   `--retry-pending` 仍用于无 lease 的 export、失败的 destroy，以及不想等 poller 的场景：
 
    ```sh
    # 在 CubeS3lvol 目录下
@@ -369,10 +382,9 @@ cubeopscli --address 127.0.0.1 --port 3010 node list --json
    test/tools/s3lvol_rpc.py --retry-pending   # 重试所有已标记且当前可删的快照
    ```
 
-   注意该机制的边界：标记**只存在于 s3lvol_tgt 进程内存中**，进程重启或 lvstore 卸载即丢失；**没有自动
-   重试**（无后台轮询），也**无法取消**已记录的标记；并且集群侧的删除路径（Cubelet `S3Cow.DeleteByKind`）
-   目前会把被拒绝的快照删除视为成功、且不会调用 `--retry-pending`，因此这类残留对象需要按上述方式在节点上
-   处理。详见 `CubeS3lvol/README.md` 的 "Retrying a refused snapshot delete"。
+   集群侧删除路径（Cubelet `S3Cow.DeleteByKind`）目前仍把被拒绝的快照删除视为成功、且不会调用
+   `--retry-pending`，因此那条路径上的残留对象仍需按上面方式在节点上处理。详见
+   `CubeS3lvol/README.md` 的 "Retrying a refused snapshot delete"。
 
 2. **DB / FS 结构相较 0.7.0 之前版本变化较大，老数据适配仅覆盖 0.6.0**：本版本相比 0.7.0 之前的版本，
    DB 表结构与文件系统目录结构均有较大调整。新版本会对老版本的数据结构做适配，用于用户清理老数据的场景，


### PR DESCRIPTION
## Summary
- Complete pending-delete with a poller, export reaper, lease-renewal floor, and `rcow_get_exports` (fixes #1634). Allow shared OpenSSL when `libssl.a` is missing so local `make` works on RHEL/TencentOS.
- Add manifest v3 / chained derived exports, snapshot cancel+converge, Cubelet-facing RPC logging, and a dataplane suite that drives cubecow's `rcow_*` order (including not-found `get_bdev`).
- Speed same-bucket restore: decouple via CopyObject ingest (prefetch + chunk-map bind), parse `CopyObjectResult` instead of HEADing every cluster, and wait for a live nvme node after reactivate. Ingest `end` now waits for in-flight binds so `s3_ingest` is not freed while journal callbacks still hold slot pointers.

## Test plan
- [x] `run_export_test.sh` (194 passed) — same-bucket import + background decouple
- [x] `run_decouple_queue_test.sh` (22 passed)
- [x] `run_agent_template_test.sh` (33 passed)
- [x] `run_cubecow_client_test.sh` (27 passed)
- [ ] Remaining CubeS3lvol dataplane suites as environment allows (`make check` in `CubeS3lvol/`)

Assisted-by: Cursor:Grok-4.6

Made with [Cursor](https://cursor.com)