### PR TITLE
fix(docs): preserve diagnostics for custom image envd smoke tests

### DIFF
--- a/docs/guide/tutorials/bring-your-own-image.md
+++ b/docs/guide/tutorials/bring-your-own-image.md
@@ -206,29 +206,58 @@ exec "$@"
 
 ## 5. Verifying the image locally (optional)
 
-Before creating a template you can run the same smoke test that CI runs
-on the base image:
+Before creating a template, check that the image stays running with its default startup command and that envd responds. Run the following steps in the same terminal; the host needs Docker, and the image needs `curl` and `/usr/bin/envd`.
+
+**1. Start the image.**
 
 ```bash
 IMG=my-registry.example.com/my-team/my-sandbox:v1
-cid=$(docker run -d --rm "$IMG")
+cid=$(docker create "$IMG") && docker start "$cid"
+```
 
-docker exec "$cid" curl -s -o /dev/null -w "envd /health => %{http_code}\n" \
+Continue only if both commands succeed. If creation fails, resolve the Docker error first. If startup fails, use the container ID in `$cid` to inspect the failure in step 3.
+
+**2. Check the container and envd.**
+
+```bash
+docker inspect --format '{{json .State}}' "$cid"
+```
+
+The state must show `"Status":"running"` and `"Running":true`. If it shows `exited`, go to step 3, even if `ExitCode` is `0`: the container must stay running to serve sandbox requests.
+
+```bash
+docker exec "$cid" curl -sS --noproxy '*' --connect-timeout 1 --max-time 3 \
+    -o /dev/null -w 'envd /health => %{http_code}\n' \
     http://127.0.0.1:49983/health
-# => envd /health => 204
+# Expected: envd /health => 204
 
 docker exec "$cid" /usr/bin/envd -version
 # => 2026.16
+```
 
+The health request must complete successfully and print `204`; any other HTTP code, including `200` or `500`, is a failed check. If envd is still starting, wait a few seconds and retry the health request. If it still fails, go to step 3. The version command must also succeed; compare its output with the envd version you installed (`2026.16` for the base image used above).
+
+A running container, a successful `204` response, and the expected version confirm basic local startup and envd readiness. If all checks pass, skip to step 4 to remove the test container. Then create a template and verify the SDK operations your application uses. Local checks do not exercise cluster image pulling, sandbox networking, or envd `/init`.
+
+**3. If a check fails, inspect the state and logs before removing the container.**
+
+```bash
+docker inspect --format '{{json .State}}' "$cid"
+docker logs --tail 100 "$cid"
+
+logdir=$(mktemp -d)
+docker cp "$cid":/var/log/envd.log "$logdir/envd.log" && tail -n 100 "$logdir/envd.log"
+```
+
+Use `ExitCode`, `OOMKilled`, and `Error` in the state output together with the startup logs to find the cause. `docker cp` can retrieve the envd log even when the container has stopped. If that file does not exist, check the startup output and the log path configured by your entrypoint. After collecting the diagnostics, remove the container in step 4. Fix the image, then repeat from step 1.
+
+**4. Clean up after verification or troubleshooting.**
+
+```bash
 docker rm -f "$cid"
 ```
 
-If `/health` does not reach `204` within a few seconds, inspect
-`/var/log/envd.log` inside the container:
-
-```bash
-docker exec "$cid" cat /var/log/envd.log
-```
+If you copied logs, they remain in `$logdir` for inspection and can be deleted when no longer needed.
 
 ## 6. Troubleshooting
 

--- a/docs/guide/tutorials/bring-your-own-image.md
+++ b/docs/guide/tutorials/bring-your-own-image.md
@@ -117,6 +117,10 @@ COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
 COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
      /usr/local/bin/cube-entrypoint.sh /usr/local/bin/cube-entrypoint.sh
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir fastapi uvicorn
 
 COPY app.py /srv/app.py
