### PR TITLE
fix(cubelet): honor node IP when host NIC has multiple IPv4 addresses

### DIFF
--- a/Cubelet/network/runtime/systemnet/device.go
+++ b/Cubelet/network/runtime/systemnet/device.go
@@ -142,7 +142,12 @@ type HostDevice struct {
 }
 
 // GetHostDevice validates the configured host interface and captures the
-// addresses CubeVS needs for SNAT and L2 forwarding.
+// addresses CubeVS needs for SNAT and L2 forwarding. The uplink NIC may carry
+// multiple IPv4 addresses (cloud hosts commonly stack secondary/alias
+// addresses), so rather than failing it selects the primary one. The returned
+// IPMask is the selected address's own mask, which becomes the eBPF NodeIPMask
+// (the on-link / bpf_fib_lookup view), so the selected address entry should
+// carry the intended subnet prefix.
 func GetHostDevice(ifName string) (*HostDevice, error) {
 	link, err := netlinkLinkByName(ifName)
 	if err != nil {
@@ -152,8 +157,9 @@ func GetHostDevice(ifName string) (*HostDevice, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(addrs) != 1 {
-		return nil, fmt.Errorf("ipv4 address on %s is not unique", ifName)
+	addr, err := selectPrimaryIPv4Addr(ifName, addrs)
+	if err != nil {
+		return nil, err
 	}
 	gwMac, err := GetGatewayMacAddr(ifName)
 	if err != nil {
@@ -166,11 +172,49 @@ func GetHostDevice(ifName string) (*HostDevice, error) {
 	return &HostDevice{
 		Index:      link.Attrs().Index,
 		Name:       link.Attrs().Name,
-		IP:         addrs[0].IP,
-		IPMask:     addrs[0].Mask,
+		IP:         addr.IP,
+		IPMask:     addr.Mask,
 		Mac:        link.Attrs().HardwareAddr,
 		GatewayMac: gatewayMac,
 	}, nil
+}
+
+// selectPrimaryIPv4Addr picks the primary IPv4 address from a NIC that may
+// carry several (cloud hosts commonly stack secondary/alias addresses). It
+// prefers the first global-scope, non-secondary, non-deprecated address and
+// falls back to the first address so a NIC with no primary still works.
+func selectPrimaryIPv4Addr(ifName string, addrs []netlink.Addr) (netlink.Addr, error) {
+	if len(addrs) == 0 {
+		return netlink.Addr{}, fmt.Errorf("ipv4 address not found on %s", ifName)
+	}
+	for _, a := range addrs {
+		if isPrimaryGlobalIPv4(a) {
+			return a, nil
+		}
+	}
+	return addrs[0], nil
+}
+
+// isPrimaryGlobalIPv4 reports whether a is a global-scope primary address,
+// excluding secondary/deprecated and loopback addresses. Addr.Flags is populated
+// by vishvananda/netlink v1.3.1 from the kernel's IFA_FLAGS attribute
+// (addr_linux.go parseAddr), so IFA_F_SECONDARY / IFA_F_DEPRECATED are reliably
+// set; if that dependency ever regresses, the secondary/deprecated skip would
+// silently no-op while the unit tests (which set Flags by hand) stay green.
+func isPrimaryGlobalIPv4(a netlink.Addr) bool {
+	if a.IPNet == nil {
+		return false
+	}
+	if a.IP.To4() == nil || a.IP.IsLoopback() {
+		return false
+	}
+	if a.Scope != unix.RT_SCOPE_UNIVERSE {
+		return false
+	}
+	if a.Flags&unix.IFA_F_SECONDARY != 0 || a.Flags&unix.IFA_F_DEPRECATED != 0 {
+		return false
+	}
+	return true
 }
 
 // GetGatewayMacAddr resolves the MAC address of the default gateway on ifName

--- a/Cubelet/network/runtime/systemnet/device_test.go
+++ b/Cubelet/network/runtime/systemnet/device_test.go
@@ -580,3 +580,95 @@ func TestGetGatewayMacAddrIncludesProbeErrorInFinalError(t *testing.T) {
 	assert.Contains(t, err.Error(), "no route to host", "final error should include the probe error message")
 	assert.ErrorIs(t, err, errGatewayMacNotFound)
 }
+
+// v4Addr builds a netlink.Addr for the given IPv4 + prefix, overriding scope
+// and flags so selection can be exercised deterministically.
+func v4Addr(ip string, maskBits, scope, flags int) netlink.Addr {
+	return netlink.Addr{
+		IPNet: &net.IPNet{IP: net.ParseIP(ip).To4(), Mask: net.CIDRMask(maskBits, 32)},
+		Scope: scope,
+		Flags: flags,
+	}
+}
+
+func TestSelectPrimaryIPv4AddrSingle(t *testing.T) {
+	addrs := []netlink.Addr{v4Addr("10.0.0.5", 24, unix.RT_SCOPE_UNIVERSE, 0)}
+	got, err := selectPrimaryIPv4Addr("ens3", addrs)
+	require.NoError(t, err)
+	assert.True(t, got.IP.Equal(net.ParseIP("10.0.0.5")))
+}
+
+func TestSelectPrimaryIPv4AddrPrefersPrimary(t *testing.T) {
+	addrs := []netlink.Addr{
+		v4Addr("10.0.0.5", 24, unix.RT_SCOPE_UNIVERSE, unix.IFA_F_SECONDARY),
+		v4Addr("192.168.1.10", 24, unix.RT_SCOPE_UNIVERSE, 0),
+	}
+	got, err := selectPrimaryIPv4Addr("ens3", addrs)
+	require.NoError(t, err)
+	assert.True(t, got.IP.Equal(net.ParseIP("192.168.1.10")),
+		"the primary (non-secondary) address should be selected")
+}
+
+func TestSelectPrimaryIPv4AddrFallsBackToFirst(t *testing.T) {
+	addrs := []netlink.Addr{
+		v4Addr("10.0.0.5", 24, unix.RT_SCOPE_UNIVERSE, unix.IFA_F_SECONDARY),
+		v4Addr("192.168.1.10", 24, unix.RT_SCOPE_UNIVERSE, unix.IFA_F_SECONDARY),
+	}
+	got, err := selectPrimaryIPv4Addr("ens3", addrs)
+	require.NoError(t, err)
+	assert.True(t, got.IP.Equal(net.ParseIP("10.0.0.5")),
+		"with no primary address, fall back to the first")
+}
+
+func TestSelectPrimaryIPv4AddrNoAddress(t *testing.T) {
+	_, err := selectPrimaryIPv4Addr("ens3", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ipv4 address not found on ens3")
+}
+
+func TestGetHostDeviceMultipleAddrs(t *testing.T) {
+	gwIP := net.ParseIP("10.0.0.1")
+	gwMac, _ := net.ParseMAC("de:ad:be:ef:00:01")
+
+	origLinkByName := netlinkLinkByName
+	origAddrList := netlinkAddrList
+	origRouteList := netlinkRouteList
+	origNeighList := netlinkNeighList
+	t.Cleanup(func() {
+		netlinkLinkByName = origLinkByName
+		netlinkAddrList = origAddrList
+		netlinkRouteList = origRouteList
+		netlinkNeighList = origNeighList
+	})
+
+	fakeLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{
+		Index:        5,
+		Name:         "ens3",
+		HardwareAddr: net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+	}}
+	netlinkLinkByName = func(name string) (netlink.Link, error) {
+		return fakeLink, nil
+	}
+	netlinkAddrList = func(link netlink.Link, family int) ([]netlink.Addr, error) {
+		return []netlink.Addr{
+			v4Addr("10.0.0.5", 24, unix.RT_SCOPE_UNIVERSE, unix.IFA_F_SECONDARY),
+			v4Addr("192.168.1.10", 24, unix.RT_SCOPE_UNIVERSE, 0),
+		}, nil
+	}
+	netlinkRouteList = func(link netlink.Link, family int) ([]netlink.Route, error) {
+		return []netlink.Route{{Dst: nil, Gw: gwIP, Priority: 100}}, nil
+	}
+	netlinkNeighList = func(linkIndex, family int) ([]netlink.Neigh, error) {
+		return []netlink.Neigh{{
+			IP: gwIP, HardwareAddr: gwMac, Family: netlink.FAMILY_V4, State: unix.NUD_REACHABLE,
+		}}, nil
+	}
+
+	dev, err := GetHostDevice("ens3")
+	require.NoError(t, err)
+	assert.Equal(t, "ens3", dev.Name)
+	assert.True(t, dev.IP.Equal(net.ParseIP("192.168.1.10")),
+		"multi-address NIC must select the primary address rather than fail with 'not unique'")
+	assert.Equal(t, net.CIDRMask(24, 32), net.IPMask(dev.IPMask),
+		"IPMask must come from the selected address entry")
+}


### PR DESCRIPTION
## Problem

`GetHostDevice` required the uplink NIC to have exactly one IPv4 address and
failed with `ipv4 address on %s is not unique` otherwise. Cloud hosts commonly
stack secondary/alias addresses on the primary NIC, so one-click compute nodes
failed to start (fixes #444).

## Fix

Instead of rejecting a multi-address NIC, select the primary address:

1. the first global-scope, non-secondary, non-deprecated IPv4 address;
2. fall back to the first address if no primary exists.

A NIC with zero IPv4 addresses still errors. The returned `IPMask` comes from
the selected address, so the eBPF `NodeIPMask` / on-link view stays consistent.

No change to `GetHostDevice`'s signature or the egress data path. Selecting the
correct egress device/address via policy routing is left to route-aware egress
(cube-router).

## Tests

Unit tests cover single-address regression, primary-address preference, fallback
when every address is secondary, the empty-NIC error, and an end-to-end
multi-address `GetHostDevice` case.