### PR TITLE
fix the message of EEXIST in s3lvol

### DIFF
--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol_rpc.c
@@ -154,6 +154,8 @@ rpc_lvol_respond_err(struct spdk_jsonrpc_request *request, int err,
 
 	if (msg && msg[0] != '\0') {
 		snprintf(buf, sizeof(buf), "%s", msg);
+	} else if (err == -EEXIST) {
+		snprintf(buf, sizeof(buf), "name already exists");
 	} else {
 		sys = spdk_strerror(-err);
 		snprintf(buf, sizeof(buf), "%s", sys);


### PR DESCRIPTION
``` 
cubecow error code=precondition_failed raw_rc=-11 action=fail: precondition failed: s3lvol rpc: File exists
``` 
cubelet can't restore s3_metadata 