@@ -125,6 +129,10 @@ EXPOSE 49983 8000
 ENTRYPOINT ["/usr/local/bin/cube-entrypoint.sh"]
 CMD ["uvicorn", "app:app", "--app-dir", "/srv", "--host", "0.0.0.0", "--port", "8000"]
 ```
+
+Section 5 runs `curl` inside the container. If your base image does not
+include `curl`, install it as part of the image build before running that
+check.
 
 Build, push and template creation are identical to sections 2.2 / 2.3.
 
@@ -237,7 +245,15 @@ docker exec "$cid" /usr/bin/envd -version
 
 The health request must complete successfully and print `204`; any other HTTP code, including `200` or `500`, is a failed check. If envd is still starting, wait a few seconds and retry the health request. If it still fails, go to step 3. The version command must also succeed; compare its output with the envd version you installed (`2026.16` for the base image used above).
 
-A running container, a successful `204` response, and the expected version confirm basic local startup and envd readiness. If all checks pass, skip to step 4 to remove the test container. Then create a template and verify the SDK operations your application uses. Local checks do not exercise cluster image pulling, sandbox networking, or envd `/init`.
+Run the state check once more after both probes:
+
+```bash
+docker inspect --format '{{json .State}}' "$cid"
+```
+
+The state must still show `"Status":"running"` and `"Running":true`. If the container has exited, go to step 3 even if both probes succeeded.
+
+A running container, a successful `204` response, and the expected version confirm basic local startup and envd readiness. If the final state check also passes, skip to step 4 to remove the test container. Then create a template and verify the SDK operations your application uses. Local checks do not exercise cluster image pulling, sandbox networking, or envd `/init`.
 
 **3. If a check fails, inspect the state and logs before removing the container.**
 

--- a/docs/guide/tutorials/bring-your-own-image.md
+++ b/docs/guide/tutorials/bring-your-own-image.md
@@ -215,7 +215,7 @@ IMG=my-registry.example.com/my-team/my-sandbox:v1
 cid=$(docker create "$IMG") && docker start "$cid"
 ```
 
-Continue only if both commands succeed. If creation fails, resolve the Docker error first. If startup fails, use the container ID in `$cid` to inspect the failure in step 3.
+If `docker create` reports an error, resolve it before continuing. If `docker start` reports an error, use the container ID in `$cid` to inspect the failure in step 3. If both commands succeed, continue to step 2: a successful `docker start` does not guarantee that the container stays running.
 
 **2. Check the container and envd.**
 

--- a/docs/zh/guide/tutorials/bring-your-own-image.md
+++ b/docs/zh/guide/tutorials/bring-your-own-image.md
@@ -113,6 +113,10 @@ COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
 COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
      /usr/local/bin/cube-entrypoint.sh /usr/local/bin/cube-entrypoint.sh
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir fastapi uvicorn
 
 COPY app.py /srv/app.py
