### PR TITLE
fix(cubelet-volume): keep detach safe when the refcount store fails

### DIFF
--- a/Cubelet/plugins/volume/manager.go
+++ b/Cubelet/plugins/volume/manager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/containerd/log"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/volume/refcount"
 )
 
@@ -170,8 +171,19 @@ func (m *Manager) Detach(ctx context.Context, req *DetachRequest) error {
 	if err != nil {
 		// Unknown driver during Detach: release ref-count and continue.
 		if rc := m.rcStore; rc != nil {
-			rr, _ := rc.Release(req.Namespace, req.VolumeID, req.SandboxID)
-			req.NodeRefLastDetach = rr.After == 0 && !rr.NotHeld
+			rr, rErr := rc.Release(req.Namespace, req.VolumeID, req.SandboxID)
+			if rErr == nil {
+				req.NodeRefLastDetach = rr.After == 0 && !rr.NotHeld
+			} else {
+				// Refcount store failure: the count is unknown; suppress
+				// the 1→0 event so CubeMaster does not incorrectly remove
+				// this node from the volume's holder list.
+				log.G(ctx).WithError(rErr).
+					WithField("driver", req.Driver).
+					WithField("volume_id", req.VolumeID).
+					WithField("sandbox_id", req.SandboxID).
+					Warn("volume: refcount release failed during unknown-driver detach; suppressing last-detach event")
+			}
 		}
 		return nil
 	}
@@ -187,13 +199,30 @@ func (m *Manager) Detach(ctx context.Context, req *DetachRequest) error {
 	if rc := m.rcStore; rc != nil {
 		rr, err := rc.Release(req.Namespace, volID, req.SandboxID)
 		if err != nil {
-			_ = err // non-fatal; don't block Destroy
-		} else if !rr.NotHeld {
-			released = true
+			// Refcount store I/O failed — the true count is unknown.
+			// Conservatively tell the plugin the volume is still held so
+			// it will NOT tear down shared host resources that other
+			// sandboxes on this node may still be using, and clear
+			// NodeRefLastDetach so CubeMaster does NOT observe a spurious
+			// 1→0 transition. Detach itself still succeeds so the caller
+			// can reclaim the per-sandbox bind. Operators must clean up
+			// the refcount store manually once the underlying I/O issue
+			// is resolved.
+			log.G(ctx).WithError(err).
+				WithField("driver", req.Driver).
+				WithField("volume_id", volID).
+				WithField("sandbox_id", req.SandboxID).
+				Warn("volume: refcount release failed; degrading to safe mode (RefCount=1)")
+			req.RefCount = 1
+			req.NodeRefLastDetach = false
+		} else {
+			if !rr.NotHeld {
+				released = true
+			}
+			req.RefCount = rr.After // 0 = last detach
+			// 1 → 0 on this node: last sandbox here stopped referencing the volume.
+			req.NodeRefLastDetach = rr.After == 0 && !rr.NotHeld
 		}
-		req.RefCount = rr.After // 0 = last detach
-		// 1 → 0 on this node: last sandbox here stopped referencing the volume.
-		req.NodeRefLastDetach = rr.After == 0 && !rr.NotHeld
 	}
 
 	if pluginErr := p.Detach(ctx, req); pluginErr != nil {

--- a/Cubelet/plugins/volume/manager_test.go
+++ b/Cubelet/plugins/volume/manager_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volume
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/volume/refcount"
+)
+
+// fakePlugin records the RefCount and NodeRefLastDetach it observes on Detach,
+// so tests can assert the Manager's ref-count bookkeeping is correct.
+type fakePlugin struct {
+	name          string
+	attachErr     error
+	detachErr     error
+	gotRefCount   int64
+	gotLastDetach bool
+	detachCalls   int
+}
+
+func (p *fakePlugin) Name() string                                 { return p.name }
+func (p *fakePlugin) PluginType() PluginType                       { return PluginTypeBuiltin }
+func (p *fakePlugin) Init(_ context.Context, _ PluginConfig) error { return nil }
+
+func (p *fakePlugin) Attach(_ context.Context, req *AttachRequest) (*AttachResult, error) {
+	if p.attachErr != nil {
+		return nil, p.attachErr
+	}
+	return &AttachResult{VolumeID: req.VolumeID, HostPath: "/tmp/" + req.VolumeID}, nil
+}
+
+func (p *fakePlugin) Detach(_ context.Context, req *DetachRequest) error {
+	p.detachCalls++
+	p.gotRefCount = req.RefCount
+	p.gotLastDetach = req.NodeRefLastDetach
+	return p.detachErr
+}
+
+func (p *fakePlugin) Close() error { return nil }
+
+func newStore(t *testing.T) (*refcount.Store, *bolt.DB) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "refcount.db")
+	db, err := bolt.Open(dbPath, 0o600, nil)
+	if err != nil {
+		t.Fatalf("open bbolt: %v", err)
+	}
+	s, err := refcount.New(db)
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("new store: %v", err)
+	}
+	return s, db
+}
+
+// When the refcount store fails on Release, Detach must:
+//   - pass RefCount=1 to the plugin (not the zero-value 0 the plugin would
+//     read as "last detach"),
+//   - clear NodeRefLastDetach so CubeMaster is not told 1→0,
+//   - still return nil so the caller can reclaim the per-sandbox bind.
+func TestDetachRefcountReleaseError(t *testing.T) {
+	store, db := newStore(t)
+	// Prime a two-holder record so a healthy Release would land on After=1.
+	if _, err := store.Acquire("ns", "vol1", "sbxA", "fake"); err != nil {
+		t.Fatalf("acquire A: %v", err)
+	}
+	if _, err := store.Acquire("ns", "vol1", "sbxB", "fake"); err != nil {
+		t.Fatalf("acquire B: %v", err)
+	}
+	// Close the underlying DB so the next Release returns an error.
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	p := &fakePlugin{name: "fake"}
+	m := &Manager{byName: map[string]VolumePlugin{}}
+	m.Register(p)
+	m.SetRefCountStore(store)
+
+	req := &DetachRequest{
+		SandboxID: "sbxA",
+		Namespace: "ns",
+		VolumeID:  "vol1",
+		Driver:    "fake",
+	}
+	if err := m.Detach(context.Background(), req); err != nil {
+		t.Fatalf("Detach returned error: %v", err)
+	}
+	if p.detachCalls != 1 {
+		t.Fatalf("plugin Detach called %d times, want 1", p.detachCalls)
+	}
+	if p.gotRefCount != 1 {
+		t.Errorf("plugin got RefCount=%d, want 1 (safe-mode fallback)", p.gotRefCount)
+	}
+	if p.gotLastDetach {
+		t.Error("plugin got NodeRefLastDetach=true, want false (suppressed on refcount error)")
+	}
+	if req.RefCount != 1 {
+		t.Errorf("req.RefCount=%d, want 1", req.RefCount)
+	}
+	if req.NodeRefLastDetach {
+		t.Error("req.NodeRefLastDetach=true, want false")
+	}
+}
+
+// Sanity: on the healthy path Detach must pass the AFTER count and set
+// NodeRefLastDetach when the count reaches zero, so the fix does not regress
+// the normal semantics.
+func TestDetachRefcountReleaseSuccessLastHolder(t *testing.T) {
+	store, db := newStore(t)
+	defer db.Close()
+	if _, err := store.Acquire("ns", "vol1", "sbxA", "fake"); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+
+	p := &fakePlugin{name: "fake"}
+	m := &Manager{byName: map[string]VolumePlugin{}}
+	m.Register(p)
+	m.SetRefCountStore(store)
+
+	req := &DetachRequest{
+		SandboxID: "sbxA",
+		Namespace: "ns",
+		VolumeID:  "vol1",
+		Driver:    "fake",
+	}
+	if err := m.Detach(context.Background(), req); err != nil {
+		t.Fatalf("Detach returned error: %v", err)
+	}
+	if p.gotRefCount != 0 {
+		t.Errorf("plugin got RefCount=%d, want 0 (last detach)", p.gotRefCount)
+	}
+	if !p.gotLastDetach {
+		t.Error("plugin got NodeRefLastDetach=false, want true (last holder)")
+	}
+}
+
+// Sanity: on the healthy path with another holder still present, the plugin
+// must see the AFTER count as 1 and NodeRefLastDetach must be false.
+func TestDetachRefcountReleaseSuccessMultiHolder(t *testing.T) {
+	store, db := newStore(t)
+	defer db.Close()
+	if _, err := store.Acquire("ns", "vol1", "sbxA", "fake"); err != nil {
+		t.Fatalf("acquire A: %v", err)
+	}
+	if _, err := store.Acquire("ns", "vol1", "sbxB", "fake"); err != nil {
+		t.Fatalf("acquire B: %v", err)
+	}
+
+	p := &fakePlugin{name: "fake"}
+	m := &Manager{byName: map[string]VolumePlugin{}}
+	m.Register(p)
+	m.SetRefCountStore(store)
+
+	req := &DetachRequest{
+		SandboxID: "sbxA",
+		Namespace: "ns",
+		VolumeID:  "vol1",
+		Driver:    "fake",
+	}
+	if err := m.Detach(context.Background(), req); err != nil {
+		t.Fatalf("Detach returned error: %v", err)
+	}
+	if p.gotRefCount != 1 {
+		t.Errorf("plugin got RefCount=%d, want 1 (one holder still present)", p.gotRefCount)
+	}
+	if p.gotLastDetach {
+		t.Error("plugin got NodeRefLastDetach=true, want false")
+	}
+}
+
+// Unknown-driver Detach must also suppress NodeRefLastDetach when the refcount
+// store fails, so CubeMaster is never told 1→0 on an unrecovered error.
+func TestDetachUnknownDriverRefcountReleaseError(t *testing.T) {
+	store, db := newStore(t)
+	if _, err := store.Acquire("ns", "vol1", "sbxA", "fake"); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	m := &Manager{byName: map[string]VolumePlugin{}}
+	m.SetRefCountStore(store)
+
+	req := &DetachRequest{
+		SandboxID: "sbxA",
+		Namespace: "ns",
+		VolumeID:  "vol1",
+		Driver:    "missing",
+	}
+	if err := m.Detach(context.Background(), req); err != nil {
+		t.Fatalf("Detach returned error: %v", err)
+	}
+	if req.NodeRefLastDetach {
+		t.Error("req.NodeRefLastDetach=true, want false (suppressed on refcount error)")
+	}
+}


