### PR TITLE
fix(s3): keep pause package after Resume so Snapshot stays incremental

### DIFF
--- a/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
@@ -449,11 +449,12 @@ func resumeFromPauseSnapshot(ctx context.Context, req *types.UpdateRequest, host
 	// After Create the sandbox runs on private disks. Ask Cubelet to drop
 	// the pause package on the node that still holds it: origin when that
 	// IP is known and not the target (also the PAUSED tombstone), otherwise
-	// this node. Cubelet decides whether the catalog actually goes away
-	// (S3 already cloned onto sb-*-memory; XFS Resume still mmaps the
-	// package and no-ops until the next Pause or Destroy). Do not key this
-	// off CrossNode — a cross-node placement with a blank origin would
-	// otherwise skip both cleanup paths and leak the package.
+	// this node. Cubelet no-ops while a live sandbox still restores from
+	// that catalog (XFS mmap; S3 Snapshot last-restore) and GCs on the
+	// next Pause or Destroy. Cross-node origin is not live, so the origin
+	// package still goes away. Do not key this off CrossNode — a
+	// cross-node placement with a blank origin would otherwise skip both
+	// cleanup paths and leak the package.
 	origin := strings.TrimSpace(rec.NodeIP)
 	if origin != "" && origin != targetIP {
 		if err := pausesnap.DropOriginTombstone(ctx, req.RequestID, req.SandboxID, origin, rec.SnapshotID, rec.Backend); err != nil {

--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -281,7 +281,7 @@ func ConstructCubeletReq(ctx context.Context, req *types.CreateCubeSandboxReq) (
 
 	out := &cubebox.RunCubeSandboxRequest{
 		RequestID:         req.RequestID,
-		Labels:            req.Labels,
+		Labels:            stripUserCubeMasterLabels(req.Labels),
 		InstanceType:      req.InstanceType,
 		NetworkType:       req.NetworkType,
 		Annotations:       make(map[string]string),
@@ -325,8 +325,12 @@ func ConstructCubeletReq(ctx context.Context, req *types.CreateCubeSandboxReq) (
 		delete(out.Annotations, AnnotationPluginVolumeSources)
 	}
 	// Sync any annotations added by checkAndGetVolumes (e.g. plugin-volume-sources)
-	// into the outgoing RunCubeSandboxRequest.
+	// into the outgoing RunCubeSandboxRequest. Do not re-add keys
+	// checkAndGetAnnotation already dropped (pause / restore-base).
 	for k, v := range req.Annotations {
+		if rejectUserCubeMasterAnnotation(k) {
+			continue
+		}
 		if _, exists := out.Annotations[k]; !exists {
 			out.Annotations[k] = v
 		}
@@ -966,10 +970,10 @@ func setCreateTimeEnvVarsAnnotation(out map[string]string, envVars map[string]st
 	return nil
 }
 
-// rejectUserCubeMasterAnnotation drops Create annotations that only Master
-// or Cubelet may stamp. Forwarding them lets a client pin
-// cube.master.pause.snapshot.id on a running sandbox and make XFS
-// CleanupTemplate no-op for another tenant's pause catalog.
+// rejectUserCubeMasterAnnotation drops Create annotations (and the same
+// keys on Labels) that only Master or Cubelet may stamp. Forwarding them
+// lets a client pin cube.master.pause.snapshot.id on a running sandbox
+// and make CleanupTemplate no-op for another tenant's pause catalog.
 func rejectUserCubeMasterAnnotation(key string) bool {
 	switch strings.TrimSpace(key) {
 	case constants.CubeAnnotationPauseSnapshotID,
@@ -980,6 +984,22 @@ func rejectUserCubeMasterAnnotation(key string) bool {
 	default:
 		return false
 	}
+}
+
+// stripUserCubeMasterLabels copies user Labels without the platform keys
+// rejectUserCubeMasterAnnotation already drops from Annotations.
+func stripUserCubeMasterLabels(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if rejectUserCubeMasterAnnotation(k) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
 }
 
 func getBlkQosAnnotation(req *types.CreateCubeSandboxReq) string {

--- a/CubeMaster/pkg/service/sandbox/util_test.go
+++ b/CubeMaster/pkg/service/sandbox/util_test.go
@@ -5,6 +5,7 @@
 package sandbox
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -315,5 +316,78 @@ func TestCheckAndGetAnnotationStripsPlatformPauseKeys(t *testing.T) {
 	}
 	if got := out.Annotations[constants.CubeAnnotationRuntimeSnapshotID]; got != "snap-user-runtime" {
 		t.Fatalf("other cube.master keys still forward, got %q", got)
+	}
+}
+
+func TestStripUserCubeMasterLabelsDropsPauseKeys(t *testing.T) {
+	got := stripUserCubeMasterLabels(map[string]string{
+		constants.CubeAnnotationPauseSnapshotID:                  "snap-forged-pause",
+		constants.CubeAnnotationLaunchMemorySnapshotID:           "tpl-forged",
+		constants.CubeAnnotationRuntimeRestoreSnapshotID:         "snap-forged-restore",
+		constants.CubeAnnotationRuntimeRestoreSnapshotAttachedAt: "2026-09-04T00:00:00Z",
+		"user.label": "keep-me",
+	})
+	if _, ok := got[constants.CubeAnnotationPauseSnapshotID]; ok {
+		t.Fatal("forged pause snapshot id must not reach Cubelet Labels")
+	}
+	if _, ok := got[constants.CubeAnnotationLaunchMemorySnapshotID]; ok {
+		t.Fatal("forged launch ancestor must not reach Cubelet Labels")
+	}
+	if _, ok := got[constants.CubeAnnotationRuntimeRestoreSnapshotID]; ok {
+		t.Fatal("forged restore-base must not reach Cubelet Labels")
+	}
+	if _, ok := got[constants.CubeAnnotationRuntimeRestoreSnapshotAttachedAt]; ok {
+		t.Fatal("forged restore-base timestamp must not reach Cubelet Labels")
+	}
+	if got["user.label"] != "keep-me" {
+		t.Fatalf("ordinary labels must pass through, got %#v", got)
+	}
+	if stripUserCubeMasterLabels(nil) != nil {
+		t.Fatal("nil labels stay nil")
+	}
+}
+
+func TestConstructCubeletReqStripsForgedPauseLabels(t *testing.T) {
+	ensureSandboxTestConfig(t)
+	req := &types.CreateCubeSandboxReq{
+		Request: &types.Request{RequestID: "req-label-strip"},
+		Containers: []*types.Container{{
+			Name: "ctr-1",
+			Resources: &types.Resource{
+				Cpu: "1",
+				Mem: "1Gi",
+			},
+			Image: &types.ImageSpec{
+				Image: "busybox:latest",
+			},
+		}},
+		Annotations: map[string]string{
+			constants.CubeAnnotationPauseSnapshotID:          "snap-anno-forged",
+			constants.CubeAnnotationRuntimeRestoreSnapshotID: "snap-anno-restore",
+		},
+		Labels: map[string]string{
+			constants.CubeAnnotationPauseSnapshotID:          "snap-label-forged",
+			constants.CubeAnnotationRuntimeRestoreSnapshotID: "snap-label-restore",
+			"app": "ok",
+		},
+	}
+	out, err := ConstructCubeletReq(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ConstructCubeletReq: %v", err)
+	}
+	if _, ok := out.Labels[constants.CubeAnnotationPauseSnapshotID]; ok {
+		t.Fatal("user Label pause snapshot id must not be forwarded")
+	}
+	if _, ok := out.Labels[constants.CubeAnnotationRuntimeRestoreSnapshotID]; ok {
+		t.Fatal("user Label restore-base must not be forwarded")
+	}
+	if out.Labels["app"] != "ok" {
+		t.Fatalf("ordinary labels must pass through, got %#v", out.Labels)
+	}
+	if _, ok := out.Annotations[constants.CubeAnnotationPauseSnapshotID]; ok {
+		t.Fatal("user annotation pause snapshot id must not be re-added after strip")
+	}
+	if _, ok := out.Annotations[constants.CubeAnnotationRuntimeRestoreSnapshotID]; ok {
+		t.Fatal("user annotation restore-base must not be re-added after strip")
 	}
 }

--- a/Cubelet/services/cubebox/cleanup_template_keep_test.go
+++ b/Cubelet/services/cubebox/cleanup_template_keep_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
+	cubebox "github.com/tencentcloud/CubeSandbox/pkgs/proto/services/cubebox/v1"
+	errorcode "github.com/tencentcloud/CubeSandbox/pkgs/proto/services/errorcode/v1"
+)
+
+func installCleanupTemplateTestHooks(t *testing.T) {
+	t.Helper()
+	origGet := getLocalSnapshotForFn
+	origList := listCubeboxesForTest
+	origCow := cleanupIsCowBackend
+	origLocal := cleanupTemplateLocalDataFn
+	origRel := cleanupReleaseS3Metadata
+	origObj := cleanupObjectsFor
+	t.Cleanup(func() {
+		getLocalSnapshotForFn = origGet
+		listCubeboxesForTest = origList
+		cleanupIsCowBackend = origCow
+		cleanupTemplateLocalDataFn = origLocal
+		cleanupReleaseS3Metadata = origRel
+		cleanupObjectsFor = origObj
+	})
+	cleanupIsCowBackend = func() bool { return false }
+	cleanupReleaseS3Metadata = func(context.Context, string, string) error { return nil }
+	cleanupObjectsFor = func(context.Context, string, []storage.CowObjectRef) error { return nil }
+}
+
+func TestCleanupTemplateKeepsLivePauseAndHonorLiveFalseDeletes(t *testing.T) {
+	installCleanupTemplateTestHooks(t)
+	snap := "snap-keep-reg-0000000000000001"
+	getLocalSnapshotForFn = func(_ context.Context, _, id string) (*storage.SnapshotCatalogEntry, error) {
+		return &storage.SnapshotCatalogEntry{SnapshotID: id, Kind: storage.CatalogKindPauseSnapshot}, nil
+	}
+	live := newCubeboxWithStatusForTest("sb-live-keep", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(live, snap)
+	live.AddLabels(map[string]string{constants.MasterAnnotationRuntimeRestoreSnapshotID: snap})
+	listCubeboxesForTest = func() []*cubeboxstore.CubeBox { return []*cubeboxstore.CubeBox{live} }
+
+	deleted := 0
+	cleanupTemplateLocalDataFn = func(context.Context, string, string) error {
+		deleted++
+		return nil
+	}
+
+	s := &service{}
+	req := &cubebox.CleanupTemplateRequest{
+		TemplateID: snap,
+		Objects:    []*cubebox.CowObjectRef{{Name: "n", Kind: "snapshot", Role: "rootfs"}},
+	}
+	rsp, err := s.cleanupTemplate(context.Background(), req, true)
+	require.NoError(t, err)
+	require.Equal(t, errorcode.ErrorCode_Success, rsp.GetRet().GetRetCode(), rsp.GetRet().GetRetMsg())
+	require.Equal(t, 0, deleted, "Master Resume Cleanup of a live pause package must no-op")
+
+	rsp, err = s.cleanupTemplate(context.Background(), req, false)
+	require.NoError(t, err)
+	require.Equal(t, errorcode.ErrorCode_Success, rsp.GetRet().GetRetCode(), rsp.GetRet().GetRetMsg())
+	require.Equal(t, 1, deleted, "next Pause / Destroy GC (honorLive=false) must still delete")
+}
+
+func TestCleanupTemplateForgedPauseLabelDoesNotKeep(t *testing.T) {
+	installCleanupTemplateTestHooks(t)
+	snap := "snap-keep-forged-0000000000001"
+	getLocalSnapshotForFn = func(_ context.Context, _, id string) (*storage.SnapshotCatalogEntry, error) {
+		return &storage.SnapshotCatalogEntry{SnapshotID: id, Kind: storage.CatalogKindPauseSnapshot}, nil
+	}
+	attacker := newCubeboxWithStatusForTest("sb-attacker", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(attacker, snap)
+	listCubeboxesForTest = func() []*cubeboxstore.CubeBox { return []*cubeboxstore.CubeBox{attacker} }
+
+	deleted := 0
+	cleanupTemplateLocalDataFn = func(context.Context, string, string) error {
+		deleted++
+		return nil
+	}
+
+	s := &service{}
+	req := &cubebox.CleanupTemplateRequest{
+		TemplateID: snap,
+		Objects:    []*cubebox.CowObjectRef{{Name: "n", Kind: "snapshot", Role: "rootfs"}},
+	}
+	rsp, err := s.cleanupTemplate(context.Background(), req, true)
+	require.NoError(t, err)
+	require.Equal(t, errorcode.ErrorCode_Success, rsp.GetRet().GetRetCode(), rsp.GetRet().GetRetMsg())
+	require.Equal(t, 1, deleted, "forged pause-id Label must not block origin GC of another sandbox's package")
+}

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -228,7 +228,7 @@ func (l *local) createContainers(ctx context.Context, flowOpts *workflow.CreateC
 		Metadata: cubeboxstore.Metadata{
 			ID:           flowOpts.SandboxID,
 			SandboxID:    flowOpts.SandboxID,
-			Labels:       deepCopyStringMap(realReq.GetLabels()),
+			Labels:       stripUserCubeMasterLabels(deepCopyStringMap(realReq.GetLabels())),
 			Annotations:  realReq.GetAnnotations(),
 			CreatedAt:    time.Now().UnixNano(),
 			InstanceType: flowOpts.GetInstanceType(),

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -283,10 +283,9 @@ func (l *local) createContainers(ctx context.Context, flowOpts *workflow.CreateC
 		setRuntimeRestoreBaseLabels(sandBox, snapshotID, now)
 		// Resume-from-pause stamps pause snapshot id. Master strips this
 		// key from user Create; only the thin Resume request carries it.
-		// XFS Resume still mmaps that package; CleanupTemplate no-ops
-		// while this label is live. Next Pause or Destroy GCs it. S3
-		// already cloned onto sb-*-memory and CleanupTemplate deletes
-		// the package.
+		// Resume still needs that package (XFS mmap; S3 Snapshot
+		// last-restore catalog). CleanupTemplate no-ops while this
+		// label is live. Next Pause or Destroy GCs it.
 		if pauseID := strings.TrimSpace(realReq.GetAnnotations()[constants.MasterAnnotationPauseSnapshotID]); pauseID != "" {
 			if sandBox.Labels == nil {
 				sandBox.Labels = map[string]string{}

--- a/Cubelet/services/cubebox/pause_cow.go
+++ b/Cubelet/services/cubebox/pause_cow.go
@@ -101,9 +101,10 @@ func (s *service) listCubeboxes() []*cubeboxstore.CubeBox {
 
 // keepLiveXFSPausePackage is true when Master's Resume-time CleanupTemplate
 // must leave this pause catalog on disk. XFS Resume mmaps the package file;
-// S3 already cloned onto sb-*-memory and must drop the package. PAUSED /
-// EXITED / UNKNOWN do not hold a live mmap, so DelPaused and leftover GC
-// still delete.
+// S3 Resume also keeps it so CommitSandbox can still resolve a last-restore
+// memory base (Snapshot does not clone sb-*-memory). PAUSED / EXITED /
+// UNKNOWN do not hold a live restore, so DelPaused and leftover GC still
+// delete.
 //
 // Only Cubelet-stamped Labels count (not user Create annotations). Match
 // the current pause id or the restore-base: Pause overwrites the pause id
@@ -111,10 +112,7 @@ func (s *service) listCubeboxes() []*cubeboxstore.CubeBox {
 // must still see the mmap / incremental source. cleanupTemplate also
 // requires catalog Kind=pause_snapshot so a forged label cannot pin a
 // template or customer snap.
-func keepLiveXFSPausePackage(boxes []*cubeboxstore.CubeBox, snapID, backend string) bool {
-	if storage.IsS3Backend(backend) {
-		return false
-	}
+func keepLiveXFSPausePackage(boxes []*cubeboxstore.CubeBox, snapID string) bool {
 	snapID = strings.TrimSpace(snapID)
 	if snapID == "" {
 		return false
@@ -668,7 +666,7 @@ func cleanupBackendForPauseSnap(preferred, snapID string) string {
 // PAUSED without those flags is not expected on the user Destroy path; skip
 // GC so we cannot drop a live pause snap if someone cubecli-destroys a
 // tombstone. UNKNOWN / FAILED / RUNNING / PAUSING may hold half-finished
-// or leftover snaps. After XFS Resume Master's CleanupTemplate no-ops
+// or leftover snaps. After Resume Master's CleanupTemplate no-ops
 // while this RUNNING sandbox still holds the pause id; a user Destroy
 // GCs it here (honorLiveXFSPause=false).
 func pauseSnapIDToGCOnDestroy(req *cubebox.DestroyCubeSandboxRequest, sb *cubeboxstore.CubeBox) string {

--- a/Cubelet/services/cubebox/pause_cow.go
+++ b/Cubelet/services/cubebox/pause_cow.go
@@ -93,10 +93,46 @@ func stampedPauseSnapshotID(sb *cubeboxstore.CubeBox) string {
 }
 
 func (s *service) listCubeboxes() []*cubeboxstore.CubeBox {
+	if listCubeboxesForTest != nil {
+		return listCubeboxesForTest()
+	}
 	if s == nil || s.cubeboxMgr == nil || s.cubeboxMgr.cubeboxManger == nil {
 		return nil
 	}
 	return s.cubeboxMgr.cubeboxManger.List()
+}
+
+// listCubeboxesForTest, when set, replaces the live CubeBox list so
+// cleanupTemplate keep/GC tests can run without a cubebox manager.
+var listCubeboxesForTest func() []*cubeboxstore.CubeBox
+
+// rejectUserCubeMasterLabel drops Create Labels that only Cubelet may
+// stamp after Resume / Pause. Master strips the same keys; this is the
+// Cubelet-side guard for cubecli-direct Create.
+func rejectUserCubeMasterLabel(key string) bool {
+	switch strings.TrimSpace(key) {
+	case constants.MasterAnnotationPauseSnapshotID,
+		constants.MasterAnnotationLaunchMemorySnapshotID,
+		constants.MasterAnnotationRuntimeRestoreSnapshotID,
+		constants.MasterAnnotationRuntimeRestoreSnapshotAttachedAt:
+		return true
+	default:
+		return false
+	}
+}
+
+func stripUserCubeMasterLabels(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if rejectUserCubeMasterLabel(k) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // keepLivePausePackage is true when Master's Resume-time CleanupTemplate
@@ -106,12 +142,13 @@ func (s *service) listCubeboxes() []*cubeboxstore.CubeBox {
 // PAUSED / EXITED / UNKNOWN do not hold a live restore, so DelPaused
 // and leftover GC still delete.
 //
-// Only Cubelet-stamped Labels count (not user Create annotations). Match
-// the current pause id or the restore-base: Pause overwrites the pause id
-// before the overlay finishes, so a delayed Cleanup of the previous package
-// must still see the mmap / incremental source. cleanupTemplate also
-// requires catalog Kind=pause_snapshot so a forged label cannot pin a
-// template or customer snap.
+// Only Cubelet-stamped Labels count (not user Create annotations or
+// Labels). Pin by restore-base, not pause id: Pause overwrites the pause
+// id before the overlay finishes, while restore-base still names the
+// previous package. A forged pause-id Label therefore cannot pin another
+// tenant's catalog. cleanupTemplate also requires catalog
+// Kind=pause_snapshot so a forged label cannot pin a template or
+// customer snap.
 func keepLivePausePackage(boxes []*cubeboxstore.CubeBox, snapID string) bool {
 	snapID = strings.TrimSpace(snapID)
 	if snapID == "" {
@@ -128,9 +165,6 @@ func keepLivePausePackage(boxes []*cubeboxstore.CubeBox, snapID string) bool {
 func sandboxHoldsLivePausePackage(sb *cubeboxstore.CubeBox, snapID string) bool {
 	if sb == nil || !sandboxLiveForPauseKeep(sb) {
 		return false
-	}
-	if cubeBoxLabel(sb, constants.MasterAnnotationPauseSnapshotID) == snapID {
-		return true
 	}
 	return cubeBoxLabel(sb, constants.MasterAnnotationRuntimeRestoreSnapshotID) == snapID
 }

--- a/Cubelet/services/cubebox/pause_cow.go
+++ b/Cubelet/services/cubebox/pause_cow.go
@@ -99,12 +99,12 @@ func (s *service) listCubeboxes() []*cubeboxstore.CubeBox {
 	return s.cubeboxMgr.cubeboxManger.List()
 }
 
-// keepLiveXFSPausePackage is true when Master's Resume-time CleanupTemplate
-// must leave this pause catalog on disk. XFS Resume mmaps the package file;
-// S3 Resume also keeps it so CommitSandbox can still resolve a last-restore
-// memory base (Snapshot does not clone sb-*-memory). PAUSED / EXITED /
-// UNKNOWN do not hold a live restore, so DelPaused and leftover GC still
-// delete.
+// keepLivePausePackage is true when Master's Resume-time CleanupTemplate
+// must leave this pause catalog on disk. XFS Resume mmaps the package
+// file; S3 Resume keeps it so CommitSandbox can still resolve a
+// last-restore memory base (Snapshot does not clone sb-*-memory).
+// PAUSED / EXITED / UNKNOWN do not hold a live restore, so DelPaused
+// and leftover GC still delete.
 //
 // Only Cubelet-stamped Labels count (not user Create annotations). Match
 // the current pause id or the restore-base: Pause overwrites the pause id
@@ -112,21 +112,21 @@ func (s *service) listCubeboxes() []*cubeboxstore.CubeBox {
 // must still see the mmap / incremental source. cleanupTemplate also
 // requires catalog Kind=pause_snapshot so a forged label cannot pin a
 // template or customer snap.
-func keepLiveXFSPausePackage(boxes []*cubeboxstore.CubeBox, snapID string) bool {
+func keepLivePausePackage(boxes []*cubeboxstore.CubeBox, snapID string) bool {
 	snapID = strings.TrimSpace(snapID)
 	if snapID == "" {
 		return false
 	}
 	for _, sb := range boxes {
-		if sandboxHoldsLiveXFSPausePackage(sb, snapID) {
+		if sandboxHoldsLivePausePackage(sb, snapID) {
 			return true
 		}
 	}
 	return false
 }
 
-func sandboxHoldsLiveXFSPausePackage(sb *cubeboxstore.CubeBox, snapID string) bool {
-	if sb == nil || !sandboxLiveForXFSPauseKeep(sb) {
+func sandboxHoldsLivePausePackage(sb *cubeboxstore.CubeBox, snapID string) bool {
+	if sb == nil || !sandboxLiveForPauseKeep(sb) {
 		return false
 	}
 	if cubeBoxLabel(sb, constants.MasterAnnotationPauseSnapshotID) == snapID {
@@ -135,7 +135,7 @@ func sandboxHoldsLiveXFSPausePackage(sb *cubeboxstore.CubeBox, snapID string) bo
 	return cubeBoxLabel(sb, constants.MasterAnnotationRuntimeRestoreSnapshotID) == snapID
 }
 
-func sandboxLiveForXFSPauseKeep(sb *cubeboxstore.CubeBox) bool {
+func sandboxLiveForPauseKeep(sb *cubeboxstore.CubeBox) bool {
 	st := sb.GetStatus()
 	if st == nil {
 		return false
@@ -166,10 +166,25 @@ func isPauseSnapshotCatalogKind(kind string) bool {
 	return strings.EqualFold(strings.TrimSpace(kind), storage.CatalogKindPauseSnapshot)
 }
 
+// shouldKeepLivePausePackage is the CleanupTemplate keep gate: Master's
+// Resume-time RPC (honorLive=true) no-ops while a live sandbox still
+// restores from this pause catalog. Cubelet's next-Pause / Destroy GC
+// passes honorLive=false and still deletes.
+func shouldKeepLivePausePackage(honorLive bool, boxes []*cubeboxstore.CubeBox, snapID, catalogKind string) bool {
+	return honorLive && keepLivePausePackage(boxes, snapID) && isPauseSnapshotCatalogKind(catalogKind)
+}
+
+func catalogKindForKeep(entry *storage.SnapshotCatalogEntry) string {
+	if entry == nil {
+		return ""
+	}
+	return entry.Kind
+}
+
 // replacedLivePauseSnapshotID is the pause snap Resume left as live. After a
 // new Pause succeeds, Cubelet CleanupTemplate's it (keep_tombstone already
 // tore down the running overlay). Empty on the first Pause from a template.
-// XFS Resume keeps that package on disk so this Pause can incremental-
+// Resume keeps that package on disk so this Pause can incremental-
 // overlay onto it; this GC is what finally removes it.
 func replacedLivePauseSnapshotID(prev, newID string) string {
 	prev = strings.TrimSpace(prev)
@@ -668,7 +683,7 @@ func cleanupBackendForPauseSnap(preferred, snapID string) string {
 // tombstone. UNKNOWN / FAILED / RUNNING / PAUSING may hold half-finished
 // or leftover snaps. After Resume Master's CleanupTemplate no-ops
 // while this RUNNING sandbox still holds the pause id; a user Destroy
-// GCs it here (honorLiveXFSPause=false).
+// GCs it here (honorLivePauseKeep=false).
 func pauseSnapIDToGCOnDestroy(req *cubebox.DestroyCubeSandboxRequest, sb *cubeboxstore.CubeBox) string {
 	if sb == nil || isPauseKeepTombstone(req) || isPauseDeleteTombstone(req) {
 		return ""

--- a/Cubelet/services/cubebox/pause_cow_test.go
+++ b/Cubelet/services/cubebox/pause_cow_test.go
@@ -222,18 +222,21 @@ func TestKeepLivePausePackage(t *testing.T) {
 	snap := "snap-keeppause0000000000000001"
 	running := newCubeboxWithStatusForTest("sb-run", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(running, snap)
+	running.AddLabels(map[string]string{constants.MasterAnnotationRuntimeRestoreSnapshotID: snap})
 	if !keepLivePausePackage([]*cubeboxstore.CubeBox{running}, snap) {
 		t.Fatal("running resume must keep the pause package")
 	}
 
 	paused := newCubeboxWithStatusForTest("sb-paused", cubeboxstore.Status{PausedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(paused, snap)
+	paused.AddLabels(map[string]string{constants.MasterAnnotationRuntimeRestoreSnapshotID: snap})
 	if keepLivePausePackage([]*cubeboxstore.CubeBox{paused}, snap) {
 		t.Fatal("PAUSED DelPaused must be allowed to delete the package")
 	}
 
 	other := newCubeboxWithStatusForTest("sb-other", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(other, "snap-other00000000000000000001")
+	other.AddLabels(map[string]string{constants.MasterAnnotationRuntimeRestoreSnapshotID: "snap-other00000000000000000001"})
 	if keepLivePausePackage([]*cubeboxstore.CubeBox{other}, snap) {
 		t.Fatal("unrelated sandbox must not pin this package")
 	}
@@ -244,6 +247,12 @@ func TestKeepLivePausePackage(t *testing.T) {
 		t.Fatal("user Create annotation must not pin a pause package")
 	}
 
+	forgedLabel := newCubeboxWithStatusForTest("sb-forged-label", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(forgedLabel, snap)
+	if keepLivePausePackage([]*cubeboxstore.CubeBox{forgedLabel}, snap) {
+		t.Fatal("pause-id Label without restore-base must not pin another tenant's package")
+	}
+
 	nextPause := newCubeboxWithStatusForTest("sb-next", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(nextPause, "snap-new000000000000000000000001")
 	nextPause.AddLabels(map[string]string{constants.MasterAnnotationRuntimeRestoreSnapshotID: snap})
@@ -252,11 +261,30 @@ func TestKeepLivePausePackage(t *testing.T) {
 	}
 }
 
+func TestStripUserCubeMasterLabels(t *testing.T) {
+	t.Parallel()
+	got := stripUserCubeMasterLabels(map[string]string{
+		constants.MasterAnnotationPauseSnapshotID:          "snap-forged",
+		constants.MasterAnnotationRuntimeRestoreSnapshotID: "snap-restore",
+		"app": "ok",
+	})
+	if _, ok := got[constants.MasterAnnotationPauseSnapshotID]; ok {
+		t.Fatal("forged pause id must be stripped from Create Labels")
+	}
+	if _, ok := got[constants.MasterAnnotationRuntimeRestoreSnapshotID]; ok {
+		t.Fatal("forged restore-base must be stripped from Create Labels")
+	}
+	if got["app"] != "ok" {
+		t.Fatalf("ordinary labels must pass through, got %#v", got)
+	}
+}
+
 func TestShouldKeepLivePausePackageHonorLive(t *testing.T) {
 	t.Parallel()
 	snap := "snap-keepgate00000000000000001"
 	running := newCubeboxWithStatusForTest("sb-s3-live", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(running, snap)
+	running.AddLabels(map[string]string{constants.MasterAnnotationRuntimeRestoreSnapshotID: snap})
 	boxes := []*cubeboxstore.CubeBox{running}
 
 	if !shouldKeepLivePausePackage(true, boxes, snap, "pause_snapshot") {

--- a/Cubelet/services/cubebox/pause_cow_test.go
+++ b/Cubelet/services/cubebox/pause_cow_test.go
@@ -222,35 +222,32 @@ func TestKeepLiveXFSPausePackage(t *testing.T) {
 	snap := "snap-keepxfs000000000000000001"
 	running := newCubeboxWithStatusForTest("sb-run", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(running, snap)
-	if !keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{running}, snap, "xfs") {
-		t.Fatal("XFS running resume must keep the pause package")
-	}
-	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{running}, snap, "s3") {
-		t.Fatal("S3 resume must drop the pause package")
+	if !keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{running}, snap) {
+		t.Fatal("running resume must keep the pause package")
 	}
 
 	paused := newCubeboxWithStatusForTest("sb-paused", cubeboxstore.Status{PausedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(paused, snap)
-	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{paused}, snap, "xfs") {
+	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{paused}, snap) {
 		t.Fatal("PAUSED DelPaused must be allowed to delete the package")
 	}
 
 	other := newCubeboxWithStatusForTest("sb-other", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(other, "snap-other00000000000000000001")
-	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{other}, snap, "xfs") {
+	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{other}, snap) {
 		t.Fatal("unrelated sandbox must not pin this package")
 	}
 
 	forged := newCubeboxWithStatusForTest("sb-forged", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	forged.AddAnnotations(map[string]string{constants.MasterAnnotationPauseSnapshotID: snap})
-	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{forged}, snap, "xfs") {
-		t.Fatal("user Create annotation must not pin an XFS pause package")
+	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{forged}, snap) {
+		t.Fatal("user Create annotation must not pin a pause package")
 	}
 
 	nextPause := newCubeboxWithStatusForTest("sb-next", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(nextPause, "snap-new000000000000000000000001")
 	nextPause.AddLabels(map[string]string{constants.MasterAnnotationRuntimeRestoreSnapshotID: snap})
-	if !keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{nextPause}, snap, "xfs") {
+	if !keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{nextPause}, snap) {
 		t.Fatal("restore-base must keep the previous package while Pause stamps a new id")
 	}
 }

--- a/Cubelet/services/cubebox/pause_cow_test.go
+++ b/Cubelet/services/cubebox/pause_cow_test.go
@@ -217,38 +217,59 @@ func TestNewPauseSnapshotConfigCarriesSnapshotType(t *testing.T) {
 	}
 }
 
-func TestKeepLiveXFSPausePackage(t *testing.T) {
+func TestKeepLivePausePackage(t *testing.T) {
 	t.Parallel()
-	snap := "snap-keepxfs000000000000000001"
+	snap := "snap-keeppause0000000000000001"
 	running := newCubeboxWithStatusForTest("sb-run", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(running, snap)
-	if !keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{running}, snap) {
+	if !keepLivePausePackage([]*cubeboxstore.CubeBox{running}, snap) {
 		t.Fatal("running resume must keep the pause package")
 	}
 
 	paused := newCubeboxWithStatusForTest("sb-paused", cubeboxstore.Status{PausedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(paused, snap)
-	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{paused}, snap) {
+	if keepLivePausePackage([]*cubeboxstore.CubeBox{paused}, snap) {
 		t.Fatal("PAUSED DelPaused must be allowed to delete the package")
 	}
 
 	other := newCubeboxWithStatusForTest("sb-other", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(other, "snap-other00000000000000000001")
-	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{other}, snap) {
+	if keepLivePausePackage([]*cubeboxstore.CubeBox{other}, snap) {
 		t.Fatal("unrelated sandbox must not pin this package")
 	}
 
 	forged := newCubeboxWithStatusForTest("sb-forged", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	forged.AddAnnotations(map[string]string{constants.MasterAnnotationPauseSnapshotID: snap})
-	if keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{forged}, snap) {
+	if keepLivePausePackage([]*cubeboxstore.CubeBox{forged}, snap) {
 		t.Fatal("user Create annotation must not pin a pause package")
 	}
 
 	nextPause := newCubeboxWithStatusForTest("sb-next", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
 	stampPauseSnapshotID(nextPause, "snap-new000000000000000000000001")
 	nextPause.AddLabels(map[string]string{constants.MasterAnnotationRuntimeRestoreSnapshotID: snap})
-	if !keepLiveXFSPausePackage([]*cubeboxstore.CubeBox{nextPause}, snap) {
+	if !keepLivePausePackage([]*cubeboxstore.CubeBox{nextPause}, snap) {
 		t.Fatal("restore-base must keep the previous package while Pause stamps a new id")
+	}
+}
+
+func TestShouldKeepLivePausePackageHonorLive(t *testing.T) {
+	t.Parallel()
+	snap := "snap-keepgate00000000000000001"
+	running := newCubeboxWithStatusForTest("sb-s3-live", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(running, snap)
+	boxes := []*cubeboxstore.CubeBox{running}
+
+	if !shouldKeepLivePausePackage(true, boxes, snap, "pause_snapshot") {
+		t.Fatal("Master Resume Cleanup of a live S3/XFS pause package must no-op")
+	}
+	if shouldKeepLivePausePackage(false, boxes, snap, "pause_snapshot") {
+		t.Fatal("Cubelet next-Pause / Destroy GC must still delete")
+	}
+	if shouldKeepLivePausePackage(true, boxes, snap, "snapshot") {
+		t.Fatal("customer snap kind must not be pinned by a pause label")
+	}
+	if shouldKeepLivePausePackage(true, boxes, snap, "") {
+		t.Fatal("missing catalog kind must not keep")
 	}
 }
 

--- a/Cubelet/services/cubebox/snapshot_base_memory.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory.go
@@ -16,6 +16,15 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
 )
 
+// Test hooks so prepareCommitMemoryArtifact's ladder can be driven without cubecow.
+var (
+	resolveBaseMemoryObjectFn        = resolveBaseMemoryObject
+	resolveRestoreBaseMemoryObjectFn = resolveRestoreBaseMemoryObject
+	commitMemoryFromBaseFor          = storage.CommitMemoryFromBaseFor
+	createMemoryVolumeFor            = storage.CreateMemoryVolumeFor
+	getImportedSandboxMemoryFor      = storage.GetImportedSandboxMemoryFor
+)
+
 // ErrNoBaseMemoryForIncremental is returned when CommitSandbox cannot
 // determine a base memory object for the running sandbox. Without a base the
 // hypervisor's incremental memory snapshot cannot be produced (it would have
@@ -370,9 +379,9 @@ func prepareCommitMemoryArtifact(
 	backend string,
 ) (*storage.CowSnapshotObject, string, error) {
 	// ─── Tier 1: soft-dirty over previous-snapshot base ───────────────
-	baseMemoryObject, baseErr := resolveBaseMemoryObject(ctx, cb, backend)
+	baseMemoryObject, baseErr := resolveBaseMemoryObjectFn(ctx, cb, backend)
 	if baseErr == nil {
-		memoryObject, err := storage.CommitMemoryFromBaseFor(ctx, backend, baseMemoryObject, templateID, memorySizeBytes)
+		memoryObject, err := commitMemoryFromBaseFor(ctx, backend, baseMemoryObject, templateID, memorySizeBytes)
 		if err != nil {
 			return nil, "", err
 		}
@@ -391,9 +400,9 @@ func prepareCommitMemoryArtifact(
 	// hand, was last reset at the VM's last restore — exactly the moment
 	// captured by the snapshot id stored in the restore-base label —
 	// which makes its bitmap consistent with this base.
-	restoreBase, restoreErr := resolveRestoreBaseMemoryObject(ctx, cb, backend)
+	restoreBase, restoreErr := resolveRestoreBaseMemoryObjectFn(ctx, cb, backend)
 	if restoreErr == nil {
-		memoryObject, err := storage.CommitMemoryFromBaseFor(ctx, backend, restoreBase, templateID, memorySizeBytes)
+		memoryObject, err := commitMemoryFromBaseFor(ctx, backend, restoreBase, templateID, memorySizeBytes)
 		if err != nil {
 			return nil, "", err
 		}
@@ -414,20 +423,21 @@ func prepareCommitMemoryArtifact(
 	if live, liveErr := importedSandboxMemoryForCommit(ctx, cb, backend); liveErr != nil {
 		stepLog.Warnf("memory artifact: own volume lookup failed (%v); falling back to full snapshot", liveErr)
 	} else if live != nil {
-		memoryObject, err := storage.CommitMemoryFromBaseFor(ctx, backend, live, templateID, memorySizeBytes)
-		if err != nil {
-			return nil, "", err
+		memoryObject, err := commitMemoryFromBaseFor(ctx, backend, live, templateID, memorySizeBytes)
+		if err == nil {
+			stepLog.Warnf("memory artifact: catalog bases unavailable (%v; %v); "+
+				"falling back to incremental(pagemap_anon) over own volume %s/%s -> %s",
+				baseErr, restoreErr, live.Name, live.Kind, memoryObject.Name)
+			return memoryObject, snapshotTypeIncremental, nil
 		}
-		stepLog.Warnf("memory artifact: catalog bases unavailable (%v; %v); "+
-			"falling back to incremental(pagemap_anon) over own volume %s/%s -> %s",
-			baseErr, restoreErr, live.Name, live.Kind, memoryObject.Name)
-		return memoryObject, snapshotTypeIncremental, nil
+		stepLog.Warnf("memory artifact: own volume %s clone failed (%v); falling back to full snapshot",
+			live.Name, err)
 	}
 
 	// ─── Tier 3: full + fresh empty volume ────────────────────────────
 	stepLog.Warnf("memory artifact: both previous-snapshot base (%v) and last-restore base (%v) "+
 		"unavailable; falling back to full snapshot", baseErr, restoreErr)
-	memoryObject, err := storage.CreateMemoryVolumeFor(ctx, backend, templateID, memorySizeBytes)
+	memoryObject, err := createMemoryVolumeFor(ctx, backend, templateID, memorySizeBytes)
 	if err != nil {
 		return nil, "", err
 	}
@@ -441,14 +451,21 @@ func importedSandboxMemoryForCommit(
 	cb *cubeboxstore.CubeBox,
 	backend string,
 ) (*storage.CowSnapshotObject, error) {
-	if !importedMemoryIsCurrentRestore(cb) {
+	sandboxID := ""
+	if cb != nil {
+		sandboxID = strings.TrimSpace(cb.ID)
+		if sandboxID == "" {
+			sandboxID = strings.TrimSpace(cb.SandboxID)
+		}
+	}
+	live, err := getImportedSandboxMemoryFor(ctx, backend, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if !shouldUseImportedMemoryForCommit(cb, live) {
 		return nil, nil
 	}
-	sandboxID := strings.TrimSpace(cb.ID)
-	if sandboxID == "" {
-		sandboxID = strings.TrimSpace(cb.SandboxID)
-	}
-	return storage.GetImportedSandboxMemoryFor(ctx, backend, sandboxID)
+	return live, nil
 }
 
 // importedMemoryIsCurrentRestore is the Tier 2b gate. ImportedMemoryVol

--- a/Cubelet/services/cubebox/snapshot_base_memory.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory.go
@@ -315,7 +315,7 @@ func preparePauseMemoryArtifact(
 // cube-runtime (CommitSandbox) will write its memory snapshot into, plus
 // the snapshot type flag for this capture.
 //
-// Three-tier degradation:
+// Four-tier degradation:
 //
 // Tier 1 — soft-dirty + reflink from previous snapshot (the happy path).
 // resolveBaseMemoryObject returns the runtime-binding snapshot's memory
@@ -339,6 +339,11 @@ func preparePauseMemoryArtifact(
 // invalidates this label so this tier is skipped. Pause uses
 // preparePauseMemoryArtifact: own vol, then ancestor only when it is
 // the last restore, otherwise last-restore catalog or full.
+//
+// Tier 2b — incremental(pagemap_anon) + clone of the S3 own volume.
+// Cross-node Resume never writes a local pause catalog; the imported
+// sb-*-memory disk is the restore image. Pause already uses this volume.
+// Same-node S3 Resume keeps the pause catalog, so this tier is unused there.
 //
 // Tier 3 — full + fresh empty volume. The last-resort fallback when even
 // the last-restore base file is gone (e.g. the source template was deleted
@@ -396,6 +401,24 @@ func prepareCommitMemoryArtifact(
 		return nil, "", restoreErr
 	}
 
+	// ─── Tier 2b: S3 own volume when the pause catalog is gone ────────
+	// Same-node S3 Resume keeps the pause catalog (tier 1/2). Cross-node
+	// Resume imports onto sb-*-memory and never writes a local pause
+	// package, so Snapshot would otherwise full-dump. Pause already
+	// clones this volume; Commit uses the same base.
+	if live, liveErr := importedSandboxMemoryForCommit(ctx, cb, backend); liveErr != nil {
+		stepLog.Warnf("memory artifact: own volume lookup failed (%v); falling back to full snapshot", liveErr)
+	} else if live != nil {
+		memoryObject, err := storage.CommitMemoryFromBaseFor(ctx, backend, live, templateID, memorySizeBytes)
+		if err != nil {
+			return nil, "", err
+		}
+		stepLog.Warnf("memory artifact: catalog bases unavailable (%v; %v); "+
+			"falling back to incremental(pagemap_anon) over own volume %s/%s -> %s",
+			baseErr, restoreErr, live.Name, live.Kind, memoryObject.Name)
+		return memoryObject, snapshotTypeIncremental, nil
+	}
+
 	// ─── Tier 3: full + fresh empty volume ────────────────────────────
 	stepLog.Warnf("memory artifact: both previous-snapshot base (%v) and last-restore base (%v) "+
 		"unavailable; falling back to full snapshot", baseErr, restoreErr)
@@ -406,4 +429,19 @@ func prepareCommitMemoryArtifact(
 	stepLog.Infof("memory artifact: created empty memory volume %s/%s, snapshot type=%s",
 		memoryObject.Name, memoryObject.Kind, snapshotTypeFull)
 	return memoryObject, snapshotTypeFull, nil
+}
+
+func importedSandboxMemoryForCommit(
+	ctx context.Context,
+	cb *cubeboxstore.CubeBox,
+	backend string,
+) (*storage.CowSnapshotObject, error) {
+	if cb == nil {
+		return nil, nil
+	}
+	sandboxID := strings.TrimSpace(cb.ID)
+	if sandboxID == "" {
+		sandboxID = strings.TrimSpace(cb.SandboxID)
+	}
+	return storage.GetImportedSandboxMemoryFor(ctx, backend, sandboxID)
 }

--- a/Cubelet/services/cubebox/snapshot_base_memory.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory.go
@@ -144,8 +144,8 @@ func resolveLaunchAncestorSnapshotID(cb *cubeboxstore.CubeBox) string {
 // satisfies that when the VM was last restored from the same image — the
 // first Pause after Create-from-template.
 //
-// After Resume the restore-base is the pause package. XFS keeps that
-// catalog so the next Pause clones it (S3 already has a live memory
+// After Resume the restore-base is the pause package. Resume keeps that
+// catalog so the next Pause can clone it (S3 also has a live memory
 // volume). Cloning the template and asking for incremental would drop
 // every page that landed in the pause image and stayed clean. The next
 // restore then comes up holey: agent health can still answer, then
@@ -227,13 +227,14 @@ func resolveMemoryObjectFromSnapshotID(ctx context.Context, backend, snapshotID 
 // overlay into.
 //
 //  1. Own memory volume (S3 same-node resume clone or cross-node import).
-//     S3 Resume deletes the pause package after cloning onto this disk.
+//     Resume keeps the pause catalog; this volume is the live clone of
+//     that image (or the cross-node import when no local catalog exists).
 //  2. Launch ancestor, but only when that image is the VM's last restore
 //     (first Pause after Create-from-template). See
 //     [launchAncestorIsLastRestore].
-//  3. Last-restore catalog. XFS Resume keeps the pause package so this
-//     Pause can incremental-overlay onto that image; Cubelet GCs the
-//     old package after this Pause succeeds (or on Destroy).
+//  3. Last-restore catalog. Resume keeps the pause package so this Pause
+//     can incremental-overlay onto that image; Cubelet GCs the old
+//     package after this Pause succeeds (or on Destroy).
 //  4. Full dump into an empty volume when no catalog/volume base is
 //     left (template gone, or an S3 own-volume clone that failed).
 func preparePauseMemoryArtifact(
@@ -342,8 +343,12 @@ func preparePauseMemoryArtifact(
 //
 // Tier 2b — incremental(pagemap_anon) + clone of the S3 own volume.
 // Cross-node Resume never writes a local pause catalog; the imported
-// sb-*-memory disk is the restore image. Pause already uses this volume.
-// Same-node S3 Resume keeps the pause catalog, so this tier is unused there.
+// sb-*-memory disk is the restore image. Same-node Resume keeps the
+// pause catalog (tier 1/2); 2b is also the fallback if that catalog is
+// later lost. Only used when ImportedMemoryVol is still the last
+// restore (restore-base label equals the pause id). Rollback restamps
+// restore-base and opaque resume invalidates it; both leave a stale
+// import that must not become a pagemap_anon dest.
 //
 // Tier 3 — full + fresh empty volume. The last-resort fallback when even
 // the last-restore base file is gone (e.g. the source template was deleted
@@ -402,10 +407,10 @@ func prepareCommitMemoryArtifact(
 	}
 
 	// ─── Tier 2b: S3 own volume when the pause catalog is gone ────────
-	// Same-node S3 Resume keeps the pause catalog (tier 1/2). Cross-node
-	// Resume imports onto sb-*-memory and never writes a local pause
-	// package, so Snapshot would otherwise full-dump. Pause already
-	// clones this volume; Commit uses the same base.
+	// Cross-node Resume imports onto sb-*-memory and never writes a
+	// local pause package. Same-node catalog miss uses the same volume
+	// only while it is still the last restore (see
+	// importedMemoryIsCurrentRestore).
 	if live, liveErr := importedSandboxMemoryForCommit(ctx, cb, backend); liveErr != nil {
 		stepLog.Warnf("memory artifact: own volume lookup failed (%v); falling back to full snapshot", liveErr)
 	} else if live != nil {
@@ -436,7 +441,7 @@ func importedSandboxMemoryForCommit(
 	cb *cubeboxstore.CubeBox,
 	backend string,
 ) (*storage.CowSnapshotObject, error) {
-	if cb == nil {
+	if !importedMemoryIsCurrentRestore(cb) {
 		return nil, nil
 	}
 	sandboxID := strings.TrimSpace(cb.ID)
@@ -444,4 +449,39 @@ func importedSandboxMemoryForCommit(
 		sandboxID = strings.TrimSpace(cb.SandboxID)
 	}
 	return storage.GetImportedSandboxMemoryFor(ctx, backend, sandboxID)
+}
+
+// importedMemoryIsCurrentRestore is the Tier 2b gate. ImportedMemoryVol
+// is minted at Create/Resume (same-node clone or cross-node import).
+// Rollback restamps RuntimeRestoreSnapshotID onto the rollback target
+// and leaves the import pointing at the pre-rollback disk. Opaque
+// resume writes invalid-runtime-restore-base and also leaves the vol
+// stale. Incremental onto that disk would drop pages that landed in
+// the new restore image.
+//
+// Require Cubelet-stamped Labels only, and require restore-base ==
+// pause id: that is the Resume path this fallback is for. FromSnap
+// without a pause binding stays on catalog / full.
+func importedMemoryIsCurrentRestore(cb *cubeboxstore.CubeBox) bool {
+	if cb == nil {
+		return false
+	}
+	restoreID := cubeBoxLabel(cb, constants.MasterAnnotationRuntimeRestoreSnapshotID)
+	if restoreID == "" || restoreID == runtimeSnapshotBindingInvalidID {
+		return false
+	}
+	pauseID := cubeBoxLabel(cb, constants.MasterAnnotationPauseSnapshotID)
+	if pauseID == "" || pauseID == runtimeSnapshotBindingInvalidID {
+		return false
+	}
+	return restoreID == pauseID
+}
+
+// shouldUseImportedMemoryForCommit is the testable Tier 2b decision:
+// a non-empty imported volume plus importedMemoryIsCurrentRestore.
+func shouldUseImportedMemoryForCommit(cb *cubeboxstore.CubeBox, live *storage.CowSnapshotObject) bool {
+	if live == nil || strings.TrimSpace(live.Name) == "" {
+		return false
+	}
+	return importedMemoryIsCurrentRestore(cb)
 }

--- a/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
@@ -5,13 +5,16 @@
 package cubebox
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
 )
@@ -413,4 +416,96 @@ func TestShouldUseImportedMemoryForCommit(t *testing.T) {
 		Name: "sb-2b-vol-memory",
 		Kind: storage.CowKindVolume,
 	}), "stale import after rollback must full-dump")
+}
+
+func installCommitMemoryTestHooks(t *testing.T) {
+	t.Helper()
+	origBase := resolveBaseMemoryObjectFn
+	origRestore := resolveRestoreBaseMemoryObjectFn
+	origCommit := commitMemoryFromBaseFor
+	origCreate := createMemoryVolumeFor
+	origImport := getImportedSandboxMemoryFor
+	t.Cleanup(func() {
+		resolveBaseMemoryObjectFn = origBase
+		resolveRestoreBaseMemoryObjectFn = origRestore
+		commitMemoryFromBaseFor = origCommit
+		createMemoryVolumeFor = origCreate
+		getImportedSandboxMemoryFor = origImport
+	})
+	resolveBaseMemoryObjectFn = func(context.Context, *cubeboxstore.CubeBox, string) (*storage.CowSnapshotObject, error) {
+		return nil, ErrNoBaseMemoryForIncremental
+	}
+	resolveRestoreBaseMemoryObjectFn = func(context.Context, *cubeboxstore.CubeBox, string) (*storage.CowSnapshotObject, error) {
+		return nil, ErrNoBaseMemoryForIncremental
+	}
+}
+
+func resumeBoxForCommit2b(id, pauseID string) *cubeboxstore.CubeBox {
+	cb := newCubeboxWithStatusForTest(id, cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(cb, pauseID)
+	setRuntimeRestoreBaseLabels(cb, pauseID, time.Now().UTC())
+	return cb
+}
+
+func TestPrepareCommitMemoryArtifactTier2bIncremental(t *testing.T) {
+	installCommitMemoryTestHooks(t)
+	pauseID := "snap-commit-2b-000000000000001"
+	cb := resumeBoxForCommit2b("sb-commit-2b", pauseID)
+	getImportedSandboxMemoryFor = func(_ context.Context, _, sandboxID string) (*storage.CowSnapshotObject, error) {
+		return &storage.CowSnapshotObject{Name: "sb-" + sandboxID + "-memory", Kind: storage.CowKindVolume}, nil
+	}
+	var clonedFrom string
+	commitMemoryFromBaseFor = func(_ context.Context, _ string, src *storage.CowSnapshotObject, id string, _ uint64) (*storage.CowSnapshotObject, error) {
+		clonedFrom = src.Name
+		return &storage.CowSnapshotObject{Name: "clone-" + id, Kind: storage.CowKindVolume}, nil
+	}
+	createMemoryVolumeFor = func(context.Context, string, string, uint64) (*storage.CowSnapshotObject, error) {
+		t.Fatal("catalog miss + imported vol must not full-dump")
+		return nil, errors.New("unexpected full")
+	}
+
+	obj, snapType, err := prepareCommitMemoryArtifact(context.Background(), log.G(context.Background()), cb, "snap-new", 4096, "s3")
+	require.NoError(t, err)
+	assert.Equal(t, snapshotTypeIncremental, snapType)
+	assert.Equal(t, "sb-sb-commit-2b-memory", clonedFrom)
+	assert.Equal(t, "clone-snap-new", obj.Name)
+}
+
+func TestPrepareCommitMemoryArtifactFullWhenImportedEmpty(t *testing.T) {
+	installCommitMemoryTestHooks(t)
+	cb := resumeBoxForCommit2b("sb-commit-full", "snap-commit-full-00000000001")
+	getImportedSandboxMemoryFor = func(context.Context, string, string) (*storage.CowSnapshotObject, error) {
+		return nil, nil
+	}
+	commitMemoryFromBaseFor = func(context.Context, string, *storage.CowSnapshotObject, string, uint64) (*storage.CowSnapshotObject, error) {
+		t.Fatal("empty import must not clone")
+		return nil, errors.New("unexpected clone")
+	}
+	createMemoryVolumeFor = func(_ context.Context, _, id string, _ uint64) (*storage.CowSnapshotObject, error) {
+		return &storage.CowSnapshotObject{Name: "empty-" + id, Kind: storage.CowKindVolume}, nil
+	}
+
+	obj, snapType, err := prepareCommitMemoryArtifact(context.Background(), log.G(context.Background()), cb, "snap-new", 4096, "s3")
+	require.NoError(t, err)
+	assert.Equal(t, snapshotTypeFull, snapType)
+	assert.Equal(t, "empty-snap-new", obj.Name)
+}
+
+func TestPrepareCommitMemoryArtifact2bCloneFailFallsToFull(t *testing.T) {
+	installCommitMemoryTestHooks(t)
+	cb := resumeBoxForCommit2b("sb-commit-2b-fail", "snap-commit-2bfail-00000001")
+	getImportedSandboxMemoryFor = func(context.Context, string, string) (*storage.CowSnapshotObject, error) {
+		return &storage.CowSnapshotObject{Name: "sb-commit-2b-fail-memory", Kind: storage.CowKindVolume}, nil
+	}
+	commitMemoryFromBaseFor = func(context.Context, string, *storage.CowSnapshotObject, string, uint64) (*storage.CowSnapshotObject, error) {
+		return nil, errors.New("clone busy")
+	}
+	createMemoryVolumeFor = func(_ context.Context, _, id string, _ uint64) (*storage.CowSnapshotObject, error) {
+		return &storage.CowSnapshotObject{Name: "empty-" + id, Kind: storage.CowKindVolume}, nil
+	}
+
+	obj, snapType, err := prepareCommitMemoryArtifact(context.Background(), log.G(context.Background()), cb, "snap-new", 4096, "s3")
+	require.NoError(t, err)
+	assert.Equal(t, snapshotTypeFull, snapType, "2b clone failure must fall through like Pause")
+	assert.Equal(t, "empty-snap-new", obj.Name)
 }

--- a/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
 )
 
 // TestErrNoBaseMemoryForIncrementalIsSentinel locks in that
@@ -360,4 +361,56 @@ func TestLaunchAncestorIsLastRestore(t *testing.T) {
 
 	assert.False(t, launchAncestorIsLastRestore(fromTpl, ""),
 		"empty ancestor is never a valid incremental dest")
+}
+
+func TestImportedMemoryIsCurrentRestore(t *testing.T) {
+	pauseID := "snap-pause-keep-2b"
+	cb := newCubeboxWithStatusForTest("sb-2b", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(cb, pauseID)
+	setRuntimeRestoreBaseLabels(cb, pauseID, time.Now().UTC())
+	assert.True(t, importedMemoryIsCurrentRestore(cb),
+		"Resume stamps restore-base to the pause id; 2b may use the import")
+
+	setRuntimeRestoreBaseLabels(cb, "snap-rollback-target", time.Now().UTC())
+	assert.False(t, importedMemoryIsCurrentRestore(cb),
+		"Rollback restamps restore-base; stale ImportedMemoryVol must not be 2b")
+
+	invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(cb, time.Now().UTC())
+	assert.False(t, importedMemoryIsCurrentRestore(cb),
+		"opaque resume invalidates restore-base; stale import must not be 2b")
+
+	fromSnap := newCubeboxWithStatusForTest("sb-fromsnap", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	setRuntimeRestoreBaseLabels(fromSnap, "snap-customer", time.Now().UTC())
+	assert.False(t, importedMemoryIsCurrentRestore(fromSnap),
+		"FromSnap without a pause binding stays on catalog / full")
+
+	forged := newCubeboxWithStatusForTest("sb-forged-2b", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	forged.AddAnnotations(map[string]string{
+		constants.MasterAnnotationPauseSnapshotID:          pauseID,
+		constants.MasterAnnotationRuntimeRestoreSnapshotID: pauseID,
+	})
+	assert.False(t, importedMemoryIsCurrentRestore(forged),
+		"user Create annotations must not open Tier 2b")
+}
+
+func TestShouldUseImportedMemoryForCommit(t *testing.T) {
+	pauseID := "snap-pause-keep-2b-vol"
+	cb := newCubeboxWithStatusForTest("sb-2b-vol", cubeboxstore.Status{StartedAt: time.Now().UnixNano()})
+	stampPauseSnapshotID(cb, pauseID)
+	setRuntimeRestoreBaseLabels(cb, pauseID, time.Now().UTC())
+
+	assert.True(t, shouldUseImportedMemoryForCommit(cb, &storage.CowSnapshotObject{
+		Name: "sb-2b-vol-memory",
+		Kind: storage.CowKindVolume,
+	}), "imported vol + current restore → incremental 2b")
+	assert.False(t, shouldUseImportedMemoryForCommit(cb, nil),
+		"empty import must fall through to full")
+	assert.False(t, shouldUseImportedMemoryForCommit(cb, &storage.CowSnapshotObject{}),
+		"nameless import must fall through to full")
+
+	setRuntimeRestoreBaseLabels(cb, "snap-after-rollback", time.Now().UTC())
+	assert.False(t, shouldUseImportedMemoryForCommit(cb, &storage.CowSnapshotObject{
+		Name: "sb-2b-vol-memory",
+		Kind: storage.CowKindVolume,
+	}), "stale import after rollback must full-dump")
 }

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -608,9 +608,10 @@ func (s *service) CleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 }
 
 // cleanupTemplate removes a catalog package. honorLiveXFSPause is true for
-// the Master RPC: XFS Resume still mmaps the pause file, so a Cleanup of
-// that snap while a live sandbox holds cube.master.pause.snapshot.id is a
-// successful no-op. Cubelet's own next-Pause / Destroy GC passes false.
+// the Master RPC: Resume still needs the pause catalog (XFS mmap, S3
+// Snapshot last-restore), so a Cleanup of that snap while a live sandbox
+// holds cube.master.pause.snapshot.id is a successful no-op. Cubelet's own
+// next-Pause / Destroy GC passes false.
 func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTemplateRequest, honorLiveXFSPause bool) (*cubebox.CleanupTemplateResponse, error) {
 	rsp := &cubebox.CleanupTemplateResponse{
 		RequestID:  req.GetRequestID(),
@@ -652,9 +653,9 @@ func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 			}
 		}
 	}
-	if honorLiveXFSPause && keepLiveXFSPausePackage(s.listCubeboxes(), rsp.TemplateID, backend) &&
+	if honorLiveXFSPause && keepLiveXFSPausePackage(s.listCubeboxes(), rsp.TemplateID) &&
 		entry != nil && isPauseSnapshotCatalogKind(entry.Kind) {
-		log.G(ctx).Infof("CleanupTemplate %s: keeping XFS pause package; a live sandbox still restores from it",
+		log.G(ctx).Infof("CleanupTemplate %s: keeping pause package; a live sandbox still restores from it",
 			rsp.TemplateID)
 		return rsp, nil
 	}

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -607,12 +607,12 @@ func (s *service) CleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 	return s.cleanupTemplate(ctx, req, true)
 }
 
-// cleanupTemplate removes a catalog package. honorLiveXFSPause is true for
+// cleanupTemplate removes a catalog package. honorLivePauseKeep is true for
 // the Master RPC: Resume still needs the pause catalog (XFS mmap, S3
 // Snapshot last-restore), so a Cleanup of that snap while a live sandbox
 // holds cube.master.pause.snapshot.id is a successful no-op. Cubelet's own
 // next-Pause / Destroy GC passes false.
-func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTemplateRequest, honorLiveXFSPause bool) (*cubebox.CleanupTemplateResponse, error) {
+func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTemplateRequest, honorLivePauseKeep bool) (*cubebox.CleanupTemplateResponse, error) {
 	rsp := &cubebox.CleanupTemplateResponse{
 		RequestID:  req.GetRequestID(),
 		TemplateID: strings.TrimSpace(req.GetTemplateID()),
@@ -653,8 +653,7 @@ func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 			}
 		}
 	}
-	if honorLiveXFSPause && keepLiveXFSPausePackage(s.listCubeboxes(), rsp.TemplateID) &&
-		entry != nil && isPauseSnapshotCatalogKind(entry.Kind) {
+	if shouldKeepLivePausePackage(honorLivePauseKeep, s.listCubeboxes(), rsp.TemplateID, catalogKindForKeep(entry)) {
 		log.G(ctx).Infof("CleanupTemplate %s: keeping pause package; a live sandbox still restores from it",
 			rsp.TemplateID)
 		return rsp, nil

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -607,6 +607,15 @@ func (s *service) CleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 	return s.cleanupTemplate(ctx, req, true)
 }
 
+// Test hooks so cleanupTemplate keep vs delete can run without cubecow.
+var (
+	getLocalSnapshotForFn      = storage.GetLocalSnapshotFor
+	cleanupIsCowBackend        = storage.IsCowBackend
+	cleanupReleaseS3Metadata   = storage.ReleaseS3MetadataVolume
+	cleanupObjectsFor          = storage.CleanupObjectsFor
+	cleanupTemplateLocalDataFn = storage.CleanupTemplateLocalData
+)
+
 // cleanupTemplate removes a catalog package. honorLivePauseKeep is true for
 // the Master RPC: Resume still needs the pause catalog (XFS mmap, S3
 // Snapshot last-restore), so a Cleanup of that snap while a live sandbox
@@ -644,10 +653,10 @@ func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 		rsp.Ret.RetMsg = err.Error()
 		return rsp, nil
 	}
-	entry, catErr := storage.GetLocalSnapshotFor(ctx, backend, rsp.TemplateID)
+	entry, catErr := getLocalSnapshotForFn(ctx, backend, rsp.TemplateID)
 	if errors.Is(catErr, storage.ErrSnapshotCatalogNotFound) {
 		if other := otherCowBackend(backend); other != backend {
-			if alt, altErr := storage.GetLocalSnapshotFor(ctx, other, rsp.TemplateID); altErr == nil {
+			if alt, altErr := getLocalSnapshotForFn(ctx, other, rsp.TemplateID); altErr == nil {
 				backend = other
 				entry = alt
 			}
@@ -669,11 +678,11 @@ func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 	// they outlive a failed object sweep and a retry can pick up where this
 	// one stopped. Objects already gone count as cleaned, so a Resume that
 	// consumed the pause package still drops the dir here.
-	if storage.IsCowBackend() {
-		if err := storage.ReleaseS3MetadataVolume(ctx, backend, rsp.TemplateID); err != nil {
+	if cleanupIsCowBackend() {
+		if err := cleanupReleaseS3Metadata(ctx, backend, rsp.TemplateID); err != nil {
 			log.G(ctx).Warnf("CleanupTemplate %s: s3 metadata umount: %v", rsp.TemplateID, err)
 		}
-		if err := storage.CleanupObjectsFor(ctx, backend, refs); err != nil {
+		if err := cleanupObjectsFor(ctx, backend, refs); err != nil {
 			log.G(ctx).Warnf("CleanupTemplate %s: cubecow object cleanup, keeping package for retry: %v",
 				rsp.TemplateID, err)
 			rsp.Ret.RetCode = errorcode.ErrorCode_Unknown
@@ -681,7 +690,7 @@ func (s *service) cleanupTemplate(ctx context.Context, req *cubebox.CleanupTempl
 			return rsp, nil
 		}
 	}
-	if err := storage.CleanupTemplateLocalData(ctx, rsp.TemplateID, snapshotPath); err != nil {
+	if err := cleanupTemplateLocalDataFn(ctx, rsp.TemplateID, snapshotPath); err != nil {
 		rerr, _ := ret.FromError(err)
 		if rerr == nil || rerr.Code() == 0 {
 			rsp.Ret.RetCode = errorcode.ErrorCode_Unknown

--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -994,11 +994,12 @@ func (l *local) prefetchRestoreMemoryVolURL(ctx context.Context, opts *workflow.
 	backend := createContextStorageBackend(opts)
 	// Cross-node imports a sandbox-private memory volume. XFS template
 	// start / pause resume / FromSnap mmap the original snapshot file
-	// MAP_PRIVATE. Master's Resume CleanupTemplate is a no-op on XFS
-	// while the live sandbox still holds that pause id; next Pause or
-	// Destroy unlinks the package (CH keeps the fd open). Same-node S3
-	// pause resume still clones onto sb-<id>-memory: deactivate of an
-	// NVMe lvol would yank the live disk, unlike an unlinked XFS file.
+	// MAP_PRIVATE. Master's Resume CleanupTemplate is a no-op while the
+	// live sandbox still holds that pause id; next Pause or Destroy
+	// unlinks the package (CH keeps the fd open). Same-node S3 pause
+	// resume still clones onto sb-<id>-memory so deactivate of the
+	// package NVMe cannot yank the live disk; the package catalog is
+	// still kept for Snapshot last-restore, like XFS.
 	if imp := CrossNodeSandboxImport(annotations); imp != nil {
 		name, devPath, err := imp.Memory(ctx)
 		if err != nil {


### PR DESCRIPTION
## Summary

- After S3 Resume, Cubelet used to delete the pause catalog immediately. `CommitSandbox` only resolves a memory base from that catalog, so the next Snapshot fell through to a full 2GiB dump (same-node and cross-node).
- Resume-time `CleanupTemplate` now no-ops on S3 the same way it already does on XFS while a live sandbox still holds the pause id. The next Pause or Destroy still GCs the old package. Cross-node origin leftover (tombstone + package) is still dropped.
- Cross-node Resume never writes a local pause catalog. `prepareCommitMemoryArtifact` now clones the imported `sb-*-memory` volume (the same base Pause already uses) instead of full-dumping.

XFS Resume keep / mmap behavior is unchanged.

## Test plan

- [ ] Unit: `TestKeepLiveXFSPausePackage` — live sandbox keeps the package; PAUSED / forged annotation still allow delete
- [ ] Same-node S3: Create → Pause → Resume → Snapshot — memory is incremental / soft-dirty, not full; pause package dir still present until next Pause or Destroy
- [ ] Same-node S3: Resume → Pause again — second pause is incremental; previous package is cleaned
- [ ] Cross-node S3: Pause@A → Resume@B → Snapshot@B — Snapshot is incremental (own volume), not Device busy
- [ ] Destroy / DelPaused still delete the pause package

Signed-off-by: ls-ggg <335814617@qq.com>