@@ -121,6 +125,9 @@ EXPOSE 49983 8000
 ENTRYPOINT ["/usr/local/bin/cube-entrypoint.sh"]
 CMD ["uvicorn", "app:app", "--app-dir", "/srv", "--host", "0.0.0.0", "--port", "8000"]
 ```
+
+第 5 节会在容器内执行 `curl`。如果你使用的基础镜像没有预装
+`curl`，请在构建镜像时先将它安装好，再执行这项检查。
 
 构建、推送、创建模板的流程和第 2.2 / 2.3 节一致。
 
@@ -228,7 +235,15 @@ docker exec "$cid" /usr/bin/envd -version
 
 探活请求必须执行成功并输出 `204`；其他 HTTP 状态码，包括 `200` 或 `500`，都不算通过。如果 envd 仍在启动，等几秒后重试探活命令；持续失败时转到第 3 步。版本命令也应成功，并确认输出与你安装的 envd 版本一致，例如上文 base 镜像的 `2026.16`。
 
-容器保持运行、探活成功返回 `204`、版本符合预期，表示基本的本地启动和 envd 就绪检查通过。全部通过后，跳到第 4 步删除测试容器，再创建模板并验证应用需要的 SDK 操作。本地检查不覆盖集群拉取镜像、sandbox 网络和 envd `/init`。
+两项探测完成后，再次检查容器状态：
+
+```bash
+docker inspect --format '{{json .State}}' "$cid"
+```
+
+状态仍应显示 `"Status":"running"` 和 `"Running":true`。如果容器已经退出，即使两项探测都成功，也应转到第 3 步排查。
+
+容器保持运行、探活成功返回 `204`、版本符合预期，表示基本的本地启动和 envd 就绪检查通过。最终状态检查也通过后，跳到第 4 步删除测试容器，再创建模板并验证应用需要的 SDK 操作。本地检查不覆盖集群拉取镜像、sandbox 网络和 envd `/init`。
 
 **3. 检查失败时，在删除容器前查看状态和日志。**
 

--- a/docs/zh/guide/tutorials/bring-your-own-image.md
+++ b/docs/zh/guide/tutorials/bring-your-own-image.md
@@ -197,27 +197,58 @@ exec "$@"
 
 ## 5. 本地验证镜像（可选）
 
-创建模板前，可以跑一遍 CI 用于验证 base 镜像的同款 smoke test：
+创建模板前, 先确认镜像使用默认启动命令时能保持运行, 且 envd 可以响应. 以下步骤请在同一个终端中执行; 宿主机需要 Docker, 镜像内需要 `curl` 和 `/usr/bin/envd`.
+
+**1. 启动镜像.**
 
 ```bash
 IMG=my-registry.example.com/my-team/my-sandbox:v1
-cid=$(docker run -d --rm "$IMG")
+cid=$(docker create "$IMG") && docker start "$cid"
+```
 
-docker exec "$cid" curl -s -o /dev/null -w "envd /health => %{http_code}\n" \
+两条命令都成功后再继续. 如果创建失败, 先处理 Docker 输出的错误; 如果启动失败, 使用 `$cid` 中的容器 ID 按第 3 步排查.
+
+**2. 检查容器状态和 envd.**
+
+```bash
+docker inspect --format '{{json .State}}' "$cid"
+```
+
+状态应显示 `"Status":"running"` 和 `"Running":true`. 如果为 `exited`, 转到第 3 步排查, 即使 `ExitCode` 是 `0` 也不能视为通过: 容器需要保持运行才能服务 sandbox 请求.
+
+```bash
+docker exec "$cid" curl -sS --noproxy '*' --connect-timeout 1 --max-time 3 \
+    -o /dev/null -w 'envd /health => %{http_code}\n' \
     http://127.0.0.1:49983/health
-# => envd /health => 204
+# 预期: envd /health => 204
 
 docker exec "$cid" /usr/bin/envd -version
 # => 2026.16