### PR DESCRIPTION
## Summary

`Manager.Detach` in `Cubelet/plugins/volume/manager.go` misuses the
`ReleaseResult` when the underlying refcount store returns an error.
Because Go zero-initializes the result on error, the code ends up
setting `req.RefCount = 0` and `req.NodeRefLastDetach = true`, i.e. it
tells the plugin *and* CubeMaster that this was the last detach when in
reality the refcount was never decremented.

The unknown-driver branch inside the same function has the same shape
of bug (`rr, _ := rc.Release(...); req.NodeRefLastDetach = rr.After == 0
&& !rr.NotHeld`).

## Impact

For any plugin that treats `RefCount == 0` as the trigger for
host-level teardown (unmounting a shared FUSE / cosfs / NFS mount,
releasing a lease, etc.), a transient store error on one sandbox's
detach can tear down resources that other sandboxes on the same node
still depend on. On the control-plane side, CubeMaster observes a
spurious 1→0 transition and removes the node from the volume's holder
list, which then lets a subsequent `Volume.destroy` bypass the
"volume in use" protection.

## When it fires

`refcount.Store.Release` is a `bbolt` `db.Update` transaction and can
return an error on:
- data disk full / read-only remount / inode exhaustion,
- bbolt txn abort (mmap failure, concurrent write timeout),
- record unmarshal error (corrupted or version-mismatched value),
- `db.Close`d before the call reaches it during shutdown races.

