### PR TITLE
ci(cubelet): run the full cubelet unit test set in CI

### DIFF
--- a/.claude/skills/run-dev/SKILL.md
+++ b/.claude/skills/run-dev/SKILL.md
@@ -84,8 +84,9 @@ make builder-run BUILDER_CMD='cd /workspace/agent && make test'
 # CubeMaster tests (Go) — needs Redis at minimum
 make builder-run BUILDER_CMD='cd /workspace/CubeMaster && make proto && CI=true CUBE_MASTER_CONFIG_PATH=/workspace/CubeMaster/test/conf.yaml go test -short ./api/... ./pkg/...'
 
-# Cubelet tests (Go)
-make builder-run BUILDER_CMD='cd /workspace/Cubelet && make proto && go test -short ./pkg/...'
+# Cubelet tests (Go) — full self-contained set (all packages except api/ and
+# integration/); root/host-capability tests probe and skip themselves
+make cubelet-test
 
 # CubeCoW native tests (Go + CGO, needs cubecow SDK built)
 make cubecow-test-native

--- a/.github/workflows/unit-test-check.yml
+++ b/.github/workflows/unit-test-check.yml
@@ -203,8 +203,9 @@ jobs:
                   add_component "cubelet"
                   ;;
                 CubeNet/*)
-                  # Embedded network runtime lives under Cubelet; CubeNet eBPF
-                  # helper changes still need the cubelet test set.
+                  # The embedded network runtime lives under
+                  # Cubelet/network/runtime and is exercised by cubelet-test,
+                  # so CubeNet eBPF helper changes re-run the cubelet test set.
                   add_component "cubelet"
                   ;;
                 pkgs/CubeLog/*)
@@ -297,7 +298,7 @@ jobs:
                     elif . == "cubelog" then "cubelog-test"
                     elif . == "cubedb" then "cubedb-test"
                     elif . == "cube-lifecycle-manager" then "cube-lifecycle-manager-test"
-                    elif . == "cubelet" then "cubelet-pkg-test"
+                    elif . == "cubelet" then "cubelet-test"
                     elif . == "cubevs" then "cubevs-test"
                     elif . == "agent" then "agent-test"
                     elif . == "hypervisor" then "hypervisor-test"

--- a/Cubelet/Makefile
+++ b/Cubelet/Makefile
@@ -34,12 +34,10 @@ PKG=github.com/tencentcloud/CubeSandbox/Cubelet/pkg
 
 PWD = $(shell pwd)
 
-# COVERAGE_PACKAGES is the coverage we care about.
+# COVERAGE_PACKAGES excludes generated api/ code and integration/ (needs a
+# live cluster); everything else is unit-testable in the builder.
 COVERAGE_PACKAGES=$(shell go list ./... \
 	| grep -v github.com/tencentcloud/CubeSandbox/Cubelet/api \
-	| grep -v github.com/tencentcloud/CubeSandbox/Cubelet/cmd \
-	| grep -v github.com/tencentcloud/CubeSandbox/Cubelet/shimlog \
-	| grep -v github.com/tencentcloud/CubeSandbox/Cubelet/runtime \
 	| grep -v /integration)
 
 # Version — injected at build time via ldflags.

--- a/Cubelet/plugins/snapshots/overlay/patchoverlay/overlay_test.go
+++ b/Cubelet/plugins/snapshots/overlay/patchoverlay/overlay_test.go
@@ -31,7 +31,7 @@ func RequiresRoot(t testing.TB) {
 		return
 	}
 	if os.Getuid() != 0 {
-		t.Error("This test must be run as root.")
+		t.Skip("skipping test that requires root")
 	}
 }
 

--- a/Cubelet/services/cubebox/probe_test.go
+++ b/Cubelet/services/cubebox/probe_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/ret"
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/telnet"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/workflow"
 	"github.com/tencentcloud/CubeSandbox/pkgs/proto/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/pkgs/proto/services/errorcode/v1"
@@ -35,6 +36,26 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+// requirePing skips the test when ICMP ping is not usable in this environment,
+// e.g. unprivileged containers without CAP_NET_RAW / ping_group_range.
+func requirePing(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ch := telnet.Telnet(ctx, &telnet.ProbeConfig{
+		Addr:             "127.0.0.1",
+		Timeout:          2 * time.Second,
+		Period:           100 * time.Millisecond,
+		SuccessThreshold: 1,
+		FailureThreshold: 3,
+		ProbeTimeout:     500 * time.Millisecond,
+		Action:           telnet.ActionPing,
+	})
+	if err := <-ch; err != nil {
+		t.Skipf("ping not available in this environment: %v", err)
+	}
 }
 
 func TestProbeErrIp(t *testing.T) {
@@ -734,6 +755,7 @@ func TestProbeTimeoutMsWithHttpProbe(t *testing.T) {
 }
 
 func TestProbeTimeoutMsWithPing(t *testing.T) {
+	requirePing(t)
 	testHost := "127.0.0.1"
 
 	tests := []struct {
@@ -1017,6 +1039,7 @@ func TestProbeConcurrent(t *testing.T) {
 }
 
 func TestProbeConcurrentMixed(t *testing.T) {
+	requirePing(t)
 
 	httpPort := 9100
 	mux := http.NewServeMux()

--- a/Cubelet/services/cubebox/probe_test.go
+++ b/Cubelet/services/cubebox/probe_test.go
@@ -38,10 +38,10 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
 
-// requirePing skips the test when ICMP ping is not usable in this environment,
-// e.g. unprivileged containers without CAP_NET_RAW / ping_group_range.
-func requirePing(t *testing.T) {
-	t.Helper()
+// pingAvailable reports whether ICMP ping works in this environment. Ping
+// needs CAP_NET_RAW or a permissive ping_group_range, which unprivileged
+// containers (e.g. the CI builder) usually lack.
+func pingAvailable() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	ch := telnet.Telnet(ctx, &telnet.ProbeConfig{
@@ -53,8 +53,14 @@ func requirePing(t *testing.T) {
 		ProbeTimeout:     500 * time.Millisecond,
 		Action:           telnet.ActionPing,
 	})
-	if err := <-ch; err != nil {
-		t.Skipf("ping not available in this environment: %v", err)
+	return <-ch == nil
+}
+
+// requirePing skips ping-only tests when ping is unavailable.
+func requirePing(t *testing.T) {
+	t.Helper()
+	if !pingAvailable() {
+		t.Skip("ping not available in this environment")
 	}
 }
 
@@ -1039,7 +1045,7 @@ func TestProbeConcurrent(t *testing.T) {
 }
 
 func TestProbeConcurrentMixed(t *testing.T) {
-	requirePing(t)
+	pingOK := pingAvailable()
 
 	httpPort := 9100
 	mux := http.NewServeMux()
@@ -1061,63 +1067,55 @@ func TestProbeConcurrentMixed(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 
+	tcpHandler := func() *cubebox.ProbeHandler {
+		return &cubebox.ProbeHandler{
+			TcpSocket: &cubebox.TCPSocketAction{
+				Port: int32(tcpPort),
+			},
+		}
+	}
+	// probeHandlerFor rotates HTTP/TCP/Ping across goroutines. Where ping is
+	// unavailable the ping slot degrades to TCP, so the mixed-concurrency
+	// assertion still exercises the probe types this environment supports.
+	probeHandlerFor := func(index int) *cubebox.ProbeHandler {
+		switch index % 3 {
+		case 0:
+			return &cubebox.ProbeHandler{
+				HttpGet: &cubebox.HTTPGetAction{
+					Port: int32(httpPort),
+					Path: pointer.String("/health"),
+				},
+			}
+		case 1:
+			return tcpHandler()
+		case 2:
+			if pingOK {
+				return &cubebox.ProbeHandler{
+					Ping: &cubebox.PingAction{
+						Udp: false,
+					},
+				}
+			}
+			return tcpHandler()
+		}
+		return nil
+	}
+
 	concurrentCount := 15
 	errCh := make(chan error, concurrentCount)
 
 	for i := 0; i < concurrentCount; i++ {
 		go func(index int) {
-			var cnt *cubebox.ContainerConfig
-
-			switch index % 3 {
-			case 0:
-				cnt = &cubebox.ContainerConfig{
-					Probe: &cubebox.Probe{
-						InitialDelayMs:   0,
-						TimeoutMs:        200,
-						PeriodMs:         10,
-						SuccessThreshold: 1,
-						FailureThreshold: 1,
-						ProbeTimeoutMs:   50,
-						ProbeHandler: &cubebox.ProbeHandler{
-							HttpGet: &cubebox.HTTPGetAction{
-								Port: int32(httpPort),
-								Path: pointer.String("/health"),
-							},
-						},
-					},
-				}
-			case 1:
-				cnt = &cubebox.ContainerConfig{
-					Probe: &cubebox.Probe{
-						InitialDelayMs:   0,
-						TimeoutMs:        200,
-						PeriodMs:         10,
-						SuccessThreshold: 1,
-						FailureThreshold: 1,
-						ProbeTimeoutMs:   50,
-						ProbeHandler: &cubebox.ProbeHandler{
-							TcpSocket: &cubebox.TCPSocketAction{
-								Port: int32(tcpPort),
-							},
-						},
-					},
-				}
-			case 2:
-				cnt = &cubebox.ContainerConfig{
-					Probe: &cubebox.Probe{
-						InitialDelayMs:   0,
-						TimeoutMs:        200,
-						PeriodMs:         10,
-						SuccessThreshold: 1,
-						FailureThreshold: 1,
-						ProbeTimeoutMs:   50,
-						ProbeHandler: &cubebox.ProbeHandler{
-							Ping: &cubebox.PingAction{
-								Udp: false,
-							},
-						},
-					},
-				}
+			cnt := &cubebox.ContainerConfig{
+				Probe: &cubebox.Probe{
+					InitialDelayMs:   0,
+					TimeoutMs:        200,
+					PeriodMs:         10,
+					SuccessThreshold: 1,
+					FailureThreshold: 1,
+					ProbeTimeoutMs:   50,
+					ProbeHandler:     probeHandlerFor(index),
+				},
 			}
 
 			req := &cubebox.RunCubeSandboxRequest{

--- a/Cubelet/services/cubebox/release_paused_resources_test.go
+++ b/Cubelet/services/cubebox/release_paused_resources_test.go
@@ -166,10 +166,9 @@ func TestScaleInt64(t *testing.T) {
 	assert.Equal(t, int64(0), scaleInt64(1000, 0))
 	assert.Equal(t, int64(1000), scaleInt64(1000, 1))
 	assert.Equal(t, int64(7), scaleInt64(10, 0.75), "truncates toward zero")
-	// Guard the load-bearing contract that callers must pass a clamped factor:
-	// a non-finite factor collapses int64(v*NaN) to math.MinInt64, which is why
-	// clampRatio sanitises the ratio before it ever reaches scaleInt64.
-	assert.Equal(t, int64(math.MinInt64), scaleInt64(4096, math.NaN()))
+	// Callers must pass a clamped factor: int64(v*NaN) is architecture-specific
+	// (MinInt64 on amd64, 0 on arm64), so no cross-arch assertion is possible
+	// here. The contract is guarded by TestClampRatio's NaN/Inf cases instead.
 }
 
 func TestAdmitResumeNoOpWhenPolicyDisabled(t *testing.T) {

--- a/Cubelet/storage/local_test.go
+++ b/Cubelet/storage/local_test.go
@@ -72,6 +72,7 @@ func probeReflink(dir string) error {
 }
 
 func TestParam(t *testing.T) {
+	requireRoot(t)
 	cfg := makeTestConfig(t)
 
 	s := &local{}
@@ -92,6 +93,7 @@ func TestParam(t *testing.T) {
 }
 
 func TestCreateDestroy(t *testing.T) {
+	requireRoot(t)
 	cfg := makeTestConfig(t)
 
 	s := &local{}
@@ -145,6 +147,7 @@ func TestCreateDestroy(t *testing.T) {
 	assert.Error(t, s.Destroy(ctx, nil))
 }
 func TestCreateDestroyInvalidVolume(t *testing.T) {
+	requireRoot(t)
 	cfg := makeTestConfig(t)
 
 	s := &local{}
@@ -454,6 +457,7 @@ func (m *fakeCowVolumeManager) GetMetrics(ctx context.Context) (map[string]uint6
 }
 
 func TestCleanupTemplateLocalDataIsIdempotent(t *testing.T) {
+	requireRoot(t)
 	cfg := makeTestConfig(t)
 
 	s := &local{}
@@ -502,6 +506,7 @@ func TestCleanupTemplateLocalDataIsIdempotent(t *testing.T) {
 }
 
 func TestCleanupTemplateLocalDataRemovesSnapIDParentDir(t *testing.T) {
+	requireRoot(t)
 	cfg := makeTestConfig(t)
 
 	s := &local{}
@@ -530,6 +535,7 @@ func TestCleanupTemplateLocalDataRemovesSnapIDParentDir(t *testing.T) {
 }
 
 func TestCreateWithTimeoutCtx(t *testing.T) {
+	requireRoot(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	time.Sleep(2 * time.Millisecond)
@@ -561,6 +567,7 @@ func TestCreateWithTimeoutCtx(t *testing.T) {
 }
 
 func TestCreateWithInvalidParam(t *testing.T) {
+	requireRoot(t)
 	ctx := context.Background()
 
 	s := &local{}
@@ -733,6 +740,7 @@ func TestSnapCreateCubebox(t *testing.T) {
 
 func TestCreateCubeboxBySnap(t *testing.T) {
 
+	requireRoot(t)
 	cfg := makeTestConfig(t)
 
 	s := &local{}
@@ -821,6 +829,7 @@ func TestCreateCubeboxBySnap(t *testing.T) {
 
 func TestInit(t *testing.T) {
 
+	requireRoot(t)
 	cfg := makeTestConfig(t)
 
 	s := &local{}

--- a/Cubelet/storage/local_test.go
+++ b/Cubelet/storage/local_test.go
@@ -617,14 +617,6 @@ func TestCreateWithInvalidParam(t *testing.T) {
 
 }
 
-func TestMain(m *testing.M) {
-	if os.Getenv("CI") != "" {
-		fmt.Println("Skipping testing in CI environment")
-		return
-	}
-	m.Run()
-}
-
 func TestPollImmediateInfiniteWithContext(t *testing.T) {
 	timeout := 5 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/Cubelet/storage/shell_test.go
+++ b/Cubelet/storage/shell_test.go
@@ -16,7 +16,18 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 )
 
+// requireRoot skips tests that format and mount ext4 images, which need root
+// (the builder container runs tests as the host UID, where mount(2) fails
+// with "only root can do that").
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Getuid() != 0 {
+		t.Skip("skipping test that requires root (mkfs/mount)")
+	}
+}
+
 func TestNewExt4BaseRaw(t *testing.T) {
+	requireRoot(t)
 	testDir := t.TempDir()
 
 	filePath := filepath.Join(testDir, "base.raw")
@@ -26,6 +37,7 @@ func TestNewExt4BaseRaw(t *testing.T) {
 }
 
 func TestNewExt4RawByCopy(t *testing.T) {
+	requireRoot(t)
 	testDir := t.TempDir()
 
 	fmt.Println(testDir)
@@ -52,6 +64,7 @@ func TestNewExt4RawByCopy(t *testing.T) {
 
 func TestNewExt4RawByReflinkCopy(t *testing.T) {
 	utils.SkipCI(t)
+	requireRoot(t)
 
 	testDir := t.TempDir()
 

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,6 @@ help:
 	@printf "  cubedb-test   Run CubeDB unit tests on the host\n"
 	@printf "  proto-test    Run pkgs/proto unit tests on the host\n"
 	@printf "  cube-lifecycle-manager-test Run cube-lifecycle-manager unit tests in Docker\n"
-	@printf "  cubelet-pkg-test Run Cubelet ./pkg/... unit tests in Docker (no coverage)\n"
 	@printf "  agent-test    Run cube-agent unit tests in Docker\n"
 	@printf "  hypervisor-test Run hypervisor --lib --bins unit tests in Docker\n"
 	@printf "  guest-kernel  Build guest kernel vmlinux/Image (KERNEL_SRC=...; native or cross x86_64<->aarch64)\n"
@@ -470,9 +469,11 @@ cube-volume-cos-rpc-test: builder-image
 cubemaster-test: builder-image
 	$(MAKE) builder-run BUILDER_CMD='cd /workspace/CubeMaster && go mod download && make test'
 
+# cubecow-sdk (CGO) and cubevs's generated BPF code are build prerequisites
+# for several Cubelet packages.
 .PHONY: cubelet-test
 cubelet-test: builder-image
-	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk && cd /workspace/CubeNet/cubevs && make gen && cd /workspace/Cubelet && go mod download && make test'
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk && cd /workspace/CubeNet/cubevs && make gen && cd /workspace/Cubelet && go mod download && make proto && make test'
 
 .PHONY: cube-proxy-test
 cube-proxy-test:
@@ -509,14 +510,6 @@ proto-test:
 .PHONY: cube-lifecycle-manager-test
 cube-lifecycle-manager-test: builder-image
 	$(MAKE) builder-run BUILDER_CMD='cd /workspace/cube-lifecycle-manager && go mod download && go test ./...'
-
-# cubelet-pkg-test bypasses cubelet-test: that target runs `go test
-# -coverprofile`, and the builder's Go toolchain lacks the `covdata` tool, so
-# any coverage build fails. Run only ./pkg/... with -short (skips the
-# Redis/KVM-dependent cases), which is self-contained in the builder.
-.PHONY: cubelet-pkg-test
-cubelet-pkg-test: builder-image
-	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk && cd /workspace/Cubelet && go mod download && make proto && go test -short ./pkg/...'
 
 # cubevs-test runs the CubeNet/cubevs module's own unit tests (dataplane policy,
 # DNS learning, migration, dump, classify), which the cubelet targets never

--- a/tests/unittest/run.sh
+++ b/tests/unittest/run.sh
@@ -12,7 +12,7 @@
 #
 # By default it runs only the self-contained components (the green gate) and
 # skips "gated" components that need a live database or a full VM. Naming a
-# gated component explicitly (e.g. `run.sh cubelet`) forces it to run.
+# gated component explicitly (e.g. `run.sh hypervisor-kvm`) forces it to run.
 #
 # Usage:
 #   tests/unittest/run.sh                 # run the default (self-contained) gate
@@ -76,10 +76,6 @@ cd "$REPO_ROOT"
 # NO_TESTS: "name|reason" — printed as an explicit skip so the absence of unit
 #   tests is visible rather than silently missing from the sweep.
 
-# cubelet does NOT use `make cubelet-test`: that target runs `go test
-# -coverprofile`, and the builder's Go toolchain lacks the `covdata` tool, so
-# any coverage build fails. Bypass coverage with a direct `go test` over the
-# same package set (`-short` skips the Redis/KVM-dependent cases).
 WITH_TESTS=(
 	"cubeops|Go|0|make cubeops-test"
 	# -gcflags=all=-l disables inlining, which is REQUIRED by the gomonkey-based
@@ -89,16 +85,10 @@ WITH_TESTS=(
 	# flaky "template store is not initialized" failures). The repo already uses
 	# this flag for the integration tests (CubeMaster/Makefile testlocal/testtt).
 	"cubemaster|Go|0|make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go mod download && make proto && if [ -f test/conf.yaml ]; then export CUBE_MASTER_CONFIG_PATH=/workspace/CubeMaster/test/conf.yaml; fi && CI=true go test -short -gcflags=all=-l -timeout=20m ./api/... ./pkg/...'"
-	# cubelet-network: the standalone network-agent module was removed in #1285 and
-	# folded into Cubelet/network/runtime (NetworkController). Its tests moved there
-	# and need the generated CubeNet/cubevs code but no cubecow/CGO, so build cubevs
-	# then run just the runtime package rather than the whole Cubelet suite.
-	"cubelet-network|Go|0|make builder-run BUILDER_CMD='cd /workspace/CubeNet/cubevs && make gen && cd /workspace/Cubelet && go mod download && go test ./network/runtime/...'"
 	# cubevs: the CubeNet/cubevs module's OWN unit tests (dataplane policy, DNS
-	# learning, migration, dump, classify). cubelet-network builds cubevs's
-	# generated code but runs Cubelet's tests, so these never ran. cubevs-test
-	# regenerates the BPF objects (make gen) and runs the full module set in a
-	# privileged root builder (eBPF load + bpffs mount need the privilege).
+	# learning, migration, dump, classify). cubevs-test regenerates the BPF
+	# objects (make gen) and runs the full module set in a privileged root
+	# builder (eBPF load + bpffs mount need the privilege).
 	"cubevs|Go|0|make cubevs-test"
 	"cubecow|Go+CGO|0|make cubecow-test-native"
 	"cube-lifecycle-manager|Go|0|make builder-run BUILDER_CMD='cd /workspace/cube-lifecycle-manager && go mod download && go test ./...'"
@@ -111,10 +101,8 @@ WITH_TESTS=(
 	# toolchain is sufficient and skipping the container is faster.
 	"cubelog|Go|0|cd pkgs/CubeLog && go test -short ./..."
 	"cubedb|Go|0|cd pkgs/cubedb && go mod download && go test ./..."
-	# cubelet runs only ./pkg/... here; the cgroupfs/host-cap-dependent tests
-	# live under ./plugins/... and ./services/... and are not in this set, so
-	# the pkg tests are self-contained in the builder.
-	"cubelet|Go|0|make builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk && cd /workspace/Cubelet && go mod download && make proto && go test -short ./pkg/...'"
+	# Same entry point as CI (unit-test-check).
+	"cubelet|Go|0|make cubelet-test"
 	# Only unit tests (--lib --bins) run here; the tests/integration.rs target
 	# needs a full VM (OS disk images, sudo/ip networking, VFIO, windows guest)
 	# and is excluded so `run.sh hypervisor` exercises the self-contained tests.


### PR DESCRIPTION
## Summary

CI and the local unit-test gate (`tests/unittest/run.sh`) previously exercised Cubelet unit tests only under `./pkg/...`, via the `cubelet-pkg-test` make target — roughly a third of the test tree. The documented reason for not using `make cubelet-test` (coverage builds failing in the builder for lack of the `covdata` tool) no longer holds: `-coverprofile` runs fine on the current builder toolchain.

## Changes

- Point the `cubelet` entry in `.github/workflows/unit-test-check.yml` at `make cubelet-test`.
- Run every Cubelet package except the generated `api/` code and `integration/`; `COVERAGE_PACKAGES` drops the stale exclusions of `cmd/`, `shimlog/` and `*runtime*`, so the embedded network runtime is exercised as well.
- Make privilege-dependent tests skip instead of failing in the unprivileged builder:
  - `RequiresRoot` now calls `t.Skip` instead of `t.Error`.
  - Storage tests that run `mkfs`/`mount` skip when not running as root (`requireRoot`).
  - Probe tests that need ICMP ping skip when ping is unavailable (`requirePing`).
- Remove the `cubelet-pkg-test` and local-only `cubelet-network` targets, align `run.sh` and the `run-dev` skill doc with the single CI entry point, and drop stale comments.

## Why

A green `Test Cubelet` job previously did not mean the whole Cubelet suite ran — only `pkg/` was guarded. After this change the CI gate covers all non-generated, non-integration packages, and capability-gated tests cleanly skip where they cannot run, so the set stays green in the unprivileged CI builder while still running for real where privileges exist.