+```
 
+探活请求必须执行成功并输出 `204`; 其他 HTTP 状态码, 包括 `200` 或 `500`, 都不算通过. 如果 envd 仍在启动, 等几秒后重试探活命令; 持续失败时转到第 3 步. 版本命令也应成功, 并确认输出与你安装的 envd 版本一致, 例如上文 base 镜像的 `2026.16`.
+
+容器保持运行、探活成功返回 `204`、版本符合预期, 表示基本的本地启动和 envd 就绪检查通过. 全部通过后, 跳到第 4 步删除测试容器, 再创建模板并验证应用需要的 SDK 操作. 本地检查不覆盖集群拉取镜像、sandbox 网络和 envd `/init`.
+
+**3. 检查失败时, 先查看状态和日志, 再删除容器.**
+
+```bash
+docker inspect --format '{{json .State}}' "$cid"
+docker logs --tail 100 "$cid"
+
+logdir=$(mktemp -d)
+docker cp "$cid":/var/log/envd.log "$logdir/envd.log" && tail -n 100 "$logdir/envd.log"
+```
+
+结合状态中的 `ExitCode`、`OOMKilled`、`Error` 和启动日志定位原因. 容器已停止时, `docker cp` 仍可提取 envd 日志. 如果文件不存在, 检查启动输出及入口脚本配置的日志路径. 收集完诊断信息后, 按第 4 步删除容器. 修复镜像后, 再从第 1 步重新验证.
+
+**4. 验证或排障结束后清理容器.**
+
+```bash
 docker rm -f "$cid"
 ```
 
-如果几秒之内 `/health` 没有返回 `204`，检查容器里 envd 的日志：
-
-```bash
-docker exec "$cid" cat /var/log/envd.log
-```
+如果复制了日志, 文件会保留在 `$logdir` 中供查看, 不再需要时可自行删除.
 
 ## 6. 排错速查
 

--- a/docs/zh/guide/tutorials/bring-your-own-image.md
+++ b/docs/zh/guide/tutorials/bring-your-own-image.md
@@ -197,24 +197,24 @@ exec "$@"
 
 ## 5. 本地验证镜像（可选）
 
-创建模板前, 先确认镜像使用默认启动命令时能保持运行, 且 envd 可以响应. 以下步骤请在同一个终端中执行; 宿主机需要 Docker, 镜像内需要 `curl` 和 `/usr/bin/envd`.
+创建模板前，先确认镜像使用默认启动命令时能保持运行，且 envd 可以响应。以下步骤请在同一个终端中执行；宿主机需要 Docker，镜像内需要 `curl` 和 `/usr/bin/envd`。
 
-**1. 启动镜像.**
+**1. 启动镜像。**
 
 ```bash
 IMG=my-registry.example.com/my-team/my-sandbox:v1
 cid=$(docker create "$IMG") && docker start "$cid"
 ```
 
-两条命令都成功后再继续. 如果创建失败, 先处理 Docker 输出的错误; 如果启动失败, 使用 `$cid` 中的容器 ID 按第 3 步排查.
+如果 `docker create` 报错，先处理错误再继续。如果 `docker start` 报错，使用 `$cid` 中的容器 ID 按第 3 步排查。两条命令都成功后，继续第 2 步：`docker start` 成功不代表容器会保持运行。
 
-**2. 检查容器状态和 envd.**
+**2. 检查容器状态和 envd。**
 
 ```bash
 docker inspect --format '{{json .State}}' "$cid"
 ```
 
-状态应显示 `"Status":"running"` 和 `"Running":true`. 如果为 `exited`, 转到第 3 步排查, 即使 `ExitCode` 是 `0` 也不能视为通过: 容器需要保持运行才能服务 sandbox 请求.
+状态应显示 `"Status":"running"` 和 `"Running":true`。如果为 `exited`，转到第 3 步排查，即使 `ExitCode` 是 `0` 也不能视为通过：容器需要保持运行才能服务 sandbox 请求。
 
 ```bash
 docker exec "$cid" curl -sS --noproxy '*' --connect-timeout 1 --max-time 3 \
@@ -226,11 +226,11 @@ docker exec "$cid" /usr/bin/envd -version
 # => 2026.16
 ```
 
-探活请求必须执行成功并输出 `204`; 其他 HTTP 状态码, 包括 `200` 或 `500`, 都不算通过. 如果 envd 仍在启动, 等几秒后重试探活命令; 持续失败时转到第 3 步. 版本命令也应成功, 并确认输出与你安装的 envd 版本一致, 例如上文 base 镜像的 `2026.16`.
+探活请求必须执行成功并输出 `204`；其他 HTTP 状态码，包括 `200` 或 `500`，都不算通过。如果 envd 仍在启动，等几秒后重试探活命令；持续失败时转到第 3 步。版本命令也应成功，并确认输出与你安装的 envd 版本一致，例如上文 base 镜像的 `2026.16`。
 
-容器保持运行、探活成功返回 `204`、版本符合预期, 表示基本的本地启动和 envd 就绪检查通过. 全部通过后, 跳到第 4 步删除测试容器, 再创建模板并验证应用需要的 SDK 操作. 本地检查不覆盖集群拉取镜像、sandbox 网络和 envd `/init`.
+容器保持运行、探活成功返回 `204`、版本符合预期，表示基本的本地启动和 envd 就绪检查通过。全部通过后，跳到第 4 步删除测试容器，再创建模板并验证应用需要的 SDK 操作。本地检查不覆盖集群拉取镜像、sandbox 网络和 envd `/init`。
 
-**3. 检查失败时, 先查看状态和日志, 再删除容器.**
+**3. 检查失败时，在删除容器前查看状态和日志。**
 
 ```bash
 docker inspect --format '{{json .State}}' "$cid"