## Fix

Both branches:
- on `Release` error, do **not** propagate the zero-value result to the
  plugin or to `NodeRefLastDetach`;
- set `RefCount = 1` on the main path so plugins that key on
  `RefCount == 0` will conservatively skip host-level cleanup;
- keep `NodeRefLastDetach = false` so CubeMaster is not told 1→0;
- log a `WARN` (was previously silent — `_ = err`) so operators can see
  the store degraded;
- still return `nil` from `Detach` so the caller can reclaim the
  per-sandbox bind, matching the original "non-fatal; don't block
  Destroy" intent.

Once the store recovers a later successful `Detach` will emit the
correct transition; the current node's record is left as-is and
requires operator cleanup, but that's already the expected posture when
the store has thrown an I/O error.

## Tests

New `Cubelet/plugins/volume/manager_test.go` covering:
- `TestDetachRefcountReleaseError` — main path with a closed bbolt DB:
  plugin sees `RefCount=1` and `NodeRefLastDetach=false`, `Detach`
  returns `nil`.
- `TestDetachRefcountReleaseSuccessLastHolder` — healthy last-holder
  path unchanged: `RefCount=0`, `NodeRefLastDetach=true`.
- `TestDetachRefcountReleaseSuccessMultiHolder` — healthy path with
  another holder still present: `RefCount=1`, `NodeRefLastDetach=false`.
- `TestDetachUnknownDriverRefcountReleaseError` — unknown-driver +
  `Release` error: `NodeRefLastDetach` stays `false`.

All four pass; `go test ./plugins/volume/...` and `go vet` clean.
