### PR TITLE
fix(snapshot): allow plugin volumes in cross-node restores

### DIFF
--- a/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
@@ -480,7 +480,7 @@ func dealCubeboxCreateReqWithTemplateCenter(ctx context.Context, templateID stri
 		templatecenter.ReportResolveStageMetric(ctx, constants.ActionTemplateResolveBind, time.Since(bindStart))
 	}()
 	if strings.EqualFold(templateKind, templatecenter.TemplateKindSnapshot) {
-		pinToOrigin := snapshotRestoreHasExternalMount(reqInOut, templateReq)
+		pinToOrigin := snapshotRestoreHasRawHostMount(reqInOut, templateReq)
 		if err := bindSnapshotCreateReplicaWithHostMount(ctx, templateID, reqInOut, pinToOrigin); err != nil {
 			return err
 		}
@@ -537,11 +537,9 @@ func dealCubeboxCreateReqWithTemplateCenter(ctx context.Context, templateID stri
 	return nil
 }
 
-func snapshotRestoreHasExternalMount(req, templateReq *types.CreateCubeSandboxReq) bool {
+func snapshotRestoreHasRawHostMount(req, templateReq *types.CreateCubeSandboxReq) bool {
 	return sandbox.CreateRequestHasHostMount(req) ||
-		sandbox.CreateRequestHasHostMount(templateReq) ||
-		sandbox.CreateRequestHasPluginVolume(req) ||
-		sandbox.CreateRequestHasPluginVolume(templateReq)
+		sandbox.CreateRequestHasHostMount(templateReq)
 }
 
 func skipTemplateLocalityReady(ctx context.Context, templateID string) bool {
@@ -596,8 +594,7 @@ func bindSnapshotCreateReplica(ctx context.Context, snapshotID string, reqInOut 
 		ctx,
 		snapshotID,
 		reqInOut,
-		sandbox.CreateRequestHasHostMount(reqInOut) ||
-			sandbox.CreateRequestHasPluginVolume(reqInOut),
+		sandbox.CreateRequestHasHostMount(reqInOut),
 	)
 }
 
@@ -612,7 +609,7 @@ func bindSnapshotCreateReplicaWithHostMount(ctx context.Context, snapshotID stri
 		return err
 	}
 	if pinToOrigin {
-		return fmt.Errorf("snapshot %s with external mount requires origin restore metadata", snapshotID)
+		return fmt.Errorf("snapshot %s with host mount requires origin restore metadata", snapshotID)
 	}
 	return bindSnapshotCreateReplicaLocal(ctx, snapshotID, reqInOut)
 }

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
@@ -436,15 +436,13 @@ func TestBindSnapshotCreateReplicaPinsRawHostMountToOrigin(t *testing.T) {
 	assert.Empty(t, req.Annotations[constants.CubeAnnotationSnapshotAllowNonLocal])
 }
 
-func TestBindSnapshotCreateReplicaPinsPluginVolumeToOrigin(t *testing.T) {
+func TestBindSnapshotCreateReplicaAllowsPluginVolumeCrossNode(t *testing.T) {
 	stubSnapshotReadyForNewUse(t)
 	origSource := getSnapshotRestoreSourceFn
 	origDecide := decideRestorePlacementFn
-	origReplica := resolveSnapshotReadyReplicaFn
 	t.Cleanup(func() {
 		getSnapshotRestoreSourceFn = origSource
 		decideRestorePlacementFn = origDecide
-		resolveSnapshotReadyReplicaFn = origReplica
 	})
 	getSnapshotRestoreSourceFn = func(context.Context, string) (*templatecenter.RestoreSource, error) {
 		return &templatecenter.RestoreSource{
@@ -453,11 +451,8 @@ func TestBindSnapshotCreateReplicaPinsPluginVolumeToOrigin(t *testing.T) {
 		}, nil
 	}
 	decideRestorePlacementFn = func(_ context.Context, in restoreplace.Input) (*restoreplace.Placement, error) {
-		assert.True(t, in.PinToOrigin)
-		return &restoreplace.Placement{NodeID: "node-a", NodeIP: "10.0.0.1"}, nil
-	}
-	resolveSnapshotReadyReplicaFn = func(context.Context, string, string) (templatecenter.ReplicaStatus, error) {
-		return templatecenter.ReplicaStatus{NodeID: "node-a"}, nil
+		assert.False(t, in.PinToOrigin)
+		return &restoreplace.Placement{NodeID: "node-b", NodeIP: "10.0.0.2", CrossNode: true}, nil
 	}
 	req := &types.CreateCubeSandboxReq{
 		Annotations: map[string]string{
@@ -467,21 +462,22 @@ func TestBindSnapshotCreateReplicaPinsPluginVolumeToOrigin(t *testing.T) {
 	}
 
 	require.NoError(t, bindSnapshotCreateReplica(context.Background(), "snap-1", req))
-	assert.Equal(t, []string{"node-a"}, req.DistributionScope)
-	assert.Empty(t, req.Annotations[constants.CubeAnnotationSnapshotAllowNonLocal])
+	assert.Equal(t, []string{"node-b"}, req.DistributionScope)
+	assert.Equal(t, "true", req.Annotations[constants.CubeAnnotationSnapshotAllowNonLocal])
+	assert.Equal(t, "true", req.Annotations[constants.CubeAnnotationSnapshotCrossNode])
 }
 
-func TestSnapshotRestoreHasExternalMountFromStoredTemplate(t *testing.T) {
+func TestSnapshotRestorePinsOnlyRawHostMountFromStoredTemplate(t *testing.T) {
 	req := &types.CreateCubeSandboxReq{Annotations: map[string]string{}}
 	templateReq := &types.CreateCubeSandboxReq{Annotations: map[string]string{
 		sandbox.AnnotationHostDirMount: `[{"hostPath":"/data/shared","mountPath":"/mnt"}]`,
 	}}
 
-	assert.True(t, snapshotRestoreHasExternalMount(req, templateReq))
+	assert.True(t, snapshotRestoreHasRawHostMount(req, templateReq))
 	templateReq.Annotations = map[string]string{
 		sandbox.AnnotationPluginVolumeMounts: `[{"name":"data","container_path":"/mnt"}]`,
 	}
-	assert.True(t, snapshotRestoreHasExternalMount(req, templateReq))
+	assert.False(t, snapshotRestoreHasRawHostMount(req, templateReq))
 }
 
 func TestBindSnapshotCreateReplicaHostMountFailsWithoutOriginMetadata(t *testing.T) {
@@ -505,7 +501,7 @@ func TestBindSnapshotCreateReplicaHostMountFailsWithoutOriginMetadata(t *testing
 
 	err := bindSnapshotCreateReplica(context.Background(), "snap-1", req)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "requires origin restore metadata")
+	assert.Contains(t, err.Error(), "with host mount requires origin restore metadata")
 }
 
 func TestBindSnapshotCreateReplicaKeepsOriginWhenPlacementSaysOrigin(t *testing.T) {

--- a/CubeMaster/pkg/service/sandbox/hostdir_mount.go
+++ b/CubeMaster/pkg/service/sandbox/hostdir_mount.go
@@ -231,28 +231,6 @@ type pluginVolumeMountEntry struct {
 	Readonly      bool   `json:"readonly,omitempty"`
 }
 
-// CreateRequestHasPluginVolume reports whether a create request depends on a
-// managed plugin volume. Reference-only snapshots use this to stay on their
-// origin node until drivers can declare portability and topology.
-func CreateRequestHasPluginVolume(req *types.CreateCubeSandboxReq) bool {
-	if req == nil {
-		return false
-	}
-	for _, key := range []string{AnnotationPluginVolumeMounts, AnnotationPluginVolumeSources} {
-		raw := strings.TrimSpace(req.Annotations[key])
-		if raw != "" && raw != "[]" && !strings.EqualFold(raw, "null") {
-			return true
-		}
-	}
-	for _, volume := range req.Volumes {
-		if volume != nil && volume.Name != "" &&
-			(volume.VolumeSource == nil || volume.VolumeSource.PluginVolume != nil) {
-			return true
-		}
-	}
-	return false
-}
-
 // injectPluginVolumeMounts reads the "plugin-volume-mounts" annotation and
 // ensures the corresponding VolumeMounts exist on every container.
 // This is the counterpart to CubeAPI's annotation-based forwarding of

--- a/CubeMaster/pkg/service/sandbox/hostdir_mount_test.go
+++ b/CubeMaster/pkg/service/sandbox/hostdir_mount_test.go
@@ -225,19 +225,6 @@ func TestInjectPluginVolumeMountsRejectsConflictingStoredMount(t *testing.T) {
 	assert.Contains(t, err.Error(), "conflicts")
 }
 
-func TestCreateRequestHasPluginVolume(t *testing.T) {
-	assert.False(t, CreateRequestHasPluginVolume(nil))
-	assert.False(t, CreateRequestHasPluginVolume(&types.CreateCubeSandboxReq{}))
-	assert.True(t, CreateRequestHasPluginVolume(&types.CreateCubeSandboxReq{
-		Annotations: map[string]string{
-			AnnotationPluginVolumeMounts: `[{"name":"dataset","container_path":"/dataset"}]`,
-		},
-	}))
-	assert.True(t, CreateRequestHasPluginVolume(&types.CreateCubeSandboxReq{
-		Volumes: []*types.Volume{{Name: "dataset"}},
-	}))
-}
-
 func TestValidateHostPath(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Ref #1599

Align snapshot restore placement with pause/resume behavior by pinning only raw host mounts to the origin node.