@@ -240,15 +240,15 @@ logdir=$(mktemp -d)
 docker cp "$cid":/var/log/envd.log "$logdir/envd.log" && tail -n 100 "$logdir/envd.log"
 ```
 
-结合状态中的 `ExitCode`、`OOMKilled`、`Error` 和启动日志定位原因. 容器已停止时, `docker cp` 仍可提取 envd 日志. 如果文件不存在, 检查启动输出及入口脚本配置的日志路径. 收集完诊断信息后, 按第 4 步删除容器. 修复镜像后, 再从第 1 步重新验证.
+结合状态中的 `ExitCode`、`OOMKilled`、`Error` 和启动日志定位原因。容器已停止时，`docker cp` 仍可提取 envd 日志。如果文件不存在，检查启动输出及入口脚本配置的日志路径。收集完诊断信息后，按第 4 步删除容器。修复镜像后，再从第 1 步重新验证。
 
-**4. 验证或排障结束后清理容器.**
+**4. 验证或排障结束后清理容器。**
 
 ```bash
 docker rm -f "$cid"
 ```
 
-如果复制了日志, 文件会保留在 `$logdir` 中供查看, 不再需要时可自行删除.
+如果复制了日志，文件会保留在 `$logdir` 中供查看，不再需要时可自行删除。
 
 ## 6. 排错速查
 


### PR DESCRIPTION
## Motivation

A custom image can exit immediately when its default startup command fails or finishes without keeping a foreground process alive. The BYOI tutorial starts the image with `docker run -d --rm`, so Docker can delete the container before the first health probe. Users then see `No such container`, with no exit status or logs available to explain the original failure.

The example also removes the container before the troubleshooting instructions, which use `docker exec` to read envd logs. Those instructions cannot work on a stopped or deleted container. This makes the local check least useful when users need it to diagnose an image before creating a template.

## What Changed

* Use `docker create` followed by `docker start` so startup failures leave a known container ID for inspection. Keep the container until verification or troubleshooting is complete.
* Explain the required image tools, expected running state, HTTP 204 response, and envd version. Guide users to retry during startup or inspect failures, including an early exit with code 0. Add connection and request timeouts so an unresponsive health endpoint does not leave curl waiting indefinitely, then re-check the container state before declaring the image ready.
* Show `docker inspect` and `docker logs` for exit state and startup output, and `docker cp` for retrieving envd file logs even after the container stops.
* Direct both successful checks and failed attempts through cleanup before template creation or another attempt. Apply the same workflow to both tutorial languages.

## Validation

* Reproduced the old `No such container` failure after an early exit on Linux amd64 with Docker 29.3.1.
* Verified that retained containers expose exit codes 0/42 and OOM state, and that envd file logs can be retrieved after exit using `docker cp`.
* Bash syntax checks for the documented command blocks, bilingual command consistency, and `git diff --check` passed. The documented sequence now also installs or calls out the `curl` prerequisite for slim base images and verifies the container is still running after both probes.

## Scope

Only the English and Chinese BYOI tutorials change. The instructions guide users through manually checking local startup and envd readiness before creating a template and validating their application's SDK operations.
