### PR TITLE
feat(templatecenter): port chart README and tpl migrate workflow

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -126,6 +126,11 @@ type templateDeleteRequest struct {
 	Sync         bool   `json:"sync,omitempty"`
 }
 
+type templateMigrateRequest struct {
+	RequestID  string `json:"requestID,omitempty"`
+	TemplateID string `json:"template_id,omitempty"`
+}
+
 func mergeCubeNetworkConfigFlags(c *cli.Context, existing *types.CubeNetworkConfig) *types.CubeNetworkConfig {
 	hasAllowInternetAccess := c.IsSet("allow-internet-access")
 	allowOut := dedupeCIDRs(c.StringSlice("allow-out-cidr"))
@@ -324,6 +329,7 @@ var TemplateCommand = cli.Command{
 		TemplateCreateCommand,
 		TemplateCommitCommand,
 		TemplateCreateFromImageCommand,
+		TemplateMergeCommand,
 		TemplateRedoCommand,
 		TemplateDeleteCommand,
 		TemplateSetAliasCommand,
@@ -986,6 +992,65 @@ var TemplateCreateFromImageCommand = cli.Command{
 	},
 }
 
+var TemplateMergeCommand = cli.Command{
+	Name: "merge",
+	// "merge" is the CLI spelling of the /cube/template/migrate API; the usage
+	// text keeps the word "migrate" so docs/errors that mention `tpl migrate`
+	// still lead here.
+	Usage:     "migrate one template artifact to the template center (the CLI command is `merge`; the API is /cube/template/migrate)",
+	ArgsUsage: "<template-id>",
+	Flags: []cli.Flag{
+		cli.StringFlag{Name: "template-id", Usage: "template id (or alias) to migrate"},
+		cli.BoolFlag{Name: "detach, no-wait", Usage: "submit and exit immediately instead of watching the merge job to completion"},
+		cli.DurationFlag{Name: "interval", Value: defaultWatchInterval, Usage: "poll interval while watching the job"},
+		cli.BoolFlag{Name: "json", Usage: "print raw json response"},
+	},
+	Action: func(c *cli.Context) error {
+		templateID := resolveTemplateID(c)
+		if templateID == "" {
+			return errors.New("template-id is required")
+		}
+		serverList = getServerAddrs(c)
+		if len(serverList) == 0 {
+			return errors.New("no server addr")
+		}
+		port = c.GlobalString("port")
+		host := serverList[rand.Int()%len(serverList)]
+		req := &templateMigrateRequest{
+			RequestID:  uuid.New().String(),
+			TemplateID: templateID,
+		}
+		body, err := jsoniter.Marshal(req)
+		if err != nil {
+			return err
+		}
+		url := fmt.Sprintf("http://%s/cube/template/migrate", net.JoinHostPort(host, port))
+		rsp := &templateImageJobResponse{}
+		if err := doHttpReq(c, url, http.MethodPost, req.RequestID, bytes.NewBuffer(body), rsp); err != nil {
+			return err
+		}
+		if rsp.Ret == nil {
+			return errors.New("empty response")
+		}
+		if rsp.Ret.RetCode != 200 {
+			return errors.New(rsp.Ret.RetMsg)
+		}
+		if c.Bool("json") {
+			commands.PrintAsJSON(rsp)
+			return nil
+		}
+		if detachRequested(c) || rsp.Job == nil {
+			printTemplateImageJob(rsp.Job)
+			return nil
+		}
+		log.Printf("submitted merge job: job_id=%s template_id=%s\n", rsp.Job.JobID, rsp.Job.TemplateID)
+		// Watch through the dedicated migrate endpoint, not the from-image one:
+		// the from-image status handler happens to return MIGRATE rows today
+		// only because it does not filter by operation.
+		return runMigrateJobWatch(c, rsp.Job.JobID)
+	},
+}
+
 var TemplateRedoCommand = cli.Command{
 	Name:      "redo",
 	Usage:     "redo a template on all, specific, or failed nodes",
@@ -1047,7 +1112,7 @@ var TemplateRedoCommand = cli.Command{
 
 var TemplateStatusCommand = cli.Command{
 	Name:  "status",
-	Usage: "show create-from-image job status",
+	Usage: "show template image/merge job status",
 	Flags: []cli.Flag{
 		cli.StringFlag{Name: "job-id", Usage: "template image job id"},
 		cli.BoolFlag{Name: "json", Usage: "print raw json response"},
@@ -1072,7 +1137,7 @@ var TemplateStatusCommand = cli.Command{
 
 var TemplateWatchCommand = cli.Command{
 	Name:  "watch",
-	Usage: "watch create-from-image job progress until completion",
+	Usage: "watch template image/merge job progress until completion",
 	Flags: []cli.Flag{
 		cli.StringFlag{Name: "job-id", Usage: "template image job id"},
 		cli.DurationFlag{Name: "interval", Value: 2 * time.Second, Usage: "poll interval"},
@@ -1303,6 +1368,28 @@ func fetchTemplateImageJob(c *cli.Context, jobID string) (*templateImageJobRespo
 	return rsp, nil
 }
 
+func fetchTemplateMigrateJob(c *cli.Context, jobID string) (*templateImageJobResponse, error) {
+	serverList = getServerAddrs(c)
+	if len(serverList) == 0 {
+		return nil, errors.New("no server addr")
+	}
+	port = c.GlobalString("port")
+	requestID := uuid.New().String()
+	host := serverList[rand.Int()%len(serverList)]
+	url := fmt.Sprintf("http://%s/cube/template/migrate?job_id=%s", net.JoinHostPort(host, port), jobID)
+	rsp := &templateImageJobResponse{}
+	if err := doHttpReq(c, url, http.MethodGet, requestID, nil, rsp); err != nil {
+		return nil, err
+	}
+	if rsp.Ret == nil {
+		return nil, errors.New("empty response")
+	}
+	if rsp.Ret.RetCode != 200 {
+		return nil, errors.New(rsp.Ret.RetMsg)
+	}
+	return rsp, nil
+}
+
 func printTemplateImageJob(job *types.TemplateImageJobInfo) {
 	if job == nil {
 		fmt.Println("job: <nil>")
@@ -1362,11 +1449,20 @@ func formatTemplateImageJobWatchPhase(job *types.TemplateImageJobInfo) string {
 	phase := "UNKNOWN"
 	if job != nil {
 		if job.Status == "READY" {
+			if job.Operation == "MIGRATE" {
+				return "READY"
+			}
 			return "[7/7] READY"
 		}
 		if job.Phase != "" {
 			phase = job.Phase
 		}
+	}
+
+	// Migrate jobs have a single transfer phase; the 7-step build progress
+	// display is meaningless for them.
+	if job != nil && job.Operation == "MIGRATE" {
+		return phase
 	}
 
 	phaseOrder := map[string]int{

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -799,6 +799,12 @@ func TestResolveTemplateIDFromAllTemplateCommands(t *testing.T) {
 			want: "tpl-redo-1",
 		},
 		{
+			name: "merge via positional arg",
+			cmd:  TemplateMergeCommand,
+			args: []string{"tpl-merge-1"},
+			want: "tpl-merge-1",
+		},
+		{
 			name: "set-alias via positional arg",
 			cmd:  TemplateSetAliasCommand,
 			args: []string{"tpl-set-1"},
@@ -819,6 +825,12 @@ func TestResolveTemplateIDFromAllTemplateCommands(t *testing.T) {
 		{
 			name: "redo flag overrides positional",
 			cmd:  TemplateRedoCommand,
+			args: []string{"--template-id", "flag-id", "positional-id"},
+			want: "flag-id",
+		},
+		{
+			name: "merge flag overrides positional",
+			cmd:  TemplateMergeCommand,
 			args: []string{"--template-id", "flag-id", "positional-id"},
 			want: "flag-id",
 		},

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_watch.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_watch.go
@@ -111,6 +111,38 @@ func runImageJobWatchPlain(c *cli.Context, jobID string) error {
 	}
 }
 
+func runMigrateJobWatch(c *cli.Context, jobID string) error {
+	interval := watchInterval(c)
+	var lastPrinted string
+	for {
+		rsp, err := fetchTemplateMigrateJob(c, jobID)
+		if err != nil {
+			return err
+		}
+		if rsp.Job == nil {
+			printTemplateImageJobWatchLine(nil)
+			printTemplateImageJobCompletionSummary(nil)
+			return errors.New("empty job")
+		}
+		current := formatTemplateImageJobWatchLine(rsp.Job)
+		if current != lastPrinted {
+			printTemplateImageJobWatchLine(rsp.Job)
+			lastPrinted = current
+		}
+		if rsp.Job.Status == "READY" || rsp.Job.Status == "FAILED" {
+			printTemplateImageJobCompletionSummary(rsp.Job)
+			if c.Bool("json") {
+				commands.PrintAsJSON(rsp)
+			}
+			if rsp.Job.Status == "FAILED" {
+				return errors.New(imageJobFailureMessage(rsp.Job))
+			}
+			return nil
+		}
+		time.Sleep(interval)
+	}
+}
+
 // runBuildWatch follows a sandbox commit build to completion.
 func runBuildWatch(c *cli.Context, buildID string) error {
 	if !shouldUseTUI(c) {

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -84,7 +84,13 @@ type CommonConf struct {
 	// CubeMaster's HTTP base URL, used by CubeTemplateCenter to report build
 	// results. Can be set here (persistent, per-deployment) or overridden by
 	// the CUBE_MASTER_ADDR environment variable (ad-hoc debugging). Env wins
-	// over yaml. Only CubeTemplateCenter reads this; CubeMaster itself ignores it.
+	// over yaml.
+	//
+	// CubeMaster also reads it (Config.MasterAddr()): it is the address every
+	// other component must use to reach this process, so it is the only
+	// trustworthy value when the incoming request's Host header is a
+	// wildcard/loopback (e.g. `curl http://0.0.0.0:8089`), which is
+	// unreachable from any other node.
 	MasterAddr string `yaml:"master_addr"`
 	// CubeOpsBootRetries: additional LoadNodes attempts (0 = single-shot).
 	// Bridges the systemd startup window.
@@ -1182,6 +1188,31 @@ func validate(cfg *Config) error {
 //go:noinline
 func GetConfig() *Config {
 	return cfg
+}
+
+// EnvMasterAddr is the deployment-wide "how to reach CubeMaster" address.
+// Read on every call so it can be changed without reloading conf.yaml.
+const EnvMasterAddr = "CUBE_MASTER_ADDR"
+
+// MasterAddr returns CubeMaster's own externally-reachable HTTP base URL with
+// no trailing slash, or "" when unset.
+//
+// CubeMaster needs it for one specific job: the artifact download base URL it
+// hands to CubeTemplateCenter (and stores in
+// rootfs_artifacts.master_node_ip) must be an address every Cubelet can
+// actually reach. Deriving it from the incoming request's Host header is
+// wrong whenever the caller used a wildcard/loopback address (`curl
+// http://0.0.0.0:8089`, `curl http://localhost:8089`): that value is
+// meaningless to any other node, so Cubelet's artifact download 404s/fails
+// while the build itself looks perfectly healthy.
+func (c *Config) MasterAddr() string {
+	if addr := strings.TrimSpace(os.Getenv(EnvMasterAddr)); addr != "" {
+		return strings.TrimRight(addr, "/")
+	}
+	if c != nil && c.Common != nil {
+		return strings.TrimRight(strings.TrimSpace(c.Common.MasterAddr), "/")
+	}
+	return ""
 }
 
 // EnvTemplateCenterAddr is how CubeMaster finds CubeTemplateCenter. It mirrors

--- a/CubeMaster/pkg/base/db/models/template_image.go
+++ b/CubeMaster/pkg/base/db/models/template_image.go
@@ -24,9 +24,9 @@ type RootfsArtifact struct {
 	GeneratedRequestJSON    string `json:"generated_request_json" gorm:"column:generated_request_json"`
 	WritableLayerSize       string `json:"writable_layer_size" gorm:"column:writable_layer_size"`
 	DownloadToken           string `json:"download_token" gorm:"column:download_token"`
-	// ArtifactURL is the S3/MinIO presigned download URL. When non-empty,
-	// distribution uses this URL directly instead of building a local HTTP URL
-	// from MasterNodeIP. Empty means the legacy local download path.
+	// ArtifactURL is the S3/MinIO presigned download URL persisted at build time.
+	// CubeMaster/TC may re-sign it when proxying downloads, but Cubelets now
+	// receive the stable CubeMaster download endpoint rather than this raw URL.
 	ArtifactURL string `json:"artifact_url" gorm:"column:artifact_url"`
 	Status      string `json:"status" gorm:"column:status"`
 	LastError   string `json:"last_error" gorm:"column:last_error"`

--- a/CubeMaster/pkg/localcache/template_locality.go
+++ b/CubeMaster/pkg/localcache/template_locality.go
@@ -6,6 +6,8 @@ package localcache
 
 import (
 	"context"
+	"sort"
+	"strconv"
 	"strings"
 
 	fwk "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/framework"
@@ -23,24 +25,47 @@ func SyncNodeTemplates(ctx context.Context, nodeID string, templateIDs []string)
 		previous = discoverNodeTemplateSet(nodeID)
 	}
 
-	log.G(ctx).Infof("SyncNodeTemplates nodeID=%s current=%v previous=%v previousCached=%v", nodeID, current, previous, ok)
-
+	deregistered := make([]string, 0)
+	registered := make([]string, 0)
 	for templateID := range previous {
 		if _, exists := current[templateID]; exists {
 			continue
 		}
-		log.G(ctx).Infof("SyncNodeTemplates deregister nodeID=%s templateID=%s", nodeID, templateID)
 		deregisterTemplateReplica(templateID, nodeID, false)
+		deregistered = append(deregistered, templateID)
 	}
 	for templateID := range current {
 		if _, exists := previous[templateID]; exists && GetImageStateByNode(templateID, nodeID) != nil {
-			log.G(ctx).Infof("SyncNodeTemplates skip nodeID=%s templateID=%s (already registered)", nodeID, templateID)
 			continue
 		}
-		log.G(ctx).Infof("SyncNodeTemplates register nodeID=%s templateID=%s", nodeID, templateID)
 		registerTemplateReplica(templateID, nodeID, 1, false)
+		registered = append(registered, templateID)
 	}
 	setCachedNodeTemplateSet(nodeID, current)
+
+	if len(deregistered) == 0 && len(registered) == 0 {
+		log.G(ctx).Debugf("SyncNodeTemplates nodeID=%s unchanged current=%d previousCached=%v", nodeID, len(current), ok)
+		return
+	}
+	log.G(ctx).Infof("SyncNodeTemplates nodeID=%s registered=%d deregistered=%d current=%d previous=%d previousCached=%v registered_templates=%s deregistered_templates=%s",
+		nodeID, len(registered), len(deregistered), len(current), len(previous), ok,
+		summarizeTemplateIDChanges(registered), summarizeTemplateIDChanges(deregistered))
+	if log.IsDebug() {
+		log.G(ctx).Debugf("SyncNodeTemplates detail nodeID=%s current=%v previous=%v", nodeID, current, previous)
+	}
+}
+
+func summarizeTemplateIDChanges(templateIDs []string) string {
+	if len(templateIDs) == 0 {
+		return "[]"
+	}
+	sorted := append([]string(nil), templateIDs...)
+	sort.Strings(sorted)
+	const maxItems = 8
+	if len(sorted) <= maxItems {
+		return "[" + strings.Join(sorted, " ") + "]"
+	}
+	return "[" + strings.Join(sorted[:maxItems], " ") + " ... +" + strconv.Itoa(len(sorted)-maxItems) + " more]"
 }
 
 func normalizeTemplateIDSet(templateIDs []string) map[string]struct{} {

--- a/CubeMaster/pkg/service/httpservice/cube/cube.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cube.go
@@ -34,6 +34,7 @@ const (
 	TemplateAction                         = "/template"
 	TemplateCompatAction                   = "/template/compat"
 	TemplateRedoAction                     = "/template/redo"
+	TemplateMigrateAction                  = "/template/migrate"
 	TemplateBuildStatusAction              = "/template/build"
 	TemplateFromImageAction                = "/template/from-image"
 	TemplateArtifactDownloadAction         = "/template/artifact/download"

--- a/CubeMaster/pkg/service/httpservice/cube/routes.go
+++ b/CubeMaster/pkg/service/httpservice/cube/routes.go
@@ -105,12 +105,14 @@ func RegisterCubeRoutes(g *gin.RouterGroup) {
 	//
 	// The proxied remainder is uncached and safe on TC: the compat matrix is
 	// a plain DB read/write and the artifact download is file serving (or an
-	// S3 redirect). Routes are enumerated explicitly (mirroring
+	// S3 proxy stream). Routes are enumerated explicitly (mirroring
 	// RegisterTemplateRoutes) rather than via a wildcard catch-all, so the
 	// local routes can be carved out; keep this list in sync with
 	// RegisterTemplateRoutes below.
 	g.POST(TemplateFromImageAction, createTemplateFromImageGinHandler)
 	g.POST(TemplateRedoAction, handleRedoTemplateAction)
+	g.POST(TemplateMigrateAction, handleTemplateMigrateAction)
+	g.GET(TemplateMigrateAction, getTemplateMigrateStatusAction)
 	g.POST(TemplateAction, createTemplateGinHandler)
 	g.DELETE(TemplateAction, deleteTemplateGinHandler)
 	g.GET(TemplateAction, getTemplateGinHandler)

--- a/CubeMaster/pkg/service/httpservice/cube/routes_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/routes_test.go
@@ -62,6 +62,8 @@ func TestCubeRoutesTemplateWritesStayOnCubeMaster(t *testing.T) {
 		"PUT /cube/template/:template_id/alias":     "setTemplateAliasGinHandler",
 		"POST /cube/template/from-image":            "createTemplateFromImageGinHandler",
 		"POST /cube/template/redo":                  "handleRedoTemplateAction",
+		"POST /cube/template/migrate":               "handleTemplateMigrateAction",
+		"GET /cube/template/migrate":                "getTemplateMigrateStatusAction",
 		"GET /cube/template/build/:build_id/status": "handleTemplateBuildStatusAction",
 		"GET /cube/template/from-image":             "getTemplateFromImageGinHandler",
 	}
@@ -122,6 +124,8 @@ func TestTemplateCenterRoutesExcludeWritesAndCachedReads(t *testing.T) {
 		"PUT /cube/template/:template_id/alias",
 		"POST /cube/template/from-image",
 		"POST /cube/template/redo",
+		"POST /cube/template/migrate",
+		"GET /cube/template/migrate",
 	}
 	for _, route := range absent {
 		method, path, _ := strings.Cut(route, " ")

--- a/CubeMaster/pkg/service/httpservice/cube/template_from_image.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_from_image.go
@@ -5,7 +5,6 @@
 package cube
 
 import (
-	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -420,45 +419,29 @@ func handleRootfsArtifactAction(c *gin.Context) {
 }
 
 // requestBaseURL returns the base URL other components must use to reach this
-// CubeMaster. An empty return means "nothing externally usable was found" and
-// callers must fall back to the artifact row / hostname hint rather than
-// persist a value no Cubelet can dial.
+// CubeMaster.
 //
-// It is NOT simply scheme+Host: the Host header reflects how the CALLER
-// addressed this process, which is frequently unreachable for everyone else.
-// `curl http://0.0.0.0:8089` (or localhost) yields a Host of 0.0.0.0 /
-// localhost, and that value used to be persisted into
-// rootfs_artifacts.master_node_ip and then handed to every Cubelet as the
-// artifact download URL -- so the artifact download failed on every node while
-// the build job itself reported success.
-//
-// Priority:
-//  1. CUBE_MASTER_ADDR (or common.master_addr), but only when it is externally
-//     usable -- one-click historically ships a loopback value here, which is
-//     fine for co-located components finding CubeMaster but wrong as the
-//     Cubelet-facing download address.
-//  2. The request Host, but only when it is a real, externally-usable host
-//     (not empty, not a wildcard bind address, not loopback).
+// The source is intentionally simple and explicit: prefer CUBE_MASTER_ADDR (or
+// common.master_addr), otherwise fall back to the current request's Host/addr.
+// Do NOT guess another address from local interfaces here: the deployment must
+// decide which address other components should use.
 func requestBaseURL(r *http.Request) string {
 	configured := ""
 	if cfg := config.GetConfig(); cfg != nil {
 		configured = strings.TrimSpace(cfg.MasterAddr())
 	}
 	if configured != "" {
-		if templatecenter.ExternallyUsableBaseURL(configured) {
-			return templatecenter.NormalizeBaseURL(configured)
-		}
-		log.G(context.Background()).Warnf("configured master addr %q is wildcard/loopback; ignoring it for cubelet-facing URLs (set CUBE_MASTER_ADDR to the address other nodes can dial)", configured)
+		return templatecenter.NormalizeBaseURL(configured)
+	}
+	if r == nil {
+		return ""
 	}
 	scheme := "http"
-	if r != nil && r.TLS != nil {
+	if r.TLS != nil {
 		scheme = "https"
 	}
-	if r != nil && templatecenter.HostReachableByOtherNodes(r.Host) {
-		return scheme + "://" + r.Host
-	}
-	if r != nil {
-		log.G(context.Background()).Warnf("request Host %q is wildcard/loopback; no externally-usable base URL for cubelet-facing downloads (configure CUBE_MASTER_ADDR)", r.Host)
+	if host := strings.TrimSpace(r.Host); host != "" {
+		return scheme + "://" + host
 	}
 	return ""
 }

--- a/CubeMaster/pkg/service/httpservice/cube/template_from_image.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_from_image.go
@@ -421,20 +421,31 @@ func handleRootfsArtifactAction(c *gin.Context) {
 // requestBaseURL returns the base URL other components must use to reach this
 // CubeMaster.
 //
-// The source is intentionally simple and explicit: prefer CUBE_MASTER_ADDR (or
-// common.master_addr), otherwise fall back to the current request's Host/addr.
-// Do NOT guess another address from local interfaces here: the deployment must
-// decide which address other components should use.
+// Prefer CUBE_MASTER_ADDR (or common.master_addr), otherwise fall back to the
+// current request's Host. Every candidate uses the same node-facing rule: rewrite
+// wildcard/loopback through CUBE_SANDBOX_NODE_IP when possible, otherwise skip it
+// so Cubelets are never asked to download from 127.0.0.1 or 0.0.0.0.
 func requestBaseURL(r *http.Request) string {
+	resolve := func(raw string) string {
+		if rewritten := templatecenter.RewriteLoopbackBaseURLWithSharedNodeIP(raw); rewritten != "" {
+			return rewritten
+		}
+		if templatecenter.ExternallyUsableBaseURL(raw) {
+			return templatecenter.NormalizeBaseURL(raw)
+		}
+		return ""
+	}
+
 	if addr := strings.TrimSpace(os.Getenv(config.EnvMasterAddr)); addr != "" {
-		return templatecenter.NormalizeBaseURL(addr)
+		if resolved := resolve(addr); resolved != "" {
+			return resolved
+		}
 	}
 	if cfg := config.GetConfig(); cfg != nil && cfg.Common != nil {
 		if addr := strings.TrimSpace(cfg.Common.MasterAddr); addr != "" {
-			if rewritten := templatecenter.RewriteLoopbackBaseURLWithSharedNodeIP(addr); rewritten != "" {
-				return rewritten
+			if resolved := resolve(addr); resolved != "" {
+				return resolved
 			}
-			return templatecenter.NormalizeBaseURL(addr)
 		}
 	}
 	if r == nil {
@@ -445,11 +456,7 @@ func requestBaseURL(r *http.Request) string {
 		scheme = "https"
 	}
 	if host := strings.TrimSpace(r.Host); host != "" {
-		raw := scheme + "://" + host
-		if rewritten := templatecenter.RewriteLoopbackBaseURLWithSharedNodeIP(raw); rewritten != "" {
-			return rewritten
-		}
-		return raw
+		return resolve(scheme + "://" + host)
 	}
 	return ""
 }

--- a/CubeMaster/pkg/service/httpservice/cube/template_from_image.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_from_image.go
@@ -426,12 +426,16 @@ func handleRootfsArtifactAction(c *gin.Context) {
 // Do NOT guess another address from local interfaces here: the deployment must
 // decide which address other components should use.
 func requestBaseURL(r *http.Request) string {
-	configured := ""
-	if cfg := config.GetConfig(); cfg != nil {
-		configured = strings.TrimSpace(cfg.MasterAddr())
+	if addr := strings.TrimSpace(os.Getenv(config.EnvMasterAddr)); addr != "" {
+		return templatecenter.NormalizeBaseURL(addr)
 	}
-	if configured != "" {
-		return templatecenter.NormalizeBaseURL(configured)
+	if cfg := config.GetConfig(); cfg != nil && cfg.Common != nil {
+		if addr := strings.TrimSpace(cfg.Common.MasterAddr); addr != "" {
+			if rewritten := templatecenter.RewriteLoopbackBaseURLWithSharedNodeIP(addr); rewritten != "" {
+				return rewritten
+			}
+			return templatecenter.NormalizeBaseURL(addr)
+		}
 	}
 	if r == nil {
 		return ""
@@ -441,7 +445,11 @@ func requestBaseURL(r *http.Request) string {
 		scheme = "https"
 	}
 	if host := strings.TrimSpace(r.Host); host != "" {
-		return scheme + "://" + host
+		raw := scheme + "://" + host
+		if rewritten := templatecenter.RewriteLoopbackBaseURLWithSharedNodeIP(raw); rewritten != "" {
+			return rewritten
+		}
+		return raw
 	}
 	return ""
 }

--- a/CubeMaster/pkg/service/httpservice/cube/template_from_image.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_from_image.go
@@ -5,14 +5,18 @@
 package cube
 
 import (
+	"context"
 	"errors"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
@@ -235,15 +239,27 @@ func openTemplateArtifactForDownload(c *gin.Context) (name string, file *os.File
 	return filepath.Base(record.Ext4Path), f, st, true
 }
 
+// artifactProxyHTTPClient has no total Timeout on purpose: artifact streams
+// are GB-scale, so a whole-request deadline would abort healthy downloads.
+// ResponseHeaderTimeout bounds the only phase that can hang silently (waiting
+// on a stalled S3/TC response), after which the stream is driven by the
+// downstream client's disconnect via the request context.
+var artifactProxyHTTPClient = &http.Client{
+	Transport: &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		ResponseHeaderTimeout: 60 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+	},
+}
+
 func downloadTemplateArtifactGinHandler(c *gin.Context) {
 	rt := CubeLog.GetTraceInfo(c.Request.Context())
 
-	// S3-backed artifacts redirect to the presigned URL; local-disk artifacts
-	// (legacy, or S3-disabled builds) are streamed from the store. The
-	// artifact row's artifact_url is the discriminator: TC writes it after a
-	// successful S3 upload, so its presence means the object lives in S3.
-	if redirectToS3Artifact(c) {
-		rt.RetCode = int64(errorcode.ErrorCode_Success)
+	// S3-backed artifacts are proxied through this endpoint rather than 302
+	// redirected to the object store. Nodes therefore only need reachability to
+	// CubeMaster's public address; Master/TC absorb any S3 endpoint topology.
+	if handled, ok := proxyS3Artifact(c); handled {
+		rt.RetCode = artifactProxyRetCode(ok)
 		return
 	}
 
@@ -259,11 +275,10 @@ func downloadTemplateArtifactGinHandler(c *gin.Context) {
 func headTemplateArtifactGinHandler(c *gin.Context) {
 	rt := CubeLog.GetTraceInfo(c.Request.Context())
 
-	// Same S3-vs-local split as downloadTemplateArtifactGinHandler: a HEAD on
-	// an S3-backed artifact redirects so the caller can probe the presigned
-	// URL directly.
-	if redirectToS3Artifact(c) {
-		rt.RetCode = int64(errorcode.ErrorCode_Success)
+	// HEAD follows the same S3 proxy-vs-local split as GET so servability probes
+	// exercise the exact node-facing download path.
+	if handled, ok := proxyS3Artifact(c); handled {
+		rt.RetCode = artifactProxyRetCode(ok)
 		return
 	}
 
@@ -275,36 +290,93 @@ func headTemplateArtifactGinHandler(c *gin.Context) {
 	rt.RetCode = int64(errorcode.ErrorCode_Success)
 }
 
-// redirectToS3Artifact issues a 302 to the artifact's presigned S3 URL when
-// the artifact row has one. Returns true when a redirect was written (caller
-// must not write anything else), false when the artifact is local-disk or the
-// row/token is invalid (caller falls through to the local-file path, which
-// produces the appropriate error response).
-func redirectToS3Artifact(c *gin.Context) bool {
+// artifactProxyRetCode keeps the request log honest: an upstream proxy failure
+// wrote a 502 to the client and must not be recorded as a success.
+func artifactProxyRetCode(ok bool) int64 {
+	if ok {
+		return int64(errorcode.ErrorCode_Success)
+	}
+	return int64(errorcode.ErrorCode_MasterInternalError)
+}
+
+// proxyS3Artifact streams an S3-backed artifact through the current handler
+// instead of redirecting the caller to the presigned URL. handled=false means
+// the artifact is local-disk or the row/token lookup failed, so the caller
+// should fall through to the local-file path which writes its own error
+// response. Once handled=true a response has been written; ok reports whether
+// the upstream fetch/stream succeeded (false -> we wrote 502, or the stream
+// broke mid-flight).
+func proxyS3Artifact(c *gin.Context) (handled bool, ok bool) {
 	artifactID := strings.TrimSpace(c.Query("artifact_id"))
 	token := strings.TrimSpace(c.Query("token"))
 	if artifactID == "" {
-		return false
+		return false, false
 	}
 	record, err := getRootfsArtifactForRedirectFn(c.Request.Context(), artifactID, token)
 	if err != nil || record == nil {
-		return false
+		return false, false
 	}
 	if record.ArtifactURL == "" {
-		return false
+		return false, false
 	}
-	// Redirect to a FRESH presigned URL: the one stored at build time expires
-	// (7d) while the artifact lives longer. artifactDownloadURL re-signs when
-	// this process holds the S3 credentials and falls back to the stored URL
-	// otherwise.
 	downloadURL := templatecenter.ArtifactDownloadURL(c.Request.Context(), record)
 	if downloadURL == "" {
-		return false
+		log.G(c.Request.Context()).Warnf("artifact proxy: empty download url for s3-backed artifact %s", record.ArtifactID)
+		c.AbortWithStatus(http.StatusBadGateway)
+		return true, false
 	}
+	// The presigned URL is signed for GET (SigV4 covers the method), so a HEAD
+	// probe must be proxied as a GET whose body we simply do not forward --
+	// forwarding HEAD verbatim gets a 403 from S3/MinIO.
+	upstreamMethod := c.Request.Method
+	if upstreamMethod == http.MethodHead {
+		upstreamMethod = http.MethodGet
+	}
+	upstreamReq, err := http.NewRequestWithContext(c.Request.Context(), upstreamMethod, downloadURL, nil)
+	if err != nil {
+		log.G(c.Request.Context()).Warnf("artifact proxy: build upstream request for %s failed: %v", record.ArtifactID, err)
+		c.AbortWithStatus(http.StatusBadGateway)
+		return true, false
+	}
+	for _, key := range []string{"Range", "If-Range", "If-Modified-Since", "If-None-Match"} {
+		if value := strings.TrimSpace(c.Request.Header.Get(key)); value != "" {
+			upstreamReq.Header.Set(key, value)
+		}
+	}
+	resp, err := artifactProxyHTTPClient.Do(upstreamReq)
+	if err != nil {
+		log.G(c.Request.Context()).Warnf("artifact proxy: fetch %s failed: %v", record.ArtifactID, err)
+		c.AbortWithStatus(http.StatusBadGateway)
+		return true, false
+	}
+	defer resp.Body.Close()
+	copyArtifactProxyHeaders(c.Writer.Header(), resp.Header)
 	c.Writer.Header().Set("X-Cube-Artifact-Id", record.ArtifactID)
 	c.Writer.Header().Set("ETag", record.Ext4SHA256)
-	c.Redirect(http.StatusFound, downloadURL)
-	return true
+	c.Status(resp.StatusCode)
+	if c.Request.Method == http.MethodHead {
+		// Drain nothing: the body is discarded so the connection can reuse or
+		// close promptly; the caller only wanted headers.
+		return true, resp.StatusCode < http.StatusBadRequest
+	}
+	if _, err := io.Copy(c.Writer, resp.Body); err != nil {
+		log.G(c.Request.Context()).Warnf("artifact proxy: stream %s failed: %v", record.ArtifactID, err)
+		return true, false
+	}
+	return true, resp.StatusCode < http.StatusBadRequest
+}
+
+func copyArtifactProxyHeaders(dst, src http.Header) {
+	for _, key := range []string{"Accept-Ranges", "Cache-Control", "Content-Disposition", "Content-Encoding", "Content-Length", "Content-Range", "Content-Type", "Last-Modified"} {
+		values := src.Values(key)
+		if len(values) == 0 {
+			continue
+		}
+		dst.Del(key)
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
 }
 
 func handleRootfsArtifactAction(c *gin.Context) {
@@ -347,10 +419,46 @@ func handleRootfsArtifactAction(c *gin.Context) {
 	})
 }
 
+// requestBaseURL returns the base URL other components must use to reach this
+// CubeMaster. An empty return means "nothing externally usable was found" and
+// callers must fall back to the artifact row / hostname hint rather than
+// persist a value no Cubelet can dial.
+//
+// It is NOT simply scheme+Host: the Host header reflects how the CALLER
+// addressed this process, which is frequently unreachable for everyone else.
+// `curl http://0.0.0.0:8089` (or localhost) yields a Host of 0.0.0.0 /
+// localhost, and that value used to be persisted into
+// rootfs_artifacts.master_node_ip and then handed to every Cubelet as the
+// artifact download URL -- so the artifact download failed on every node while
+// the build job itself reported success.
+//
+// Priority:
+//  1. CUBE_MASTER_ADDR (or common.master_addr), but only when it is externally
+//     usable -- one-click historically ships a loopback value here, which is
+//     fine for co-located components finding CubeMaster but wrong as the
+//     Cubelet-facing download address.
+//  2. The request Host, but only when it is a real, externally-usable host
+//     (not empty, not a wildcard bind address, not loopback).
 func requestBaseURL(r *http.Request) string {
+	configured := ""
+	if cfg := config.GetConfig(); cfg != nil {
+		configured = strings.TrimSpace(cfg.MasterAddr())
+	}
+	if configured != "" {
+		if templatecenter.ExternallyUsableBaseURL(configured) {
+			return templatecenter.NormalizeBaseURL(configured)
+		}
+		log.G(context.Background()).Warnf("configured master addr %q is wildcard/loopback; ignoring it for cubelet-facing URLs (set CUBE_MASTER_ADDR to the address other nodes can dial)", configured)
+	}
 	scheme := "http"
-	if r.TLS != nil {
+	if r != nil && r.TLS != nil {
 		scheme = "https"
 	}
-	return scheme + "://" + r.Host
+	if r != nil && templatecenter.HostReachableByOtherNodes(r.Host) {
+		return scheme + "://" + r.Host
+	}
+	if r != nil {
+		log.G(context.Background()).Warnf("request Host %q is wildcard/loopback; no externally-usable base URL for cubelet-facing downloads (configure CUBE_MASTER_ADDR)", r.Host)
+	}
+	return ""
 }

--- a/CubeMaster/pkg/service/httpservice/cube/template_from_image_baseurl_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_from_image_baseurl_test.go
@@ -64,6 +64,7 @@ func TestRequestBaseURLNilRequestDoesNotPanic(t *testing.T) {
 
 func TestRequestBaseURLKeepsConfiguredLoopbackAddr(t *testing.T) {
 	t.Setenv("CUBE_MASTER_ADDR", "http://127.0.0.1:8089")
+	t.Setenv("CUBE_SANDBOX_NODE_IP", "10.0.0.8")
 	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
 	r.Host = "9.135.79.34:8089"
 	if got, want := requestBaseURL(r), "http://127.0.0.1:8089"; got != want {
@@ -71,7 +72,16 @@ func TestRequestBaseURLKeepsConfiguredLoopbackAddr(t *testing.T) {
 	}
 }
 
-func TestRequestBaseURLFallsBackToRequestHostWhenUnset(t *testing.T) {
+func TestRequestBaseURLUsesSharedNodeIPForLoopbackRequestHostWhenUnset(t *testing.T) {
+	t.Setenv("CUBE_SANDBOX_NODE_IP", "10.0.0.8")
+	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
+	r.Host = "127.0.0.1:8089"
+	if got, want := requestBaseURL(r), "http://10.0.0.8:8089"; got != want {
+		t.Fatalf("requestBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestRequestBaseURLFallsBackToRequestHostWhenSharedNodeIPUnset(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
 	r.Host = "0.0.0.0:8089"
 	if got, want := requestBaseURL(r), "http://0.0.0.0:8089"; got != want {

--- a/CubeMaster/pkg/service/httpservice/cube/template_from_image_baseurl_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_from_image_baseurl_test.go
@@ -62,12 +62,21 @@ func TestRequestBaseURLNilRequestDoesNotPanic(t *testing.T) {
 	_ = requestBaseURL(nil)
 }
 
-func TestRequestBaseURLKeepsConfiguredLoopbackAddr(t *testing.T) {
+func TestRequestBaseURLRewritesConfiguredLoopbackAddr(t *testing.T) {
 	t.Setenv("CUBE_MASTER_ADDR", "http://127.0.0.1:8089")
 	t.Setenv("CUBE_SANDBOX_NODE_IP", "10.0.0.8")
 	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
 	r.Host = "9.135.79.34:8089"
-	if got, want := requestBaseURL(r), "http://127.0.0.1:8089"; got != want {
+	if got, want := requestBaseURL(r), "http://10.0.0.8:8089"; got != want {
+		t.Fatalf("requestBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestRequestBaseURLSkipsUnrewritableLoopbackEnvToRequestHost(t *testing.T) {
+	t.Setenv("CUBE_MASTER_ADDR", "http://127.0.0.1:8089")
+	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
+	r.Host = "9.135.79.34:8089"
+	if got, want := requestBaseURL(r), "http://9.135.79.34:8089"; got != want {
 		t.Fatalf("requestBaseURL() = %q, want %q", got, want)
 	}
 }
@@ -81,10 +90,10 @@ func TestRequestBaseURLUsesSharedNodeIPForLoopbackRequestHostWhenUnset(t *testin
 	}
 }
 
-func TestRequestBaseURLFallsBackToRequestHostWhenSharedNodeIPUnset(t *testing.T) {
+func TestRequestBaseURLRejectsWildcardRequestHostWhenSharedNodeIPUnset(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
 	r.Host = "0.0.0.0:8089"
-	if got, want := requestBaseURL(r), "http://0.0.0.0:8089"; got != want {
+	if got, want := requestBaseURL(r), ""; got != want {
 		t.Fatalf("requestBaseURL() = %q, want %q", got, want)
 	}
 }

--- a/CubeMaster/pkg/service/httpservice/cube/template_from_image_baseurl_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_from_image_baseurl_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
+)
+
+func TestHostReachableByOtherNodes(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"9.135.79.34:8089", true},
+		{"cube-master.cube-system.svc:8089", true},
+		{"master.example.com", true},
+
+		// Wildcard bind addresses and loopback are meaningless to any other
+		// node: a Cubelet told to download from them fails.
+		{"0.0.0.0:8089", false},
+		{"0.0.0.0", false},
+		{"[::]:8089", false},
+		{"localhost:8089", false},
+		{"127.0.0.1:8089", false},
+		{"[::1]:8089", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := templatecenter.HostReachableByOtherNodes(c.host); got != c.want {
+			t.Fatalf("HostReachableByOtherNodes(%q) = %v, want %v", c.host, got, c.want)
+		}
+	}
+}
+
+// A real, externally-usable Host is still honored when nothing is configured.
+func TestRequestBaseURLKeepsUsableHost(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
+	r.Host = "9.135.79.34:8089"
+	if got, want := requestBaseURL(r), "http://9.135.79.34:8089"; got != want {
+		t.Fatalf("requestBaseURL() = %q, want %q", got, want)
+	}
+}
+
+// The regression: a request that arrived on a wildcard Host (e.g. `curl
+// http://0.0.0.0:8089`) used to make that address the artifact download base
+// URL. It is persisted into rootfs_artifacts.master_node_ip and handed to
+// every Cubelet, whose artifact download then fails while the build job
+// itself looks healthy. A configured address must win over the Host header.
+func TestRequestBaseURLPrefersConfiguredMasterAddrOverWildcardHost(t *testing.T) {
+	t.Setenv("CUBE_MASTER_ADDR", "http://9.135.79.34:8089")
+	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
+	r.Host = "0.0.0.0:8089"
+	if got, want := requestBaseURL(r), "http://9.135.79.34:8089"; got != want {
+		t.Fatalf("requestBaseURL() = %q, want %q (Host header must not win)", got, want)
+	}
+}
+
+func TestRequestBaseURLNilRequestDoesNotPanic(t *testing.T) {
+	// With no request and no usable configuration there is no externally
+	// usable base URL; callers fall back to the artifact row / hostname hint.
+	_ = requestBaseURL(nil)
+}
+
+// A loopback/wildcard CUBE_MASTER_ADDR must not become the Cubelet-facing
+// download URL: one-click ships exactly that value, and remote nodes then
+// download from their own loopback while the build job reports success.
+func TestRequestBaseURLRejectsLoopbackConfiguredAddr(t *testing.T) {
+	t.Setenv("CUBE_MASTER_ADDR", "http://127.0.0.1:8089")
+	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
+	r.Host = "9.135.79.34:8089"
+	if got, want := requestBaseURL(r), "http://9.135.79.34:8089"; got != want {
+		t.Fatalf("requestBaseURL() = %q, want %q (loopback CUBE_MASTER_ADDR must be ignored)", got, want)
+	}
+}
+
+// With nothing usable configured and a wildcard Host, the function must say
+// "no usable base URL" instead of persisting an address no node can dial.
+func TestRequestBaseURLEmptyWhenNothingUsable(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
+	r.Host = "0.0.0.0:8089"
+	if got := requestBaseURL(r); got != "" {
+		t.Fatalf("requestBaseURL() = %q, want empty (0.0.0.0 is not dialable from other nodes)", got)
+	}
+}

--- a/CubeMaster/pkg/service/httpservice/cube/template_from_image_baseurl_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_from_image_baseurl_test.go
@@ -47,44 +47,34 @@ func TestRequestBaseURLKeepsUsableHost(t *testing.T) {
 	}
 }
 
-// The regression: a request that arrived on a wildcard Host (e.g. `curl
-// http://0.0.0.0:8089`) used to make that address the artifact download base
-// URL. It is persisted into rootfs_artifacts.master_node_ip and handed to
-// every Cubelet, whose artifact download then fails while the build job
-// itself looks healthy. A configured address must win over the Host header.
-func TestRequestBaseURLPrefersConfiguredMasterAddrOverWildcardHost(t *testing.T) {
+// A configured address always wins over the request Host, even when the caller
+// reached CubeMaster through a different addr.
+func TestRequestBaseURLPrefersConfiguredMasterAddrOverRequestHost(t *testing.T) {
 	t.Setenv("CUBE_MASTER_ADDR", "http://9.135.79.34:8089")
 	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
 	r.Host = "0.0.0.0:8089"
 	if got, want := requestBaseURL(r), "http://9.135.79.34:8089"; got != want {
-		t.Fatalf("requestBaseURL() = %q, want %q (Host header must not win)", got, want)
+		t.Fatalf("requestBaseURL() = %q, want %q (configured addr must win)", got, want)
 	}
 }
 
 func TestRequestBaseURLNilRequestDoesNotPanic(t *testing.T) {
-	// With no request and no usable configuration there is no externally
-	// usable base URL; callers fall back to the artifact row / hostname hint.
 	_ = requestBaseURL(nil)
 }
 
-// A loopback/wildcard CUBE_MASTER_ADDR must not become the Cubelet-facing
-// download URL: one-click ships exactly that value, and remote nodes then
-// download from their own loopback while the build job reports success.
-func TestRequestBaseURLRejectsLoopbackConfiguredAddr(t *testing.T) {
+func TestRequestBaseURLKeepsConfiguredLoopbackAddr(t *testing.T) {
 	t.Setenv("CUBE_MASTER_ADDR", "http://127.0.0.1:8089")
 	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
 	r.Host = "9.135.79.34:8089"
-	if got, want := requestBaseURL(r), "http://9.135.79.34:8089"; got != want {
-		t.Fatalf("requestBaseURL() = %q, want %q (loopback CUBE_MASTER_ADDR must be ignored)", got, want)
+	if got, want := requestBaseURL(r), "http://127.0.0.1:8089"; got != want {
+		t.Fatalf("requestBaseURL() = %q, want %q", got, want)
 	}
 }
 
-// With nothing usable configured and a wildcard Host, the function must say
-// "no usable base URL" instead of persisting an address no node can dial.
-func TestRequestBaseURLEmptyWhenNothingUsable(t *testing.T) {
+func TestRequestBaseURLFallsBackToRequestHostWhenUnset(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/cube/template/from-image", nil)
 	r.Host = "0.0.0.0:8089"
-	if got := requestBaseURL(r); got != "" {
-		t.Fatalf("requestBaseURL() = %q, want empty (0.0.0.0 is not dialable from other nodes)", got)
+	if got, want := requestBaseURL(r), "http://0.0.0.0:8089"; got != want {
+		t.Fatalf("requestBaseURL() = %q, want %q", got, want)
 	}
 }

--- a/CubeMaster/pkg/service/httpservice/cube/template_from_image_redirect_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_from_image_redirect_test.go
@@ -24,87 +24,103 @@ func stubRedirectLookup(t *testing.T, fn func(ctx context.Context, artifactID, t
 	t.Cleanup(func() { getRootfsArtifactForRedirectFn = old })
 }
 
-func newRedirectContext(query string) (*gin.Context, *httptest.ResponseRecorder) {
+func newArtifactProxyContext(method, query string) (*gin.Context, *httptest.ResponseRecorder) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	req := httptest.NewRequest(http.MethodGet, "/cube/template/artifact/download?"+query, nil)
+	req := httptest.NewRequest(method, "/cube/template/artifact/download?"+query, nil)
 	c.Request = req
 	return c, w
 }
 
-func TestRedirectToS3ArtifactMissingArtifactID(t *testing.T) {
+func TestProxyS3ArtifactMissingArtifactID(t *testing.T) {
 	stubRedirectLookup(t, func(ctx context.Context, artifactID, token string) (*models.RootfsArtifact, error) {
 		t.Fatalf("lookup must not be called when artifact_id is empty")
 		return nil, nil
 	})
-	c, w := newRedirectContext("token=abc")
-	if redirectToS3Artifact(c) {
-		t.Fatalf("expected false when artifact_id missing")
+	c, w := newArtifactProxyContext(http.MethodGet, "token=abc")
+	if handled, _ := proxyS3Artifact(c); handled {
+		t.Fatalf("expected handled=false when artifact_id missing")
 	}
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected no response written, got code=%d", w.Code)
 	}
 }
 
-func TestRedirectToS3ArtifactLookupError(t *testing.T) {
+func TestProxyS3ArtifactLookupError(t *testing.T) {
 	stubRedirectLookup(t, func(ctx context.Context, artifactID, token string) (*models.RootfsArtifact, error) {
 		return nil, gorm.ErrRecordNotFound
 	})
-	c, w := newRedirectContext("artifact_id=rfs-x&token=t")
-	if redirectToS3Artifact(c) {
-		t.Fatalf("expected false on lookup error")
+	c, w := newArtifactProxyContext(http.MethodGet, "artifact_id=rfs-x&token=t")
+	if handled, _ := proxyS3Artifact(c); handled {
+		t.Fatalf("expected handled=false on lookup error")
 	}
-	// Must not write a partial response (the local-file path writes its own).
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected no response written on lookup error, got code=%d", w.Code)
 	}
 }
 
-func TestRedirectToS3ArtifactInvalidToken(t *testing.T) {
+func TestProxyS3ArtifactInvalidToken(t *testing.T) {
 	stubRedirectLookup(t, func(ctx context.Context, artifactID, token string) (*models.RootfsArtifact, error) {
 		return nil, errors.New("invalid artifact token")
 	})
-	c, w := newRedirectContext("artifact_id=rfs-x&token=wrong")
-	if redirectToS3Artifact(c) {
-		t.Fatalf("expected false on invalid token")
+	c, w := newArtifactProxyContext(http.MethodGet, "artifact_id=rfs-x&token=wrong")
+	if handled, _ := proxyS3Artifact(c); handled {
+		t.Fatalf("expected handled=false on invalid token")
 	}
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected no response written on invalid token, got code=%d", w.Code)
 	}
 }
 
-func TestRedirectToS3ArtifactNoArtifactURL(t *testing.T) {
+func TestProxyS3ArtifactNoArtifactURL(t *testing.T) {
 	stubRedirectLookup(t, func(ctx context.Context, artifactID, token string) (*models.RootfsArtifact, error) {
-		// Legacy/local-disk artifact: no S3 URL -> fall through to local stream.
 		return &models.RootfsArtifact{ArtifactID: "rfs-x", ArtifactURL: ""}, nil
 	})
-	c, w := newRedirectContext("artifact_id=rfs-x&token=t")
-	if redirectToS3Artifact(c) {
-		t.Fatalf("expected false when artifact_url empty (local-disk artifact)")
+	c, w := newArtifactProxyContext(http.MethodGet, "artifact_id=rfs-x&token=t")
+	if handled, _ := proxyS3Artifact(c); handled {
+		t.Fatalf("expected handled=false when artifact_url empty (local-disk artifact)")
 	}
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected no response written for local artifact, got code=%d", w.Code)
 	}
 }
 
-func TestRedirectToS3ArtifactSuccess(t *testing.T) {
+func TestProxyS3ArtifactSuccessGET(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+		if got := r.Header.Get("Range"); got != "bytes=0-0" {
+			t.Fatalf("Range=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Range", "bytes 0-0/1")
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer upstream.Close()
+
 	stubRedirectLookup(t, func(ctx context.Context, artifactID, token string) (*models.RootfsArtifact, error) {
 		return &models.RootfsArtifact{
 			ArtifactID:  "rfs-abc",
-			ArtifactURL: "https://minio:9000/bucket/rfs-abc.ext4?X-Amz-Signature=xyz",
+			ArtifactURL: upstream.URL + "/bucket/rfs-abc.ext4?X-Amz-Signature=xyz",
 			Ext4SHA256:  "deadbeef",
 		}, nil
 	})
-	c, w := newRedirectContext("artifact_id=rfs-abc&token=t")
-	if !redirectToS3Artifact(c) {
-		t.Fatalf("expected true on successful redirect")
+
+	c, w := newArtifactProxyContext(http.MethodGet, "artifact_id=rfs-abc&token=t")
+	c.Request.Header.Set("Range", "bytes=0-0")
+	handled, ok := proxyS3Artifact(c)
+	if !handled || !ok {
+		t.Fatalf("expected handled=true ok=true on successful proxy, got %v/%v", handled, ok)
 	}
-	if w.Code != http.StatusFound {
-		t.Fatalf("expected 302, got %d", w.Code)
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("expected 206, got %d", w.Code)
 	}
-	if loc := w.Header().Get("Location"); loc != "https://minio:9000/bucket/rfs-abc.ext4?X-Amz-Signature=xyz" {
-		t.Fatalf("Location=%q", loc)
+	if body := w.Body.String(); body != "x" {
+		t.Fatalf("body=%q", body)
 	}
 	if got := w.Header().Get("X-Cube-Artifact-Id"); got != "rfs-abc" {
 		t.Fatalf("X-Cube-Artifact-Id=%q", got)
@@ -112,17 +128,88 @@ func TestRedirectToS3ArtifactSuccess(t *testing.T) {
 	if got := w.Header().Get("ETag"); got != "deadbeef" {
 		t.Fatalf("ETag=%q", got)
 	}
+	if got := w.Header().Get("Content-Range"); got != "bytes 0-0/1" {
+		t.Fatalf("Content-Range=%q", got)
+	}
 }
 
-func TestRedirectToS3ArtifactNilRecord(t *testing.T) {
+func TestProxyS3ArtifactSuccessHEAD(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The presigned URL is signed for GET (SigV4 binds the method), so a
+		// HEAD probe must be proxied as a GET whose body is discarded.
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method %s, want GET (HEAD is proxied as GET)", r.Method)
+		}
+		if got := r.Header.Get("If-None-Match"); got != "client-etag" {
+			t.Fatalf("If-None-Match=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", "123")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
 	stubRedirectLookup(t, func(ctx context.Context, artifactID, token string) (*models.RootfsArtifact, error) {
-		return nil, nil // nil record, nil error
+		return &models.RootfsArtifact{
+			ArtifactID:  "rfs-head",
+			ArtifactURL: upstream.URL + "/bucket/rfs-head.ext4?X-Amz-Signature=xyz",
+			Ext4SHA256:  "sha-head",
+		}, nil
 	})
-	c, w := newRedirectContext("artifact_id=rfs-x&token=t")
-	if redirectToS3Artifact(c) {
-		t.Fatalf("expected false on nil record")
+
+	c, w := newArtifactProxyContext(http.MethodHead, "artifact_id=rfs-head&token=t")
+	c.Request.Header.Set("If-None-Match", "client-etag")
+	handled, ok := proxyS3Artifact(c)
+	if !handled || !ok {
+		t.Fatalf("expected handled=true ok=true on successful head proxy, got %v/%v", handled, ok)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if body := w.Body.String(); body != "" {
+		t.Fatalf("HEAD body=%q", body)
+	}
+	if got := w.Header().Get("Content-Length"); got != "123" {
+		t.Fatalf("Content-Length=%q", got)
+	}
+	if got := w.Header().Get("ETag"); got != "sha-head" {
+		t.Fatalf("ETag=%q", got)
+	}
+}
+
+func TestProxyS3ArtifactNilRecord(t *testing.T) {
+	stubRedirectLookup(t, func(ctx context.Context, artifactID, token string) (*models.RootfsArtifact, error) {
+		return nil, nil
+	})
+	c, w := newArtifactProxyContext(http.MethodGet, "artifact_id=rfs-x&token=t")
+	if handled, _ := proxyS3Artifact(c); handled {
+		t.Fatalf("expected handled=false on nil record")
 	}
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected no response written on nil record, got code=%d", w.Code)
+	}
+}
+
+// An upstream failure writes 502 to the client and must be reported as
+// ok=false so the request log does not record a broken download as success.
+func TestProxyS3ArtifactUpstreamFailureReportedAsFailure(t *testing.T) {
+	stubRedirectLookup(t, func(ctx context.Context, artifactID, token string) (*models.RootfsArtifact, error) {
+		return &models.RootfsArtifact{
+			ArtifactID:  "rfs-down",
+			ArtifactURL: "http://127.0.0.1:1/bucket/rfs-down.ext4?X-Amz-Signature=xyz",
+			Ext4SHA256:  "sha-down",
+		}, nil
+	})
+
+	c, w := newArtifactProxyContext(http.MethodGet, "artifact_id=rfs-down&token=t")
+	handled, ok := proxyS3Artifact(c)
+	if !handled {
+		t.Fatalf("expected handled=true on upstream failure (502 was written)")
+	}
+	if ok {
+		t.Fatalf("expected ok=false on upstream failure")
+	}
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", w.Code)
 	}
 }

--- a/CubeMaster/pkg/service/httpservice/cube/template_migrate.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_migrate.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
+	"github.com/tencentcloud/CubeSandbox/pkgs/CubeLog"
+)
+
+var submitTemplateMigrateFn = templatecenter.SubmitTemplateMigrate
+var getTemplateMigrateJobInfoFn = templatecenter.GetTemplateMigrateJobInfo
+
+type migrateTemplateRequest struct {
+	RequestID  string `json:"requestID,omitempty"`
+	TemplateID string `json:"template_id,omitempty"`
+}
+
+type migrateTemplateResponse struct {
+	*types.Res
+	Job *types.TemplateImageJobInfo `json:"job,omitempty"`
+}
+
+func handleTemplateMigrateAction(c *gin.Context) {
+	rt := CubeLog.GetTraceInfo(c.Request.Context())
+	req := &migrateTemplateRequest{}
+	if err := common.GetBodyReq(c.Request, req); err != nil {
+		common.WriteAPI(c, &migrateTemplateResponse{
+			Res: &types.Res{Ret: &types.Ret{RetCode: int(errorcode.ErrorCode_MasterParamsError), RetMsg: err.Error()}},
+		})
+		return
+	}
+	if strings.TrimSpace(req.TemplateID) == "" {
+		common.WriteAPI(c, &migrateTemplateResponse{
+			Res: &types.Res{RequestID: req.RequestID, Ret: &types.Ret{RetCode: int(errorcode.ErrorCode_MasterParamsError), RetMsg: "template_id is required"}},
+		})
+		return
+	}
+	if rt != nil {
+		rt.RequestID = req.RequestID
+	}
+	ctx := log.WithLogger(c.Request.Context(), log.G(c.Request.Context()).WithFields(map[string]any{
+		"RequestId":  req.RequestID,
+		"Action":     "SubmitTemplateMigrate",
+		"TemplateID": req.TemplateID,
+	}))
+	resolvedTemplateID, err := resolveTemplateIdentifierFn(ctx, req.TemplateID)
+	if err != nil {
+		code := int(errorcode.ErrorCode_MasterInternalError)
+		if errors.Is(err, templatecenter.ErrTemplateNotFound) {
+			code = int(errorcode.ErrorCode_NotFound)
+		}
+		if rt != nil {
+			rt.RetCode = int64(code)
+		}
+		common.WriteAPI(c, &migrateTemplateResponse{
+			Res: &types.Res{RequestID: req.RequestID, Ret: &types.Ret{RetCode: code, RetMsg: err.Error()}},
+		})
+		return
+	}
+	job, err := submitTemplateMigrateFn(ctx, resolvedTemplateID, req.RequestID)
+	if err != nil {
+		code := int(errorcode.ErrorCode_MasterInternalError)
+		switch {
+		case errors.Is(err, templatecenter.ErrTemplateNotFound):
+			code = int(errorcode.ErrorCode_NotFound)
+		case errors.Is(err, templatecenter.ErrTemplateStoreNotInitialized):
+			code = int(errorcode.ErrorCode_DBError)
+		case errors.Is(err, templatecenter.ErrTemplateNotReady):
+			code = int(errorcode.ErrorCode_Conflict)
+		}
+		if rt != nil {
+			rt.RetCode = int64(code)
+		}
+		common.WriteAPI(c, &migrateTemplateResponse{
+			Res: &types.Res{RequestID: req.RequestID, Ret: &types.Ret{RetCode: code, RetMsg: err.Error()}},
+		})
+		return
+	}
+	if rt != nil {
+		rt.RetCode = int64(errorcode.ErrorCode_Success)
+	}
+	common.WriteAPI(c, &migrateTemplateResponse{
+		Res: &types.Res{RequestID: req.RequestID, Ret: &types.Ret{RetCode: int(errorcode.ErrorCode_Success), RetMsg: "success"}},
+		Job: job,
+	})
+}
+
+func getTemplateMigrateStatusAction(c *gin.Context) {
+	jobID := strings.TrimSpace(c.Query("job_id"))
+	if jobID == "" {
+		common.WriteAPI(c, &migrateTemplateResponse{
+			Res: &types.Res{Ret: &types.Ret{RetCode: int(errorcode.ErrorCode_MasterParamsError), RetMsg: "job_id is required"}},
+		})
+		return
+	}
+	ctx := log.WithLogger(c.Request.Context(), log.G(c.Request.Context()).WithFields(map[string]any{
+		"Action": "GetTemplateMigrateStatus",
+		"JobID":  jobID,
+	}))
+	job, err := getTemplateMigrateJobInfoFn(ctx, jobID)
+	if err != nil {
+		// Shared with every other job-status reader so the handlers cannot
+		// disagree on what an absent job means.
+		code := templateImageJobErrorCode(err)
+		rt := CubeLog.GetTraceInfo(c.Request.Context())
+		if rt != nil {
+			rt.RetCode = int64(code)
+		}
+		common.WriteAPI(c, &migrateTemplateResponse{
+			Res: &types.Res{Ret: &types.Ret{RetCode: code, RetMsg: err.Error()}},
+		})
+		return
+	}
+	common.WriteAPI(c, &migrateTemplateResponse{
+		Res: &types.Res{Ret: &types.Ret{RetCode: int(errorcode.ErrorCode_Success), RetMsg: "success"}},
+		Job: job,
+	})
+}

--- a/CubeMaster/pkg/service/httpservice/cube/template_migrate_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_migrate_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
+	CubeLog "github.com/tencentcloud/CubeSandbox/pkgs/CubeLog"
+)
+
+func newMigrateTestContext(t *testing.T, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodPost, "/cube/template/migrate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(CubeLog.WithRequestTrace(req.Context(), &CubeLog.RequestTrace{}))
+	c.Request = req
+	return c, w
+}
+
+func newMigrateStatusTestContext(t *testing.T, jobID string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	url := "/cube/template/migrate?job_id=" + jobID
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req = req.WithContext(CubeLog.WithRequestTrace(req.Context(), &CubeLog.RequestTrace{}))
+	c.Request = req
+	return c, w
+}
+
+func TestHandleTemplateMigrateAction_ResolvesAliasIdentifier(t *testing.T) {
+	origResolve := resolveTemplateIdentifierFn
+	origSubmit := submitTemplateMigrateFn
+	t.Cleanup(func() {
+		resolveTemplateIdentifierFn = origResolve
+		submitTemplateMigrateFn = origSubmit
+	})
+
+	resolveTemplateIdentifierFn = func(ctx context.Context, identifier string) (string, error) {
+		if identifier != "stable-alias" {
+			t.Fatalf("resolve identifier=%q, want stable-alias", identifier)
+		}
+		return "tpl-resolved", nil
+	}
+	submitTemplateMigrateFn = func(ctx context.Context, templateID, requestID string) (*types.TemplateImageJobInfo, error) {
+		if templateID != "tpl-resolved" {
+			t.Fatalf("submit templateID=%q, want tpl-resolved", templateID)
+		}
+		if requestID != "req-1" {
+			t.Fatalf("submit requestID=%q, want req-1", requestID)
+		}
+		return &types.TemplateImageJobInfo{
+			JobID:      "job-1",
+			TemplateID: "tpl-resolved",
+			ArtifactID: "rfs-1",
+			Operation:  templatecenter.JobOperationMigrate,
+			Status:     templatecenter.JobStatusPending,
+			Phase:      templatecenter.JobPhaseMigratingArtifact,
+		}, nil
+	}
+
+	c, w := newMigrateTestContext(t, `{"requestID":"req-1","template_id":"stable-alias"}`)
+	handleTemplateMigrateAction(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := &migrateTemplateResponse{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), resp), "body=%s", w.Body.String())
+	require.NotNil(t, resp.Ret)
+	assert.Equal(t, int(errorcode.ErrorCode_Success), resp.Ret.RetCode)
+	require.NotNil(t, resp.Job)
+	assert.Equal(t, "job-1", resp.Job.JobID)
+	assert.Equal(t, "tpl-resolved", resp.Job.TemplateID)
+}
+
+func TestHandleTemplateMigrateAction_ResolveAliasNotFound(t *testing.T) {
+	origResolve := resolveTemplateIdentifierFn
+	origSubmit := submitTemplateMigrateFn
+	t.Cleanup(func() {
+		resolveTemplateIdentifierFn = origResolve
+		submitTemplateMigrateFn = origSubmit
+	})
+
+	resolveTemplateIdentifierFn = func(ctx context.Context, identifier string) (string, error) {
+		return "", templatecenter.ErrTemplateNotFound
+	}
+	submitCalled := false
+	submitTemplateMigrateFn = func(ctx context.Context, templateID, requestID string) (*types.TemplateImageJobInfo, error) {
+		submitCalled = true
+		return nil, nil
+	}
+
+	c, w := newMigrateTestContext(t, `{"requestID":"req-2","template_id":"missing-alias"}`)
+	handleTemplateMigrateAction(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := &migrateTemplateResponse{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), resp), "body=%s", w.Body.String())
+	require.NotNil(t, resp.Ret)
+	assert.Equal(t, int(errorcode.ErrorCode_NotFound), resp.Ret.RetCode)
+	assert.False(t, submitCalled, "submit must not be called when identifier resolution fails")
+}
+
+func TestGetTemplateMigrateStatusAction_Success(t *testing.T) {
+	origGet := getTemplateMigrateJobInfoFn
+	t.Cleanup(func() { getTemplateMigrateJobInfoFn = origGet })
+
+	getTemplateMigrateJobInfoFn = func(ctx context.Context, jobID string) (*types.TemplateImageJobInfo, error) {
+		if jobID != "job-1" {
+			t.Fatalf("unexpected job id: %s", jobID)
+		}
+		return &types.TemplateImageJobInfo{
+			JobID:      "job-1",
+			TemplateID: "tpl-1",
+			Operation:  templatecenter.JobOperationMigrate,
+			Status:     templatecenter.JobStatusRunning,
+			Phase:      templatecenter.JobPhaseMigratingArtifact,
+			Progress:   60,
+		}, nil
+	}
+
+	c, w := newMigrateStatusTestContext(t, "job-1")
+	getTemplateMigrateStatusAction(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := &migrateTemplateResponse{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), resp), "body=%s", w.Body.String())
+	require.NotNil(t, resp.Ret)
+	assert.Equal(t, int(errorcode.ErrorCode_Success), resp.Ret.RetCode)
+	require.NotNil(t, resp.Job)
+	assert.Equal(t, int32(60), resp.Job.Progress)
+}

--- a/CubeMaster/pkg/tcclient/client.go
+++ b/CubeMaster/pkg/tcclient/client.go
@@ -12,8 +12,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -28,6 +30,14 @@ import (
 type StatusError struct {
 	StatusCode int
 	Body       string
+}
+
+type UploadArtifactResponse struct {
+	Status        string `json:"status"`
+	ArtifactID    string `json:"artifact_id"`
+	Ext4Path      string `json:"ext4_path"`
+	Ext4SHA256    string `json:"ext4_sha256"`
+	Ext4SizeBytes int64  `json:"ext4_size_bytes"`
 }
 
 func (e *StatusError) Error() string {
@@ -149,4 +159,76 @@ func (c *Client) DeleteArtifact(ctx context.Context, artifactID string) error {
 
 	log.G(ctx).Infof("artifact delete requested from TC successfully: artifact_id=%s", artifactID)
 	return nil
+}
+
+// UploadArtifact uploads one local ext4 file into CubeTemplateCenter's own
+// artifact store and returns the stored metadata.
+func (c *Client) UploadArtifact(ctx context.Context, artifactID, localFilePath string) (*UploadArtifactResponse, error) {
+	f, err := os.Open(localFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("open local artifact file: %w", err)
+	}
+	defer f.Close()
+
+	pr, pw := io.Pipe()
+	// Closing the reader on every exit path unblocks the writer goroutine
+	// (its writes fail with ErrClosedPipe) when the request never happens --
+	// e.g. NewRequestWithContext fails below -- instead of leaking it.
+	defer pr.Close()
+	writer := multipart.NewWriter(pw)
+	writeErrCh := make(chan error, 1)
+	go func() {
+		defer pw.Close()
+		if err := writer.WriteField("artifact_id", artifactID); err != nil {
+			writeErrCh <- fmt.Errorf("write multipart artifact_id: %w", err)
+			return
+		}
+		part, err := writer.CreateFormFile("file", filepath.Base(localFilePath))
+		if err != nil {
+			writeErrCh <- fmt.Errorf("create multipart file field: %w", err)
+			return
+		}
+		if _, err := io.Copy(part, f); err != nil {
+			writeErrCh <- fmt.Errorf("copy local artifact into multipart body: %w", err)
+			return
+		}
+		if err := writer.Close(); err != nil {
+			writeErrCh <- fmt.Errorf("close multipart body: %w", err)
+			return
+		}
+		writeErrCh <- nil
+	}()
+
+	url := fmt.Sprintf("%s/tc/api/v1/artifact/upload", c.endpoint)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", writer.FormDataContentType())
+	setSharedTokenHeader(httpReq)
+
+	uploadClient := &http.Client{Timeout: 10 * time.Minute}
+	resp, err := uploadClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http post: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := <-writeErrCh; err != nil {
+		return nil, err
+	}
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("read upload response body: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &StatusError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	out := &UploadArtifactResponse{}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return nil, fmt.Errorf("decode upload artifact response: %w", err)
+	}
+	return out, nil
 }

--- a/CubeMaster/pkg/tcclient/client_test.go
+++ b/CubeMaster/pkg/tcclient/client_test.go
@@ -1,23 +1,20 @@
-// Copyright (c) 2026 Tencent Inc.
-// SPDX-License-Identifier: Apache-2.0
-//
-
 package tcclient
 
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 )
 
 // DeleteArtifact must POST the artifact_id to /tc/api/v1/artifact/delete and
-// treat a 200 response as success. This is the piece that was entirely
-// missing before: CubeMaster could Submit a build job but had no way to ask
-// TC to delete the artifact's S3 object, which is how S3 objects leaked.
+// treat a 200 response as success.
 func TestDeleteArtifactSuccess(t *testing.T) {
 	var gotPath string
 	var gotBody map[string]any
@@ -70,18 +67,28 @@ func TestDeleteArtifactUnreachable(t *testing.T) {
 // shared-token header so TC's auth middleware accepts the request; when the
 // env is empty the header must be absent (matching a token-less TC).
 func TestSharedTokenHeader(t *testing.T) {
-	var gotDelete, gotSubmit string
+	var gotDelete, gotSubmit, gotUpload string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/tc/api/v1/artifact/delete":
 			gotDelete = r.Header.Get(constants.TemplateCallbackTokenHeader)
 		case "/tc/api/v1/build":
 			gotSubmit = r.Header.Get(constants.TemplateCallbackTokenHeader)
+		case "/tc/api/v1/artifact/upload":
+			gotUpload = r.Header.Get(constants.TemplateCallbackTokenHeader)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(UploadArtifactResponse{Status: "uploaded", ArtifactID: "art-1"})
+			return
 		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	}))
 	defer srv.Close()
+
+	artifactPath := filepath.Join(t.TempDir(), "art-1.ext4")
+	if err := os.WriteFile(artifactPath, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write artifact file: %v", err)
+	}
 
 	t.Setenv(constants.TemplateCallbackTokenEnv, "s3cr3t")
 	c := NewClient(srv.URL)
@@ -91,19 +98,81 @@ func TestSharedTokenHeader(t *testing.T) {
 	if err := c.SubmitBuildJob(context.Background(), "job-1", nil, "", "", nil); err != nil {
 		t.Fatalf("SubmitBuildJob() error = %v", err)
 	}
-	if gotDelete != "s3cr3t" || gotSubmit != "s3cr3t" {
-		t.Fatalf("token header = %q/%q, want s3cr3t on both", gotDelete, gotSubmit)
+	if _, err := c.UploadArtifact(context.Background(), "art-1", artifactPath); err != nil {
+		t.Fatalf("UploadArtifact() error = %v", err)
+	}
+	if gotDelete != "s3cr3t" || gotSubmit != "s3cr3t" || gotUpload != "s3cr3t" {
+		t.Fatalf("token header = %q/%q/%q, want s3cr3t on all three", gotDelete, gotSubmit, gotUpload)
 	}
 
 	t.Setenv(constants.TemplateCallbackTokenEnv, "")
-	gotDelete, gotSubmit = "", ""
+	gotDelete, gotSubmit, gotUpload = "", "", ""
 	if err := c.DeleteArtifact(context.Background(), "art-1"); err != nil {
 		t.Fatalf("DeleteArtifact() error = %v", err)
 	}
 	if err := c.SubmitBuildJob(context.Background(), "job-1", nil, "", "", nil); err != nil {
 		t.Fatalf("SubmitBuildJob() error = %v", err)
 	}
-	if gotDelete != "" || gotSubmit != "" {
-		t.Fatalf("token header must be absent when env unset, got %q/%q", gotDelete, gotSubmit)
+	if _, err := c.UploadArtifact(context.Background(), "art-1", artifactPath); err != nil {
+		t.Fatalf("UploadArtifact() error = %v", err)
+	}
+	if gotDelete != "" || gotSubmit != "" || gotUpload != "" {
+		t.Fatalf("token header must be absent when env unset, got %q/%q/%q", gotDelete, gotSubmit, gotUpload)
+	}
+}
+
+func TestUploadArtifactStreamsMultipart(t *testing.T) {
+	tmpDir := t.TempDir()
+	artifactPath := filepath.Join(tmpDir, "rfs-test.ext4")
+	payload := []byte("test-ext4-content")
+	if err := os.WriteFile(artifactPath, payload, 0o644); err != nil {
+		t.Fatalf("write artifact file: %v", err)
+	}
+
+	var gotArtifactID string
+	var gotFileBytes []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tc/api/v1/artifact/upload" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			t.Fatalf("parse multipart form: %v", err)
+		}
+		gotArtifactID = r.FormValue("artifact_id")
+		f, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("form file: %v", err)
+		}
+		defer f.Close()
+		gotFileBytes, err = io.ReadAll(f)
+		if err != nil {
+			t.Fatalf("read uploaded file: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(UploadArtifactResponse{
+			Status:        "uploaded",
+			ArtifactID:    gotArtifactID,
+			Ext4Path:      artifactPath,
+			Ext4SHA256:    "sha256",
+			Ext4SizeBytes: int64(len(gotFileBytes)),
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	resp, err := client.UploadArtifact(context.Background(), "rfs-test", artifactPath)
+	if err != nil {
+		t.Fatalf("UploadArtifact failed: %v", err)
+	}
+	if gotArtifactID != "rfs-test" {
+		t.Fatalf("artifact_id=%q, want rfs-test", gotArtifactID)
+	}
+	if string(gotFileBytes) != string(payload) {
+		t.Fatalf("uploaded bytes=%q, want %q", string(gotFileBytes), string(payload))
+	}
+	if resp.Ext4SizeBytes != int64(len(payload)) {
+		t.Fatalf("resp.Ext4SizeBytes=%d, want %d", resp.Ext4SizeBytes, len(payload))
 	}
 }

--- a/CubeMaster/pkg/templatecenter/artifact_presence.go
+++ b/CubeMaster/pkg/templatecenter/artifact_presence.go
@@ -219,11 +219,33 @@ func artifactServedLocally(downloadBaseURL string, localHosts map[string]bool) b
 
 // artifactAuthoritativeHere reports whether this node may rewrite the shared
 // database row for an artifact whose file it cannot find.
+type artifactOwnership int
+
+const (
+	artifactOwnershipUnknown artifactOwnership = iota
+	artifactOwnershipLocal
+	artifactOwnershipRemote
+	artifactOwnershipObjectStore
+)
+
+func artifactOwnershipOf(record *models.RootfsArtifact) artifactOwnership {
+	if record == nil {
+		return artifactOwnershipUnknown
+	}
+	if strings.TrimSpace(record.ArtifactURL) != "" {
+		return artifactOwnershipObjectStore
+	}
+	if artifactServedLocally(record.MasterNodeIP, localArtifactHostsFn()) {
+		return artifactOwnershipLocal
+	}
+	return artifactOwnershipRemote
+}
+
 func artifactAuthoritativeHere(record *models.RootfsArtifact) bool {
 	if record == nil {
 		return false
 	}
-	return artifactServedLocally(record.MasterNodeIP, localArtifactHostsFn())
+	return artifactOwnershipOf(record) == artifactOwnershipLocal
 }
 
 // demoteMissingRootfsArtifact flips a READY row whose file vanished to FAILED so
@@ -278,7 +300,7 @@ func resolveMissingArtifact(ctx context.Context, record *models.RootfsArtifact) 
 	if record == nil {
 		return artifactMissingVerdictNone
 	}
-	if strings.TrimSpace(record.ArtifactURL) != "" {
+	if artifactOwnershipOf(record) == artifactOwnershipObjectStore {
 		// S3/MinIO-backed: the durable copy is the object behind artifact_url
 		// and cubelets pull straight from it, so the local ext4 is only a
 		// build-time cache. Its absence (node-local disk wiped, artifact
@@ -356,9 +378,10 @@ func rootfsArtifactReuseVerdict(ctx context.Context, record *models.RootfsArtifa
 		return errors.New("no artifact record")
 	}
 	if strings.TrimSpace(record.ArtifactURL) != "" {
-		// S3/MinIO-backed: the object behind artifact_url is the durable copy
-		// and cubelets download from it directly, so the local ext4's
-		// presence/size must not gate reuse (see resolveMissingArtifact).
+		// S3/MinIO-backed: the object behind artifact_url is the durable copy,
+		// so the local ext4's presence/size must not gate reuse (see
+		// resolveMissingArtifact). Distribution/create later probe the unified
+		// download endpoint separately.
 		return nil
 	}
 	if artifactServedByRemoteTier() {

--- a/CubeMaster/pkg/templatecenter/artifact_presence_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_presence_test.go
@@ -462,6 +462,57 @@ func TestResolveMissingArtifactNilRecord(t *testing.T) {
 	}
 }
 
+func TestArtifactOwnershipOf(t *testing.T) {
+	localHosts := map[string]bool{"localhost": true, "127.0.0.1": true, "node-a": true}
+	orig := localArtifactHostsFn
+	localArtifactHostsFn = func() map[string]bool { return localHosts }
+	t.Cleanup(func() { localArtifactHostsFn = orig })
+
+	tests := []struct {
+		name   string
+		record *models.RootfsArtifact
+		want   artifactOwnership
+	}{
+		{
+			name:   "nil record",
+			record: nil,
+			want:   artifactOwnershipUnknown,
+		},
+		{
+			name: "s3 backed",
+			record: &models.RootfsArtifact{
+				ArtifactURL:  "https://minio:9000/bucket/rfs-1.ext4?sig=1",
+				MasterNodeIP: "http://node-a:8089",
+			},
+			want: artifactOwnershipObjectStore,
+		},
+		{
+			name: "local holder",
+			record: &models.RootfsArtifact{
+				ArtifactURL:  "",
+				MasterNodeIP: "http://node-a:8089",
+			},
+			want: artifactOwnershipLocal,
+		},
+		{
+			name: "remote holder",
+			record: &models.RootfsArtifact{
+				ArtifactURL:  "",
+				MasterNodeIP: "http://node-b:8089",
+			},
+			want: artifactOwnershipRemote,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := artifactOwnershipOf(tt.record); got != tt.want {
+				t.Fatalf("artifactOwnershipOf()=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // A foreign artifact must not be reused either: this node would hand cubelets a
 // download URL it cannot serve.
 func TestReadyArtifactUsableForReuseRejectsForeignArtifact(t *testing.T) {

--- a/CubeMaster/pkg/templatecenter/artifact_servability.go
+++ b/CubeMaster/pkg/templatecenter/artifact_servability.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
@@ -143,13 +144,68 @@ func classifyArtifactServability(status int, header http.Header, body []byte) (a
 	return artifactServabilityUnknown, fmt.Sprintf("http status %d", status)
 }
 
+const (
+	// servabilityProbeTTL bounds how long a positive servability answer is
+	// reused. The preflight runs once per artifact per distribution/redo, and a
+	// batch distribution repeats it for every target, so without this the
+	// download endpoint sees one ranged GET per artifact per operation.
+	servabilityProbeTTL = 30 * time.Second
+	// servabilityProbeCacheMax bounds the map: artifact ids are bounded by
+	// live templates, but a long-lived master must not grow it without limit.
+	servabilityProbeCacheMax = 4096
+)
+
+var (
+	servabilityProbeMu    sync.Mutex
+	servabilityProbeCache = map[string]artifactServabilityProbe{}
+)
+
+type artifactServabilityProbe struct {
+	verdict artifactServability
+	reason  string
+	at      time.Time
+}
+
+// probeServabilityOnce reuses a recent positive answer, then probes.
+//
+// Only artifactServabilityServable is cached. Caching Missing would keep
+// handing out an artifact the serving tier has already lost, and caching
+// Unknown would extend a transient outage by the TTL -- both are exactly the
+// failure modes the probe exists to catch.
+func probeServabilityOnce(ctx context.Context, artifact *models.RootfsArtifact) (artifactServability, string) {
+	if artifact == nil {
+		return artifactServabilityUnknown, "nil artifact"
+	}
+	now := time.Now()
+	servabilityProbeMu.Lock()
+	cached, ok := servabilityProbeCache[artifact.ArtifactID]
+	servabilityProbeMu.Unlock()
+	if ok && now.Sub(cached.at) < servabilityProbeTTL {
+		return cached.verdict, cached.reason
+	}
+
+	verdict, reason := probeArtifactServability(ctx, artifact)
+	if verdict == artifactServabilityServable {
+		servabilityProbeMu.Lock()
+		if len(servabilityProbeCache) >= servabilityProbeCacheMax {
+			// Cheap full reset rather than an LRU: entries expire on their own
+			// within servabilityProbeTTL, so dropping all of them only costs
+			// one extra probe per live artifact.
+			servabilityProbeCache = map[string]artifactServabilityProbe{}
+		}
+		servabilityProbeCache[artifact.ArtifactID] = artifactServabilityProbe{verdict: verdict, reason: reason, at: now}
+		servabilityProbeMu.Unlock()
+	}
+	return verdict, reason
+}
+
 // probeArtifactServability issues the same request a cubelet would issue for
 // this artifact and classifies the answer.
 func probeArtifactServability(ctx context.Context, artifact *models.RootfsArtifact) (artifactServability, string) {
 	if artifact == nil {
 		return artifactServabilityUnknown, "nil artifact"
 	}
-	rawURL := buildDownloadURL(artifact.MasterNodeIP, artifact.ArtifactID, artifact.DownloadToken)
+	rawURL := buildDownloadURL(effectiveArtifactDownloadBaseURL("", artifact), artifact.ArtifactID, artifact.DownloadToken)
 	status, header, body, err := getArtifactDownloadRange(ctx, rawURL)
 	if err != nil {
 		return artifactServabilityUnknown, fmt.Sprintf("get %q: %v", rawURL, err)
@@ -166,13 +222,28 @@ func probeArtifactServability(ctx context.Context, artifact *models.RootfsArtifa
 var demoteUnservableRootfsArtifact = func(ctx context.Context, artifactID, reason string) {
 	log.G(ctx).Errorf("rootfs artifact %s: download path reports missing (%s); demoting to %s so the next create rebuilds it",
 		artifactID, reason, ArtifactStatusFailed)
-	if err := updateRootfsArtifact(ctx, artifactID, map[string]any{
+	// Read the current status and demote with a CAS rather than a blind update:
+	// the row may have been claimed for deletion (or rebuilt) between the probe
+	// and this write, and overwriting it would either resurrect a deleted
+	// artifact or discard a fresh rebuild. Losing the demotion only costs
+	// another failed attempt that retries this same probe, so it must not fail
+	// the caller.
+	artifact, err := getRootfsArtifactByID(ctx, artifactID)
+	if err != nil {
+		log.G(ctx).Warnf("rootfs artifact %s: demote to %s skipped, cannot re-read row: %v", artifactID, ArtifactStatusFailed, err)
+		return
+	}
+	ok, err := updateRootfsArtifactIfStatus(ctx, artifactID, artifact.Status, map[string]any{
 		"status":     ArtifactStatusFailed,
 		"last_error": fmt.Sprintf("download endpoint reports the artifact missing (%s); artifact must be rebuilt", reason),
-	}); err != nil {
-		// Losing the demotion only costs another failed attempt that retries
-		// this same probe, so it must not fail the caller.
+	})
+	if err != nil {
 		log.G(ctx).Warnf("rootfs artifact %s: demote to %s fail: %v", artifactID, ArtifactStatusFailed, err)
+		return
+	}
+	if !ok {
+		log.G(ctx).Infof("rootfs artifact %s: demote skipped, status changed to %s while the probe was in flight",
+			artifactID, artifact.Status)
 	}
 }
 
@@ -192,24 +263,51 @@ func artifactServabilityUnknownError(artifact *models.RootfsArtifact, reason str
 	return fmt.Errorf(
 		"cannot verify rootfs artifact %s is servable at %q: %s; "+
 			"leaving the row untouched (the serving tier may be unreachable) — retry or redo",
-		artifact.ArtifactID, artifact.MasterNodeIP, reason)
+		artifact.ArtifactID, effectiveArtifactDownloadBaseURL("", artifact), reason)
 }
 
 // verifyArtifactServability is the distribution/redo preflight: the artifact
-// row must be backed by data the download path can actually serve.
+// row must be backed by data the node-facing download path can actually serve.
 //
-//   - S3-backed rows (artifact_url set): the durable copy is the bucket
-//     object; no probe needed (see resolveMissingArtifact).
-//   - Remote-TC topology (this process is CubeMaster): its own disk is never
-//     the holder, so the check probes the download URL end-to-end.
-//   - Otherwise this process IS the serving tier and the classic node-local
-//     probe runs.
+//   - Remote-TC topology with a resolvable download base URL: probe the
+//     CubeMaster download endpoint end-to-end, regardless of whether the
+//     artifact data ultimately lives on TC-local disk or in S3/MinIO. The
+//     endpoint is what Cubelets dial after the K8s multi-node fix, so this is
+//     the only probe that matches reality.
+//   - Otherwise (no remote tier, or a legacy row predating the download
+//     base URL column) this process IS assumed to be the serving tier and
+//     the classic node-local probe runs.
+//
+// WHY OWNERSHIP MUST NOT GATE THE REMOTE PROBE
+// ---------------------------------------------
+// artifactOwnershipOf classifies a row as Local whenever its recorded
+// MasterNodeIP matches THIS host's own identity. That is true far more often
+// than it looks: MasterNodeIP is populated from the inbound request's Host
+// header (requestBaseURL), so in a single-node / one-click deployment where
+// clients simply call this same CubeMaster's own address, ownership resolves
+// to Local -- even though CUBE_TEMPLATE_CENTER_ADDR is configured and the
+// build was forwarded to the standalone CubeTemplateCenter tier. Once
+// artifactServedByRemoteTier() is true, TC is the ONLY thing that ever
+// builds a fresh ext4 (see the file header comment), so "Local" here just
+// means "this host answered the HTTP request", not "this host holds the
+// file". Gating on ownership made the node-local disk probe run in exactly
+// that case, which used to accidentally work only because CubeMaster and TC
+// shared one physical artifact-store directory; once they use independent
+// directories the stat always misses and every distribution/redo wrongly
+// demotes a perfectly healthy artifact to FAILED. This mirrors the fix in
+// rootfsArtifactReuseVerdict (artifact_presence.go), which checks
+// artifactServedByRemoteTier() alone for the same reason.
+//
+// The one case that must still fall through to the node-local probe is a
+// legacy row from before the download-base-url column existed
+// (MasterNodeIP == ""): those may genuinely have their ext4 sitting on this
+// node's disk from before this CubeMaster started delegating builds to TC.
 func verifyArtifactServability(ctx context.Context, artifact *models.RootfsArtifact) error {
 	if artifact == nil {
 		return fmt.Errorf("verifyArtifactServability: artifact is nil")
 	}
-	if strings.TrimSpace(artifact.ArtifactURL) == "" && artifactServedByRemoteTier() {
-		switch verdict, reason := probeArtifactServability(ctx, artifact); verdict {
+	if artifactServedByRemoteTier() && strings.TrimSpace(effectiveArtifactDownloadBaseURL("", artifact)) != "" {
+		switch verdict, reason := probeServabilityOnce(ctx, artifact); verdict {
 		case artifactServabilityServable:
 			return nil
 		case artifactServabilityMissing:

--- a/CubeMaster/pkg/templatecenter/artifact_servability_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_servability_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -92,6 +93,32 @@ func TestVerifyArtifactServabilityRemoteServable(t *testing.T) {
 	}
 }
 
+func TestVerifyArtifactServabilityLocalOwnershipSkipsRemoteProbe(t *testing.T) {
+	probeCalled := false
+	stubRemoteTier(t, true, func(ctx context.Context, url string) (int, http.Header, []byte, error) {
+		probeCalled = true
+		return 0, nil, nil, errors.New("must not be called for local ownership")
+	})
+	artDir := t.TempDir()
+	ext4Path := artDir + "/rfs-local.ext4"
+	if err := os.WriteFile(ext4Path, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write ext4: %v", err)
+	}
+	artifact := &models.RootfsArtifact{
+		ArtifactID:    "rfs-local",
+		Status:        ArtifactStatusReady,
+		Ext4Path:      ext4Path,
+		MasterNodeIP:  "",
+		DownloadToken: "tok",
+	}
+	if err := verifyArtifactServability(context.Background(), artifact); err != nil {
+		t.Fatalf("local-owned artifact must use local check, got %v", err)
+	}
+	if probeCalled {
+		t.Fatal("local-owned artifact must not use remote servability probe")
+	}
+}
+
 func TestVerifyArtifactServabilityRemoteMissingDemotes(t *testing.T) {
 	stubRemoteTier(t, true, envelopeProbe(int(errorcode.ErrorCode_NotFound), "artifact source missing"))
 	demoted := ""
@@ -146,23 +173,25 @@ func TestVerifyArtifactServabilityRemoteUnknownKeepsRow(t *testing.T) {
 	}
 }
 
-func TestVerifyArtifactServabilitySkipsS3Backed(t *testing.T) {
-	probeCalled := false
+func TestVerifyArtifactServabilityProbesS3BackedDownloadEndpoint(t *testing.T) {
+	probedURL := ""
 	stubRemoteTier(t, true, func(ctx context.Context, url string) (int, http.Header, []byte, error) {
-		probeCalled = true
-		return 0, nil, nil, errors.New("must not be called")
+		probedURL = url
+		return servableProbe(http.StatusPartialContent, "rfs-s3")(ctx, url)
 	})
 	artifact := &models.RootfsArtifact{
-		ArtifactID:   "rfs-s3",
-		Status:       ArtifactStatusReady,
-		ArtifactURL:  "http://minio:9000/bucket/rfs-s3.ext4?sig=...",
-		MasterNodeIP: "http://master:8089",
+		ArtifactID:    "rfs-s3",
+		Status:        ArtifactStatusReady,
+		ArtifactURL:   "http://minio:9000/bucket/rfs-s3.ext4?sig=...",
+		MasterNodeIP:  "http://master:8089",
+		DownloadToken: "tok-s3",
 	}
 	if err := verifyArtifactServability(context.Background(), artifact); err != nil {
-		t.Fatalf("S3-backed artifact must not be probed, got %v", err)
+		t.Fatalf("S3-backed artifact should be probed through the unified download endpoint, got %v", err)
 	}
-	if probeCalled {
-		t.Fatal("S3-backed artifact must skip the download-path probe")
+	want := "http://master:8089/cube/template/artifact/download?artifact_id=rfs-s3&token=tok-s3"
+	if probedURL != want {
+		t.Fatalf("probe url=%q, want %q", probedURL, want)
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/artifact_url_refresh.go
+++ b/CubeMaster/pkg/templatecenter/artifact_url_refresh.go
@@ -26,10 +26,11 @@ import (
 // --------------------
 // artifact_url is a presigned GET URL with a finite validity (7 days, the
 // SigV4 maximum), but the artifact itself lives far longer. Every consumer of
-// the URL sits on the CubeMaster side -- distribution hands it to cubelets,
-// the download endpoint 302-redirects to it -- so freshness is Master's
-// concern, not CubeTemplateCenter's (TC only ever WRITES the URL at build
-// time). Re-signing lazily at each use beats a periodic DB rewrite on every
+// the URL sits on the CubeMaster/TC serving side -- the download endpoint now
+// proxies S3 through a stable CubeMaster URL rather than handing the raw URL to
+// cubelets -- so freshness is Master's concern, not CubeTemplateCenter's (TC
+// only ever WRITES the URL at build time). Re-signing lazily at each use beats
+// a periodic DB rewrite on every
 // axis: no background sweep, no concurrent-write guarding, no row churn, and
 // the handed-out URL always has its full lifetime ahead of it regardless of
 // how old the row is.
@@ -163,6 +164,45 @@ var presignArtifactGetURL = func(ctx context.Context, artifactID string) (string
 }
 
 var errS3PresignNotConfigured = fmt.Errorf("s3 presign not configured on cubemaster")
+
+// statArtifactObjectInS3 checks whether the S3 object for artifactID exists.
+// Returns (false, nil) only for a definitive "not found".
+var statArtifactObjectInS3 = func(ctx context.Context, artifactID string) (bool, error) {
+	s3PresignerOnce.Do(func() {
+		s3PresignerInst = loadS3Presigner()
+	})
+	if s3PresignerInst == nil {
+		return false, errS3PresignNotConfigured
+	}
+	s := s3PresignerInst
+	_, err := s.client.StatObject(ctx, s.bucket, s3ArtifactObjectKey(s.prefix, artifactID), minio.StatObjectOptions{})
+	if err != nil {
+		code := minio.ToErrorResponse(err).Code
+		if code == "NoSuchKey" || code == "NotFound" {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat s3 object for artifact %s: %w", artifactID, err)
+	}
+	return true, nil
+}
+
+// uploadArtifactFileToS3 uploads filePath as the object of artifactID.
+var uploadArtifactFileToS3 = func(ctx context.Context, artifactID, filePath string) error {
+	s3PresignerOnce.Do(func() {
+		s3PresignerInst = loadS3Presigner()
+	})
+	if s3PresignerInst == nil {
+		return errS3PresignNotConfigured
+	}
+	s := s3PresignerInst
+	_, err := s.client.FPutObject(ctx, s.bucket, s3ArtifactObjectKey(s.prefix, artifactID), filePath, minio.PutObjectOptions{
+		ContentType: "application/octet-stream",
+	})
+	if err != nil {
+		return fmt.Errorf("upload artifact %s to s3 from %s: %w", artifactID, filePath, err)
+	}
+	return nil
+}
 
 // ArtifactDownloadURL exports artifactDownloadURL for the HTTP layer (the
 // download redirect endpoint), which lives in a different package.

--- a/CubeMaster/pkg/templatecenter/cache.go
+++ b/CubeMaster/pkg/templatecenter/cache.go
@@ -227,6 +227,17 @@ func invalidateTemplateCaches(templateID string) {
 	localcache.InvalidateImageState(templateID)
 }
 
+// invalidateTemplateAliasMutationCaches clears the query/runtime caches for an
+// alias write. Alias transfers mutate two definitions (the new holder and the
+// displaced holder), so both IDs must be invalidated after the DB transaction
+// commits; otherwise detail/list reads can keep serving the previous alias.
+func invalidateTemplateAliasMutationCaches(templateID, displacedTemplateID string) {
+	invalidateTemplateCaches(templateID)
+	if displacedTemplateID != "" && displacedTemplateID != templateID {
+		invalidateTemplateCaches(displacedTemplateID)
+	}
+}
+
 // invalidateTemplateListCache drops the aggregate list cache only. Used by
 // write paths that do not have a specific templateID in scope but still
 // mutate the list (e.g. GC deleting orphaned definitions).

--- a/CubeMaster/pkg/templatecenter/cache_query_test.go
+++ b/CubeMaster/pkg/templatecenter/cache_query_test.go
@@ -202,3 +202,43 @@ func TestInvalidateTemplateCachesClearsListAndInfo(t *testing.T) {
 		t.Fatalf("expected info cache cleared by invalidateTemplateCaches")
 	}
 }
+
+func TestInvalidateTemplateAliasMutationCachesClearsTargetAndDisplaced(t *testing.T) {
+	templateListCache.Flush()
+	templateInfoCache.Flush()
+
+	setTemplateListCache([]TemplateInfo{
+		{TemplateID: "tpl-new", DisplayName: "alias"},
+		{TemplateID: "tpl-old", DisplayName: "alias"},
+	})
+	setTemplateInfoCache("tpl-new", &TemplateInfo{TemplateID: "tpl-new", DisplayName: "alias"})
+	setTemplateInfoCache("tpl-old", &TemplateInfo{TemplateID: "tpl-old", DisplayName: "alias"})
+
+	invalidateTemplateAliasMutationCaches("tpl-new", "tpl-old")
+
+	for _, templateID := range []string{"tpl-new", "tpl-old"} {
+		if _, ok := getCachedTemplateInfo(templateID); ok {
+			t.Fatalf("expected info cache cleared for %s", templateID)
+		}
+	}
+	if _, ok := getCachedTemplateList(); ok {
+		t.Fatalf("expected list cache cleared for alias transfer")
+	}
+}
+
+func TestInvalidateTemplateAliasMutationCachesSkipsDuplicateDisplacedID(t *testing.T) {
+	templateListCache.Flush()
+	templateInfoCache.Flush()
+
+	setTemplateListCache([]TemplateInfo{{TemplateID: "tpl-same"}})
+	setTemplateInfoCache("tpl-same", &TemplateInfo{TemplateID: "tpl-same"})
+
+	invalidateTemplateAliasMutationCaches("tpl-same", "tpl-same")
+
+	if _, ok := getCachedTemplateInfo("tpl-same"); ok {
+		t.Fatalf("expected info cache cleared for target")
+	}
+	if _, ok := getCachedTemplateList(); ok {
+		t.Fatalf("expected list cache cleared for target")
+	}
+}

--- a/CubeMaster/pkg/templatecenter/cache_query_test.go
+++ b/CubeMaster/pkg/templatecenter/cache_query_test.go
@@ -202,3 +202,50 @@ func TestInvalidateTemplateCachesClearsListAndInfo(t *testing.T) {
 		t.Fatalf("expected info cache cleared by invalidateTemplateCaches")
 	}
 }
+
+func TestInvalidateTemplateAliasMutationCachesClearsTargetAndDisplaced(t *testing.T) {
+	templateListCache.Flush()
+	templateInfoCache.Flush()
+
+	setTemplateListCache([]TemplateInfo{
+		{TemplateID: "tpl-new", DisplayName: "alias"},
+		{TemplateID: "tpl-old", DisplayName: "alias"},
+	})
+	setTemplateInfoCache("tpl-new", &TemplateInfo{TemplateID: "tpl-new", DisplayName: "alias"})
+	setTemplateInfoCache("tpl-old", &TemplateInfo{TemplateID: "tpl-old", DisplayName: "alias"})
+
+	invalidateTemplateAliasMutationCaches("tpl-new", "tpl-old")
+
+	for _, templateID := range []string{"tpl-new", "tpl-old"} {
+		if _, ok := getCachedTemplateInfo(templateID); ok {
+			t.Fatalf("expected info cache cleared for %s", templateID)
+		}
+	}
+	if _, ok := getCachedTemplateList(); ok {
+		t.Fatalf("expected list cache cleared for alias transfer")
+	}
+}
+
+func TestInvalidateTemplateAliasMutationCachesSkipsDuplicateDisplacedID(t *testing.T) {
+	templateListCache.Flush()
+	templateInfoCache.Flush()
+
+	setTemplateListCache([]TemplateInfo{{TemplateID: "tpl-same"}})
+	setTemplateInfoCache("tpl-same", &TemplateInfo{TemplateID: "tpl-same"})
+
+	// (x, x) and (x, "") clear the same cache keys, and invalidation is
+	// idempotent, so cache-state assertions cannot distinguish "cleared once"
+	// from "cleared twice" — they only assert the entry is actually cleared.
+	// Verifying the guard runs exactly once would require counting
+	// invalidateTemplateCaches calls; gomonkey-based patching replaces the real
+	// body (so the cache is never cleared under some -race builds) and panics
+	// on macOS, so we deliberately keep this as a state assertion only.
+	invalidateTemplateAliasMutationCaches("tpl-same", "tpl-same")
+
+	if _, ok := getCachedTemplateInfo("tpl-same"); ok {
+		t.Fatalf("expected info cache cleared for target")
+	}
+	if _, ok := getCachedTemplateList(); ok {
+		t.Fatalf("expected list cache cleared for target")
+	}
+}

--- a/CubeMaster/pkg/templatecenter/distribution.go
+++ b/CubeMaster/pkg/templatecenter/distribution.go
@@ -161,11 +161,12 @@ func ensureArtifactDistributable(ctx context.Context, artifact *models.RootfsArt
 	if artifact == nil {
 		return fmt.Errorf("distributeRootfsArtifact: artifact is nil")
 	}
-	if artifact.Status != ArtifactStatusReady || artifact.Ext4SizeBytes == 0 || strings.TrimSpace(artifact.Ext4SHA256) == "" || strings.TrimSpace(artifact.DownloadToken) == "" || strings.TrimSpace(artifact.MasterNodeIP) == "" {
+	downloadBaseURL := effectiveArtifactDownloadBaseURL("", artifact)
+	if artifact.Status != ArtifactStatusReady || artifact.Ext4SizeBytes == 0 || strings.TrimSpace(artifact.Ext4SHA256) == "" || strings.TrimSpace(artifact.DownloadToken) == "" || downloadBaseURL == "" {
 		return fmt.Errorf(
-			"artifact %s is not ready for distribution (status=%s size_bytes=%d sha256_set=%t token_set=%t master_node_ip=%q); template build likely did not complete — check cubemaster logs for buildRootfsArtifact errors",
+			"artifact %s is not ready for distribution (status=%s size_bytes=%d sha256_set=%t token_set=%t download_base_url=%q master_node_ip=%q); template build likely did not complete — check cubemaster logs for buildRootfsArtifact errors",
 			artifact.ArtifactID, artifact.Status, artifact.Ext4SizeBytes,
-			strings.TrimSpace(artifact.Ext4SHA256) != "", strings.TrimSpace(artifact.DownloadToken) != "", artifact.MasterNodeIP,
+			strings.TrimSpace(artifact.Ext4SHA256) != "", strings.TrimSpace(artifact.DownloadToken) != "", downloadBaseURL, artifact.MasterNodeIP,
 		)
 	}
 	// The five checks above only read the artifact row. A row can be perfectly
@@ -189,15 +190,10 @@ func ensureArtifactDistributable(ctx context.Context, artifact *models.RootfsArt
 // exactly the nodes that lack a READY replica instead of re-resolving the
 // full healthy-node set. Callers must run ensureArtifactDistributable first.
 func distributeRootfsArtifactToNodes(ctx context.Context, req *types.CreateTemplateFromImageReq, generatedReq *types.CreateCubeSandboxReq, artifact *models.RootfsArtifact, templateID, jobID string, targets []*node.Node) ([]*node.Node, int32, int32, int32, error) {
-	// S3-backed artifacts get a FRESH presigned URL here, not the one stored
-	// at build time: the stored signature expires (7d) while the artifact
-	// lives on, and this distribution may be a redo / scale-out / re-push
-	// long after the build. artifactDownloadURL re-signs when this process
-	// holds the S3 credentials and otherwise falls back to the stored URL.
-	downloadURL := artifactDownloadURL(ctx, artifact)
-	if downloadURL == "" {
-		downloadURL = buildDownloadURL(artifact.MasterNodeIP, artifact.ArtifactID, artifact.DownloadToken)
-	}
+	// Always give Cubelets the CubeMaster download endpoint. That keeps the
+	// node-facing address uniform across local-disk and S3-backed artifacts and
+	// avoids per-node dependence on the object-store endpoint's reachability.
+	downloadURL := buildDownloadURL(effectiveArtifactDownloadBaseURL("", artifact), artifact.ArtifactID, artifact.DownloadToken)
 	spec := &imagev1.ImageSpec{
 		Image:        artifact.ArtifactID,
 		StorageMedia: imagev1.ImageStorageMediaType_ext4.String(),

--- a/CubeMaster/pkg/templatecenter/image_job_reconciler.go
+++ b/CubeMaster/pkg/templatecenter/image_job_reconciler.go
@@ -135,6 +135,12 @@ func runImageJobReconcilePass(ctx context.Context) {
 		if err := resumeStuckBuiltJobs(ctx); err != nil {
 			logger.Errorf("resume stuck BUILT jobs: %v", err)
 		}
+		// MIGRATE jobs run on CubeMaster itself (unlike PENDING/RUNNING build
+		// jobs, which are TC's responsibility), so this reconciler IS the
+		// right owner for sweeping the ones a crash stranded.
+		if err := failAllStaleTemplateMigrateJobs(ctx, migrateJobStaleAfter); err != nil {
+			logger.Errorf("stale migrate job sweep: %v", err)
+		}
 		if err := reconcileOrphanReplicaCleanups(ctx); err != nil {
 			logger.Errorf("orphan replica cleanup sweep: %v", err)
 		}
@@ -304,8 +310,10 @@ func remoteBuildResultFromResultJSON(payload string) (*RemoteBuildResult, error)
 		return nil, err
 	}
 	// The ext4 must still be on disk. CubeMaster and CubeTemplateCenter share
-	// the artifact directory (design §9.7), so this holds even if TC has since
-	// been shut down -- but not if GC already reclaimed the artifact.
+	// the artifact volume, mounted at possibly different roots (design §9.7),
+	// so localize the TC-reported path onto Master's own mount first; this
+	// holds even if TC has since been shut down -- but not if GC already
+	// reclaimed the artifact.
 	//
 	// S3-backed results (ArtifactURL set) skip the probe: the durable copy is
 	// the bucket object and cubelets pull from the presigned URL, so the local

--- a/CubeMaster/pkg/templatecenter/job_constants.go
+++ b/CubeMaster/pkg/templatecenter/job_constants.go
@@ -44,6 +44,7 @@ const (
 	JobOperationCreate           = "CREATE"
 	JobOperationRedo             = "REDO"
 	JobOperationCommit           = "COMMIT"
+	JobOperationMigrate          = "MIGRATE"
 	JobOperationLegacy           = "LEGACY"
 	JobOperationSnapshotCreate   = "SNAPSHOT_CREATE"
 	JobOperationSnapshotRollback = "SNAPSHOT_ROLLBACK"
@@ -69,6 +70,7 @@ const (
 	JobPhaseRollbackDriving    = "ROLLBACK_DRIVING"
 	JobPhaseRollbackRecovering = "ROLLBACK_RECOVERING"
 	JobPhaseDeleting           = "DELETING"
+	JobPhaseMigratingArtifact  = "MIGRATING_ARTIFACT"
 	JobPhaseReady              = "READY"
 
 	defaultTemplateCPU         = "2000m"

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -210,8 +210,12 @@ func listTemplatesFromDB(ctx context.Context) ([]TemplateInfo, error) {
 		Order("updated_at desc").Find(&defs).Error; err != nil {
 		return nil, err
 	}
+	// Only CREATE/REDO jobs carry the source image identity used for display.
+	// A COMMIT/MIGRATE/snapshot row carries no source image ref, and a MIGRATE
+	// row would otherwise win the attempt_no ordering and blank image_info.
 	var jobs []models.TemplateImageJob
 	if err := store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+		Where("operation IN ?", createRedoJobOperations).
 		Order("template_id asc, attempt_no desc, id desc").Find(&jobs).Error; err != nil {
 		return nil, err
 	}
@@ -997,7 +1001,10 @@ func getTemplateInfoFromDB(ctx context.Context, templateID string) (*TemplateInf
 	out := &info
 	out.CreatedAt = formatUTCRFC3339(def.CreatedAt)
 	out.ImageInfo = extractImageInfoFromRequestJSON(def.RequestJSON)
-	if latestJob, jobErr := getLatestTemplateImageJobByTemplateID(ctx, templateID); jobErr == nil && latestJob != nil {
+	// Display fields come from the latest CREATE/REDO job only: a MIGRATE job
+	// carries no source image ref, and letting it win the attempt_no ordering
+	// would blank image_info right after `tpl merge`.
+	if latestJob, jobErr := getLatestCreateRedoImageJobByTemplateIDTx(store.db.WithContext(ctx), templateID); jobErr == nil && latestJob != nil {
 		out.ImageInfo = composeImageInfo(latestJob.SourceImageRef, latestJob.SourceImageDigest)
 		out.JobID = latestJobIDFromJob(latestJob)
 	}
@@ -1259,6 +1266,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 		err = run()
 	}
 	if err == nil {
+		invalidateTemplateAliasMutationCaches(templateID, displacedTemplateID)
 		if claimed {
 			if displacedTemplateID != "" {
 				log.G(ctx).Warnf("alias %q transferred from template %s to newer template build %s", alias, displacedTemplateID, templateID)
@@ -1280,6 +1288,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 	if statusErr := publishTemplateStatusWithoutAlias(ctx, templateID, expectedStatus, status, lastError); statusErr != nil {
 		return "", "", statusErr
 	}
+	invalidateTemplateAliasMutationCaches(templateID, "")
 	if isDuplicateAliasError(claimErr) {
 		return "", "", nil
 	}
@@ -1542,7 +1551,9 @@ func setTemplateAliasLocked(ctx context.Context, templateID, alias string) error
 	if !isReady() {
 		return ErrTemplateStoreNotInitialized
 	}
-	return retryOnceOnDeadlock(func() error {
+	oldHolderToInvalidate := ""
+	err := retryOnceOnDeadlock(func() error {
+		oldHolderToInvalidate = ""
 		return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			def, err := lockTemplateDefinitionTx(tx, templateID)
 			if err != nil {
@@ -1587,10 +1598,16 @@ func setTemplateAliasLocked(ctx context.Context, templateID, alias string) error
 				if err := syncCreateRedoImageJobAliasTx(tx, oldHolder, ""); err != nil {
 					return err
 				}
+				oldHolderToInvalidate = oldHolder
 			}
 			return nil
 		})
 	})
+	if err != nil {
+		return err
+	}
+	invalidateTemplateAliasMutationCaches(templateID, oldHolderToInvalidate)
+	return nil
 }
 
 // applyAliasToRequestJSON returns payload with its "alias" field set to alias

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -1200,6 +1200,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 	expectedStatus := ""
 	claimed := false
 	displacedTemplateID := ""
+	displacedHolderDeleting := false
 	claimWarning = ""
 	var claimErr error
 	run := func() error {
@@ -1209,6 +1210,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 			expectedStatus = ""
 			claimed = false
 			displacedTemplateID = ""
+			displacedHolderDeleting = false
 			claimWarning = ""
 			claimErr = nil
 			return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -1242,6 +1244,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 					}
 					claimed = claimResult.Claimed
 					displacedTemplateID = claimResult.DisplacedTemplateID
+					displacedHolderDeleting = claimResult.DisplacedHolderDeleting
 					claimWarning = claimResult.Warning
 				}
 				return tx.Table(constants.TemplateDefinitionTableName).
@@ -1259,9 +1262,17 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 		err = run()
 	}
 	if err == nil {
+		invalidateTemplateAliasMutationCaches(templateID, displacedTemplateID)
 		if claimed {
 			if displacedTemplateID != "" {
-				log.G(ctx).Warnf("alias %q transferred from template %s to newer template build %s", alias, displacedTemplateID, templateID)
+				// The DELETING branch never compares job order, so calling the
+				// released template a "newer template build" would assert an
+				// ordering that was never evaluated.
+				if displacedHolderDeleting {
+					log.G(ctx).Warnf("alias %q released from deleting template %s to template %s", alias, displacedTemplateID, templateID)
+				} else {
+					log.G(ctx).Warnf("alias %q transferred from template %s to newer template build %s", alias, displacedTemplateID, templateID)
+				}
 			}
 			return alias, claimWarning, nil
 		}
@@ -1280,6 +1291,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 	if statusErr := publishTemplateStatusWithoutAlias(ctx, templateID, expectedStatus, status, lastError); statusErr != nil {
 		return "", "", statusErr
 	}
+	invalidateTemplateAliasMutationCaches(templateID, "")
 	if isDuplicateAliasError(claimErr) {
 		return "", "", nil
 	}
@@ -1324,9 +1336,10 @@ func publishTemplateStatusWithoutAlias(ctx context.Context, templateID, expected
 }
 
 type orderedAliasClaimResult struct {
-	Claimed             bool
-	DisplacedTemplateID string
-	Warning             string
+	Claimed                 bool
+	DisplacedTemplateID     string
+	DisplacedHolderDeleting bool
+	Warning                 string
 }
 
 func claimTemplateAliasByJobOrderTx(tx *gorm.DB, templateID string, claimantJobRowID uint, alias string) (orderedAliasClaimResult, error) {
@@ -1362,6 +1375,11 @@ func claimTemplateAliasByJobOrderTx(tx *gorm.DB, templateID string, claimantJobR
 		if err := syncCreateRedoImageJobAliasTx(tx, holder.TemplateID, ""); err != nil {
 			return result, err
 		}
+		// The DELETING holder's display_name and job alias were cleared above,
+		// so it is a displaced holder regardless of whether the claimant ends
+		// up claiming the alias. Report it so the caller invalidates both IDs.
+		result.DisplacedTemplateID = holder.TemplateID
+		result.DisplacedHolderDeleting = true
 		update := tx.Table(constants.TemplateDefinitionTableName).
 			Where("template_id = ? AND status <> ?", templateID, StatusDeleting).
 			Update("display_name", alias)
@@ -1421,15 +1439,41 @@ func lockTemplateDefinitionTx(tx *gorm.DB, templateID string) (*models.TemplateD
 	return def, nil
 }
 
+// getTemplateByAliasTx resolves the current alias holder, excluding DELETING
+// templates: read paths (sandbox create by alias, detail/list display) must
+// never treat a template that is being deleted as the alias holder.
 func getTemplateByAliasTx(tx *gorm.DB, alias string) (*models.TemplateDefinition, error) {
+	return getTemplateByAliasFilteredTx(tx, alias, true)
+}
+
+// getTemplateByAliasAnyStatusTx resolves the alias holder without filtering
+// DELETING rows. Alias writes release the previous holder by alias_key alone
+// (claimTemplateAliasTx matches every row whose alias_key matches, with no
+// status predicate), so callers that must invalidate the displaced holder need
+// this unfiltered view: getTemplateByAliasTx would report "not found" for a
+// DELETING holder and silently skip invalidating a row that the write did
+// mutate.
+func getTemplateByAliasAnyStatusTx(tx *gorm.DB, alias string) (*models.TemplateDefinition, error) {
+	return getTemplateByAliasFilteredTx(tx, alias, false)
+}
+
+// getTemplateByAliasFilteredTx is the shared implementation behind both alias
+// lookups. They differ only in whether DELETING rows are excluded — the
+// distinction between "who currently holds this alias" (reads) and "which rows
+// an alias write actually mutated" (cache invalidation). Rows are matched by
+// alias_key, not display_name, because alias_key is the unique constraint the
+// write path actually updates.
+func getTemplateByAliasFilteredTx(tx *gorm.DB, alias string, excludeDeleting bool) (*models.TemplateDefinition, error) {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
 		return nil, ErrTemplateNotFound
 	}
+	query := tx.Table(constants.TemplateDefinitionTableName).Where("alias_key = ?", alias)
+	if excludeDeleting {
+		query = query.Where("status <> ?", StatusDeleting)
+	}
 	def := &models.TemplateDefinition{}
-	err := tx.Table(constants.TemplateDefinitionTableName).
-		Where("alias_key = ? AND status <> ?", alias, StatusDeleting).
-		First(def).Error
+	err := query.First(def).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrTemplateNotFound
@@ -1542,7 +1586,9 @@ func setTemplateAliasLocked(ctx context.Context, templateID, alias string) error
 	if !isReady() {
 		return ErrTemplateStoreNotInitialized
 	}
-	return retryOnceOnDeadlock(func() error {
+	oldHolderToInvalidate := ""
+	err := retryOnceOnDeadlock(func() error {
+		oldHolderToInvalidate = ""
 		return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			def, err := lockTemplateDefinitionTx(tx, templateID)
 			if err != nil {
@@ -1572,7 +1618,7 @@ func setTemplateAliasLocked(ctx context.Context, templateID, alias string) error
 				return ErrTemplateNotReady
 			}
 			oldHolder := ""
-			if cur, err := getTemplateByAliasTx(tx, alias); err == nil && cur != nil && cur.TemplateID != templateID {
+			if cur, err := getTemplateByAliasAnyStatusTx(tx, alias); err == nil && cur != nil && cur.TemplateID != templateID {
 				oldHolder = cur.TemplateID
 			} else if err != nil && !errors.Is(err, ErrTemplateNotFound) {
 				return err
@@ -1587,10 +1633,16 @@ func setTemplateAliasLocked(ctx context.Context, templateID, alias string) error
 				if err := syncCreateRedoImageJobAliasTx(tx, oldHolder, ""); err != nil {
 					return err
 				}
+				oldHolderToInvalidate = oldHolder
 			}
 			return nil
 		})
 	})
+	if err != nil {
+		return err
+	}
+	invalidateTemplateAliasMutationCaches(templateID, oldHolderToInvalidate)
+	return nil
 }
 
 // applyAliasToRequestJSON returns payload with its "alias" field set to alias

--- a/CubeMaster/pkg/templatecenter/store_alias_docker_test.go
+++ b/CubeMaster/pkg/templatecenter/store_alias_docker_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,6 +78,21 @@ func runAliasStoreCases(t *testing.T, db *gorm.DB) {
 	})
 	t.Run("ClearAliasSyncsCreateRedoLeavesCommit", func(t *testing.T) {
 		testClearAliasSyncsCreateRedoLeavesCommit(t, db)
+	})
+	t.Run("SetAliasInvalidatesQueryCaches", func(t *testing.T) {
+		testSetAliasInvalidatesQueryCaches(t, db)
+	})
+	t.Run("SetAliasTransferInvalidatesBothQueryCaches", func(t *testing.T) {
+		testSetAliasTransferInvalidatesBothQueryCaches(t, db)
+	})
+	t.Run("SetAliasTransferFromDeletingHolderInvalidatesBothQueryCaches", func(t *testing.T) {
+		testSetAliasTransferFromDeletingHolderInvalidatesBothQueryCaches(t, db)
+	})
+	t.Run("PublishStatusTransferInvalidatesBothQueryCaches", func(t *testing.T) {
+		testPublishStatusTransferInvalidatesBothQueryCaches(t, db)
+	})
+	t.Run("PublishStatusClaimFailureInvalidatesQueryCaches", func(t *testing.T) {
+		testPublishStatusClaimFailureInvalidatesQueryCaches(t, db)
 	})
 }
 
@@ -510,4 +526,194 @@ func testClearAliasSyncsCreateRedoLeavesCommit(t *testing.T, db *gorm.DB) {
 	assert.NotContains(t, loadJob(createID).RequestJSON, `"alias"`)
 	assert.NotContains(t, loadJob(redoID).RequestJSON, `"alias"`)
 	assert.Equal(t, commitJSON, loadJob(commitID).RequestJSON, "COMMIT RequestJSON must be byte-identical after clear")
+}
+
+func primeTemplateQueryCaches(templateIDs ...string) {
+	infos := make([]TemplateInfo, 0, len(templateIDs))
+	for _, templateID := range templateIDs {
+		info := &TemplateInfo{TemplateID: templateID, Status: StatusReady, DisplayName: "cached-alias"}
+		setTemplateInfoCache(templateID, info)
+		infos = append(infos, *info)
+	}
+	setTemplateListCache(infos)
+}
+
+func requireTemplateQueryCachesHit(t *testing.T, templateIDs ...string) {
+	t.Helper()
+	for _, templateID := range templateIDs {
+		_, ok := getCachedTemplateInfo(templateID)
+		require.Truef(t, ok, "expected info cache hit for %s", templateID)
+	}
+	_, ok := getCachedTemplateList()
+	require.True(t, ok, "expected list cache hit")
+}
+
+func requireTemplateQueryCachesMiss(t *testing.T, templateIDs ...string) {
+	t.Helper()
+	for _, templateID := range templateIDs {
+		_, ok := getCachedTemplateInfo(templateID)
+		require.Falsef(t, ok, "expected info cache miss for %s", templateID)
+	}
+	_, ok := getCachedTemplateList()
+	require.False(t, ok, "expected list cache miss")
+}
+
+func testSetAliasInvalidatesQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	tplID := "tpl-cache-set-" + suf
+	alias := "alias-cache-set-" + suf
+	insertReadyTemplate(t, db, tplID, "")
+	cleanupTemplatesAndJobs(t, db, []string{tplID}, nil)
+	t.Cleanup(func() { invalidateTemplateCaches(tplID) })
+
+	primeTemplateQueryCaches(tplID)
+	requireTemplateQueryCachesHit(t, tplID)
+	require.NoError(t, SetTemplateAlias(context.Background(), tplID, alias))
+	requireTemplateQueryCachesMiss(t, tplID)
+
+	primeTemplateQueryCaches(tplID)
+	requireTemplateQueryCachesHit(t, tplID)
+	require.NoError(t, SetTemplateAlias(context.Background(), tplID, ""))
+	requireTemplateQueryCachesMiss(t, tplID)
+}
+
+func testSetAliasTransferInvalidatesBothQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	oldTemplateID := "tpl-cache-transfer-old-" + suf
+	newTemplateID := "tpl-cache-transfer-new-" + suf
+	alias := "alias-cache-transfer-" + suf
+	insertReadyTemplate(t, db, oldTemplateID, alias)
+	insertReadyTemplate(t, db, newTemplateID, "")
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, nil)
+	t.Cleanup(func() {
+		invalidateTemplateCaches(oldTemplateID)
+		invalidateTemplateCaches(newTemplateID)
+	})
+
+	primeTemplateQueryCaches(oldTemplateID, newTemplateID)
+	requireTemplateQueryCachesHit(t, oldTemplateID, newTemplateID)
+	require.NoError(t, SetTemplateAlias(context.Background(), newTemplateID, alias))
+	requireTemplateQueryCachesMiss(t, oldTemplateID, newTemplateID)
+
+	oldDef, err := GetDefinition(context.Background(), oldTemplateID)
+	require.NoError(t, err)
+	assert.Empty(t, oldDef.DisplayName)
+	newDef, err := GetDefinition(context.Background(), newTemplateID)
+	require.NoError(t, err)
+	assert.Equal(t, alias, newDef.DisplayName)
+}
+
+func testSetAliasTransferFromDeletingHolderInvalidatesBothQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	oldTemplateID := "tpl-cache-transfer-deleting-" + suf
+	newTemplateID := "tpl-cache-transfer-claimant-" + suf
+	oldJobID := "job-cache-transfer-deleting-" + suf
+	alias := "alias-cache-transfer-deleting-" + suf
+	// A DELETING holder is invisible to the status-filtered alias lookup, but
+	// claimTemplateAliasTx still clears it by alias_key. This pins the
+	// unfiltered holder resolution: the displaced DELETING holder's caches must
+	// be invalidated too, not just the claimant's. The job row additionally pins
+	// the behavior change that SetTemplateAlias now rewrites the deleting
+	// holder's CREATE/REDO request JSON.
+	insertTemplate(t, db, oldTemplateID, StatusDeleting, alias)
+	insertReadyTemplate(t, db, newTemplateID, "")
+	insertCreateJob(t, db, oldTemplateID, oldJobID, alias)
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, []string{oldJobID})
+	t.Cleanup(func() {
+		invalidateTemplateCaches(oldTemplateID)
+		invalidateTemplateCaches(newTemplateID)
+	})
+
+	primeTemplateQueryCaches(oldTemplateID, newTemplateID)
+	requireTemplateQueryCachesHit(t, oldTemplateID, newTemplateID)
+	require.NoError(t, SetTemplateAlias(context.Background(), newTemplateID, alias))
+	requireTemplateQueryCachesMiss(t, oldTemplateID, newTemplateID)
+
+	oldDef, err := GetDefinition(context.Background(), oldTemplateID)
+	require.NoError(t, err)
+	assert.Empty(t, oldDef.DisplayName)
+	newDef, err := GetDefinition(context.Background(), newTemplateID)
+	require.NoError(t, err)
+	assert.Equal(t, alias, newDef.DisplayName)
+
+	// With the unfiltered lookup, SetTemplateAlias now also rewrites the
+	// deleting holder's CREATE/REDO request JSON (dropping the alias).
+	var oldJob models.TemplateImageJob
+	require.NoError(t, db.Where("job_id = ?", oldJobID).First(&oldJob).Error)
+	assert.Empty(t, aliasFromRequestJSON(oldJob.RequestJSON))
+}
+
+func testPublishStatusTransferInvalidatesBothQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	oldTemplateID := "tpl-cache-publish-old-" + suf
+	newTemplateID := "tpl-cache-publish-new-" + suf
+	oldJobID := "job-cache-publish-old-" + suf
+	newJobID := "job-cache-publish-new-" + suf
+	alias := "alias-cache-publish-" + suf
+	insertReadyTemplate(t, db, oldTemplateID, alias)
+	insertTemplate(t, db, newTemplateID, StatusPending, "")
+	insertCreateJob(t, db, oldTemplateID, oldJobID, alias)
+	insertImageJob(t, db, &models.TemplateImageJob{
+		JobID:       newJobID,
+		TemplateID:  newTemplateID,
+		RequestID:   "req-" + newJobID,
+		Operation:   JobOperationCreate,
+		Status:      JobStatusRunning,
+		RequestJSON: `{"alias":"` + alias + `"}`,
+	})
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, []string{oldJobID, newJobID})
+	t.Cleanup(func() {
+		invalidateTemplateCaches(oldTemplateID)
+		invalidateTemplateCaches(newTemplateID)
+	})
+
+	primeTemplateQueryCaches(oldTemplateID, newTemplateID)
+	requireTemplateQueryCachesHit(t, oldTemplateID, newTemplateID)
+	displayName, warning, err := publishTemplateStatusWithAlias(context.Background(), newTemplateID, newJobID, StatusReady, "")
+	require.NoError(t, err)
+	require.Empty(t, warning)
+	require.Equal(t, alias, displayName)
+	requireTemplateQueryCachesMiss(t, oldTemplateID, newTemplateID)
+
+	holder, err := GetTemplateByAlias(context.Background(), alias)
+	require.NoError(t, err)
+	assert.Equal(t, newTemplateID, holder.TemplateID)
+	oldDef, err := GetDefinition(context.Background(), oldTemplateID)
+	require.NoError(t, err)
+	assert.Empty(t, oldDef.DisplayName)
+}
+
+func testPublishStatusClaimFailureInvalidatesQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	templateID := "tpl-cache-claim-fail-" + suf
+	jobID := "job-cache-claim-fail-" + suf
+	// publishTemplateStatusWithAlias does not validate job aliases itself; an
+	// over-length value makes the claim fail inside the transaction, forcing
+	// the fallback status publish. This exercises its cache invalidation path
+	// against both MySQL and PostgreSQL varchar(256) display_name columns.
+	alias := strings.Repeat("a", 300)
+	insertTemplate(t, db, templateID, StatusPending, "")
+	insertImageJob(t, db, &models.TemplateImageJob{
+		JobID:       jobID,
+		TemplateID:  templateID,
+		RequestID:   "req-" + jobID,
+		Operation:   JobOperationCreate,
+		Status:      JobStatusRunning,
+		RequestJSON: `{"alias":"` + alias + `"}`,
+	})
+	cleanupTemplatesAndJobs(t, db, []string{templateID}, []string{jobID})
+	t.Cleanup(func() { invalidateTemplateCaches(templateID) })
+
+	primeTemplateQueryCaches(templateID)
+	requireTemplateQueryCachesHit(t, templateID)
+	displayName, warning, err := publishTemplateStatusWithAlias(context.Background(), templateID, jobID, StatusReady, "")
+	require.NoError(t, err)
+	assert.Empty(t, displayName)
+	assert.Contains(t, warning, "could not be claimed")
+	requireTemplateQueryCachesMiss(t, templateID)
+
+	def, err := GetDefinition(context.Background(), templateID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusReady, def.Status)
+	assert.Empty(t, def.DisplayName)
 }

--- a/CubeMaster/pkg/templatecenter/store_alias_docker_test.go
+++ b/CubeMaster/pkg/templatecenter/store_alias_docker_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,6 +78,18 @@ func runAliasStoreCases(t *testing.T, db *gorm.DB) {
 	})
 	t.Run("ClearAliasSyncsCreateRedoLeavesCommit", func(t *testing.T) {
 		testClearAliasSyncsCreateRedoLeavesCommit(t, db)
+	})
+	t.Run("SetAliasInvalidatesQueryCaches", func(t *testing.T) {
+		testSetAliasInvalidatesQueryCaches(t, db)
+	})
+	t.Run("SetAliasTransferInvalidatesBothQueryCaches", func(t *testing.T) {
+		testSetAliasTransferInvalidatesBothQueryCaches(t, db)
+	})
+	t.Run("PublishStatusTransferInvalidatesBothQueryCaches", func(t *testing.T) {
+		testPublishStatusTransferInvalidatesBothQueryCaches(t, db)
+	})
+	t.Run("PublishStatusClaimFailureInvalidatesQueryCaches", func(t *testing.T) {
+		testPublishStatusClaimFailureInvalidatesQueryCaches(t, db)
 	})
 }
 
@@ -510,4 +523,154 @@ func testClearAliasSyncsCreateRedoLeavesCommit(t *testing.T, db *gorm.DB) {
 	assert.NotContains(t, loadJob(createID).RequestJSON, `"alias"`)
 	assert.NotContains(t, loadJob(redoID).RequestJSON, `"alias"`)
 	assert.Equal(t, commitJSON, loadJob(commitID).RequestJSON, "COMMIT RequestJSON must be byte-identical after clear")
+}
+
+func primeTemplateQueryCaches(templateIDs ...string) {
+	infos := make([]TemplateInfo, 0, len(templateIDs))
+	for _, templateID := range templateIDs {
+		info := &TemplateInfo{TemplateID: templateID, Status: StatusReady, DisplayName: "cached-alias"}
+		setTemplateInfoCache(templateID, info)
+		infos = append(infos, *info)
+	}
+	setTemplateListCache(infos)
+}
+
+func requireTemplateQueryCachesHit(t *testing.T, templateIDs ...string) {
+	t.Helper()
+	for _, templateID := range templateIDs {
+		_, ok := getCachedTemplateInfo(templateID)
+		require.Truef(t, ok, "expected info cache hit for %s", templateID)
+	}
+	_, ok := getCachedTemplateList()
+	require.True(t, ok, "expected list cache hit")
+}
+
+func requireTemplateQueryCachesMiss(t *testing.T, templateIDs ...string) {
+	t.Helper()
+	for _, templateID := range templateIDs {
+		_, ok := getCachedTemplateInfo(templateID)
+		require.Falsef(t, ok, "expected info cache miss for %s", templateID)
+	}
+	_, ok := getCachedTemplateList()
+	require.False(t, ok, "expected list cache miss")
+}
+
+func testSetAliasInvalidatesQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	tplID := "tpl-cache-set-" + suf
+	alias := "alias-cache-set-" + suf
+	insertReadyTemplate(t, db, tplID, "")
+	cleanupTemplatesAndJobs(t, db, []string{tplID}, nil)
+	t.Cleanup(func() { invalidateTemplateCaches(tplID) })
+
+	primeTemplateQueryCaches(tplID)
+	requireTemplateQueryCachesHit(t, tplID)
+	require.NoError(t, SetTemplateAlias(context.Background(), tplID, alias))
+	requireTemplateQueryCachesMiss(t, tplID)
+
+	primeTemplateQueryCaches(tplID)
+	requireTemplateQueryCachesHit(t, tplID)
+	require.NoError(t, SetTemplateAlias(context.Background(), tplID, ""))
+	requireTemplateQueryCachesMiss(t, tplID)
+}
+
+func testSetAliasTransferInvalidatesBothQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	oldTemplateID := "tpl-cache-transfer-old-" + suf
+	newTemplateID := "tpl-cache-transfer-new-" + suf
+	alias := "alias-cache-transfer-" + suf
+	insertReadyTemplate(t, db, oldTemplateID, alias)
+	insertReadyTemplate(t, db, newTemplateID, "")
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, nil)
+	t.Cleanup(func() {
+		invalidateTemplateCaches(oldTemplateID)
+		invalidateTemplateCaches(newTemplateID)
+	})
+
+	primeTemplateQueryCaches(oldTemplateID, newTemplateID)
+	requireTemplateQueryCachesHit(t, oldTemplateID, newTemplateID)
+	require.NoError(t, SetTemplateAlias(context.Background(), newTemplateID, alias))
+	requireTemplateQueryCachesMiss(t, oldTemplateID, newTemplateID)
+
+	oldDef, err := GetDefinition(context.Background(), oldTemplateID)
+	require.NoError(t, err)
+	assert.Empty(t, oldDef.DisplayName)
+	newDef, err := GetDefinition(context.Background(), newTemplateID)
+	require.NoError(t, err)
+	assert.Equal(t, alias, newDef.DisplayName)
+}
+
+func testPublishStatusTransferInvalidatesBothQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	oldTemplateID := "tpl-cache-publish-old-" + suf
+	newTemplateID := "tpl-cache-publish-new-" + suf
+	oldJobID := "job-cache-publish-old-" + suf
+	newJobID := "job-cache-publish-new-" + suf
+	alias := "alias-cache-publish-" + suf
+	insertReadyTemplate(t, db, oldTemplateID, alias)
+	insertTemplate(t, db, newTemplateID, StatusPending, "")
+	insertCreateJob(t, db, oldTemplateID, oldJobID, alias)
+	insertImageJob(t, db, &models.TemplateImageJob{
+		JobID:       newJobID,
+		TemplateID:  newTemplateID,
+		RequestID:   "req-" + newJobID,
+		Operation:   JobOperationCreate,
+		Status:      JobStatusRunning,
+		RequestJSON: `{"alias":"` + alias + `"}`,
+	})
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, []string{oldJobID, newJobID})
+	t.Cleanup(func() {
+		invalidateTemplateCaches(oldTemplateID)
+		invalidateTemplateCaches(newTemplateID)
+	})
+
+	primeTemplateQueryCaches(oldTemplateID, newTemplateID)
+	requireTemplateQueryCachesHit(t, oldTemplateID, newTemplateID)
+	displayName, warning, err := publishTemplateStatusWithAlias(context.Background(), newTemplateID, newJobID, StatusReady, "")
+	require.NoError(t, err)
+	require.Empty(t, warning)
+	require.Equal(t, alias, displayName)
+	requireTemplateQueryCachesMiss(t, oldTemplateID, newTemplateID)
+
+	holder, err := GetTemplateByAlias(context.Background(), alias)
+	require.NoError(t, err)
+	assert.Equal(t, newTemplateID, holder.TemplateID)
+	oldDef, err := GetDefinition(context.Background(), oldTemplateID)
+	require.NoError(t, err)
+	assert.Empty(t, oldDef.DisplayName)
+}
+
+func testPublishStatusClaimFailureInvalidatesQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	templateID := "tpl-cache-claim-fail-" + suf
+	jobID := "job-cache-claim-fail-" + suf
+	// publishTemplateStatusWithAlias does not validate job aliases itself; an
+	// over-length value makes the claim fail inside the transaction, forcing
+	// the fallback status publish. This exercises its cache invalidation path
+	// against both MySQL and PostgreSQL varchar(256) display_name columns.
+	alias := strings.Repeat("a", 300)
+	insertTemplate(t, db, templateID, StatusPending, "")
+	insertImageJob(t, db, &models.TemplateImageJob{
+		JobID:       jobID,
+		TemplateID:  templateID,
+		RequestID:   "req-" + jobID,
+		Operation:   JobOperationCreate,
+		Status:      JobStatusRunning,
+		RequestJSON: `{"alias":"` + alias + `"}`,
+	})
+	cleanupTemplatesAndJobs(t, db, []string{templateID}, []string{jobID})
+	t.Cleanup(func() { invalidateTemplateCaches(templateID) })
+
+	primeTemplateQueryCaches(templateID)
+	requireTemplateQueryCachesHit(t, templateID)
+	displayName, warning, err := publishTemplateStatusWithAlias(context.Background(), templateID, jobID, StatusReady, "")
+	require.NoError(t, err)
+	assert.Empty(t, displayName)
+	assert.Contains(t, warning, "could not be claimed")
+	requireTemplateQueryCachesMiss(t, templateID)
+
+	def, err := GetDefinition(context.Background(), templateID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusReady, def.Status)
+	assert.Empty(t, def.DisplayName)
 }

--- a/CubeMaster/pkg/templatecenter/store_test.go
+++ b/CubeMaster/pkg/templatecenter/store_test.go
@@ -466,6 +466,8 @@ func TestGetTemplateRequestAssignsRuntimeRequestID(t *testing.T) {
 }
 
 func TestGetTemplateInfoPopulatesCreatedAtAndImageInfoFromDefinitionAndLatestJob(t *testing.T) {
+	stubSweepStore(t)
+
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
@@ -487,7 +489,7 @@ func TestGetTemplateInfoPopulatesCreatedAtAndImageInfoFromDefinitionAndLatestJob
 	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
 		return nil, nil
 	})
-	patches.ApplyFunc(getLatestTemplateImageJobByTemplateID, func(ctx context.Context, templateID string) (*models.TemplateImageJob, error) {
+	patches.ApplyFunc(getLatestCreateRedoImageJobByTemplateIDTx, func(tx *gorm.DB, templateID string) (*models.TemplateImageJob, error) {
 		return &models.TemplateImageJob{
 			TemplateID:        templateID,
 			SourceImageRef:    "docker.io/library/python:3.12",

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -599,6 +599,9 @@ func TestGenerateTemplateCreateRequestInjectsImmutableRootfsMetadata(t *testing.
 	if got.Containers[0].Image == nil || got.Containers[0].Image.Image != "artifact-1" {
 		t.Fatalf("artifact image was not injected")
 	}
+	if got.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactURL] != "http://master.example/cube/template/artifact/download?artifact_id=artifact-1&token=token-1" {
+		t.Fatalf("unexpected artifact download url: %q", got.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactURL])
+	}
 	if got.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactSHA256] != "sha256-1" {
 		t.Fatalf("unexpected artifact sha annotation")
 	}
@@ -610,6 +613,62 @@ func TestGenerateTemplateCreateRequestInjectsImmutableRootfsMetadata(t *testing.
 	}
 	if _, ok := got.Annotations[constants.CubeAnnotationStorageBackend]; ok {
 		t.Fatal("omitted backend must not inject cube.master.storage.backend")
+	}
+}
+
+func TestGenerateTemplateCreateRequestUsesMasterDownloadEndpointForS3Artifacts(t *testing.T) {
+	req := &types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-s3"},
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		TemplateID:        "template-s3",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+	}
+	artifact := &models.RootfsArtifact{
+		ArtifactID:              "artifact-s3",
+		TemplateSpecFingerprint: "fingerprint-s3",
+		Ext4SHA256:              "sha256-s3",
+		Ext4SizeBytes:           2048,
+		DownloadToken:           "token-s3",
+		MasterNodeIP:            "http://0.0.0.0:8089",
+		ArtifactURL:             "http://minio:9000/cube-volumes/artifact-s3.ext4?sig=stale",
+	}
+	got, err := generateTemplateCreateRequest(context.Background(), req, artifact, DockerImageConfig{}, "http://master.example")
+	if err != nil {
+		t.Fatalf("generateTemplateCreateRequest failed: %v", err)
+	}
+	want := "http://master.example/cube/template/artifact/download?artifact_id=artifact-s3&token=token-s3"
+	if got.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactURL] != want {
+		t.Fatalf("artifact download url=%q, want %q", got.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactURL], want)
+	}
+}
+
+func TestGenerateTemplateCreateRequestFallsBackToArtifactRowForS3WhenNoExplicitBase(t *testing.T) {
+	req := &types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-s3-row"},
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		TemplateID:        "template-s3-row",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+	}
+	artifact := &models.RootfsArtifact{
+		ArtifactID:              "artifact-s3-row",
+		TemplateSpecFingerprint: "fingerprint-s3-row",
+		Ext4SHA256:              "sha256-s3-row",
+		Ext4SizeBytes:           2048,
+		DownloadToken:           "token-s3-row",
+		MasterNodeIP:            "http://master-from-row:8089",
+		ArtifactURL:             "http://minio:9000/cube-volumes/artifact-s3-row.ext4?sig=stale",
+	}
+	got, err := generateTemplateCreateRequest(context.Background(), req, artifact, DockerImageConfig{}, "")
+	if err != nil {
+		t.Fatalf("generateTemplateCreateRequest failed: %v", err)
+	}
+	want := "http://master-from-row:8089/cube/template/artifact/download?artifact_id=artifact-s3-row&token=token-s3-row"
+	if got.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactURL] != want {
+		t.Fatalf("artifact download url=%q, want %q", got.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactURL], want)
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/template_migrate.go
+++ b/CubeMaster/pkg/templatecenter/template_migrate.go
@@ -1,0 +1,345 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/tcclient"
+)
+
+// TemplateArtifactMigrationResult is the outcome of migrating one template's
+// rootfs artifact from CubeMaster local disk to TC-backed S3/local storage.
+type TemplateArtifactMigrationResult struct {
+	TemplateID string
+	ArtifactID string
+	Migrated   bool
+	Cleaned    bool
+}
+
+type templateCenterUploadResult struct {
+	Ext4Path   string
+	Ext4SHA256 string
+	SizeBytes  int64
+}
+
+// validateTCLocalArtifactPath ensures the path TC reports back for a migrated
+// local-disk artifact really is a file inside TC's own artifact store. The
+// row update below persists this path verbatim; without this guard a
+// misconfigured or malicious upload response could leave rootfs_artifacts
+// pointing at an arbitrary host path, which later breaks download probes,
+// reuse checks, and cleanup.
+func validateTCLocalArtifactPath(artifactID, path string) error {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "" {
+		return fmt.Errorf("template center returned an empty ext4 path for artifact %s", artifactID)
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("template center returned non-absolute ext4 path %q for artifact %s", path, artifactID)
+	}
+	if filepath.Base(path) != artifactID+".ext4" || filepath.Base(filepath.Dir(path)) != artifactID {
+		return fmt.Errorf("template center returned ext4 path %q that does not match the artifact layout for %s", path, artifactID)
+	}
+	roots := []string{ArtifactStoreRootDir()}
+	if strings.TrimSpace(os.Getenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR")) == "" {
+		roots = append(roots, ArtifactFallbackStoreRootDir())
+	}
+	for _, root := range roots {
+		root = filepath.Clean(root)
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			continue
+		}
+		if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil
+		}
+	}
+	return fmt.Errorf("template center returned ext4 path %q outside the TC artifact store roots %v", path, roots)
+}
+
+// uploadArtifactFileToTC uploads one artifact ext4 file into CubeTemplateCenter's
+// own artifact store and returns the stored file metadata.
+var uploadArtifactFileToTC = func(ctx context.Context, artifactID, filePath string) (*templateCenterUploadResult, error) {
+	endpoint := ""
+	if cfg := config.GetConfig(); cfg != nil {
+		endpoint = cfg.TemplateCenterAddr()
+	}
+	if strings.TrimSpace(endpoint) == "" {
+		return nil, fmt.Errorf("template center endpoint is not configured")
+	}
+	res, err := tcclient.NewClient(endpoint).UploadArtifact(ctx, artifactID, filePath)
+	if err != nil {
+		return nil, err
+	}
+	return &templateCenterUploadResult{
+		Ext4Path:   res.Ext4Path,
+		Ext4SHA256: res.Ext4SHA256,
+		SizeBytes:  res.Ext4SizeBytes,
+	}, nil
+}
+
+// MigrateTemplateArtifactToTC migrates one template's rootfs artifact to
+// TC-backed storage and removes the local ext4 file on CubeMaster.
+//
+// The caller must pass a concrete template ID (resolve alias beforehand).
+func MigrateTemplateArtifactToTC(ctx context.Context, templateID string) (*TemplateArtifactMigrationResult, error) {
+	if !isReady() {
+		return nil, ErrTemplateStoreNotInitialized
+	}
+	templateID = strings.TrimSpace(templateID)
+	if templateID == "" {
+		return nil, ErrTemplateIDRequired
+	}
+	result := &TemplateArtifactMigrationResult{TemplateID: templateID}
+
+	type artifactSnapshot struct {
+		artifactID  string
+		status      string
+		artifactURL string
+		ext4Path    string
+	}
+	snapshot := artifactSnapshot{}
+	if err := withTemplateWriteLock(templateID, func() error {
+		def, err := GetDefinition(ctx, templateID)
+		if err != nil {
+			return err
+		}
+		if def.Status == StatusDeleting {
+			return ErrTemplateNotFound
+		}
+		if def.Status != StatusReady {
+			return ErrTemplateNotReady
+		}
+		artifactID := strings.TrimSpace(def.RootfsArtifactID)
+		if artifactID == "" {
+			return fmt.Errorf("template %s has no rootfs artifact id", templateID)
+		}
+		artifact, err := getRootfsArtifactByID(ctx, artifactID)
+		if err != nil {
+			return err
+		}
+		snapshot = artifactSnapshot{
+			artifactID:  artifactID,
+			status:      strings.TrimSpace(artifact.Status),
+			artifactURL: strings.TrimSpace(artifact.ArtifactURL),
+			ext4Path:    strings.TrimSpace(artifact.Ext4Path),
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	result.ArtifactID = snapshot.artifactID
+
+	// Already S3-backed: verify object existence, then clean local residue.
+	if snapshot.artifactURL != "" {
+		exists, statErr := statArtifactObjectInS3(ctx, snapshot.artifactID)
+		if statErr != nil {
+			return nil, fmt.Errorf("check s3 object for artifact %s: %w", snapshot.artifactID, statErr)
+		}
+		if !exists {
+			// Not "re-run the migration": the object is already gone, so there
+			// is nothing left to upload and a re-run hits this same check.
+			return nil, fmt.Errorf("artifact %s is marked as s3-backed but the object is missing from the bucket; "+
+				"migration cannot repair it (there is nothing left to upload) -- rebuild the rootfs instead "+
+				"(`cubemastercli tpl redo --template-id %s`)", snapshot.artifactID, templateID)
+		}
+		cleaned, cleanErr := removeLocalArtifactFile(snapshot.ext4Path)
+		if cleanErr != nil {
+			// Best-effort: the artifact is already fully durable in S3, so
+			// failing the whole job over a stale local file would be misleading.
+			log.G(ctx).Errorf("artifact %s already migrated to s3 but failed to remove stale local file %q; will retry on next `tpl merge`: %v",
+				snapshot.artifactID, snapshot.ext4Path, cleanErr)
+			result.Migrated = false
+			result.Cleaned = false
+			return result, nil
+		}
+		result.Migrated = false
+		result.Cleaned = cleaned
+		if result.Cleaned {
+			invalidateTemplateCaches(templateID)
+		}
+		return result, nil
+	}
+
+	ext4Path := snapshot.ext4Path
+	if ext4Path == "" {
+		return nil, fmt.Errorf("artifact %s ext4_path is empty", snapshot.artifactID)
+	}
+	info, err := os.Stat(ext4Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Idempotency: in split-tier mode, a migrated artifact's ext4_path may
+			// point to TC-local disk and therefore be absent on CubeMaster.
+			if artifactServedByRemoteTier() {
+				artifact, loadErr := getRootfsArtifactByID(ctx, snapshot.artifactID)
+				if loadErr == nil {
+					if verifyErr := verifyArtifactServability(ctx, artifact); verifyErr == nil {
+						result.Migrated = false
+						result.Cleaned = false
+						return result, nil
+					}
+				}
+			}
+			return nil, fmt.Errorf("artifact %s local ext4 is missing at %q", snapshot.artifactID, ext4Path)
+		}
+		return nil, fmt.Errorf("stat local ext4 %q for artifact %s: %w", ext4Path, snapshot.artifactID, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("artifact %s ext4 path %q is not a regular file", snapshot.artifactID, ext4Path)
+	}
+
+	// Upload happens OUTSIDE the template write lock so long transfers do not
+	// block unrelated writes (delete/redo/alias updates) for this template.
+	updates := map[string]any{}
+	uploadedToS3 := false
+	targetExt4Path := ext4Path
+	if err := uploadArtifactFileToS3(ctx, snapshot.artifactID, ext4Path); err == nil {
+		presignedURL, presignErr := presignArtifactGetURL(ctx, snapshot.artifactID)
+		if presignErr != nil {
+			return nil, fmt.Errorf("presign migrated artifact %s: %w", snapshot.artifactID, presignErr)
+		}
+		uploadedToS3 = true
+		updates = map[string]any{
+			"artifact_url": presignedURL,
+			"status":       ArtifactStatusReady,
+			"last_error":   "",
+		}
+	} else {
+		if !errors.Is(err, errS3PresignNotConfigured) {
+			return nil, err
+		}
+		uploadRes, uploadErr := uploadArtifactFileToTC(ctx, snapshot.artifactID, ext4Path)
+		if uploadErr != nil {
+			return nil, fmt.Errorf("upload artifact %s to template center store: %w", snapshot.artifactID, uploadErr)
+		}
+		if err := validateTCLocalArtifactPath(snapshot.artifactID, uploadRes.Ext4Path); err != nil {
+			return nil, fmt.Errorf("invalid template center upload path for artifact %s: %w", snapshot.artifactID, err)
+		}
+		targetExt4Path = uploadRes.Ext4Path
+		updates = map[string]any{
+			"artifact_url": "",
+			"ext4_path":    uploadRes.Ext4Path,
+			"status":       ArtifactStatusReady,
+			"last_error":   "",
+		}
+		if strings.TrimSpace(uploadRes.Ext4SHA256) != "" {
+			updates["ext4_sha256"] = uploadRes.Ext4SHA256
+		}
+		if uploadRes.SizeBytes > 0 {
+			updates["ext4_size_bytes"] = uploadRes.SizeBytes
+		}
+	}
+
+	if err := withTemplateWriteLock(templateID, func() error {
+		def, err := GetDefinition(ctx, templateID)
+		if err != nil {
+			return err
+		}
+		if def.Status == StatusDeleting {
+			return ErrTemplateNotFound
+		}
+		if def.Status != StatusReady {
+			return ErrTemplateNotReady
+		}
+		if strings.TrimSpace(def.RootfsArtifactID) != snapshot.artifactID {
+			return fmt.Errorf("template %s rootfs artifact changed from %s to %s while migration was in flight",
+				templateID, snapshot.artifactID, strings.TrimSpace(def.RootfsArtifactID))
+		}
+		// Same cross-replica CAS reasoning as before: if a peer claimed this row
+		// for deletion during the upload, do not resurrect it.
+		ok, updErr := updateRootfsArtifactIfStatus(ctx, snapshot.artifactID, snapshot.status, updates)
+		if updErr != nil {
+			if uploadedToS3 {
+				return fmt.Errorf("update rootfs artifact %s after s3 migration: %w", snapshot.artifactID, updErr)
+			}
+			return fmt.Errorf("update rootfs artifact %s after tc-local migration: %w", snapshot.artifactID, updErr)
+		}
+		if !ok {
+			if uploadedToS3 {
+				return fmt.Errorf("artifact %s changed status concurrently (likely claimed for deletion on another replica); "+
+					"the object was uploaded to s3 but the row was left untouched to avoid resurrecting a deleted artifact -- "+
+					"the uploaded s3 object may be orphaned and require manual cleanup", snapshot.artifactID)
+			}
+			return fmt.Errorf("artifact %s changed status concurrently (likely claimed for deletion on another replica); "+
+				"the object was uploaded to the template center store but the row was left untouched to avoid resurrecting "+
+				"a deleted artifact -- the uploaded object may be orphaned and require manual cleanup", snapshot.artifactID)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if !uploadedToS3 && shouldSkipLocalCleanup(ext4Path, targetExt4Path) {
+		// Nothing was removed, but the row's stored path did change above.
+		result.Migrated = true
+		result.Cleaned = false
+		invalidateTemplateCaches(templateID)
+		return result, nil
+	}
+
+	// Local cleanup is best-effort in both branches.
+	cleaned, cleanErr := removeLocalArtifactFile(ext4Path)
+	if cleanErr != nil {
+		if uploadedToS3 {
+			log.G(ctx).Errorf("artifact %s migrated to s3 but failed to remove stale local file %q; will retry on next `tpl merge`: %v",
+				snapshot.artifactID, ext4Path, cleanErr)
+		} else {
+			log.G(ctx).Errorf("artifact %s migrated to template center store but failed to remove stale local file %q; manual cleanup required: %v",
+				snapshot.artifactID, ext4Path, cleanErr)
+		}
+		result.Migrated = true
+		result.Cleaned = false
+		invalidateTemplateCaches(templateID)
+		return result, nil
+	}
+	result.Migrated = true
+	result.Cleaned = cleaned
+	invalidateTemplateCaches(templateID)
+	return result, nil
+}
+
+func shouldSkipLocalCleanup(sourcePath, targetPath string) bool {
+	sourcePath = strings.TrimSpace(sourcePath)
+	targetPath = strings.TrimSpace(targetPath)
+	if sourcePath == "" || targetPath == "" {
+		return false
+	}
+	if filepath.Clean(sourcePath) == filepath.Clean(targetPath) {
+		return true
+	}
+	// One physical file can still show up under two different path strings
+	// (for example, a hard-linked staging file being ingested into the shared
+	// artifact layout). String comparison cannot catch that; deleting the
+	// source would remove the only copy the migrated row now points at.
+	// Compare file identity before allowing the delete.
+	sourceInfo, sourceErr := os.Stat(sourcePath)
+	targetInfo, targetErr := os.Stat(targetPath)
+	if sourceErr == nil && targetErr == nil && os.SameFile(sourceInfo, targetInfo) {
+		return true
+	}
+	return false
+}
+
+func removeLocalArtifactFile(path string) (bool, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false, nil
+	}
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("remove local artifact file %q: %w", path, err)
+	}
+	_ = os.Remove(filepath.Dir(path))
+	return true, nil
+}

--- a/CubeMaster/pkg/templatecenter/template_migrate_job.go
+++ b/CubeMaster/pkg/templatecenter/template_migrate_job.go
@@ -1,0 +1,398 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"gorm.io/gorm"
+)
+
+const (
+	migrateJobStaleAfter = 10 * time.Minute
+
+	// migrateAttemptInsertMaxAttempts bounds the duplicate-attempt recovery
+	// loop. attempt_no is unique across all operations for a template, so a
+	// concurrent create/redo/merge on another replica can still win the next
+	// number after we read it; retrying a small, deterministic number of times
+	// turns that race into a successful insert instead of surfacing 1062.
+	migrateAttemptInsertMaxAttempts = 4
+
+	// migrateJobHeartbeatInterval must stay well below migrateJobStaleAfter.
+	// The runner writes the job row only when it starts and when it finishes,
+	// so without a heartbeat `updated_at` freezes for the whole transfer and
+	// failStaleActiveTemplateMigrateJob (which is driven by updated_at) would
+	// fail a job that is still uploading and let the next submit start a second,
+	// concurrent migration of the same artifact.
+	migrateJobHeartbeatInterval = 1 * time.Minute
+)
+
+func getActiveTemplateMigrateJobByTemplateID(ctx context.Context, templateID string) (*models.TemplateImageJob, error) {
+	record := &models.TemplateImageJob{}
+	err := store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+		Where("template_id = ? AND operation = ? AND status IN ?", templateID, JobOperationMigrate, []string{JobStatusPending, JobStatusRunning}).
+		Order("id desc").First(record).Error
+	if err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+func failStaleActiveTemplateMigrateJob(ctx context.Context, templateID string, staleAfter time.Duration) error {
+	if staleAfter <= 0 {
+		return nil
+	}
+	cutoff := time.Now().Add(-staleAfter)
+	return store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+		Where("template_id = ? AND operation = ? AND status IN ? AND updated_at < ?", templateID, JobOperationMigrate, []string{JobStatusPending, JobStatusRunning}, cutoff).
+		Updates(map[string]any{
+			"status":        JobStatusFailed,
+			"phase":         JobPhaseMigratingArtifact,
+			"progress":      100,
+			"error_message": fmt.Sprintf("stale migrate job marked failed after %s", staleAfter),
+		}).Error
+}
+
+// failAllStaleTemplateMigrateJobs sweeps stale MIGRATE rows across ALL
+// templates. MIGRATE jobs are executed by an in-process CubeMaster goroutine,
+// so the "PENDING/RUNNING belongs to TC" boundary the image-job reconciler
+// observes for build jobs does not apply here: a CubeMaster crash mid-upload
+// strands the row, and without this sweep every later create/redo for that
+// template keeps failing with ErrTemplateAttemptInProgress until someone
+// happens to re-run `tpl merge` (the only other caller of the stale check).
+func failAllStaleTemplateMigrateJobs(ctx context.Context, staleAfter time.Duration) error {
+	if staleAfter <= 0 {
+		return nil
+	}
+	cutoff := time.Now().Add(-staleAfter)
+	return store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+		Where("operation = ? AND status IN ? AND updated_at < ?", JobOperationMigrate, []string{JobStatusPending, JobStatusRunning}, cutoff).
+		Updates(map[string]any{
+			"status":        JobStatusFailed,
+			"phase":         JobPhaseMigratingArtifact,
+			"progress":      100,
+			"error_message": fmt.Sprintf("stale migrate job marked failed after %s (reconciler sweep)", staleAfter),
+		}).Error
+}
+
+func getLatestTemplateMigrateJobByTemplateID(ctx context.Context, templateID string) (*models.TemplateImageJob, error) {
+	record := &models.TemplateImageJob{}
+	err := store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+		Where("template_id = ? AND operation = ?", templateID, JobOperationMigrate).
+		Order("attempt_no desc, id desc").First(record).Error
+	if err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+// beforeTemplateMigrateJobInsert is a test seam for reproducing the cross-
+// replica race between "read latest attempt_no" and INSERT.
+var beforeTemplateMigrateJobInsert = func(ctx context.Context, record *models.TemplateImageJob) {}
+
+func latestTemplateAttemptNo(ctx context.Context, templateID string) (int32, error) {
+	latestJob, err := getLatestTemplateImageJobByTemplateID(ctx, templateID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return latestJob.AttemptNo, nil
+}
+
+// insertTemplateMigrateJobWithAttemptRetry creates a migrate job using the
+// next attempt number across ALL template job operations, then recovers from
+// the one race withTemplateWriteLock cannot cover: a peer process inserting a
+// job for the same template after this process read the latest attempt.
+func insertTemplateMigrateJobWithAttemptRetry(ctx context.Context, templateID string, record *models.TemplateImageJob) error {
+	latestAttemptNo, err := latestTemplateAttemptNo(ctx, templateID)
+	if err != nil {
+		return err
+	}
+	record.AttemptNo = nextAttemptNoFromLatest(latestAttemptNo)
+
+	var createErr error
+	for attempt := 0; attempt < migrateAttemptInsertMaxAttempts; attempt++ {
+		beforeTemplateMigrateJobInsert(ctx, record)
+		createErr = store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).Create(record).Error
+		if createErr == nil {
+			return nil
+		}
+		if !isDuplicateKeyError(createErr) {
+			return createErr
+		}
+		latestAttemptNo, err = latestTemplateAttemptNo(ctx, templateID)
+		if err != nil {
+			return errors.Join(createErr, fmt.Errorf("reload latest attempt for template %s: %w", templateID, err))
+		}
+		nextAttemptNo := nextAttemptNoFromLatest(latestAttemptNo)
+		if nextAttemptNo <= record.AttemptNo {
+			nextAttemptNo = record.AttemptNo + 1
+		}
+		record.AttemptNo = nextAttemptNo
+	}
+	return fmt.Errorf("create migrate job for template %s after resolving attempt conflicts: %w", templateID, createErr)
+}
+
+// SubmitTemplateMigrate submits (or reuses) a template migrate job and starts
+// the async executor when a fresh job is created.
+func SubmitTemplateMigrate(ctx context.Context, templateID, requestID string) (*types.TemplateImageJobInfo, error) {
+	if !isReady() {
+		return nil, ErrTemplateStoreNotInitialized
+	}
+	templateID = strings.TrimSpace(templateID)
+	if templateID == "" {
+		return nil, ErrTemplateIDRequired
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		requestID = uuid.NewString()
+	}
+
+	jobID := uuid.NewString()
+	reusedExistingJob := false
+	if err := withTemplateWriteLock(templateID, func() error {
+		def, err := GetDefinition(ctx, templateID)
+		if err != nil {
+			return err
+		}
+		if def.Status == StatusDeleting {
+			return ErrTemplateNotFound
+		}
+		if def.Status != StatusReady {
+			return ErrTemplateNotReady
+		}
+		artifactID := strings.TrimSpace(def.RootfsArtifactID)
+		if artifactID == "" {
+			return fmt.Errorf("template %s has no rootfs artifact id", templateID)
+		}
+
+		if err := failStaleActiveTemplateMigrateJob(ctx, templateID, migrateJobStaleAfter); err != nil {
+			return err
+		}
+
+		if job, err := getActiveTemplateMigrateJobByTemplateID(ctx, templateID); err == nil {
+			jobID = job.JobID
+			reusedExistingJob = true
+			return nil
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		// retry_of_job_id stays migrate-scoped, while attempt_no is assigned by
+		// insertTemplateMigrateJobWithAttemptRetry across all job operations.
+		retryOfJobID := ""
+		if latestMigrateJob, err := getLatestTemplateMigrateJobByTemplateID(ctx, templateID); err == nil {
+			retryOfJobID = latestMigrateJob.JobID
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		record := &models.TemplateImageJob{
+			JobID:        jobID,
+			TemplateID:   templateID,
+			RequestID:    requestID,
+			RetryOfJobID: retryOfJobID,
+			Operation:    JobOperationMigrate,
+			ArtifactID:   artifactID,
+			Status:       JobStatusPending,
+			Phase:        JobPhaseMigratingArtifact,
+			Progress:     0,
+		}
+		if err := insertTemplateMigrateJobWithAttemptRetry(ctx, templateID, record); err != nil {
+			return err
+		}
+
+		// Cross-replica race guard. withTemplateWriteLock only serializes
+		// submissions within THIS CubeMaster process; the
+		// getActiveTemplateMigrateJobByTemplateID check above reads the
+		// shared DB, but two replicas can still both observe "no active job"
+		// before either INSERT commits, and both create a row here. Re-check
+		// right after the insert and yield to whichever row is earliest by
+		// id: every racing replica runs this same query and every loser sees
+		// a smaller-id winner, so at most one of them proceeds to spawn a
+		// migrate goroutine.
+		earliest := &models.TemplateImageJob{}
+		qerr := store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+			Where("template_id = ? AND operation = ? AND status IN ?", templateID, JobOperationMigrate, []string{JobStatusPending, JobStatusRunning}).
+			Order("id asc").First(earliest).Error
+		if qerr != nil && !errors.Is(qerr, gorm.ErrRecordNotFound) {
+			return qerr
+		}
+		if earliest.JobID != "" && earliest.JobID != jobID {
+			if uerr := store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+				Where("job_id = ?", jobID).
+				Updates(map[string]any{
+					"status":        JobStatusFailed,
+					"progress":      100,
+					"error_message": fmt.Sprintf("superseded by concurrently-created migrate job %s on another replica", earliest.JobID),
+				}).Error; uerr != nil {
+				return uerr
+			}
+			jobID = earliest.JobID
+			reusedExistingJob = true
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if !reusedExistingJob {
+		go runTemplateMigrateJob(detachTemplateImageJobContext(ctx, "template_migrate", map[string]any{
+			"job_id":      jobID,
+			"template_id": templateID,
+		}), jobID, templateID)
+	}
+	return GetTemplateImageJobInfo(ctx, jobID)
+}
+
+// GetTemplateMigrateJobInfo returns one migrate job by job_id.
+func GetTemplateMigrateJobInfo(ctx context.Context, jobID string) (*types.TemplateImageJobInfo, error) {
+	info, err := GetTemplateImageJobInfo(ctx, jobID)
+	if err != nil {
+		return nil, err
+	}
+	if info == nil || info.Operation != JobOperationMigrate {
+		return nil, fmt.Errorf("%w: migrate job_id=%s", ErrTemplateImageJobNotFound, jobID)
+	}
+	return info, nil
+}
+
+// startMigrateJobHeartbeat keeps the job row's updated_at advancing while the
+// artifact is being uploaded.
+//
+// MigrateTemplateArtifactToTC only touches the artifact row during the
+// transfer, so without this the job row looks frozen from the moment the
+// runner starts until it completes. failStaleActiveTemplateMigrateJob reads
+// updated_at, so a transfer longer than migrateJobStaleAfter would be failed
+// by the next submit even though it is still healthy -- and that submit would
+// then spawn a second runner uploading the same artifact.
+//
+// The returned stop function waits for the goroutine to exit so the job row is
+// never written after the runner has returned.
+func startMigrateJobHeartbeat(ctx context.Context, jobID string) (stop func()) {
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		// A panic here must not take the process down: like every other job
+		// runner in this package, the heartbeat owns nothing and only logs.
+		defer func() {
+			if r := recover(); r != nil {
+				log.G(ctx).Errorf("migrate job %s heartbeat panic: %v\n%s", jobID, r, debug.Stack())
+			}
+		}()
+		ticker := time.NewTicker(migrateJobHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-stopCh:
+				return
+			case <-ticker.C:
+				// The heartbeat goes through the guarded transition helper with
+				// RUNNING as the allowed predecessor: once the runner (or the
+				// stale sweep, or a cross-replica supersede) has written a
+				// terminal status, this write is refused instead of stamping
+				// MIGRATING_ARTIFACT back onto a finished job. A refused write
+				// also means there is nothing left to heartbeat, so the
+				// goroutine exits.
+				if err := UpdateTemplateImageJobIfTransitionAllowed(ctx, jobID, map[string]any{
+					"status": JobStatusRunning,
+					"phase":  JobPhaseMigratingArtifact,
+				}, JobStatusRunning); err != nil {
+					if errors.Is(err, ErrTerminalJobStatusFlip) {
+						return
+					}
+					log.G(ctx).Warnf("migrate job %s heartbeat fail: %v", jobID, err)
+				}
+			}
+		}
+	}()
+	return func() {
+		close(stopCh)
+		<-doneCh
+	}
+}
+
+func runTemplateMigrateJob(ctx context.Context, jobID, templateID string) {
+	logger := log.G(ctx).WithFields(map[string]any{"job_id": jobID, "template_id": templateID})
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Errorf("template migrate job panic: %v\n%s", r, debug.Stack())
+			_ = UpdateTemplateImageJobIfTransitionAllowed(ctx, jobID, map[string]any{
+				"status":        JobStatusFailed,
+				"phase":         JobPhaseMigratingArtifact,
+				"progress":      100,
+				"error_message": fmt.Sprintf("template migrate job panic: %v", r),
+			}, JobStatusFailed)
+		}
+	}()
+
+	// Marking RUNNING is a guarded transition, not a blind write: a job that the
+	// cross-replica supersede (SubmitTemplateMigrate) or the stale sweep already
+	// finished must not be brought back to life, or this process would upload
+	// the same artifact a second time in parallel.
+	if err := UpdateTemplateImageJobIfTransitionAllowed(ctx, jobID, map[string]any{
+		"status":   JobStatusRunning,
+		"phase":    JobPhaseMigratingArtifact,
+		"progress": 20,
+	}, JobStatusRunning); err != nil {
+		logger.Errorf("mark migrate job running fail: %v", err)
+		if errors.Is(err, ErrTerminalJobStatusFlip) {
+			return
+		}
+		_ = UpdateTemplateImageJobIfTransitionAllowed(ctx, jobID, map[string]any{
+			"status":        JobStatusFailed,
+			"phase":         JobPhaseMigratingArtifact,
+			"progress":      100,
+			"error_message": fmt.Sprintf("mark migrate job running failed: %v", err),
+		}, JobStatusFailed)
+		return
+	}
+
+	stopHeartbeat := startMigrateJobHeartbeat(ctx, jobID)
+	defer stopHeartbeat()
+
+	result, err := MigrateTemplateArtifactToTC(ctx, templateID)
+	if err != nil {
+		logger.Errorf("migrate template artifact fail: %v", err)
+		_ = UpdateTemplateImageJobIfTransitionAllowed(ctx, jobID, map[string]any{
+			"status":        JobStatusFailed,
+			"phase":         JobPhaseMigratingArtifact,
+			"progress":      100,
+			"error_message": err.Error(),
+		}, JobStatusFailed)
+		return
+	}
+
+	// Same guard on the way out: a runner that outlived the stale window must
+	// not flip its already-FAILED job back to READY and report the migration as
+	// successful while a second attempt exists.
+	if err := UpdateTemplateImageJobIfTransitionAllowed(ctx, jobID, map[string]any{
+		"artifact_id":     result.ArtifactID,
+		"status":          JobStatusReady,
+		"phase":           JobPhaseReady,
+		"progress":        100,
+		"artifact_status": ArtifactStatusReady,
+		"error_message":   "",
+	}, JobStatusReady); err != nil {
+		logger.Errorf("mark migrate job ready fail: %v", err)
+		return
+	}
+	logger.Infof("template artifact migrated: artifact_id=%s migrated=%t cleaned=%t", result.ArtifactID, result.Migrated, result.Cleaned)
+}

--- a/CubeMaster/pkg/templatecenter/template_migrate_job_test.go
+++ b/CubeMaster/pkg/templatecenter/template_migrate_job_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// The heartbeat decides whether a long upload survives the stale sweep, so the
+// interval has to stay well inside the stale window: if a future change makes
+// it longer, failStaleActiveTemplateMigrateJob starts failing live jobs again
+// (and every such submit spawns a second, concurrent migration).
+func TestMigrateJobHeartbeatFitsInsideStaleWindow(t *testing.T) {
+	if migrateJobHeartbeatInterval <= 0 {
+		t.Fatalf("migrateJobHeartbeatInterval must be positive, got %v", migrateJobHeartbeatInterval)
+	}
+	if migrateJobHeartbeatInterval*2 >= migrateJobStaleAfter {
+		t.Fatalf("migrateJobHeartbeatInterval %v must stay far below migrateJobStaleAfter %v",
+			migrateJobHeartbeatInterval, migrateJobStaleAfter)
+	}
+}
+
+func TestMigrateAttemptNoMustAccountForAllTemplateJobs(t *testing.T) {
+	latest := nextAttemptNoFromLatest(3)
+	if latest != 4 {
+		t.Fatalf("nextAttemptNoFromLatest(3)=%d, want 4", latest)
+	}
+}
+
+func newMigrateAttemptTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dbName := "file:" + strings.ReplaceAll(t.Name(), "/", "_") + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dbName), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.TemplateDefinition{}, &models.TemplateImageJob{}))
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX idx_template_image_template_attempt ON "+constants.TemplateImageJobTableName+"(template_id, attempt_no)").Error)
+	oldDB := store.db
+	store.db = db
+	t.Cleanup(func() { store.db = oldDB })
+	return db
+}
+
+func TestInsertTemplateMigrateJobUsesGlobalAttemptNo(t *testing.T) {
+	db := newMigrateAttemptTestDB(t)
+	require.NoError(t, db.Create(&models.TemplateImageJob{
+		JobID:      "job-create",
+		TemplateID: "tpl-global-attempt",
+		RequestID:  "req-create",
+		AttemptNo:  1,
+		Operation:  JobOperationCreate,
+		Status:     JobStatusReady,
+	}).Error)
+
+	record := &models.TemplateImageJob{
+		JobID:      "job-migrate",
+		TemplateID: "tpl-global-attempt",
+		RequestID:  "req-migrate",
+		Operation:  JobOperationMigrate,
+		Status:     JobStatusPending,
+	}
+	require.NoError(t, insertTemplateMigrateJobWithAttemptRetry(context.Background(), "tpl-global-attempt", record))
+	require.Equal(t, int32(2), record.AttemptNo)
+}
+
+func TestInsertTemplateMigrateJobRetriesAfterConcurrentAttemptInsert(t *testing.T) {
+	db := newMigrateAttemptTestDB(t)
+	require.NoError(t, db.Create(&models.TemplateImageJob{
+		JobID:      "job-create",
+		TemplateID: "tpl-attempt-race",
+		RequestID:  "req-create",
+		AttemptNo:  1,
+		Operation:  JobOperationCreate,
+		Status:     JobStatusReady,
+	}).Error)
+
+	oldHook := beforeTemplateMigrateJobInsert
+	conflictInserted := false
+	beforeTemplateMigrateJobInsert = func(ctx context.Context, record *models.TemplateImageJob) {
+		if conflictInserted {
+			return
+		}
+		conflictInserted = true
+		require.NoError(t, db.Create(&models.TemplateImageJob{
+			JobID:      "job-concurrent-redo",
+			TemplateID: "tpl-attempt-race",
+			RequestID:  "req-concurrent-redo",
+			AttemptNo:  2,
+			Operation:  JobOperationRedo,
+			Status:     JobStatusPending,
+		}).Error)
+	}
+	t.Cleanup(func() { beforeTemplateMigrateJobInsert = oldHook })
+
+	record := &models.TemplateImageJob{
+		JobID:      "job-migrate",
+		TemplateID: "tpl-attempt-race",
+		RequestID:  "req-migrate",
+		Operation:  JobOperationMigrate,
+		Status:     JobStatusPending,
+	}
+	require.NoError(t, insertTemplateMigrateJobWithAttemptRetry(context.Background(), "tpl-attempt-race", record))
+	require.True(t, conflictInserted, "test must insert the concurrent attempt")
+	require.Equal(t, int32(3), record.AttemptNo)
+}
+
+// stop must return even though the next tick is a minute away and the row write
+// it performs fails in a process without a store, and the goroutine must not
+// write to the job row after the runner has returned.
+func TestStartMigrateJobHeartbeatStopsWithTheRunner(t *testing.T) {
+	stop := startMigrateJobHeartbeat(context.Background(), "job-heartbeat")
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		stop()
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startMigrateJobHeartbeat stop blocked: the goroutine never exited")
+	}
+}

--- a/CubeMaster/pkg/templatecenter/template_migrate_test.go
+++ b/CubeMaster/pkg/templatecenter/template_migrate_test.go
@@ -1,0 +1,245 @@
+package templatecenter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newMigrateSharedStoreTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dbName := "file:" + strings.ReplaceAll(t.Name(), "/", "_") + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dbName), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.TemplateDefinition{}, &models.RootfsArtifact{}))
+	oldDB := store.db
+	store.db = db
+	t.Cleanup(func() { store.db = oldDB })
+	return db
+}
+
+// stubMigrateS3Unavailable forces the TC-local upload branch: S3 is not
+// configured, so migration falls back to uploading into TC's own store.
+func stubMigrateS3Unavailable(t *testing.T) {
+	t.Helper()
+	oldUpload := uploadArtifactFileToS3
+	uploadArtifactFileToS3 = func(ctx context.Context, artifactID, filePath string) error {
+		return errS3PresignNotConfigured
+	}
+	t.Cleanup(func() { uploadArtifactFileToS3 = oldUpload })
+}
+
+func stubMigrateTCUpload(t *testing.T, fn func(ctx context.Context, artifactID, filePath string) (*templateCenterUploadResult, error)) {
+	t.Helper()
+	oldUpload := uploadArtifactFileToTC
+	uploadArtifactFileToTC = fn
+	t.Cleanup(func() { uploadArtifactFileToTC = oldUpload })
+}
+
+func seedMigratingTemplate(t *testing.T, db *gorm.DB, templateID, artifactID, ext4Path string) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.TemplateDefinition{
+		TemplateID:       templateID,
+		Status:           StatusReady,
+		RootfsArtifactID: artifactID,
+	}).Error)
+	require.NoError(t, db.Create(&models.RootfsArtifact{
+		ArtifactID: artifactID,
+		Status:     ArtifactStatusReady,
+		Ext4Path:   ext4Path,
+	}).Error)
+}
+
+// Regression guard for the shared-store data loss: when Master and TC share
+// one artifact volume, TC "ingests" the very file it was handed and reports
+// the same path back. Cleanup must NOT remove it, or the migrated row points
+// at a deleted file.
+func TestMigrateTemplateArtifactToTCSamePathKeepsLocalFile(t *testing.T) {
+	db := newMigrateSharedStoreTestDB(t)
+	sharedRoot := t.TempDir()
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", sharedRoot)
+
+	artifactID := "rfs-shared-same-path"
+	storeDir := filepath.Join(sharedRoot, artifactID)
+	require.NoError(t, os.MkdirAll(storeDir, 0o755))
+	ext4Path := filepath.Join(storeDir, artifactID+".ext4")
+	require.NoError(t, os.WriteFile(ext4Path, []byte("ext4-bytes"), 0o644))
+
+	templateID := "tpl-shared-same-path"
+	seedMigratingTemplate(t, db, templateID, artifactID, ext4Path)
+	stubMigrateS3Unavailable(t)
+	stubMigrateTCUpload(t, func(ctx context.Context, id, filePath string) (*templateCenterUploadResult, error) {
+		return &templateCenterUploadResult{Ext4Path: filePath}, nil
+	})
+
+	result, err := MigrateTemplateArtifactToTC(context.Background(), templateID)
+	require.NoError(t, err)
+	require.True(t, result.Migrated)
+	require.False(t, result.Cleaned, "same-path migration must not delete the only copy")
+	if _, statErr := os.Stat(ext4Path); statErr != nil {
+		t.Fatalf("migrated artifact file must survive same-path migration: %v", statErr)
+	}
+}
+
+// Even in the shared-store model the source path can differ from the target
+// path string (for example, a hard-linked staging file copied into the shared
+// artifact layout). SameFile must still prevent deleting the only bytes.
+func TestMigrateTemplateArtifactToTCSameInodeDifferentPathKeepsLocalFile(t *testing.T) {
+	db := newMigrateSharedStoreTestDB(t)
+	sharedRoot := t.TempDir()
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", sharedRoot)
+
+	artifactID := "rfs-shared-inode"
+	srcDir := filepath.Join(t.TempDir(), artifactID)
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	srcPath := filepath.Join(srcDir, artifactID+".ext4")
+	require.NoError(t, os.WriteFile(srcPath, []byte("ext4-bytes"), 0o644))
+
+	dstDir := filepath.Join(sharedRoot, artifactID)
+	require.NoError(t, os.MkdirAll(dstDir, 0o755))
+	dstPath := filepath.Join(dstDir, artifactID+".ext4")
+	require.NoError(t, os.Link(srcPath, dstPath))
+
+	templateID := "tpl-shared-inode"
+	seedMigratingTemplate(t, db, templateID, artifactID, srcPath)
+	stubMigrateS3Unavailable(t)
+	stubMigrateTCUpload(t, func(ctx context.Context, id, filePath string) (*templateCenterUploadResult, error) {
+		return &templateCenterUploadResult{Ext4Path: dstPath}, nil
+	})
+
+	result, err := MigrateTemplateArtifactToTC(context.Background(), templateID)
+	require.NoError(t, err)
+	require.True(t, result.Migrated)
+	require.False(t, result.Cleaned, "same-inode migration must not delete the source")
+	if _, statErr := os.Stat(srcPath); statErr != nil {
+		t.Fatalf("source must survive when TC destination is the same inode: %v", statErr)
+	}
+}
+
+// A genuinely different destination must still clean up the local source after
+// a successful migration.
+func TestMigrateTemplateArtifactToTCDifferentPathCleansUp(t *testing.T) {
+	db := newMigrateSharedStoreTestDB(t)
+	sharedRoot := t.TempDir()
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", sharedRoot)
+
+	artifactID := "rfs-split-store"
+	srcDir := filepath.Join(t.TempDir(), artifactID)
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	srcPath := filepath.Join(srcDir, artifactID+".ext4")
+	require.NoError(t, os.WriteFile(srcPath, []byte("ext4-bytes"), 0o644))
+
+	dstDir := filepath.Join(sharedRoot, artifactID)
+	require.NoError(t, os.MkdirAll(dstDir, 0o755))
+	dstPath := filepath.Join(dstDir, artifactID+".ext4")
+
+	templateID := "tpl-split-store"
+	seedMigratingTemplate(t, db, templateID, artifactID, srcPath)
+	stubMigrateS3Unavailable(t)
+	stubMigrateTCUpload(t, func(ctx context.Context, id, filePath string) (*templateCenterUploadResult, error) {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+			return nil, err
+		}
+		return &templateCenterUploadResult{Ext4Path: dstPath}, nil
+	})
+
+	result, err := MigrateTemplateArtifactToTC(context.Background(), templateID)
+	require.NoError(t, err)
+	require.True(t, result.Migrated)
+	require.True(t, result.Cleaned, "different-path migration should remove the local source")
+	if _, statErr := os.Stat(srcPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected local source removed, stat err=%v", statErr)
+	}
+}
+
+func TestValidateTCLocalArtifactPath(t *testing.T) {
+	primary := t.TempDir()
+	fallback := filepath.Join(t.TempDir(), "fallback")
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", primary)
+
+	valid := filepath.Join(primary, "rfs-1", "rfs-1.ext4")
+	if err := validateTCLocalArtifactPath("rfs-1", valid); err != nil {
+		t.Fatalf("expected path under shared store root to pass, got %v", err)
+	}
+
+	badRoots := []string{
+		filepath.Join(primary, "rfs-1", "nested", "rfs-1.ext4"),
+		filepath.Join(primary, "rfs-1", "other.ext4"),
+		filepath.Join(filepath.Dir(primary), "rfs-1", "rfs-1.ext4"),
+		filepath.Join(fallback, "rfs-1", "rfs-1.ext4"),
+	}
+	for _, path := range badRoots {
+		if err := validateTCLocalArtifactPath("rfs-1", path); err == nil {
+			t.Fatalf("expected path %q to be rejected", path)
+		}
+	}
+}
+
+func TestValidateTCLocalArtifactPathAllowsFallbackStoreWhenEnvUnset(t *testing.T) {
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", "")
+	fallbackRoot := ArtifactFallbackStoreRootDir()
+	valid := filepath.Join(fallbackRoot, "rfs-2", "rfs-2.ext4")
+	if err := validateTCLocalArtifactPath("rfs-2", valid); err != nil {
+		t.Fatalf("expected fallback store path to pass when env unset, got %v", err)
+	}
+}
+
+func TestShouldSkipLocalCleanup(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourcePath string
+		targetPath string
+		want       bool
+	}{
+		{
+			name:       "same path skips cleanup",
+			sourcePath: "/data/CubeMaster/storage/rfs-1/rfs-1.ext4",
+			targetPath: "/data/CubeMaster/storage/rfs-1/rfs-1.ext4",
+			want:       true,
+		},
+		{
+			name:       "same cleaned path skips cleanup",
+			sourcePath: filepath.Clean("/data/CubeMaster/storage/rfs-1//rfs-1.ext4"),
+			targetPath: "/data/CubeMaster/storage/rfs-1/rfs-1.ext4",
+			want:       true,
+		},
+		{
+			name:       "different paths do not skip",
+			sourcePath: "/data/CubeMaster/storage/rfs-1/rfs-1.ext4",
+			targetPath: "/data/CubeMaster/storage/rfs-2/rfs-2.ext4",
+			want:       false,
+		},
+		{
+			name:       "empty source does not skip",
+			sourcePath: "",
+			targetPath: "/data/CubeMaster/storage/rfs-1/rfs-1.ext4",
+			want:       false,
+		},
+		{
+			name:       "empty target does not skip",
+			sourcePath: "/data/CubeMaster/storage/rfs-1/rfs-1.ext4",
+			targetPath: "",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSkipLocalCleanup(tt.sourcePath, tt.targetPath); got != tt.want {
+				t.Fatalf("shouldSkipLocalCleanup(%q, %q)=%v, want %v", tt.sourcePath, tt.targetPath, got, tt.want)
+			}
+		})
+	}
+}

--- a/CubeMaster/pkg/templatecenter/template_request.go
+++ b/CubeMaster/pkg/templatecenter/template_request.go
@@ -319,7 +319,13 @@ func baseURLHostNeedsSharedNodeIP(host string) bool {
 // callers already treat as "not ready for distribution").
 func effectiveArtifactDownloadBaseURL(fallback string, artifact *models.RootfsArtifact) string {
 	if addr := strings.TrimSpace(os.Getenv(config.EnvMasterAddr)); addr != "" {
-		return NormalizeBaseURL(addr)
+		if rewritten := RewriteLoopbackBaseURLWithSharedNodeIP(addr); rewritten != "" {
+			return rewritten
+		}
+		if ExternallyUsableBaseURL(addr) {
+			return NormalizeBaseURL(addr)
+		}
+		log.G(context.Background()).Warnf("environment %s=%q is wildcard/loopback and %s is unavailable; falling through", config.EnvMasterAddr, addr, sharedEnvNodeIP)
 	}
 	if cfg := config.GetConfig(); cfg != nil && cfg.Common != nil {
 		if addr := strings.TrimSpace(cfg.Common.MasterAddr); addr != "" {

--- a/CubeMaster/pkg/templatecenter/template_request.go
+++ b/CubeMaster/pkg/templatecenter/template_request.go
@@ -13,8 +13,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/pkgs/proto/services/cubebox/v1"
 	imagev1 "github.com/tencentcloud/CubeSandbox/pkgs/proto/services/images/v1"
@@ -51,14 +53,12 @@ func generateTemplateCreateRequest(ctx context.Context, req *types.CreateTemplat
 			},
 		},
 	}
-	// Re-sign S3-backed artifact URLs at the point of use; the stored
-	// presigned URL expires (7d) while the artifact lives longer. Falls back
-	// to the stored URL when this process cannot sign (see
-	// artifactDownloadURL).
-	downloadURL := artifactDownloadURL(ctx, artifact)
-	if downloadURL == "" {
-		downloadURL = buildDownloadURL(downloadBaseURL, artifact.ArtifactID, artifact.DownloadToken)
-	}
+	// Always hand Cubelets / create-requests the CubeMaster download endpoint,
+	// never a direct S3 presigned URL. The endpoint is the one address the
+	// deployment guarantees every node can reach; it can then proxy to
+	// CubeTemplateCenter / S3 as needed. This avoids K8s multi-node drift where
+	// some nodes can dial the object store endpoint and others cannot.
+	downloadURL := buildDownloadURL(effectiveArtifactDownloadBaseURL(downloadBaseURL, artifact), artifact.ArtifactID, artifact.DownloadToken)
 	imageAnnotations := map[string]string{
 		constants.CubeAnnotationRootfsArtifactID:        artifact.ArtifactID,
 		constants.CubeAnnotationRootfsArtifactURL:       downloadURL,
@@ -216,6 +216,87 @@ func buildDownloadURL(baseURL, artifactID, token string) string {
 	query.Set("token", token)
 	u.RawQuery = query.Encode()
 	return u.String()
+}
+
+// HostReachableByOtherNodes reports whether a host[:port] value can be dialed
+// from another node. Wildcard binds (0.0.0.0, [::], ::) and loopback
+// (localhost, 127.0.0.0/8, ::1) are only meaningful on this host, so they must
+// never be handed to a Cubelet as a download address.
+func HostReachableByOtherNodes(host string) bool {
+	host = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	if host == "" {
+		return false
+	}
+	if host[0] == '[' {
+		if end := strings.Index(host, "]"); end > 0 {
+			host = host[1:end]
+		}
+	} else if idx := strings.LastIndex(host, ":"); idx > 0 && !strings.Contains(host[idx+1:], "]") {
+		host = host[:idx]
+	}
+	host = strings.ToLower(host)
+	switch host {
+	case "", "0.0.0.0", "::", "localhost", "localhost.localdomain", "ip6-localhost":
+		return false
+	}
+	if strings.HasPrefix(host, "127.") || host == "::1" {
+		return false
+	}
+	return true
+}
+
+// ExternallyUsableBaseURL reports whether raw is a base URL other nodes can
+// dial: non-empty, parseable, and not wildcard/loopback.
+func ExternallyUsableBaseURL(raw string) bool {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return false
+	}
+	u, err := url.Parse(NormalizeBaseURL(trimmed))
+	if err != nil {
+		return false
+	}
+	return HostReachableByOtherNodes(u.Host)
+}
+
+// effectiveArtifactDownloadBaseURL picks the CubeMaster base URL embedded into
+// Cubelet-facing download URLs. Every candidate must be externally usable:
+// one-click historically ships CUBE_MASTER_ADDR=http://127.0.0.1:8089, and old
+// artifact rows may carry a wildcard master_node_ip (http://0.0.0.0:8089) --
+// handing either to a remote Cubelet makes every artifact download fail while
+// the build job itself reports success. Unusable candidates are skipped with a
+// warning so resolution falls through to the next source (or "" , which
+// callers already treat as "not ready for distribution").
+func effectiveArtifactDownloadBaseURL(fallback string, artifact *models.RootfsArtifact) string {
+	if cfg := config.GetConfig(); cfg != nil {
+		if addr := strings.TrimSpace(cfg.MasterAddr()); addr != "" {
+			if ExternallyUsableBaseURL(addr) {
+				return NormalizeBaseURL(addr)
+			}
+			log.G(context.Background()).Warnf("configured master addr %q is wildcard/loopback; not usable as the cubelet-facing download base URL, falling through", addr)
+		}
+	}
+	if addr := strings.TrimSpace(os.Getenv(config.EnvMasterAddr)); addr != "" {
+		if ExternallyUsableBaseURL(addr) {
+			return NormalizeBaseURL(addr)
+		}
+		log.G(context.Background()).Warnf("%s=%q is wildcard/loopback; not usable as the cubelet-facing download base URL, falling through", config.EnvMasterAddr, addr)
+	}
+	if trimmed := strings.TrimSpace(fallback); trimmed != "" {
+		if ExternallyUsableBaseURL(trimmed) {
+			return NormalizeBaseURL(trimmed)
+		}
+		log.G(context.Background()).Warnf("request-derived download base URL %q is wildcard/loopback; falling through to the artifact row", trimmed)
+	}
+	if artifact != nil {
+		if trimmed := strings.TrimSpace(artifact.MasterNodeIP); trimmed != "" {
+			if ExternallyUsableBaseURL(trimmed) {
+				return NormalizeBaseURL(trimmed)
+			}
+			log.G(context.Background()).Warnf("artifact %s master_node_ip %q is wildcard/loopback; no usable download base URL", artifact.ArtifactID, trimmed)
+		}
+	}
+	return ""
 }
 
 func artifactRootHostHint() string {

--- a/CubeMaster/pkg/templatecenter/template_request.go
+++ b/CubeMaster/pkg/templatecenter/template_request.go
@@ -7,6 +7,7 @@ package templatecenter
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"sort"
@@ -245,6 +246,8 @@ func HostReachableByOtherNodes(host string) bool {
 	return true
 }
 
+const sharedEnvNodeIP = "CUBE_SANDBOX_NODE_IP"
+
 // ExternallyUsableBaseURL reports whether raw is a base URL other nodes can
 // dial: non-empty, parseable, and not wildcard/loopback.
 func ExternallyUsableBaseURL(raw string) bool {
@@ -259,6 +262,53 @@ func ExternallyUsableBaseURL(raw string) bool {
 	return HostReachableByOtherNodes(u.Host)
 }
 
+// RewriteLoopbackBaseURLWithSharedNodeIP rewrites a loopback/wildcard base URL
+// (127.0.0.1 / localhost / 0.0.0.0 / ::) to the routable node IP already
+// exported in CUBE_SANDBOX_NODE_IP, preserving scheme and port.
+//
+// Returns "" when raw does not need rewriting, the node IP env is absent, or
+// the env itself is unusable.
+func RewriteLoopbackBaseURLWithSharedNodeIP(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	nodeIP := strings.TrimSpace(os.Getenv(sharedEnvNodeIP))
+	if nodeIP == "" {
+		return ""
+	}
+	parsedNodeIP := net.ParseIP(nodeIP)
+	if parsedNodeIP == nil || parsedNodeIP.IsLoopback() || parsedNodeIP.IsUnspecified() {
+		return ""
+	}
+	u, err := url.Parse(NormalizeBaseURL(raw))
+	if err != nil {
+		return ""
+	}
+	host := strings.TrimSpace(strings.ToLower(u.Hostname()))
+	if !baseURLHostNeedsSharedNodeIP(host) {
+		return ""
+	}
+	if port := strings.TrimSpace(u.Port()); port != "" {
+		u.Host = net.JoinHostPort(nodeIP, port)
+	} else {
+		u.Host = nodeIP
+	}
+	return strings.TrimRight(u.String(), "/")
+}
+
+func baseURLHostNeedsSharedNodeIP(host string) bool {
+	switch host {
+	case "", "localhost", "localhost.localdomain", "ip6-localhost":
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsUnspecified()
+}
+
 // effectiveArtifactDownloadBaseURL picks the CubeMaster base URL embedded into
 // Cubelet-facing download URLs. Every candidate must be externally usable:
 // one-click historically ships CUBE_MASTER_ADDR=http://127.0.0.1:8089, and old
@@ -268,32 +318,38 @@ func ExternallyUsableBaseURL(raw string) bool {
 // warning so resolution falls through to the next source (or "" , which
 // callers already treat as "not ready for distribution").
 func effectiveArtifactDownloadBaseURL(fallback string, artifact *models.RootfsArtifact) string {
-	if cfg := config.GetConfig(); cfg != nil {
-		if addr := strings.TrimSpace(cfg.MasterAddr()); addr != "" {
+	if addr := strings.TrimSpace(os.Getenv(config.EnvMasterAddr)); addr != "" {
+		return NormalizeBaseURL(addr)
+	}
+	if cfg := config.GetConfig(); cfg != nil && cfg.Common != nil {
+		if addr := strings.TrimSpace(cfg.Common.MasterAddr); addr != "" {
+			if rewritten := RewriteLoopbackBaseURLWithSharedNodeIP(addr); rewritten != "" {
+				return rewritten
+			}
 			if ExternallyUsableBaseURL(addr) {
 				return NormalizeBaseURL(addr)
 			}
-			log.G(context.Background()).Warnf("configured master addr %q is wildcard/loopback; not usable as the cubelet-facing download base URL, falling through", addr)
+			log.G(context.Background()).Warnf("configured master addr %q is wildcard/loopback and %s is unavailable; falling through", addr, sharedEnvNodeIP)
 		}
-	}
-	if addr := strings.TrimSpace(os.Getenv(config.EnvMasterAddr)); addr != "" {
-		if ExternallyUsableBaseURL(addr) {
-			return NormalizeBaseURL(addr)
-		}
-		log.G(context.Background()).Warnf("%s=%q is wildcard/loopback; not usable as the cubelet-facing download base URL, falling through", config.EnvMasterAddr, addr)
 	}
 	if trimmed := strings.TrimSpace(fallback); trimmed != "" {
+		if rewritten := RewriteLoopbackBaseURLWithSharedNodeIP(trimmed); rewritten != "" {
+			return rewritten
+		}
 		if ExternallyUsableBaseURL(trimmed) {
 			return NormalizeBaseURL(trimmed)
 		}
-		log.G(context.Background()).Warnf("request-derived download base URL %q is wildcard/loopback; falling through to the artifact row", trimmed)
+		log.G(context.Background()).Warnf("request-derived download base URL %q is wildcard/loopback and %s is unavailable; falling through to the artifact row", trimmed, sharedEnvNodeIP)
 	}
 	if artifact != nil {
 		if trimmed := strings.TrimSpace(artifact.MasterNodeIP); trimmed != "" {
+			if rewritten := RewriteLoopbackBaseURLWithSharedNodeIP(trimmed); rewritten != "" {
+				return rewritten
+			}
 			if ExternallyUsableBaseURL(trimmed) {
 				return NormalizeBaseURL(trimmed)
 			}
-			log.G(context.Background()).Warnf("artifact %s master_node_ip %q is wildcard/loopback; no usable download base URL", artifact.ArtifactID, trimmed)
+			log.G(context.Background()).Warnf("artifact %s master_node_ip %q is wildcard/loopback and %s is unavailable; no usable download base URL", artifact.ArtifactID, trimmed, sharedEnvNodeIP)
 		}
 	}
 	return ""

--- a/CubeMaster/pkg/templatecenter/template_request_test.go
+++ b/CubeMaster/pkg/templatecenter/template_request_test.go
@@ -22,6 +22,14 @@ func TestEffectiveArtifactDownloadBaseURLFallsBackToArtifactRow(t *testing.T) {
 	}
 }
 
+func TestEffectiveArtifactDownloadBaseURLRewritesLoopbackArtifactRowWithSharedNodeIP(t *testing.T) {
+	t.Setenv("CUBE_SANDBOX_NODE_IP", "10.0.0.8")
+	artifact := &models.RootfsArtifact{MasterNodeIP: "http://127.0.0.1:8089"}
+	if got, want := effectiveArtifactDownloadBaseURL("", artifact), "http://10.0.0.8:8089"; got != want {
+		t.Fatalf("effectiveArtifactDownloadBaseURL() = %q, want %q", got, want)
+	}
+}
+
 func TestCloneEgressRuleDeepCopiesPort(t *testing.T) {
 	port := 8443
 	rule := &types.EgressRule{

--- a/CubeMaster/pkg/templatecenter/template_request_test.go
+++ b/CubeMaster/pkg/templatecenter/template_request_test.go
@@ -15,6 +15,23 @@ func TestEffectiveArtifactDownloadBaseURLPrefersConfiguredMasterAddr(t *testing.
 	}
 }
 
+func TestEffectiveArtifactDownloadBaseURLRewritesLoopbackEnvWithSharedNodeIP(t *testing.T) {
+	t.Setenv("CUBE_MASTER_ADDR", "http://127.0.0.1:8089")
+	t.Setenv("CUBE_SANDBOX_NODE_IP", "10.0.0.8")
+	artifact := &models.RootfsArtifact{MasterNodeIP: "http://master-from-row:8089"}
+	if got, want := effectiveArtifactDownloadBaseURL("http://fallback.example", artifact), "http://10.0.0.8:8089"; got != want {
+		t.Fatalf("effectiveArtifactDownloadBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestEffectiveArtifactDownloadBaseURLSkipsUnrewritableLoopbackEnv(t *testing.T) {
+	t.Setenv("CUBE_MASTER_ADDR", "http://127.0.0.1:8089")
+	artifact := &models.RootfsArtifact{MasterNodeIP: "http://master-from-row:8089"}
+	if got, want := effectiveArtifactDownloadBaseURL("http://fallback.example", artifact), "http://fallback.example"; got != want {
+		t.Fatalf("effectiveArtifactDownloadBaseURL() = %q, want %q", got, want)
+	}
+}
+
 func TestEffectiveArtifactDownloadBaseURLFallsBackToArtifactRow(t *testing.T) {
 	artifact := &models.RootfsArtifact{MasterNodeIP: "http://master-from-row:8089"}
 	if got, want := effectiveArtifactDownloadBaseURL("", artifact), "http://master-from-row:8089"; got != want {

--- a/CubeMaster/pkg/templatecenter/template_request_test.go
+++ b/CubeMaster/pkg/templatecenter/template_request_test.go
@@ -3,8 +3,24 @@ package templatecenter
 import (
 	"testing"
 
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 )
+
+func TestEffectiveArtifactDownloadBaseURLPrefersConfiguredMasterAddr(t *testing.T) {
+	t.Setenv("CUBE_MASTER_ADDR", "http://cube-master.cube-system.svc:8089")
+	artifact := &models.RootfsArtifact{MasterNodeIP: "http://0.0.0.0:8089"}
+	if got, want := effectiveArtifactDownloadBaseURL("http://fallback.example", artifact), "http://cube-master.cube-system.svc:8089"; got != want {
+		t.Fatalf("effectiveArtifactDownloadBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestEffectiveArtifactDownloadBaseURLFallsBackToArtifactRow(t *testing.T) {
+	artifact := &models.RootfsArtifact{MasterNodeIP: "http://master-from-row:8089"}
+	if got, want := effectiveArtifactDownloadBaseURL("", artifact), "http://master-from-row:8089"; got != want {
+		t.Fatalf("effectiveArtifactDownloadBaseURL() = %q, want %q", got, want)
+	}
+}
 
 func TestCloneEgressRuleDeepCopiesPort(t *testing.T) {
 	port := 8443

--- a/CubeTemplateCenter/README.md
+++ b/CubeTemplateCenter/README.md
@@ -60,6 +60,12 @@ artifact store is shared. The chart refuses these on `helm install`:
   its own storage). The installer only models control + compute, never
   two controls. Migrate to Helm + `s3Backed=true` first.
 
+## Migrating legacy local artifacts (`tpl merge`)
+
+`tpl merge` migrates a legacy READY template artifact from CubeMaster local disk into TC-managed storage. Keep the wording consistent in runbooks: **`tpl merge` solves historical artifact storage convergence, while `tpl redo` solves node-side redistribution / rebuild when needed.**
+
+The typical case is that historical artifacts were created before the cluster enabled `s3Backed=true`, so they still live on local disk and now need to be moved into S3-backed storage. If the same maintenance also needs to repopulate target nodes, run `tpl redo` after `tpl merge` completes.
+
 ## API
 
 Internal endpoints (called by CubeMaster):
@@ -67,7 +73,7 @@ Internal endpoints (called by CubeMaster):
 | Method | Path | Purpose |
 |---|---|---|
 | POST | `/tc/api/v1/build` | submit a build job |
-| POST | `/tc/api/v1/artifact/upload` | ingest a local ext4 uploaded by CubeMaster (`tpl merge`) into TC's artifact store |
+| POST | `/tc/api/v1/artifact/upload` | ingest a local ext4 uploaded by CubeMaster (`tpl merge`) into TC's artifact store / S3-backed storage |
 | POST | `/tc/api/v1/artifact/delete` | delete artifact data (local file / S3 object) |
 
 Public routes reverse-proxied from CubeMaster (actually served by TC):

--- a/CubeTemplateCenter/README.md
+++ b/CubeTemplateCenter/README.md
@@ -1,35 +1,18 @@
 # CubeTemplateCenter
 
-模板中心的独立进程，负责构建模板：拉镜像、在 envd 沙箱里跑构建、生成 rootfs ext4、算指纹，再把结果回报给 CubeMaster。CubeMaster 负责剩下的：任务落库、对外 API、跨节点分发。
+The standalone process that builds templates: pulls the image, runs the build in an envd sandbox, produces the rootfs ext4, computes the fingerprint, and reports the result back to CubeMaster. CubeMaster handles the rest: job persistence, the public API, and cross-node distribution.
 
-逻辑代码在 `CubeMaster/pkg/templatecenter`，TC 只是把它跑成独立进程。
+The route layer is shared from `CubeMaster/pkg/service/httpservice` (`RegisterTemplateRoutes`); the build and storage logic lives in TC's own `pkg/build`, `pkg/image`, and `pkg/s3store`.
 
-## 和 CubeMaster 的分工
+## Split with CubeMaster
 
-| 职责 | CubeMaster | TC |
-|---|---|---|
-| 模板 API（`/cube/template*`） | 提供 | 不提供 |
-| 任务落库 / 状态机 | 负责 | 不负责 |
-| 构建（拉镜像、建 ext4、指纹） | 不做 | 负责 |
-| 产物发给 Cubelet | 从共享磁盘读 | 只写盘 |
-| 跨节点分发 / redo | 负责 | 不负责 |
+TC owns the build (pull, ext4, fingerprint, S3 upload) and the artifact data (local file + S3 object).
+CubeMaster owns the template API, job state, cross-node distribution, and deletion orchestration.
+Compat matrix and download routes: CubeMaster reverse-proxies to TC (302 to S3 for downloads).
 
-产物默认不走网络：两者挂同一块磁盘（`/data/CubeMaster/storage`），TC 写、CubeMaster 读，所以默认必须同机、单副本。配置 S3/MinIO（`controlPlane.artifactStore.s3Backed=true`）后持久副本在对象存储里，本地盘只是构建临时区，此时 TC 和 CubeMaster 都可以多副本（见下文"多副本"）。
+## Run
 
-## 配置
-
-没有开关：CubeMaster 已经不能本地构建模板，所有 `template-from-image` 都会转发给 TC，TC 不可达就直接失败。只需要两个地址：
-
-| 项 | 在哪 | 值 |
-|---|---|---|
-| CubeMaster 找 TC | 环境变量 | `CUBE_TEMPLATE_CENTER_ADDR`，如 `http://127.0.0.1:8090` |
-| TC 回报 CubeMaster | 环境变量 | `CUBE_MASTER_ADDR`，如 `http://127.0.0.1:8089` |
-
-地址随部署变，所以走环境变量（也可以在 CubeMaster `conf.yaml` 用 `common.template_center_addr` 持久化配置，环境变量优先）。
-
-## 启动
-
-没有 `-conf` 参数，靠环境变量找配置：
+No `-conf` flag; config is located via env var:
 
 ```bash
 export CUBE_TEMPLATE_CENTER_CONFIG_PATH=/path/to/conf.yaml
@@ -37,43 +20,83 @@ export CUBE_MASTER_ADDR=http://127.0.0.1:8089
 ./templatecenter
 ```
 
-默认监听 `:8090`（CubeMaster 是 `:8089`）。监听地址和端口在 conf.yaml 的 `common.http_bind`、`common.http_port`。
+Listens on `:8090` by default (CubeMaster uses `:8089`). Bind address and port come from `common.http_bind` and `common.http_port` in conf.yaml.
 
-## 部署
+## Deploy
 
-**Kubernetes（推荐）**，Helm 直接装（TC 是管控面默认组件，`controlPlane.enabled=true` 时自动部署，没有独立开关）：
+**Kubernetes (recommended)**, plain Helm install (TC is a default control-plane component and deploys automatically with `controlPlane.enabled=true`; there is no separate switch):
 
 ```bash
 helm upgrade --install cube deploy/kubernetes/chart -n cube-system
 ```
 
-conf、双向地址、PVC、同节点亲和都自动配好。
+Conf, both addresses, PVC, and same-node affinity are wired automatically.
 
-**裸机 / one-click**：`cube-sandbox-cube-templatecenter.service` 属于默认管控面组件（control target 的 `Wants=` 已包含，install.sh 会显式 enable），模板构建开箱即用。默认地址 `http://127.0.0.1:8090` 已经由 `cubemaster-start.sh` 导出，跨机部署才需要在 `.one-click.env` 覆盖 `CUBE_TEMPLATE_CENTER_ADDR`。
+**Bare metal / one-click**: `cube-sandbox-cube-templatecenter.service` is part of the default control-plane stack (the control target `Wants=` it and install.sh enables it), so template builds work out of the box. The default address `http://127.0.0.1:8090` is already exported by `cubemaster-start.sh`; only override `CUBE_TEMPLATE_CENTER_ADDR` in `.one-click.env` for a split deployment.
 
-**多副本**：推荐 `controlPlane.artifactStore.s3Backed=true`（持久副本在 S3/MinIO，本地盘只做临时区）：副本之间通过数据库会话锁（`GET_LOCK`，按构建指纹）协调同规格的去重构建，chart 的 validate 会校验前置条件（S3 凭据到达 master 和 TC Pod、本地盘为 per-Pod scratch 等）。不用 S3 时多副本也允许但属于**降级模式**（安装时会打印告警）：产物在节点本地盘，下载可能落到没构建过该产物的 master 副本上，TC 副本间也无法去重构建。注意：默认的 ReadWriteOnce 产物 PVC 无法多节点挂载，多副本 master 挂着它会被 validate 直接拒绝（第二个副本永远 Pending）——不用 S3 又要多副本时，请 `controlPlane.master.persistence.enabled=false`（每 Pod 临时盘）或用 ReadWriteMany 共享卷（CFS/NFS，TC 默认挂 master 的同一张 claim）。
+## Usage scenarios (topology matrix)
+
+| Scenario | TC replicas | Artifact store | OK? |
+|---|---|---|---|
+| Bare metal / one-click co-located | 1 | shared host disk directory with CubeMaster (`/data/CubeMaster/storage`) | ✅ |
+| K8s default (single TC replica) | 1 | master's artifact PVC, mounted at the same in-container path (`/data/CubeMaster/storage`) | ✅ |
+| One-click multi-node (1 control + N compute) | 1 on the control node | host disk on the control node | ✅ — set `ONE_CLICK_DEPLOY_ROLE=compute` on every worker node |
+| K8s single replica | 1 | node-local disk (PVC recommended; emptyDir loses artifacts on restart) | ✅ — **keep at 1 replica**; forcing multi-replica here is broken (each replica only has its own builds, any load balancer routes downloads to non-builders → 404) |
+| K8s multi-replica TC | ≥2 | **requires** `s3Backed=true` **or** ReadWriteMany | ✅ |
+| K8s multi-replica master only | 1 | node-local disk | ✅ — downloads proxy to the single TC |
+
+**Not supported** — every TC replica must see the same bytes, and a load
+balancer that points external traffic at "any" replica only works when the
+artifact store is shared. The chart refuses these on `helm install`:
+
+- **K8s + Internal CLB + multi-replica TC + node-local disk.** The CLB
+  load-balances external requests across TC replicas, but each replica's
+  builds only live on its own disk → 404 on any non-builder replica.
+  Fix: `s3Backed=true`, ReadWriteMany, or `templateCenter.replicas=1`.
+- **K8s + multi-replica master + default ReadWriteOnce artifact PVC.** The
+  second master replica stays `Pending` forever. Fix:
+  `master.persistence.enabled=false` or ReadWriteMany.
+- **One-click multi-control-plane** (full install on two hosts, each with
+  its own storage). The installer only models control + compute, never
+  two controls. Migrate to Helm + `s3Backed=true` first.
 
 ## API
 
-主要是 CubeMaster 内部调用：
+Internal endpoints (called by CubeMaster):
 
-| 方法 | 路径 | 用途 |
+| Method | Path | Purpose |
 |---|---|---|
-| POST | `/tc/api/v1/build` | 提交构建任务 |
-| GET | `/health` | 探针 |
-| GET | `/metrics` | Prometheus 指标 |
+| POST | `/tc/api/v1/build` | submit a build job |
+| POST | `/tc/api/v1/artifact/upload` | ingest a local ext4 uploaded by CubeMaster (`tpl merge`) into TC's artifact store |
+| POST | `/tc/api/v1/artifact/delete` | delete artifact data (local file / S3 object) |
 
-构建完成后 TC 主动回报：`POST $CUBE_MASTER_ADDR/internal/template/jobs/:job_id/status`。
+Public routes reverse-proxied from CubeMaster (actually served by TC):
 
-## 目录
+| Method | Path | Purpose |
+|---|---|---|
+| GET / HEAD | `/cube/template/artifact/download` | artifact download (streams from local disk; 302 to the presigned URL for S3 artifacts) |
+| GET / POST | `/cube/template/compat` | template compat matrix read/write |
+
+Build-status polls (`/cube/template/build/:build_id/status`, `/cube/template/from-image?job_id=`) stay local on CubeMaster (they read the job rows Master writes); TC registers them too for direct-to-TC access.
+
+Probes and metrics: `GET /health`, `GET /metrics` (Prometheus).
+
+When a build finishes, TC reports back: `POST $CUBE_MASTER_ADDR/internal/template/jobs/:job_id/status`.
+
+## Layout
 
 ```
-pkg/tcconfig/     环境变量读取
-pkg/build/        构建执行 + 状态回报
-pkg/reconcile/    任务对账
-pkg/httpservice/  gin server（只注册模板路由）
+pkg/tcconfig/     env-var reading
+pkg/build/        build execution + status reporting + artifact deletion
+pkg/image/        image pull and ext4 production
+pkg/s3store/      S3/MinIO artifact store
+pkg/lock/         cross-replica DB session locks (build dedup / reconciler mutual exclusion)
+pkg/cube_egress_ca/  bakes the CubeEgress root CA into template rootfs
+pkg/reconcile/    job reconciliation
+pkg/api/          internal endpoints (/tc/api/v1/*)
+pkg/httpservice/  gin server (health/metrics + proxied route registration)
 ```
 
 ---
 
-[English](README_EN.md)
+[中文文档](README_zh.md)

--- a/CubeTemplateCenter/README_zh.md
+++ b/CubeTemplateCenter/README_zh.md
@@ -1,14 +1,97 @@
 # CubeTemplateCenter
 
-模板中心的独立进程，负责构建模板：拉镜像、在 envd 沙箱里跑构建、生成 rootfs ext4、算指纹，再把结果回报给 CubeMaster。CubeMaster 负责剩下的：任务落库、对外 API、跨节点分发。
+CubeTemplateCenter（TC）是 CubeSandbox 的**模板构建与 artifact 存储数据面**。它负责拉取 OCI 镜像、在构建沙箱里生成 rootfs ext4、上传 / 保管 artifact，并把构建结果回报给 CubeMaster。CubeMaster 继续负责对外 API、job 落库、模板元数据、跨节点分发和删除编排。
 
 路由层复用 `CubeMaster/pkg/service/httpservice`（`RegisterTemplateRoutes`）；构建与存储逻辑在 TC 自己的 `pkg/build`、`pkg/image`、`pkg/s3store`。
 
 ## 和 CubeMaster 的分工
 
-TC 负责构建（拉镜像、ext4、指纹、S3 上传）和产物数据（本地文件 + S3 对象）。
-CubeMaster 负责模板 API、任务状态、跨节点分发和删除编排。
-compat 矩阵和下载路由由 CubeMaster 反代到 TC（下载走 S3 则 302）。
+| 主题 | CubeTemplateCenter | CubeMaster |
+| --- | --- | --- |
+| `from-image` 构建 | 拉镜像、解包、生成 ext4、写 artifact、回报状态 | 创建 / 复用 job、对外暴露 API、转发构建请求 |
+| `tpl merge` | 接收本地 ext4 上传到 TC 自己的 artifact store | 发起 `/cube/template/migrate`、落 migrate job、更新 artifact 行 |
+| 模板元数据 | 不拥有模板 definition / alias / replica | 拥有 definition / alias / replica / compat / job 行 |
+| 下载 | 实际提供下载字节流（或 302 到 S3） | 暴露公共下载路由并反代到 TC |
+| 删除 | 物理删除本地文件 / S3 对象 | 编排引用计数、placement 清理、最终通知 TC 删除 |
+
+一句话概括：**TC 管字节，CubeMaster 管状态与编排。**
+
+## 典型操作流
+
+### 1. 从镜像创建模板
+
+用户通过 `cubemastercli` 调 CubeMaster；CubeMaster 落 job 并把构建提交给 TC：
+
+```bash
+cubemastercli --address <cubemaster-host> --port 8089 tpl create-from-image \
+  --image ghcr.io/tencentcloud/cubesandbox-base:latest \
+  --writable-layer-size 10Gi \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health
+```
+
+构建期间，轮询读取的是 CubeMaster 落库的 job 行：
+
+```bash
+cubemastercli --address <cubemaster-host> --port 8089 tpl watch --job-id <job-id>
+cubemastercli --address <cubemaster-host> --port 8089 tpl status --job-id <job-id>
+```
+
+### 2. 把历史本地产物迁到 TC 存储（`tpl merge`）
+
+`tpl merge` 的语义是：**把一个已经 `READY` 的模板 rootfs artifact，从 CubeMaster 本地磁盘迁到 TC 管理的 artifact store（S3 或 TC 本地 store）**。CLI 命令名叫 `merge`，但对应的 API 路径是 `/cube/template/migrate`。
+
+```bash
+cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id>
+```
+
+默认会**阻塞等待 migrate job 结束**；如果只想提交任务就返回，使用：
+
+```bash
+cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id> --detach
+```
+
+适用场景：
+
+- **历史模板 / 旧部署**：artifact 还只在 CubeMaster 本地盘上。
+- **开启了 `s3Backed=true` 之后**：希望把旧的本地 ext4 收敛进 S3。
+- **清理残留本地副本**：当 artifact 已经是 S3-backed 时，再次执行 `tpl merge` 会做幂等检查，并尽量清理遗留的本地 ext4。
+
+对于**存量镜像对应的历史模板**，文档建议把标准迁移顺序写成：**先 `tpl merge`，再 `tpl redo`**。
+
+- **先 `tpl merge`**：把历史模板还留在 CubeMaster 本地盘上的 rootfs artifact 迁进 TC 管理的 artifact store。
+- **再 `tpl redo`**：让后续续跑 / 分发基于迁移后的 artifact 继续进行，尤其适合切到 `s3Backed=true` 之后、需要让旧模板重新覆盖目标节点的场景。
+
+> **高亮提醒**
+> 如果**不做迁移**，这些存量模板的 rootfs artifact 仍然只依赖 **CubeMaster 本地磁盘**，不会自动收敛到 TC 管理的存储。
+>
+> - **运维风险**：后续 `redo` / 分发仍然受这份本地 ext4 的可用性约束，不能获得迁移后的统一存储路径。
+> - **恢复风险**：如果本地 ext4 已经丢失，再补跑 `tpl merge` **也修不回来**；因为已经没有可上传的文件，最终只能通过 `tpl redo` 重新构建 rootfs。
+
+示例：
+
+```bash
+cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id>
+cubemastercli --address <cubemaster-host> --port 8089 tpl redo --template-id <template-id>
+```
+
+注意：`tpl merge` **不是** `tpl render` / `merged_request` 里的“请求合并”；它只处理 rootfs artifact 的**存储迁移**。
+
+### 3. 用独立验证工具做端到端验证
+
+仓库里提供了一个**完全独立**的 Go 验证工具：`CubeMaster/cmd/templateverify`。它不依赖 `cubemastercli` 命令体系，会自己发 HTTP、轮询 job，并可选做 MySQL / 下载校验。
+
+```bash
+cd CubeMaster
+go run ./cmd/templateverify \
+  --master http://127.0.0.1:8089 \
+  --image ghcr.io/tencentcloud/cubesandbox-base:latest \
+  --writable-layer-size 10Gi \
+  --skip-db
+```
+
+如果需要把 `create-from-image -> merge -> artifact 下载` 整条链路一次性打通，优先使用这个工具。
 
 ## 启动
 
@@ -20,79 +103,93 @@ export CUBE_MASTER_ADDR=http://127.0.0.1:8089
 ./templatecenter
 ```
 
-默认监听 `:8090`（CubeMaster 是 `:8089`）。监听地址和端口在 conf.yaml 的 `common.http_bind`、`common.http_port`。
+默认监听 `:8090`（CubeMaster 默认是 `:8089`）。监听地址和端口来自 `conf.yaml` 的 `common.http_bind`、`common.http_port`。
 
 ## 部署
 
-**Kubernetes（推荐）**，Helm 直接装（TC 是管控面默认组件，`controlPlane.enabled=true` 时自动部署，没有独立开关）：
+### Kubernetes（推荐）
+
+Helm 直接安装即可。TC 是默认管控面组件；`controlPlane.enabled=true` 时会自动部署：
 
 ```bash
 helm upgrade --install cube deploy/kubernetes/chart -n cube-system
 ```
 
-conf、双向地址、PVC、同节点亲和都自动配好。
+chart 会自动接好：
 
-**裸机 / one-click**：`cube-sandbox-cube-templatecenter.service` 属于默认管控面组件（control target 的 `Wants=` 已包含，install.sh 会显式 enable），模板构建开箱即用。默认地址 `http://127.0.0.1:8090` 已经由 `cubemaster-start.sh` 导出，跨机部署才需要在 `.one-click.env` 覆盖 `CUBE_TEMPLATE_CENTER_ADDR`。
+- `CUBE_TEMPLATE_CENTER_ADDR` / `CUBE_MASTER_ADDR`
+- artifact PVC / 存储类
+- 同节点亲和（本地盘模式）
+- 健康检查与 Service
+
+### 裸机 / one-click
+
+`cube-sandbox-cube-templatecenter.service` 属于默认 control-plane 组件。安装完成后模板构建默认可用：
+
+- 默认 TC 地址：`http://127.0.0.1:8090`
+- 默认由 `cubemaster-start.sh` 导出到 `CUBE_TEMPLATE_CENTER_ADDR`
+- 只有跨机拆分部署时，才需要在 `.one-click.env` 覆盖 `CUBE_TEMPLATE_CENTER_ADDR`
 
 ## 使用场景（拓扑矩阵）
 
 | 场景 | TC 副本 | 产物存储 | 是否支持 |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | 裸机 / one-click（同机） | 1 | 与 CubeMaster 共享宿主机目录（`/data/CubeMaster/storage`） | ✅ |
-| K8s 默认（TC 单副本） | 1 | 复用 master 的产物 PVC，并使用相同容器内路径（`/data/CubeMaster/storage`） | ✅ |
+| K8s 默认（TC 单副本） | 1 | 复用 master 的 artifact PVC，并使用相同容器内路径（`/data/CubeMaster/storage`） | ✅ |
 | one-click 多节点（1 控制面 + N 计算节点） | 控制面 1 个 | 控制面宿主机本地盘 | ✅ — 计算节点上设 `ONE_CLICK_DEPLOY_ROLE=compute` |
-| K8s 单副本 | 1 | 本地盘（PVC 推荐；emptyDir 重启丢产物） | ✅ — **保持 1 副本**；强行开多副本 + 本地盘会坏（每个副本只存自己的构建，任何 LB 都会把下载路由到非构建副本 → 404） |
-| K8s 多副本 TC | ≥2 | **必须** `s3Backed=true` **或** ReadWriteMany | ✅ |
-| K8s 多副本 master | TC 单副本 | 本地盘 | ✅ — 下载走反代到唯一 TC |
+| K8s 单副本 | 1 | 本地盘（PVC 推荐；`emptyDir` 重启丢产物） | ✅ — **保持 1 副本**；强行多副本 + 本地盘会把下载流量打到没构建过的副本 → 404 |
+| K8s 多副本 TC | ≥ 2 | **必须** `s3Backed=true` **或** ReadWriteMany | ✅ |
+| K8s 多副本 master | TC 单副本或多副本 | 共享存储 / S3 | ✅ |
 
-**不支持**——每个 TC 副本必须拿到同一份字节；把外部流量随机打到"任意
-副本"的 LB 仅在产物存储共享时才有意义。`helm install` 在编译期直接
-拒绝以下组合：
+**不支持**：把外部流量随机打到多个 TC 副本，但这些副本又看不到同一份 artifact 字节。
 
-- **K8s + 内部 CLB + 多副本 TC + 本地盘。** CLB 把外部请求 LB 到多个
-  TC 副本，但每个副本的构建只在自己盘上 → 打到没构建过的副本就 404。
-  修复：`s3Backed=true`、ReadWriteMany、或 `templateCenter.replicas=1`。
-- **K8s + 多副本 master + 默认 ReadWriteOnce 产物 PVC。** 第二副本永远
-  Pending。修复：`master.persistence.enabled=false` 或 ReadWriteMany。
-- **one-click 多控制面**（两台主机各自跑完整安装、各自有自己的存储）。
-  安装器只建模"控制面 + 计算节点"，不建模"两个控制面"。要先扩控制面，
-  请迁 Helm chart + `s3Backed=true`。
+chart 会拒绝以下组合：
+
+- **K8s + 内部 CLB + 多副本 TC + 本地盘**：CLB 会把下载打到没持有该 artifact 的副本。
+- **K8s + 多副本 master + 默认 ReadWriteOnce artifact PVC**：第二个 master 永远 `Pending`。
+- **one-click 多控制面**（两台机器各自完整安装、各自有独立存储）：安装器只建模“控制面 + 计算节点”，不建模“双控制面共享模板存储”。
 
 ## API
 
-内部端点（CubeMaster 调用）：
+### TC 内部端点（CubeMaster 调用）
 
 | 方法 | 路径 | 用途 |
-|---|---|---|
-| POST | `/tc/api/v1/build` | 提交构建任务 |
-| POST | `/tc/api/v1/artifact/upload` | 接收 CubeMaster（`tpl merge`）上传的本地 ext4，落入 TC 产物存储 |
-| POST | `/tc/api/v1/artifact/delete` | 删除产物数据（本地文件 / S3 对象） |
+| --- | --- | --- |
+| POST | `/tc/api/v1/build` | 提交 `from-image` 构建任务 |
+| POST | `/tc/api/v1/artifact/upload` | 接收 CubeMaster 通过 `tpl merge` 上传的本地 ext4，写入 TC artifact store |
+| POST | `/tc/api/v1/artifact/delete` | 删除 artifact 物理数据（本地文件 / S3 对象） |
 
-经 CubeMaster 反代的公共路由（TC 实际服务）：
+### 通过 CubeMaster 暴露的用户路径
 
-| 方法 | 路径 | 用途 |
-|---|---|---|
-| GET / HEAD | `/cube/template/artifact/download` | 产物下载（本地盘直接服务；S3 产物 302 到 presigned URL） |
-| GET / POST | `/cube/template/compat` | 模板兼容矩阵读写 |
+| 方法 | 路径 | 实际服务方 | 用途 |
+| --- | --- | --- | --- |
+| POST | `/cube/template/from-image` | CubeMaster（本地） | 创建 / 复用模板构建 job，并转发给 TC |
+| GET | `/cube/template/from-image?job_id=...` | CubeMaster（本地） | 查询 `from-image` job 状态 |
+| POST | `/cube/template/migrate` | CubeMaster（本地） | 提交 artifact migrate job（CLI 命令：`tpl merge`） |
+| GET | `/cube/template/migrate?job_id=...` | CubeMaster（本地） | 查询 migrate job 状态 |
+| GET / HEAD | `/cube/template/artifact/download` | TC（经 CubeMaster 反代） | 下载 artifact；S3-backed 时 302 到 presigned URL |
+| GET / POST | `/cube/template/compat` | TC（经 CubeMaster 反代） | 读写模板 compat 矩阵 |
 
-构建状态轮询（`/cube/template/build/:build_id/status`、`/cube/template/from-image?job_id=`）留在 Master 本地服务（读的是 Master 落库的任务行）；TC 也注册这两个路由，供绕开 Master 直连 TC 的场景使用。
+另外，`/cube/template/build/:build_id/status` 仍由 CubeMaster 本地服务，用于 `tpl commit` 的 build-status / build-watch。
 
-探针与指标：`GET /health`、`GET /metrics`（Prometheus）。
+### 探针与回调
 
-构建完成后 TC 主动回报：`POST $CUBE_MASTER_ADDR/internal/template/jobs/:job_id/status`。
+- 健康检查：`GET /health`
+- 指标：`GET /metrics`
+- 构建完成后 TC 主动回调 CubeMaster：`POST $CUBE_MASTER_ADDR/internal/template/jobs/:job_id/status`
 
 ## 目录
 
-```
-pkg/tcconfig/     环境变量读取
-pkg/build/        构建执行 + 状态回报 + 产物删除
-pkg/image/        镜像拉取与 ext4 生成
-pkg/s3store/      S3/MinIO 产物存取
-pkg/lock/         跨副本 DB 会话锁（构建去重 / reconciler 互斥）
-pkg/cube_egress_ca/ 模板内烘焙 CubeEgress 根 CA
-pkg/reconcile/    任务对账
-pkg/api/          内部端点（/tc/api/v1/*）
-pkg/httpservice/  gin server（健康检查 / 指标 + 注册反代路由）
+```text
+pkg/tcconfig/        环境变量读取
+pkg/build/           构建执行、状态回报、artifact 删除
+pkg/image/           镜像拉取与 ext4 生成
+pkg/s3store/         S3 / MinIO artifact 存取
+pkg/lock/            跨副本 DB 会话锁（构建去重 / reconciler 互斥）
+pkg/cube_egress_ca/  模板内烘焙 CubeEgress 根 CA
+pkg/reconcile/       job 对账
+pkg/api/             内部端点（/tc/api/v1/*）
+pkg/httpservice/     gin server（健康检查 / 指标 + 注册反代路由）
 ```
 
 ---

--- a/CubeTemplateCenter/README_zh.md
+++ b/CubeTemplateCenter/README_zh.md
@@ -1,0 +1,100 @@
+# CubeTemplateCenter
+
+模板中心的独立进程，负责构建模板：拉镜像、在 envd 沙箱里跑构建、生成 rootfs ext4、算指纹，再把结果回报给 CubeMaster。CubeMaster 负责剩下的：任务落库、对外 API、跨节点分发。
+
+路由层复用 `CubeMaster/pkg/service/httpservice`（`RegisterTemplateRoutes`）；构建与存储逻辑在 TC 自己的 `pkg/build`、`pkg/image`、`pkg/s3store`。
+
+## 和 CubeMaster 的分工
+
+TC 负责构建（拉镜像、ext4、指纹、S3 上传）和产物数据（本地文件 + S3 对象）。
+CubeMaster 负责模板 API、任务状态、跨节点分发和删除编排。
+compat 矩阵和下载路由由 CubeMaster 反代到 TC（下载走 S3 则 302）。
+
+## 启动
+
+没有 `-conf` 参数，靠环境变量找配置：
+
+```bash
+export CUBE_TEMPLATE_CENTER_CONFIG_PATH=/path/to/conf.yaml
+export CUBE_MASTER_ADDR=http://127.0.0.1:8089
+./templatecenter
+```
+
+默认监听 `:8090`（CubeMaster 是 `:8089`）。监听地址和端口在 conf.yaml 的 `common.http_bind`、`common.http_port`。
+
+## 部署
+
+**Kubernetes（推荐）**，Helm 直接装（TC 是管控面默认组件，`controlPlane.enabled=true` 时自动部署，没有独立开关）：
+
+```bash
+helm upgrade --install cube deploy/kubernetes/chart -n cube-system
+```
+
+conf、双向地址、PVC、同节点亲和都自动配好。
+
+**裸机 / one-click**：`cube-sandbox-cube-templatecenter.service` 属于默认管控面组件（control target 的 `Wants=` 已包含，install.sh 会显式 enable），模板构建开箱即用。默认地址 `http://127.0.0.1:8090` 已经由 `cubemaster-start.sh` 导出，跨机部署才需要在 `.one-click.env` 覆盖 `CUBE_TEMPLATE_CENTER_ADDR`。
+
+## 使用场景（拓扑矩阵）
+
+| 场景 | TC 副本 | 产物存储 | 是否支持 |
+|---|---|---|---|
+| 裸机 / one-click（同机） | 1 | 与 CubeMaster 共享宿主机目录（`/data/CubeMaster/storage`） | ✅ |
+| K8s 默认（TC 单副本） | 1 | 复用 master 的产物 PVC，并使用相同容器内路径（`/data/CubeMaster/storage`） | ✅ |
+| one-click 多节点（1 控制面 + N 计算节点） | 控制面 1 个 | 控制面宿主机本地盘 | ✅ — 计算节点上设 `ONE_CLICK_DEPLOY_ROLE=compute` |
+| K8s 单副本 | 1 | 本地盘（PVC 推荐；emptyDir 重启丢产物） | ✅ — **保持 1 副本**；强行开多副本 + 本地盘会坏（每个副本只存自己的构建，任何 LB 都会把下载路由到非构建副本 → 404） |
+| K8s 多副本 TC | ≥2 | **必须** `s3Backed=true` **或** ReadWriteMany | ✅ |
+| K8s 多副本 master | TC 单副本 | 本地盘 | ✅ — 下载走反代到唯一 TC |
+
+**不支持**——每个 TC 副本必须拿到同一份字节；把外部流量随机打到"任意
+副本"的 LB 仅在产物存储共享时才有意义。`helm install` 在编译期直接
+拒绝以下组合：
+
+- **K8s + 内部 CLB + 多副本 TC + 本地盘。** CLB 把外部请求 LB 到多个
+  TC 副本，但每个副本的构建只在自己盘上 → 打到没构建过的副本就 404。
+  修复：`s3Backed=true`、ReadWriteMany、或 `templateCenter.replicas=1`。
+- **K8s + 多副本 master + 默认 ReadWriteOnce 产物 PVC。** 第二副本永远
+  Pending。修复：`master.persistence.enabled=false` 或 ReadWriteMany。
+- **one-click 多控制面**（两台主机各自跑完整安装、各自有自己的存储）。
+  安装器只建模"控制面 + 计算节点"，不建模"两个控制面"。要先扩控制面，
+  请迁 Helm chart + `s3Backed=true`。
+
+## API
+
+内部端点（CubeMaster 调用）：
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| POST | `/tc/api/v1/build` | 提交构建任务 |
+| POST | `/tc/api/v1/artifact/upload` | 接收 CubeMaster（`tpl merge`）上传的本地 ext4，落入 TC 产物存储 |
+| POST | `/tc/api/v1/artifact/delete` | 删除产物数据（本地文件 / S3 对象） |
+
+经 CubeMaster 反代的公共路由（TC 实际服务）：
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| GET / HEAD | `/cube/template/artifact/download` | 产物下载（本地盘直接服务；S3 产物 302 到 presigned URL） |
+| GET / POST | `/cube/template/compat` | 模板兼容矩阵读写 |
+
+构建状态轮询（`/cube/template/build/:build_id/status`、`/cube/template/from-image?job_id=`）留在 Master 本地服务（读的是 Master 落库的任务行）；TC 也注册这两个路由，供绕开 Master 直连 TC 的场景使用。
+
+探针与指标：`GET /health`、`GET /metrics`（Prometheus）。
+
+构建完成后 TC 主动回报：`POST $CUBE_MASTER_ADDR/internal/template/jobs/:job_id/status`。
+
+## 目录
+
+```
+pkg/tcconfig/     环境变量读取
+pkg/build/        构建执行 + 状态回报 + 产物删除
+pkg/image/        镜像拉取与 ext4 生成
+pkg/s3store/      S3/MinIO 产物存取
+pkg/lock/         跨副本 DB 会话锁（构建去重 / reconciler 互斥）
+pkg/cube_egress_ca/ 模板内烘焙 CubeEgress 根 CA
+pkg/reconcile/    任务对账
+pkg/api/          内部端点（/tc/api/v1/*）
+pkg/httpservice/  gin server（健康检查 / 指标 + 注册反代路由）
+```
+
+---
+
+[English](README.md)

--- a/CubeTemplateCenter/README_zh.md
+++ b/CubeTemplateCenter/README_zh.md
@@ -58,18 +58,17 @@ cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id> --
 - **开启了 `s3Backed=true` 之后**：希望把旧的本地 ext4 收敛进 S3。
 - **清理残留本地副本**：当 artifact 已经是 S3-backed 时，再次执行 `tpl merge` 会做幂等检查，并尽量清理遗留的本地 ext4。
 
-对于**存量镜像对应的历史模板**，文档建议把标准迁移顺序写成：**先 `tpl merge`，再 `tpl redo`**。
+对于**存量镜像对应的历史模板**，文档口径应统一为：**`tpl merge` 解决历史 artifact 的存储收敛问题，`tpl redo` 解决节点侧重新分发 / 必要时重建问题。**
 
-- **先 `tpl merge`**：把历史模板还留在 CubeMaster 本地盘上的 rootfs artifact 迁进 TC 管理的 artifact store。
-- **再 `tpl redo`**：让后续续跑 / 分发基于迁移后的 artifact 继续进行，尤其适合切到 `s3Backed=true` 之后、需要让旧模板重新覆盖目标节点的场景。
+典型场景是：模板最初的 artifact 仍保存在 CubeMaster 本地盘，后续集群开启了 `s3Backed=true`，需要将这批历史 artifact 从本地盘迁移到 **S3 托管存储**。如果同一次运维还需要让模板重新覆盖目标节点，则在 `tpl merge` 完成后继续执行 `tpl redo`。
 
 > **高亮提醒**
-> 如果**不做迁移**，这些存量模板的 rootfs artifact 仍然只依赖 **CubeMaster 本地磁盘**，不会自动收敛到 TC 管理的存储。
+> 在默认共盘 / 共享 PVC 部署里，不执行 `tpl merge` 通常**不会立刻影响现有模板下载**；真正的问题是这些历史 artifact 仍未完成从**本地盘到 S3 托管存储**的收敛。
 >
-> - **运维风险**：后续 `redo` / 分发仍然受这份本地 ext4 的可用性约束，不能获得迁移后的统一存储路径。
-> - **恢复风险**：如果本地 ext4 已经丢失，再补跑 `tpl merge` **也修不回来**；因为已经没有可上传的文件，最终只能通过 `tpl redo` 重新构建 rootfs。
+> - **存储侧**：开启 `s3Backed=true` 后，旧模板不会自动补做迁移。
+> - **恢复侧**：如果本地 ext4 已经丢失，再补跑 `tpl merge` **也修不回来**；因为已经没有可上传的文件，这时只能对可重建的 `from-image` 模板通过 `tpl redo` 回退到重建流程。
 
-示例：
+如果你的场景**既要把旧文件迁进统一存储，又要重新覆盖节点**，可以按下面的顺序执行：
 
 ```bash
 cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id>

--- a/CubeTemplateCenter/conf.yaml
+++ b/CubeTemplateCenter/conf.yaml
@@ -1,6 +1,8 @@
 common:
   http_port: 8090
-  http_readtimeout: 120
+  # Generous read timeout: artifact upload streams multi-GB ext4 bodies through
+  # this server, and ReadTimeout covers the whole request body read.
+  http_readtimeout: 600
   http_writetimeout: 360
   http_idletimeout: 360
   sync_meta_data_interval: 30s

--- a/CubeTemplateCenter/pkg/api/internal.go
+++ b/CubeTemplateCenter/pkg/api/internal.go
@@ -5,10 +5,16 @@
 package api
 
 import (
+	"context"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -16,6 +22,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeTemplateCenter/pkg/build"
+	"github.com/tencentcloud/CubeSandbox/CubeTemplateCenter/pkg/image"
 	"github.com/tencentcloud/CubeSandbox/CubeTemplateCenter/pkg/tcconfig"
 )
 
@@ -106,6 +113,165 @@ func handleArtifactDelete(c *gin.Context) {
 	c.JSON(http.StatusOK, ArtifactDeleteResponse{Status: "deleted", ArtifactID: req.ArtifactID})
 }
 
+// handleArtifactUpload ingests a local ext4 uploaded by CubeMaster and stores
+// it into CubeTemplateCenter's own artifact store.
+//
+// The body is consumed with a single streaming MultipartReader pass rather
+// than c.PostForm/c.FormFile: those parse the whole form first, buffering up
+// to MaxMultipartMemory in RAM and spooling the rest into os.TempDir() -- for
+// GB-scale ext4 artifacts that means a full extra copy in /tmp (often tmpfs,
+// i.e. RAM) before a single byte reaches the artifact store.
+//
+// artifact_id must arrive BEFORE the file part (tcclient writes it first):
+// the id shapes the destination path, so it is validated before any payload
+// byte touches the filesystem.
+// maxArtifactUploadBytes caps the upload body so a stolen callback token (or
+// a buggy Master) cannot fill TC's disk. Ext4 artifacts are single-digit GiB
+// in practice; 32 GiB leaves ample headroom while still failing closed.
+const maxArtifactUploadBytes = 32 << 30
+
+func handleArtifactUpload(c *gin.Context) {
+	ctx := c.Request.Context()
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxArtifactUploadBytes)
+	mr, err := c.Request.MultipartReader()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: fmt.Sprintf("read multipart body: %v", err)})
+		return
+	}
+
+	artifactID := ""
+	for {
+		part, nextErr := mr.NextPart()
+		if errors.Is(nextErr, io.EOF) {
+			break
+		}
+		if nextErr != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: fmt.Sprintf("read multipart part: %v", nextErr)})
+			return
+		}
+		switch part.FormName() {
+		case "artifact_id":
+			data, readErr := io.ReadAll(io.LimitReader(part, 1024))
+			part.Close()
+			if readErr != nil {
+				c.JSON(http.StatusBadRequest, ErrorResponse{Error: fmt.Sprintf("read artifact_id field: %v", readErr)})
+				return
+			}
+			artifactID = strings.TrimSpace(string(data))
+			if !image.ValidArtifactID(artifactID) {
+				c.JSON(http.StatusBadRequest, ErrorResponse{Error: "artifact_id has an invalid shape"})
+				return
+			}
+		case "file":
+			if artifactID == "" {
+				part.Close()
+				c.JSON(http.StatusBadRequest, ErrorResponse{Error: "artifact_id field must precede the file part"})
+				return
+			}
+			handleArtifactUploadFilePart(c, ctx, artifactID, part)
+			part.Close()
+			return
+		default:
+			part.Close()
+		}
+	}
+	if artifactID == "" {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "artifact_id is required"})
+		return
+	}
+	c.JSON(http.StatusBadRequest, ErrorResponse{Error: "file is required"})
+}
+
+// handleArtifactUploadFilePart streams one validated file part into the
+// artifact store, deduping on identical content already in place.
+func handleArtifactUploadFilePart(c *gin.Context, ctx context.Context, artifactID string, reader io.Reader) {
+	storeDir, err := image.ResolveArtifactStoreDir(ctx, artifactID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: fmt.Sprintf("resolve artifact store dir: %v", err)})
+		return
+	}
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: fmt.Sprintf("create artifact store dir: %v", err)})
+		return
+	}
+
+	tmpFile, err := os.CreateTemp(storeDir, artifactID+".upload-*.tmp")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: fmt.Sprintf("create temp file: %v", err)})
+		return
+	}
+	tmpPath := tmpFile.Name()
+	cleanupTmp := true
+	defer func() {
+		_ = tmpFile.Close()
+		if cleanupTmp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	hasher := sha256.New()
+	size, err := io.Copy(io.MultiWriter(tmpFile, hasher), reader)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: fmt.Sprintf("save uploaded file: %v", err)})
+		return
+	}
+	sha := hex.EncodeToString(hasher.Sum(nil))
+	if size <= 0 {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "uploaded file is empty"})
+		return
+	}
+	if err := tmpFile.Close(); err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: fmt.Sprintf("close temp file: %v", err)})
+		return
+	}
+
+	dstPath := filepath.Join(storeDir, artifactID+".ext4")
+	if st, statErr := os.Stat(dstPath); statErr == nil && st.Mode().IsRegular() {
+		dstSha, shaErr := fileSHA256(dstPath)
+		if shaErr == nil && st.Size() == size && dstSha == sha {
+			cleanupTmp = true
+			c.JSON(http.StatusOK, ArtifactUploadResponse{
+				Status:        "reused",
+				ArtifactID:    artifactID,
+				Ext4Path:      dstPath,
+				Ext4SHA256:    dstSha,
+				Ext4SizeBytes: st.Size(),
+			})
+			return
+		}
+	}
+
+	if err := os.Rename(tmpPath, dstPath); err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: fmt.Sprintf("promote uploaded artifact file: %v", err)})
+		return
+	}
+	cleanupTmp = false
+	if err := os.Chmod(dstPath, 0o644); err != nil {
+		log.G(ctx).Warnf("artifact upload: chmod %s failed: %v", dstPath, err)
+	}
+
+	c.JSON(http.StatusOK, ArtifactUploadResponse{
+		Status:        "uploaded",
+		ArtifactID:    artifactID,
+		Ext4Path:      dstPath,
+		Ext4SHA256:    sha,
+		Ext4SizeBytes: size,
+	})
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
 // sharedTokenWarnOnce rate-limits the "unauthenticated endpoint" warning.
 var sharedTokenWarnOnce sync.Once
 
@@ -171,4 +337,5 @@ func RegisterInternalRoutes(g *gin.RouterGroup) {
 	internal := g.Group("/tc/api/v1", internalAuthMiddleware())
 	internal.POST("/build", handleBuildSubmit)
 	internal.POST("/artifact/delete", handleArtifactDelete)
+	internal.POST("/artifact/upload", handleArtifactUpload)
 }

--- a/CubeTemplateCenter/pkg/api/types.go
+++ b/CubeTemplateCenter/pkg/api/types.go
@@ -38,3 +38,12 @@ type ArtifactDeleteResponse struct {
 	Status     string `json:"status"`
 	ArtifactID string `json:"artifact_id"`
 }
+
+// ArtifactUploadResponse is the response returned after ingesting an ext4 upload.
+type ArtifactUploadResponse struct {
+	Status        string `json:"status"`
+	ArtifactID    string `json:"artifact_id"`
+	Ext4Path      string `json:"ext4_path"`
+	Ext4SHA256    string `json:"ext4_sha256"`
+	Ext4SizeBytes int64  `json:"ext4_size_bytes"`
+}

--- a/CubeTemplateCenter/pkg/build/build.go
+++ b/CubeTemplateCenter/pkg/build/build.go
@@ -451,10 +451,35 @@ func reportArtifactBuilt(
 	return nil
 }
 
+// artifactS3Ops is the subset of s3store.Client artifactPresignedURL needs;
+// an interface so tests can fake the bucket.
+type artifactS3Ops interface {
+	Stat(ctx context.Context, artifactID string) (bool, error)
+	PresignedGetURL(ctx context.Context, artifactID string) (string, error)
+}
+
 // artifactPresignedURL returns a presigned URL for an S3-backed artifact, or
-// an empty string when S3 is disabled or URL generation fails.
-func artifactPresignedURL(ctx context.Context, s3CfgEnabled bool, s3Client *s3store.Client, artifactID string, logger *cubelog.Entry) string {
+// an empty string when S3 is disabled, the object is missing, or URL
+// generation fails.
+//
+// The Stat guard matters on the REUSE path: reuseExistingArtifact can match a
+// legacy artifact that predates S3 (built local-only, artifact_url empty,
+// ext4 still on disk). Presigning a URL for an object that was never uploaded
+// hands Cubelets a signed URL that 404s (NoSuchKey) -- worse than no URL at
+// all, because the row then looks S3-backed and the local-file serving path
+// is skipped. Returning "" keeps the artifact on the local-disk download path
+// (and `tpl merge` can migrate it to S3 later).
+func artifactPresignedURL(ctx context.Context, s3CfgEnabled bool, s3Client artifactS3Ops, artifactID string, logger *cubelog.Entry) string {
 	if !s3CfgEnabled || s3Client == nil {
+		return ""
+	}
+	exists, err := s3Client.Stat(ctx, artifactID)
+	if err != nil {
+		logger.Warnf("stat s3 object before presign fail: %v", err)
+		return ""
+	}
+	if !exists {
+		logger.Warnf("artifact %s has no s3 object (predates s3 or was never uploaded); not presigning, keeping the local-disk download path", artifactID)
 		return ""
 	}
 	url, err := s3Client.PresignedGetURL(ctx, artifactID)

--- a/CubeTemplateCenter/pkg/build/build_test.go
+++ b/CubeTemplateCenter/pkg/build/build_test.go
@@ -4,12 +4,15 @@
 package build
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 )
 
 // Regression coverage for the P1 bug where READY-artifact reuse only ever
@@ -81,5 +84,47 @@ func TestArtifactDataExistsLocalOnlyArtifact(t *testing.T) {
 	artifact.Ext4Path = filepath.Join(dir, "missing.ext4")
 	if _, ok := artifactDataExists(artifact, nil); ok {
 		t.Fatal("expected no-reuse for a local-only artifact whose ext4 file is missing")
+	}
+}
+
+// fakeArtifactS3 is an in-memory artifactS3Ops for presign-guard tests.
+type fakeArtifactS3 struct {
+	objects map[string]bool
+}
+
+func (f *fakeArtifactS3) Stat(_ context.Context, artifactID string) (bool, error) {
+	return f.objects[artifactID], nil
+}
+
+func (f *fakeArtifactS3) PresignedGetURL(_ context.Context, artifactID string) (string, error) {
+	return "https://s3.example.com/bucket/" + artifactID + ".ext4?sig=x", nil
+}
+
+// Regression: reusing a legacy artifact that predates S3 (artifact_url empty,
+// ext4 on local disk, nothing in the bucket) must NOT produce a presigned URL
+// -- the signed URL 404s for cubelets and marks the row S3-backed, skipping
+// the working local-file serving path.
+func TestArtifactPresignedURLSkipsObjectsMissingFromBucket(t *testing.T) {
+	s3 := &fakeArtifactS3{objects: map[string]bool{}}
+	logger := log.G(context.Background())
+	if got := artifactPresignedURL(context.Background(), true, s3, "rfs-legacy", logger); got != "" {
+		t.Fatalf("expected empty URL for an object that was never uploaded, got %q", got)
+	}
+}
+
+func TestArtifactPresignedURLSignsExistingObject(t *testing.T) {
+	s3 := &fakeArtifactS3{objects: map[string]bool{"rfs-fresh": true}}
+	logger := log.G(context.Background())
+	got := artifactPresignedURL(context.Background(), true, s3, "rfs-fresh", logger)
+	if !strings.Contains(got, "rfs-fresh.ext4") {
+		t.Fatalf("expected presigned URL for an existing object, got %q", got)
+	}
+}
+
+func TestArtifactPresignedURLDisabledWhenS3Off(t *testing.T) {
+	s3 := &fakeArtifactS3{objects: map[string]bool{"rfs-1": true}}
+	logger := log.G(context.Background())
+	if got := artifactPresignedURL(context.Background(), false, s3, "rfs-1", logger); got != "" {
+		t.Fatalf("expected empty URL when S3 is disabled, got %q", got)
 	}
 }

--- a/CubeTemplateCenter/pkg/image/image_test.go
+++ b/CubeTemplateCenter/pkg/image/image_test.go
@@ -921,10 +921,10 @@ func TestArtifactStoreRootDirDefaultAndEnvOverride(t *testing.T) {
 		t.Fatalf("ArtifactStoreRootDir default=%q, want %q", got, defaultArtifactStoreDir)
 	}
 
-	customDir := filepath.Join(t.TempDir(), "artifact-store")
-	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", customDir)
-	if got := ArtifactStoreRootDir(); got != customDir {
-		t.Fatalf("ArtifactStoreRootDir=%q, want %q", got, customDir)
+	sharedDir := filepath.Join(t.TempDir(), "artifact-store-shared")
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", sharedDir)
+	if got := ArtifactStoreRootDir(); got != sharedDir {
+		t.Fatalf("ArtifactStoreRootDir override=%q, want %q", got, sharedDir)
 	}
 }
 

--- a/CubeTemplateCenter/pkg/image/paths.go
+++ b/CubeTemplateCenter/pkg/image/paths.go
@@ -7,14 +7,18 @@ package image
 import (
 	"context"
 	"fmt"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 )
 
 const (
+	// TC shares CubeMaster's artifact store (design §9.7): TC writes the ext4,
+	// CubeMaster serves the download, and both resolve the same directory.
 	defaultArtifactStoreDir  = "/data/CubeMaster/storage"
 	fallbackArtifactStoreDir = "cubemaster-rootfs-artifacts-store"
 )
@@ -26,8 +30,12 @@ func ArtifactWorkRootDir() string {
 	return filepath.Join(os.TempDir(), "cubemaster-rootfs-artifacts")
 }
 
+func artifactStoreRootOverride() string {
+	return strings.TrimSpace(os.Getenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR"))
+}
+
 func ArtifactStoreRootDir() string {
-	if value := strings.TrimSpace(os.Getenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR")); value != "" {
+	if value := artifactStoreRootOverride(); value != "" {
 		return value
 	}
 	return defaultArtifactStoreDir
@@ -72,12 +80,27 @@ func ArtifactFallbackStoreRootDir() string {
 	return filepath.Join(os.TempDir(), fallbackArtifactStoreDir)
 }
 
+// artifactIDShape is the strict whitelist for artifact IDs used in filesystem
+// paths. Anything with separators or ".." would let a caller escape the
+// artifact store root via filepath.Join, so the shape is enforced both at the
+// upload handler (400) and here (defense in depth for every other caller).
+var artifactIDShape = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+// ValidArtifactID reports whether artifactID is safe to use as a filesystem
+// path component inside the artifact store.
+func ValidArtifactID(artifactID string) bool {
+	return artifactIDShape.MatchString(artifactID) && !strings.Contains(artifactID, "..")
+}
+
 func artifactStoreDir(artifactID string) string {
 	return filepath.Join(ArtifactStoreRootDir(), artifactID)
 }
 
 func ResolveArtifactStoreDir(ctx context.Context, artifactID string) (string, error) {
-	if configured := strings.TrimSpace(os.Getenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR")); configured != "" {
+	if !ValidArtifactID(artifactID) {
+		return "", fmt.Errorf("invalid artifact id %q: must match %s without path separators or '..'", artifactID, artifactIDShape)
+	}
+	if configured := artifactStoreRootOverride(); configured != "" {
 		dir := filepath.Join(configured, artifactID)
 		if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
 			return "", fmt.Errorf("prepare configured artifact store root %s failed: %w", configured, err)

--- a/CubeTemplateCenter/pkg/tcconfig/config.go
+++ b/CubeTemplateCenter/pkg/tcconfig/config.go
@@ -52,10 +52,9 @@ const (
 	EnvConfigPath       = "CUBE_TEMPLATE_CENTER_CONFIG_PATH"
 	legacyEnvConfigPath = "CUBE_MASTER_CONFIG_PATH"
 
-	// EnvArtifactStoreDir is where finished ext4 artifacts land. It MUST resolve
-	// to the same directory CubeMaster serves downloads from (design §9.7).
-	EnvArtifactStoreDir       = "CUBE_TEMPLATE_CENTER_ARTIFACT_STORE_DIR"
-	legacyEnvArtifactStoreDir = "CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR"
+	// The finished-artifact store dir is owned by shared CubeMaster code and is
+	// configured only via CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR. TC and
+	// CubeMaster must always resolve the exact same directory (design §9.7).
 
 	// EnvArtifactWorkDir is the scratch directory for layer unpacking. Unlike
 	// the store dir this one is genuinely private to the building process.
@@ -340,13 +339,12 @@ func NodeIP() string {
 // sharedEnvAliases maps a new name to the legacy name a shared reader expects.
 var sharedEnvAliases = []struct{ newName, legacyName string }{
 	{EnvConfigPath, legacyEnvConfigPath},
-	{EnvArtifactStoreDir, legacyEnvArtifactStoreDir},
 	{EnvArtifactWorkDir, legacyEnvArtifactWorkDir},
 	{EnvLoopMountExt4, legacyEnvLoopMountExt4},
 }
 
-// ApplySharedEnvAliases publishes the CUBE_TEMPLATE_CENTER_* values under the
-// legacy names that shared CubeMaster code reads.
+// ApplySharedEnvAliases publishes the remaining CUBE_TEMPLATE_CENTER_* values
+// under the legacy names that shared CubeMaster code reads.
 //
 // MUST be called before config.Init and before any artifact path is resolved:
 // the config loader reads its variable during Init, and the path helpers cache

--- a/CubeTemplateCenter/pkg/tcconfig/config_test.go
+++ b/CubeTemplateCenter/pkg/tcconfig/config_test.go
@@ -188,17 +188,15 @@ func TestMasterEndpointNamePrecedence(t *testing.T) {
 // Shared aliases
 // ---------------------------------------------------------------------------
 
-func TestApplySharedEnvAliasesPublishesLegacyName(t *testing.T) {
-	// The point of the shim: shared CubeMaster code reads the legacy name, so
-	// setting only the new one must still reach it.
-	clearEnv(t, EnvArtifactStoreDir, legacyEnvArtifactStoreDir)
+func TestApplySharedEnvAliasesPublishesArtifactStoreLegacyName(t *testing.T) {
+	const legacyArtifactStoreDir = "CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR"
+	clearEnv(t, EnvArtifactStoreDir, legacyArtifactStoreDir)
 	t.Setenv(EnvArtifactStoreDir, "/data/CubeMaster/storage")
 
 	ApplySharedEnvAliases()
 
-	if got := envValue(legacyEnvArtifactStoreDir); got != "/data/CubeMaster/storage" {
-		t.Fatalf("%s = %q, want the value published from %s",
-			legacyEnvArtifactStoreDir, got, EnvArtifactStoreDir)
+	if got := envValue(legacyArtifactStoreDir); got != "/data/CubeMaster/storage" {
+		t.Fatalf("%s = %q, want aliased value from %s", legacyArtifactStoreDir, got, EnvArtifactStoreDir)
 	}
 }
 
@@ -216,48 +214,13 @@ func TestApplySharedEnvAliasesLeavesLegacyOnlyAlone(t *testing.T) {
 	}
 }
 
-func TestApplySharedEnvAliasesConflictIsLoud(t *testing.T) {
-	// Two different artifact directories is the worst case this whole rename can
-	// produce: TC builds into one, CubeMaster serves from the other, and every
-	// download 404s with nothing in either log pointing at the cause. The new
-	// name wins (it is what the operator just wrote) but the disagreement must
-	// not be silent.
-	clearEnv(t, EnvArtifactStoreDir, legacyEnvArtifactStoreDir)
-	t.Setenv(EnvArtifactStoreDir, "/data/new/storage")
-	t.Setenv(legacyEnvArtifactStoreDir, "/data/old/storage")
-
-	ApplySharedEnvAliases()
-
-	if got := envValue(legacyEnvArtifactStoreDir); got != "/data/new/storage" {
-		t.Fatalf("%s = %q, want the new name to win", legacyEnvArtifactStoreDir, got)
-	}
-	if !hasWarningAbout("disagree") {
-		t.Fatalf("a conflicting artifact directory must be reported, got %v", Warnings())
-	}
-}
-
-func TestApplySharedEnvAliasesIdenticalValuesAreQuiet(t *testing.T) {
-	clearEnv(t, EnvArtifactStoreDir, legacyEnvArtifactStoreDir)
-	t.Setenv(EnvArtifactStoreDir, "/data/CubeMaster/storage")
-	t.Setenv(legacyEnvArtifactStoreDir, "/data/CubeMaster/storage")
-
-	ApplySharedEnvAliases()
-
-	// A deployment exporting both with the same value is transitional but
-	// correct; warning about it would train operators to ignore warnings.
-	if len(Warnings()) != 0 {
-		t.Fatalf("identical values must not warn, got %v", Warnings())
-	}
-}
-
 func TestApplySharedEnvAliasesCoversEveryPair(t *testing.T) {
 	// Guards against adding a shared variable to the constants without wiring it
 	// into the shim, which would leave the new spelling silently inert.
 	want := map[string]string{
-		EnvConfigPath:       legacyEnvConfigPath,
-		EnvArtifactStoreDir: legacyEnvArtifactStoreDir,
-		EnvArtifactWorkDir:  legacyEnvArtifactWorkDir,
-		EnvLoopMountExt4:    legacyEnvLoopMountExt4,
+		EnvConfigPath:      legacyEnvConfigPath,
+		EnvArtifactWorkDir: legacyEnvArtifactWorkDir,
+		EnvLoopMountExt4:   legacyEnvLoopMountExt4,
 	}
 	if len(sharedEnvAliases) != len(want) {
 		t.Fatalf("sharedEnvAliases has %d entries, want %d", len(sharedEnvAliases), len(want))

--- a/CubeTemplateCenter/pkg/tcconfig/config_test.go
+++ b/CubeTemplateCenter/pkg/tcconfig/config_test.go
@@ -188,18 +188,6 @@ func TestMasterEndpointNamePrecedence(t *testing.T) {
 // Shared aliases
 // ---------------------------------------------------------------------------
 
-func TestApplySharedEnvAliasesPublishesArtifactStoreLegacyName(t *testing.T) {
-	const legacyArtifactStoreDir = "CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR"
-	clearEnv(t, EnvArtifactStoreDir, legacyArtifactStoreDir)
-	t.Setenv(EnvArtifactStoreDir, "/data/CubeMaster/storage")
-
-	ApplySharedEnvAliases()
-
-	if got := envValue(legacyArtifactStoreDir); got != "/data/CubeMaster/storage" {
-		t.Fatalf("%s = %q, want aliased value from %s", legacyArtifactStoreDir, got, EnvArtifactStoreDir)
-	}
-}
-
 func TestApplySharedEnvAliasesLeavesLegacyOnlyAlone(t *testing.T) {
 	clearEnv(t, EnvConfigPath, legacyEnvConfigPath)
 	t.Setenv(legacyEnvConfigPath, "/etc/cube/conf.yaml")
@@ -218,10 +206,9 @@ func TestApplySharedEnvAliasesCoversEveryPair(t *testing.T) {
 	// Guards against adding a shared variable to the constants without wiring it
 	// into the shim, which would leave the new spelling silently inert.
 	want := map[string]string{
-		EnvConfigPath:       legacyEnvConfigPath,
-		EnvArtifactStoreDir: legacyEnvArtifactStoreDir,
-		EnvArtifactWorkDir:  legacyEnvArtifactWorkDir,
-		EnvLoopMountExt4:    legacyEnvLoopMountExt4,
+		EnvConfigPath:      legacyEnvConfigPath,
+		EnvArtifactWorkDir: legacyEnvArtifactWorkDir,
+		EnvLoopMountExt4:   legacyEnvLoopMountExt4,
 	}
 	if len(sharedEnvAliases) != len(want) {
 		t.Fatalf("sharedEnvAliases has %d entries, want %d", len(sharedEnvAliases), len(want))

--- a/CubeTemplateCenter/pkg/tcconfig/config_test.go
+++ b/CubeTemplateCenter/pkg/tcconfig/config_test.go
@@ -218,9 +218,10 @@ func TestApplySharedEnvAliasesCoversEveryPair(t *testing.T) {
 	// Guards against adding a shared variable to the constants without wiring it
 	// into the shim, which would leave the new spelling silently inert.
 	want := map[string]string{
-		EnvConfigPath:      legacyEnvConfigPath,
-		EnvArtifactWorkDir: legacyEnvArtifactWorkDir,
-		EnvLoopMountExt4:   legacyEnvLoopMountExt4,
+		EnvConfigPath:       legacyEnvConfigPath,
+		EnvArtifactStoreDir: legacyEnvArtifactStoreDir,
+		EnvArtifactWorkDir:  legacyEnvArtifactWorkDir,
+		EnvLoopMountExt4:    legacyEnvLoopMountExt4,
 	}
 	if len(sharedEnvAliases) != len(want) {
 		t.Fatalf("sharedEnvAliases has %d entries, want %d", len(sharedEnvAliases), len(want))

--- a/docs/dev/templatecenter-design.md
+++ b/docs/dev/templatecenter-design.md
@@ -68,6 +68,8 @@ DISTRIBUTING). BUILT is terminal for the build itself; the resume pipeline
 
 ### 3.3 Error mapping
 
+CubeMaster also exposes `POST /cube/template/migrate` (CLI spelling: `tpl merge`) to migrate a legacy READY template artifact from CubeMaster local disk into TC-managed storage. In operational documentation, the wording should stay consistent: **`tpl merge` solves historical artifact storage convergence, while `tpl redo` solves node-side redistribution / rebuild when needed.** The typical case is that historical artifacts still live on local disk and the cluster later enables `s3Backed=true`, so those artifacts must be migrated from local disk into S3-backed storage. If the same maintenance window also needs to repopulate target nodes, run `tpl redo` after `tpl merge` completes.
+
 The HTTP layer maps domain errors to API codes: `ErrTemplateIDRequired`,
 `ErrDuplicateTemplate`, `ErrNoTemplateNodes` → params error;
 `ErrTemplateStoreNotInitialized` → DB error; not-found → 130404. The staged
@@ -77,7 +79,7 @@ split moves further error translation into the store layer over time.
 
 `POST /cube/template/redo` resumes a FAILED job. An artifact left READY by a
 job that failed during distribution is reused instead of rebuilt (reusing
-PENDING/BUILDING artifacts would read a half-written ext4).
+PENDING/BUILDING artifacts would read a half-written ext4). If the original artifact is no longer reusable, redo falls back to a full rebuild from `source_image_ref`.
 
 ### 3.5 Resume pipeline
 

--- a/docs/guide/cli-tools.md
+++ b/docs/guide/cli-tools.md
@@ -54,7 +54,17 @@ cubemastercli --address <cubemaster-host> --port 8089 tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49983 \
   --probe 49983
+
+# Migrate a READY template artifact into TC-managed storage.
+# Typical case: historical artifacts still live on local disk and the cluster later enables s3Backed=true.
+cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id>
+
+# If the same maintenance also needs to repopulate nodes, run redo after merge.
+# Redo handles node-side redistribution and may rebuild when the old artifact is no longer reusable.
+cubemastercli --address <cubemaster-host> --port 8089 tpl redo --template-id <template-id>
 ```
+
+For historical image-based templates, keep the wording consistent in runbooks: **`tpl merge` solves historical artifact storage convergence, while `tpl redo` solves node-side redistribution / rebuild when needed.** The common scenario is enabling `s3Backed=true` after templates already exist on CubeMaster local disk; `tpl merge` moves those legacy artifacts into S3-backed storage, and `tpl redo` is only needed if you also want to repopulate target nodes.
 
 Destructive operations should be used carefully:
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -57,7 +57,7 @@ CubeSandbox supports two approaches:
 - **Create from an OCI image**: Prepare an OCI image containing the operating system, tools, and application dependencies, then let CubeSandbox convert it into a template. This is the usual choice for reproducible templates. See [Create Templates from OCI Image](./tutorials/template-from-image.md).
 - **Create from a running sandbox**: Install software or adjust the environment interactively, then commit the sandbox's current filesystem and memory state as a new template. This is useful for iterative development and quickly preserving a working environment. See [Commit a Running Sandbox as a Template](./tutorials/template-from-sandbox.md).
 
-In either case, template creation consists of preparing the root filesystem, booting a MicroVM and waiting for the environment to become ready, taking a snapshot, and registering the resulting template. Once ready, the template can be used to create new sandboxes quickly.
+In either case, template creation consists of preparing the root filesystem, booting a MicroVM and waiting for the environment to become ready, taking a snapshot, and registering the resulting template. Once ready, the template can be used to create new sandboxes quickly. For historical image-based templates whose artifacts still live on CubeMaster local disk, keep the runbook wording consistent: **`tpl merge` solves historical artifact storage convergence, while `tpl redo` solves node-side redistribution / rebuild when needed.** The typical case is enabling `s3Backed=true` later and migrating those historical artifacts from local disk into S3-backed storage; run `tpl redo` afterward only if you also need to repopulate nodes.
 
 ## Templates and Images
 

--- a/docs/guide/tutorials/template-from-image.md
+++ b/docs/guide/tutorials/template-from-image.md
@@ -174,8 +174,20 @@ cubemastercli tpl render --template-id tpl-748094d2f2374b0a8a37e6ec --json
 
 For a user-oriented walkthrough of what each output means and how to preview the effective request, see [Template Inspection and Request Preview](../template-inspection-and-preview.md).
 
+## Step 5 — (Optional) Migrate Legacy Local Artifacts
 
-## Deleting a Template
+Most newly created `from-image` templates already build through the current TC data plane, so you usually do **not** need to run `tpl merge` for them. The typical migration case is older templates whose rootfs artifacts still live on CubeMaster local disk, and the cluster later enables `s3Backed=true` so those historical artifacts need to be moved into S3-backed storage.
+
+Keep the wording consistent in operations docs: **`tpl merge` solves historical artifact storage convergence, while `tpl redo` solves node-side redistribution / rebuild when needed.** If the same maintenance window needs both storage migration and node repopulation, run them in this order:
+
+```bash
+cubemastercli tpl merge tpl-748094d2f2374b0a8a37e6ec
+cubemastercli tpl redo --template-id tpl-748094d2f2374b0a8a37e6ec
+```
+
+> ⚠️ In default co-located / shared-PVC deployments, skipping `tpl merge` does not usually break downloads for existing `READY` templates immediately. The real issue is that those historical artifacts have not yet converged from local disk into S3-backed storage. If the local ext4 is already gone, rerunning `tpl merge` cannot recover it; for rebuildable `from-image` templates, `tpl redo` must fall back to rebuild.
+
+## Step 6 — Deleting a Template
 
 ```bash
 cubemastercli tpl delete tpl-748094d2f2374b0a8a37e6ec

--- a/docs/zh/dev/templatecenter-design.md
+++ b/docs/zh/dev/templatecenter-design.md
@@ -1,33 +1,48 @@
 # CubeTemplateCenter 设计
 
-CubeTemplateCenter（TC）是从 CubeMaster 拆分出来的独立模板构建服务。本文描述已实现架构；代码注释以 `design §x.y` 引用本文章节。
+CubeTemplateCenter（TC）是从 CubeMaster 拆分出来的独立模板构建服务。本文描述**当前已实现架构**；代码注释里出现的 `design §x.y` 引用本文章节。
 
 ## 1. 概述
 
 历史上 CubeMaster 在进程内完成模板 ext4 构建：拉取源 OCI 镜像、解包 layer、执行 `mkfs.ext4`、上传 artifact、分发到节点——全部发生在对外提供沙箱管控面的同一进程里。TC 接管其中的数据面工作。
 
-拆分的三个理由：
+拆分的主要理由：
 
-- **权限隔离。** 构建需要 root（`umoci unpack` 保留 uid/gid、`mkfs.ext4`、loop 设备）。把这些移出应答公开 API 的进程可以缩小爆炸半径。
-- **资源隔离。** 构建会瞬时打满 CPU/IO；管控面的时延 SLO 不应受并发构建数影响。
-- **独立生命周期。** TC 是带节点本地状态的单例；CubeMaster 无状态、可水平扩展（见 §9）。
+- **权限隔离。** 构建需要 root（`umoci unpack` 保留 uid/gid、`mkfs.ext4`、loop 设备）。把这些操作移出公开 API 进程，可以缩小爆炸半径。
+- **资源隔离。** 构建会瞬时打满 CPU / IO；管控面的时延 SLO 不应直接受并发构建影响。
+- **独立生命周期。** CubeMaster 主要承载 API、状态与编排；TC 主要承载构建、artifact 落盘 / 上传、对账。两者可以独立升级和排障。
+
+除了 `from-image` 构建链路，当前版本还支持把**历史本地模板 artifact** 迁进 TC 存储。对应 API 是 `/cube/template/migrate`，CLI 命令名是 `tpl merge`。
 
 ## 2. 进程拓扑
 
 ### 2.1 进程
 
-- **CubeMaster** —— 管控面：持久化 job 行、向 TC 转发构建、接收状态回调、向节点分发 artifact、服务所有模板写操作与带缓存的读操作。
-- **CubeTemplateCenter** —— 数据面：拉镜像、构建 ext4、上传 S3、回传状态。永远只有一个实例（§9.1）。
+- **CubeMaster** —— 管控面：持久化 job 行、暴露模板 API、向 TC 提交构建 / migrate 请求、接收状态回调、向节点分发 artifact、编排删除与 redo。
+- **CubeTemplateCenter** —— 数据面：拉镜像、构建 ext4、上传 S3、接收 `tpl merge` 上传的 ext4、提供 artifact 下载 / 302、回传构建状态。
+
+TC **不是语义上的“永远单例”**：
+
+- 使用**本地盘**时，通常保持 **1 副本**，因为每个副本只看得到自己的本地 artifact。
+- 使用 **S3-backed** 或 **ReadWriteMany 共享存储** 时，可以部署 **多副本 TC**。
 
 ### 2.2 通信
 
-- CubeMaster → TC：内部 HTTP `POST /tc/api/v1/build`（提交）、`POST /tc/api/v1/artifact/delete`（物理删除）。
-- TC → CubeMaster：`POST /internal/template/jobs/:job_id/status`（状态回调，带认证——§6.1）。
-- 两者共享 CubeDB 与 artifact 目录（§9.7）。
+- CubeMaster → TC：
+  - `POST /tc/api/v1/build`（提交 `from-image` 构建）
+  - `POST /tc/api/v1/artifact/upload`（`tpl merge` 上传本地 ext4）
+  - `POST /tc/api/v1/artifact/delete`（物理删除 artifact 数据）
+- TC → CubeMaster：
+  - `POST /internal/template/jobs/:job_id/status`（构建状态回调，带认证——见 §6.1）
+- 存储共享：
+  - 共享 CubeDB
+  - artifact 字节可以落在同机共享目录、ReadWriteMany 卷，或 S3 / MinIO
 
 ### 2.3 所有权划分
 
-CubeMaster 拥有全部业务状态写入（job 行、definition、replica、别名）与全部 cubelet RPC。TC 只拥有 artifact 的物理数据（本地 ext4 文件、S3 对象）。TC 从不初始化 worker（cubelet）grpc 连接池，因此任何可能发起 cubelet RPC 的 handler——快照创建、删除、redo 续跑——都由 CubeMaster 服务，且根本不在 TC 上注册路由（见 §4）。
+CubeMaster 拥有全部**业务状态写入**（job 行、definition、replica、alias、compat）与全部 cubelet RPC。TC 只拥有 artifact 的**物理数据**（本地 ext4 文件、S3 对象）以及与之直接相关的对账 / 删除。
+
+TC 不初始化 worker（cubelet）grpc 连接池，因此任何可能发起 cubelet RPC 的 handler——快照创建、删除、redo 续跑、模板分发——都仍由 CubeMaster 服务，且不在 TC 上注册写路由。
 
 ## 3. API 与 job 模型
 
@@ -35,119 +50,204 @@ CubeMaster 拥有全部业务状态写入（job 行、definition、replica、别
 
 模板别名是可选的稳定名字（`[a-z0-9-]`，最长 64 字符），沙箱创建请求可以用它代替生成的 `tpl-*` id。`PUT /cube/template/:template_id/alias` 传 absent / null / `""` 表示清除别名。
 
-### 3.2 构建 job 状态
+### 3.2 `from-image` 构建 job
 
-`t_cube_template_image_job.status`：PENDING → RUNNING → BUILT | FAILED。`phase` 跟踪流水线步骤（PULLING / BUILDING / UPLOADING / DISTRIBUTING）。BUILT 是构建本身的终态；随后 resume 流水线（§3.5）注册 artifact 并分发。
+`from-image` job 由 CubeMaster 创建 / 复用并持久化，TC 负责真正执行构建。job 会携带进度字段（`phase`、`progress`、pull bytes / layers、distribution counters），便于 CLI 和 UI 轮询展示。
 
-### 3.3 错误映射
+构建链路大致分为：
 
-HTTP 层把领域错误映射为 API 错误码：`ErrTemplateIDRequired`、`ErrDuplicateTemplate`、`ErrNoTemplateNodes` → 参数错误；`ErrTemplateStoreNotInitialized` → DB 错误；not-found → 130404。渐进式拆分会把更多错误翻译逐步下沉到 store 层。
+1. 拉取 / 解包源镜像
+2. 生成 ext4 rootfs
+3. 计算模板规格指纹与 artifact 元数据
+4. 回调 CubeMaster，触发 resume 流水线
+5. 由 CubeMaster 注册 artifact、向节点分发、写最终模板 / job 状态
 
-### 3.4 Redo
+### 3.3 `tpl merge` / migrate job
 
-`POST /cube/template/redo` 续跑 FAILED 的 job。分发阶段失败但 artifact 已为 READY 的 job 会复用 artifact 而不是重建（复用 PENDING/BUILDING 的 artifact 会读到写了一半的 ext4）。
+`POST /cube/template/migrate` 会提交一个 **migrate job**。CLI 命令名保持用户习惯上的 `tpl merge`，但后端 API 路径明确使用 `migrate`，强调它做的是**artifact 存储迁移**，不是“模板请求 merge”。
 
-### 3.5 Resume 流水线
+语义如下：
 
-收到 BUILT 回调后 CubeMaster 执行三步 resume：（1）注册远端构建的 artifact，（2）向目标节点分发，（3）写 job 终态行。分发解析不到目标节点时以 `ErrNoTemplateNodes` 失败，并且有意不写 definition/replica 行。
+- 输入是一个已经 `READY` 的模板。
+- 如果 artifact 仍在 CubeMaster 本地磁盘：
+  - 优先迁到 S3（若已配置）
+  - 否则上传到 TC 自己的 artifact store（`/tc/api/v1/artifact/upload`）
+- 如果 artifact 已经是 S3-backed：
+  - 做幂等检查
+  - 尝试清理遗留的本地 ext4 副本
 
-### 3.6 Job 幂等
+对**存量镜像制作出来的历史模板**，本文约定的标准运维顺序是：**先 `tpl merge`，再 `tpl redo`**。原因是 `merge` 负责把旧的本地 artifact 收敛进 TC 管理的存储，而 `redo` 负责后续续跑 / 分发；两者职责不同，不应互相替代。
 
-不变量 **I1**：同一模板规格最多存在一个活跃（PENDING/RUNNING）job。首次创建 job 的 JSON 与 REDO job 的 RequestJSON 与状态翻转在同一个 DB 事务里写入，崩溃不会留下与负载不一致的行。COMMIT / SNAPSHOT_* / LEGACY job 不在 from-image 幂等窗口内。
+> **高亮提醒**
+> 不迁移的直接后果，是这类历史模板的 artifact 仍旧停留在 **CubeMaster 本地盘**，而不是 TC 管理的 artifact store。
+>
+> - **存储侧**：切到 `s3Backed=true` 或远端 TC 拓扑后，存量模板仍然没有完成存储收敛。
+> - **运行侧**：后续 `redo` / 分发仍会继续依赖这份历史本地 ext4，而不是迁移后的统一 artifact。
+> - **恢复侧**：如果本地 ext4 先丢了，再跑 `tpl merge` 也无法补救，因为已经“没有东西可上传”；这时只能重新 `tpl redo` 去重建 rootfs。
+
+migrate job 有自己独立的状态读取路径：`GET /cube/template/migrate?job_id=...`。
+
+### 3.4 错误映射
+
+HTTP 层把领域错误映射为 API 错误码：
+
+- `ErrTemplateIDRequired`、`ErrDuplicateTemplate`、`ErrNoTemplateNodes` → 参数错误
+- `ErrTemplateStoreNotInitialized` → DB / store 初始化错误
+- not-found → `130404`
+- `ErrTemplateNotReady` → conflict
+
+渐进式拆分会把更多错误翻译逐步下沉到 store 层。
+
+### 3.5 Redo
+
+`POST /cube/template/redo` 用于续跑失败的模板 job。分发阶段失败但 artifact 已为 `READY` 的 job 会复用 artifact，而不是重建；复用 `PENDING` / `BUILDING` 的 artifact 会读到半成品 ext4，因此是禁止的。
+
+在运维文档里，`redo` 还承担“让模板基于**已经迁移完成**的 artifact 重新续跑 / 分发”的角色。因此面对**存量模板**时，顺序应写成 **先 `merge`、后 `redo`**，而不是只写 `redo`。
+
+### 3.6 Resume 流水线
+
+TC 上报 `BUILT` / 构建完成后，CubeMaster 执行 resume：
+
+1. 注册远端构建产出的 artifact
+2. 向目标节点分发 artifact
+3. 写 template / replica / job 终态
+
+当解析不到目标节点时，resume 会以 `ErrNoTemplateNodes` 失败，并有意不写 definition / replica 行。
+
+### 3.7 Job 幂等
+
+不变量 **I1**：同一模板规格最多存在一个活跃（`PENDING` / `RUNNING`）`from-image` job。
+
+对 migrate 也有类似约束：同一模板在同一时刻最多存在一个活跃 migrate job；跨副本并发提交时，后写入者会在 DB 中让位给“更早创建的赢家”并复用其 job id，避免多个副本同时上传同一个 ext4。
 
 ## 4. 路由划分
 
-CubeMaster 上的公开 `/cube/template*` 路由：
+CubeMaster 上对外暴露的 `/cube/template*` 路由：
 
 | 路由 | 服务方 | 原因 |
 | --- | --- | --- |
-| POST `/cube/template`、`/from-image`、`/redo`；DELETE；GET；PUT alias | CubeMaster（本地） | 涉及 cubelet RPC、进程内缓存或转发构建的环境变量 |
-| GET `/cube/template/build/:id/status`、GET `/from-image` | CubeMaster（本地） | master 自有 job 行的纯 DB 读；反代会在 TC 不可用时出现 create 200/轮询 502 |
-| GET/POST `/cube/template/compat` | 反代到 TC | 无缓存的 DB 读写 |
-| GET/HEAD `/cube/template/artifact/download` | 反代到 TC | 文件服务 / S3 重定向 |
-| GET `/cube/template/artifact/...`（rootfs、CA） | CubeMaster（本地） | cubelet 经 master 从共享盘拉取 |
+| POST `/cube/template`、`/from-image`、`/redo`、`/migrate`；DELETE；GET；PUT alias | CubeMaster（本地） | 涉及 job 持久化、状态编排、cubelet RPC、缓存或向 TC 转发请求 |
+| GET `/cube/template/build/:id/status` | CubeMaster（本地） | `tpl commit` 的 build-status / build-watch 读取的是 master 本地 job 行 |
+| GET `/cube/template/from-image?job_id=...` | CubeMaster（本地） | `from-image` job 轮询读取 master 持久化状态 |
+| GET `/cube/template/migrate?job_id=...` | CubeMaster（本地） | migrate job 轮询读取 master 持久化状态 |
+| GET / POST `/cube/template/compat` | 反代到 TC | 无缓存的 DB 读写 |
+| GET / HEAD `/cube/template/artifact/download` | 反代到 TC | 文件服务 / S3 重定向 |
+| GET `/cube/rootfs-artifact?...` 等元数据接口 | CubeMaster（本地） | 返回的是 master 维护的 artifact 行与模板元数据 |
 
-`RegisterTemplateRoutes`（TC 进程）只注册无缓存纯 DB 与文件服务的子集。两份清单由合同测试钉住（`TestCubeRoutesTemplateWritesStayOnCubeMaster`、`TestCubeRoutesTemplateProxyRemainder`、`TestTemplateCenterRoutesExcludeWritesAndCachedReads`）。
+`RegisterTemplateRoutes`（TC 进程）只注册**无缓存纯 DB 路由**与**artifact 下载 / 内部 API**子集。两份清单由合同测试钉住，保证“模板写路由不漂移到 TC”。
 
 ## 5. 配置
 
 ### 5.1 命名
 
-TC 读取的变量一律是 `CUBE_TEMPLATE_CENTER_*`。CubeMaster 读取 `CUBE_TEMPLATE_CENTER_ADDR`（构建提交地址）与 `CUBE_TEMPLATE_CALLBACK_TOKEN`（§6.1）。
+TC 读取的变量一律是 `CUBE_TEMPLATE_CENTER_*`。CubeMaster 主要读取：
+
+- `CUBE_TEMPLATE_CENTER_ADDR`：提交构建 / artifact 上传 / 删除的内部地址
+- `CUBE_TEMPLATE_CALLBACK_TOKEN`：TC 回调认证令牌（见 §6.1）
 
 ### 5.2 地址接线
 
-- Helm：`cube.templateCenterEndpoint` 把集群内 ClusterIP 地址渲染进 master 的 `CUBE_TEMPLATE_CENTER_ADDR` 环境变量和 conf.yaml 的 `template_center_addr`。TC 侧以同样方式得到 `CUBE_MASTER_ADDR`。
-- one-click：`cubemaster-start.sh` 把 `CUBE_TEMPLATE_CENTER_ADDR` 默认设为 `http://127.0.0.1:8090`；TC 的 conf.yaml 由安装期解析 `__CUBETEMPLATECENTER_*__` 占位符生成。
+- **Helm**：`cube.templateCenterEndpoint` 把集群内 Service 地址渲染进 master 的 `CUBE_TEMPLATE_CENTER_ADDR` 环境变量和 `conf.yaml` 的 `template_center_addr`。TC 侧以同样方式获得 `CUBE_MASTER_ADDR`。
+- **one-click**：`cubemaster-start.sh` 默认把 `CUBE_TEMPLATE_CENTER_ADDR` 设为 `http://127.0.0.1:8090`；TC 的 `conf.yaml` 则在安装期由 `__CUBETEMPLATECENTER_*__` 占位符渲染得到。
 
 ### 5.3 向后兼容窗口
 
-改名前的拼写（`CUBE_TC_*`、`CUBE_MASTER_*`、`CUBEMASTER_*`）仍作为 fallback 生效，并记录弃用提示（可通过 `tcconfig.Warnings()` 获取）。保留窗口是因为未同步更新的部署脚本否则会静默把 artifact 写到错误目录，直到很久以后下载 404 才暴露。新部署应只使用 `CUBE_TEMPLATE_CENTER_*` 命名。
+改名前的拼写（`CUBE_TC_*`、`CUBE_MASTER_*`、`CUBEMASTER_*`）仍作为 fallback 生效，并记录弃用提示（可通过 `tcconfig.Warnings()` 获取）。保留窗口的原因是：未同步更新的部署脚本否则可能静默把 artifact 写到错误目录，最后只在下载 404 时暴露。
+
+新部署应只使用 `CUBE_TEMPLATE_CENTER_*` 命名。
 
 ## 6. 安全
 
 ### 6.1 回调认证
 
-状态回调的 payload 被 resume 流水线整体信任——伪造的 BUILT 上报里的 artifact id/sha 会成为节点启动用的 rootfs。因此该端点要求共享密钥：TC 发送 `X-Cube-Template-Callback-Token`，CubeMaster 用常量时间与 `CUBE_TEMPLATE_CALLBACK_TOKEN` 比较，不匹配返回 401。当 CubeMaster 上该变量未设置时端点保持开放（打印一次警告），以便滚动升级期间旧版 TC 继续工作；Helm（自动生成 `cube-template-callback-token` Secret key）、one-click（生成进 `.one-click.env`）与 terraform（`random_password`）都会默认接好。
+状态回调的 payload 会被 resume 流水线整体信任——伪造的 `BUILT` 上报里的 artifact id / sha 可能最终成为节点启动使用的 rootfs。因此该端点要求共享密钥：
 
-### 6.2 TC 构建端点
+- TC 发送 `X-Cube-Template-Callback-Token`
+- CubeMaster 用常量时间与 `CUBE_TEMPLATE_CALLBACK_TOKEN` 比较
+- 不匹配返回 `401`
 
-TC 的内部 `/tc/api/v1/*` 端点不带认证，必须保持在集群内部 / VPC 内部地址（chart 把可选 CLB 渲染为仅内网；one-click 默认把 TC 绑到 loopback）。
+为了兼容滚动升级，若 CubeMaster 未设置该变量，端点会暂时保持开放并打印一次警告。Helm、one-click 与 terraform 都会默认接好该密钥。
 
-## 7.  reconcile（对账）
+### 6.2 TC 内部端点
+
+TC 的 `/tc/api/v1/*` 端点不带认证，必须保持在集群内部 / VPC 内部地址上；不要把它们直接暴露到公网。chart 默认渲染成内网 Service / 内网 LB；one-click 默认绑定 loopback。
+
+## 7. Reconcile（对账）
 
 ### 7.1 进度快照
 
-实时拉取进度写 Redis；持久化的终态快照通过状态回调落库。
+实时进度会写 Redis；持久化终态快照通过状态回调落库。
 
 ### 7.2 停滞构建检测
 
-TC 侧的 reconciler（pkg/reconcile）周期性扫描进度上报停止的 job 并标记 FAILED。
+TC 侧 reconciler（`pkg/reconcile`）周期性扫描进度上报停止的 job，并把长期停滞的 job 标记为 `FAILED`。
 
 ### 7.3 被遗弃的构建
 
-TC 重启会丢掉内存中的构建状态。reconciler 按停滞阈值清扫卡在 RUNNING 的 job（默认 10 分钟一轮，可用 `CUBE_TEMPLATE_CENTER_RECONCILE_*` 调整）并置为 FAILED；客户端必须重试（存在 READY artifact 时 redo 会复用，§3.4）。该机制是强制的而非可选：没有它，一次崩溃的构建会借助不变量 I1（§3.6）把模板永远卡死。
+TC 重启会丢失内存中的构建状态。reconciler 按停滞阈值清扫卡在 `RUNNING` 的 job（默认 10 分钟一轮，可通过 `CUBE_TEMPLATE_CENTER_RECONCILE_*` 调整）并置为 `FAILED`；客户端需要重试。若已经存在 `READY` artifact，redo 会优先复用。
+
+该机制是强制的：没有它，一次崩溃的构建会借助不变量 I1 把模板永久卡死在“已有活跃 job”的状态里。
 
 ## 8. 健康与就绪
 
-- CubeMaster：`GET /notify/health`——不依赖 DB 或 nodemeta。
-- TC：`GET /health`——store 已连接且 `nodemeta` 已初始化才算就绪。`nodemeta.Ready()` 表示"Init 已完成"，而不是"release manifest 存在"：manifest（`release-manifest.json`）只有 one-click 包会安装，CubeMaster 在 Kubernetes 里没有它也能正常运行，因此缺失不应导致就绪失败。声明的组件版本只是兼容扫描的输入。
+- **CubeMaster**：`GET /notify/health` —— 不依赖 DB 或 nodemeta。
+- **TC**：`GET /health` —— store 已连接且 `nodemeta` 已初始化才算就绪。
+
+`nodemeta.Ready()` 表示“初始化已完成”，而不是“release manifest 文件存在”。`release-manifest.json` 只有 one-click 包会安装；Kubernetes 部署里没有它也不应导致 TC 就绪失败。
 
 ## 9. 存储与并发
 
-### 9.1 单例
+### 9.1 副本模型与 artifact 存储
 
-TC 永远只有一个实例。artifact 存放在 ReadWriteOnce PVC 后的节点本地盘上；第二个副本既读不到第一个的 ext4 也接不了它的构建，两个副本还会在同一 artifact 目录上竞争。要扩容请扩 CubeMaster（无状态的一半）。
+TC 的副本策略取决于 artifact 字节存在哪里：
+
+- **本地盘 / RWO PVC**：推荐 **1 副本**。否则不同副本彼此看不到对方构建出的 ext4，请求被打到非构建副本时会 404。
+- **ReadWriteMany 共享卷**：可多副本，所有副本能看到同一份 ext4 字节。
+- **S3-backed**：可多副本；artifact 下载统一走 presigned URL / 302。
+
+因此，正确结论不是“TC 永远单例”，而是：**本地盘模式通常单副本；共享存储或 S3 模式支持多副本。** CubeMaster 仍然是无状态、最适合水平扩展的一侧。
 
 ### 9.2 DB 锁
 
-跨进程互斥（如构建时的 artifact 认领）使用 MySQL `GET_LOCK` 命名锁，取代无法跨越 CubeMaster 与 TC 的进程内 `sync.Map[artifactID]*sync.Mutex`。锁名会做归一化以保持在 MySQL 64 字符限制内。
+跨进程互斥（如 artifact 认领、并发迁移、对账互斥）使用 MySQL `GET_LOCK` 命名锁，取代无法跨越 CubeMaster 与 TC 的进程内 `sync.Mutex`。锁名会做归一化，以保持在 MySQL 64 字符限制内。
 
 ### 9.3 孤儿 GC
 
-CubeMaster 上的后台清扫移除引用计数归零（模板删除、构建失败）且超过 GC 期限的 artifact，执行与在线删除相同的三阶段清理（§9.5）。
+CubeMaster 上的后台清扫会移除引用计数归零（模板删除、构建失败）且超过 GC 期限的 artifact，并执行与在线删除相同的三阶段清理。
 
 ### 9.4 Job 归属
 
-job 表没有 owner 列：TC 重启后任何 TC 实例（也只有一个，§9.1）都可以对账所有停滞 job。进度上报会刷新停滞时钟。
+job 表没有 owner 列：TC 重启后，任何仍然存活的 TC 副本都可以对账停滞 job。进度上报会刷新停滞时钟，因此对账依赖的是共享 DB / 状态时间戳，而不是“某个固定副本拥有某个 job”。
 
 ### 9.5 Artifact 删除
 
-三阶段最后属主清理（`cleanupArtifactFully`）：Phase 1（短事务，行 FOR UPDATE）统计剩余引用并把行标记为 CLEANUP_PENDING；Phase 2（无锁、幂等）销毁各放置节点上的 ext4；Phase 3（短事务）复查引用与状态、删除放置行，然后通知 TC 移除物理数据。只有 TC 删除 S3 对象 / 本地文件 / artifact 行——过去由 CubeMaster 直接删会泄漏 S3 对象，且没有 CLEANUP_PENDING 行留给兜底清扫。
+删除采用三阶段最后属主清理（`cleanupArtifactFully`）：
+
+1. **Phase 1（短事务）**：统计剩余引用，把行标为 `CLEANUP_PENDING`
+2. **Phase 2（无锁、幂等）**：删除各放置节点上的 ext4
+3. **Phase 3（短事务）**：复查引用与状态、删除 placement 行，并通知 TC 删除物理数据
+
+只有 TC 删除 S3 对象 / 本地文件 / artifact 行。过去由 CubeMaster 直接删会泄漏 S3 对象，而且没有 `CLEANUP_PENDING` 行留给兜底清扫。
 
 ### 9.6 节点放置
 
-`ArtifactNodePlacement` 行记录哪些节点持有副本，同时驱动 Phase 2 删除与下载就近性。
+`ArtifactNodePlacement` 行记录哪些节点持有副本，同时驱动删除 Phase 2 与下载就近性。
 
 ### 9.7 共享 artifact 存储
 
-TC 写 ext4，CubeMaster 通过 `/cube/template/artifact/download` 把它提供给 cubelet——两个进程必须看到同一个目录。one-click：同机文件系统。Helm：同一个 PVC（ReadWriteOnce 是节点级约束，chart 用 required podAffinity 把 TC 钉在 master 所在节点；`colocateWithMaster=false` 要求真正共享的 ReadWriteMany 卷）。terraform：启用 CFS 时共享，否则单副本 pod 本地 emptyDir 共置。因为目录是共享的，构建期记录的路径对 reconciler 始终有效，即使 TC 中途重启过。
+TC 写 ext4，CubeMaster 通过 `/cube/template/artifact/download` 把它提供给 cubelet——两个进程必须看到同一份 artifact 字节，或者都能通过同一套 S3 路径 / presigned URL 找到它。
+
+- one-click：同机文件系统共享
+- Helm：同一个 PVC（本地盘模式时通过同节点亲和保证 master / TC 共置）
+- `s3Backed=true`：由对象存储统一承载 artifact 字节
+
+因为 artifact 存储是共享的 / 可寻址的，构建期记录的路径与对象引用对 reconciler 始终有效，即使中途发生 TC 重启也不需要把 job “绑死”在某个实例上。
 
 ## 10. 已知限制与后续项
 
-以下问题随当前版本发布时已知，逐项列出后续计划。
+以下问题在当前版本里仍然存在：
 
-- **37 天预签名 URL 不刷新。** 上传到 S3 的 artifact 在构建时记录长时效预签名 URL；没有刷新任务，超过预签名时效的模板需要 redo 来生成新 URL。
-- **`hasActiveJob` 不含 BUILT。** 幂等窗口（§3.6）覆盖 PENDING/RUNNING；已 BUILT 但 resume 流水线仍在分发的 job 在窗口之外，此时重复创建会发起第二次分发而不是挂到第一次上。
-- **envd 时代的 redo 直接 FAILED。** 续跑由旧版进程内构建器产出的模板时没有可复用的 artifact 记录，会快速失败而不是重建；这类模板请从源镜像重新创建。
-- **TC 仍依赖 CubeMaster 包。** TC 复用 CubeMaster 的 config loader、log、recov、nodemeta 与 templatecenter store 包，而没有抽成共享库，这就是 TC 的 go.mod 带 CubeMaster `replace` 的原因。把共享部分抽到 `pkgs/` 是后续工作。
+- **37 天预签名 URL 不刷新。** 上传到 S3 的 artifact 在构建时记录长时效 presigned URL；没有单独的刷新任务，超过时效后需要 redo 或重新 merge / rebuild 才会得到新 URL。
+- **`hasActiveJob` 不含 `BUILT`。** 幂等窗口覆盖 `PENDING` / `RUNNING`；已 `BUILT` 但 resume 流水线还在分发时，重复创建可能发起第二次分发，而不是挂到第一次上。
+- **envd 时代的 redo 直接 `FAILED`。** 对旧版进程内构建器产出的模板，若缺少可复用 artifact 记录，redo 会快速失败而不是自动重建；这类模板请从源镜像重新创建。
+- **TC 仍依赖 CubeMaster 包。** TC 复用 CubeMaster 的 config loader、log、recovery、nodemeta 与 templatecenter store 包，所以当前 `go.mod` 里仍需要 `replace`。把共享部分抽到 `pkgs/` 仍是后续工作。

--- a/docs/zh/dev/templatecenter-design.md
+++ b/docs/zh/dev/templatecenter-design.md
@@ -76,14 +76,15 @@ TC 不初始化 worker（cubelet）grpc 连接池，因此任何可能发起 cub
   - 做幂等检查
   - 尝试清理遗留的本地 ext4 副本
 
-对**存量镜像制作出来的历史模板**，本文约定的标准运维顺序是：**先 `tpl merge`，再 `tpl redo`**。原因是 `merge` 负责把旧的本地 artifact 收敛进 TC 管理的存储，而 `redo` 负责后续续跑 / 分发；两者职责不同，不应互相替代。
+对**存量镜像制作出来的历史模板**，运维文档应统一采用以下口径：**`tpl merge` 解决历史 artifact 的存储收敛问题，`tpl redo` 解决节点侧重新分发 / 必要时重建问题。**
+
+典型场景是：模板最初的 artifact 仍保存在 CubeMaster 本地盘，后续集群开启了 `s3Backed=true`，需要将这批历史 artifact 从本地盘迁移到 **S3 托管存储**。在这个场景下，应先执行 `tpl merge` 完成存储迁移；若同一次运维还需要让模板重新覆盖目标节点，再继续执行 `tpl redo`。
 
 > **高亮提醒**
-> 不迁移的直接后果，是这类历史模板的 artifact 仍旧停留在 **CubeMaster 本地盘**，而不是 TC 管理的 artifact store。
+> 在默认共盘 / 共享存储拓扑下，未执行 `tpl merge` 并不意味着现有 `READY` 模板会立即失去下载能力；真正的问题是历史 artifact 仍未完成从**本地盘到 S3 托管存储**的收敛。
 >
-> - **存储侧**：切到 `s3Backed=true` 或远端 TC 拓扑后，存量模板仍然没有完成存储收敛。
-> - **运行侧**：后续 `redo` / 分发仍会继续依赖这份历史本地 ext4，而不是迁移后的统一 artifact。
-> - **恢复侧**：如果本地 ext4 先丢了，再跑 `tpl merge` 也无法补救，因为已经“没有东西可上传”；这时只能重新 `tpl redo` 去重建 rootfs。
+> - **存储侧**：开启 `s3Backed=true` 后，旧模板不会自动补做迁移。
+> - **恢复侧**：如果本地 ext4 先丢了，再跑 `tpl merge` 也无法补救，因为已经没有可上传的文件；这时只能对可重建的 `from-image` 模板执行 `tpl redo`，回退到重建流程。
 
 migrate job 有自己独立的状态读取路径：`GET /cube/template/migrate?job_id=...`。
 
@@ -100,9 +101,9 @@ HTTP 层把领域错误映射为 API 错误码：
 
 ### 3.5 Redo
 
-`POST /cube/template/redo` 用于续跑失败的模板 job。分发阶段失败但 artifact 已为 `READY` 的 job 会复用 artifact，而不是重建；复用 `PENDING` / `BUILDING` 的 artifact 会读到半成品 ext4，因此是禁止的。
+`POST /cube/template/redo` 用于续跑失败的模板 job。分发阶段失败但 artifact 已为 `READY` 的 job 会复用 artifact，而不是重建；复用 `PENDING` / `BUILDING` 的 artifact 会读到半成品 ext4，因此是禁止的。若 artifact 不再可复用，redo 会退回到从 `source_image_ref` 做 full rebuild（该构建由 TC 执行，而不是依赖先前 `merge` 的结果）。
 
-在运维文档里，`redo` 还承担“让模板基于**已经迁移完成**的 artifact 重新续跑 / 分发”的角色。因此面对**存量模板**时，顺序应写成 **先 `merge`、后 `redo`**，而不是只写 `redo`。
+在运维文档中，`tpl merge` 应描述为**历史 artifact 从本地盘迁移到 S3 托管存储**的存储收敛动作，`tpl redo` 应描述为**节点侧重新分发 / 必要时重建**动作。只有在同一次运维同时涉及历史 artifact 迁移和节点重新覆盖时，才需要按 **先 `merge`、后 `redo`** 的顺序执行。
 
 ### 3.6 Resume 流水线
 

--- a/docs/zh/guide/cli-tools.md
+++ b/docs/zh/guide/cli-tools.md
@@ -60,24 +60,23 @@ cubemastercli --address <cubemaster-host> --port 8089 tpl create-from-image \
 # 存量模板如果不迁移，artifact 仍留在 CubeMaster 本地盘上。
 cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id>
 
-# 存量镜像 / 历史模板的标准顺序：merge 完成后，再 redo。
-# 否则后续 redo / 分发仍会继续依赖那份历史本地 ext4。
+# 如果场景是把历史 artifact 从本地盘迁到 S3 托管存储，且还要重新覆盖节点，可在 merge 完成后再 redo。
+# redo 负责节点侧重新分发；原 artifact 不可复用时会回退到重建流程。
 cubemastercli --address <cubemaster-host> --port 8089 tpl redo --template-id <template-id>
 
 # 只提交 migrate job，不等待结束。
 cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id> --detach
 ```
 
-对于**存量镜像 / 历史模板**，这里建议把顺序理解成：**先 `tpl merge`，再 `tpl redo`**。
+对于**存量镜像 / 历史模板**，文档口径应统一为：**`tpl merge` 解决历史 artifact 的存储收敛问题，`tpl redo` 解决节点侧重新分发 / 必要时重建问题。**
 
-- **先 `tpl merge`**：把历史模板还留在 `CubeMaster` 本地盘上的 rootfs artifact 迁进 TC 管理的 artifact store。
-- **再 `tpl redo`**：让后续续跑 / 分发基于**迁移后的 artifact** 继续执行，而不是继续依赖旧的本地 ext4。
+典型场景是：模板最初的 artifact 仍保存在 `CubeMaster` 本地盘，后续集群开启了 `s3Backed=true`，需要将这批历史 artifact 从本地盘迁移到 **S3 托管存储**。如果同一次运维还需要让模板重新覆盖目标节点，则在 `tpl merge` 完成后继续执行 `tpl redo`。
 
 > **高亮提醒**
-> 如果跳过 `tpl merge`，这些存量模板的 artifact 仍然会停留在 **`CubeMaster` 本地磁盘**，不会自动收敛到 TC 管理的存储。
+> 在默认共盘 / 共享 PVC 部署里，不执行 `tpl merge` 通常**不会立刻影响现有模板下载**；真正的问题是旧 artifact 仍未完成从**本地盘到 S3 托管存储**的收敛。
 >
-> - **运行风险**：后续 `redo` / 分发仍会继续依赖这份历史本地 ext4。
-> - **恢复风险**：如果本地 ext4 已经丢失，再补跑 `tpl merge` 也修不回来，因为已经没有可上传的文件；这时只能执行 `tpl redo` 去重新构建 rootfs。
+> - **存储侧**：开启 `s3Backed=true` 后，旧模板不会自动补做迁移。
+> - **恢复侧**：如果本地 ext4 已经丢失，再补跑 `tpl merge` 也修不回来，因为已经没有可上传的文件；这时只能对可重建的 `from-image` 模板执行 `tpl redo`，回退到重建流程。
 
 破坏性操作需要谨慎执行：
 

--- a/docs/zh/guide/cli-tools.md
+++ b/docs/zh/guide/cli-tools.md
@@ -54,7 +54,30 @@ cubemastercli --address <cubemaster-host> --port 8089 tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49983 \
   --probe 49983
+
+# 把一个 READY 模板的 rootfs artifact 迁入 TC 存储。
+# CLI 叫 merge，对应 API 是 /cube/template/migrate。
+# 存量模板如果不迁移，artifact 仍留在 CubeMaster 本地盘上。
+cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id>
+
+# 存量镜像 / 历史模板的标准顺序：merge 完成后，再 redo。
+# 否则后续 redo / 分发仍会继续依赖那份历史本地 ext4。
+cubemastercli --address <cubemaster-host> --port 8089 tpl redo --template-id <template-id>
+
+# 只提交 migrate job，不等待结束。
+cubemastercli --address <cubemaster-host> --port 8089 tpl merge <template-id> --detach
 ```
+
+对于**存量镜像 / 历史模板**，这里建议把顺序理解成：**先 `tpl merge`，再 `tpl redo`**。
+
+- **先 `tpl merge`**：把历史模板还留在 `CubeMaster` 本地盘上的 rootfs artifact 迁进 TC 管理的 artifact store。
+- **再 `tpl redo`**：让后续续跑 / 分发基于**迁移后的 artifact** 继续执行，而不是继续依赖旧的本地 ext4。
+
+> **高亮提醒**
+> 如果跳过 `tpl merge`，这些存量模板的 artifact 仍然会停留在 **`CubeMaster` 本地磁盘**，不会自动收敛到 TC 管理的存储。
+>
+> - **运行风险**：后续 `redo` / 分发仍会继续依赖这份历史本地 ext4。
+> - **恢复风险**：如果本地 ext4 已经丢失，再补跑 `tpl merge` 也修不回来，因为已经没有可上传的文件；这时只能执行 `tpl redo` 去重新构建 rootfs。
 
 破坏性操作需要谨慎执行：
 

--- a/docs/zh/guide/templates.md
+++ b/docs/zh/guide/templates.md
@@ -58,7 +58,7 @@ CubeSandbox 支持两种制作方式：
 - **从 OCI 镜像制作**：准备包含系统、工具和应用依赖的 OCI 镜像，再由 CubeSandbox 将其转换为模板。这是创建可复现模板的常用方式，详见[从 OCI 镜像制作模板](./tutorials/template-from-image.md)。
 - **从运行中的沙箱制作**：先在沙箱内安装软件或调整环境，再将其当前文件系统和内存状态提交为新模板。适合交互式调试和快速固化环境，详见[将运行中的沙箱提交为模板](./tutorials/template-from-sandbox.md)。
 
-无论采用哪种方式，模板制作过程都可以概括为：准备根文件系统，启动 MicroVM 并等待环境就绪，生成快照，最后注册并发布模板。模板就绪后，CubeSandbox 可以用它快速创建新的沙箱；如果是历史模板或旧部署中仍保存在 CubeMaster 本地盘上的 artifact，也可以后续再用 `cubemastercli tpl merge <template-id>` 把该 rootfs 迁入 TC 管理的 artifact 存储。对于**存量镜像对应的历史模板**，文档里的推荐顺序是：**先 `tpl merge`，再 `tpl redo`**；如果不迁移，artifact 会继续滞留在本地盘上，后续 `redo` / 分发也仍然受这份历史 ext4 的可用性约束。
+无论采用哪种方式，模板制作过程都可以概括为：准备根文件系统，启动 MicroVM 并等待环境就绪，生成快照，最后注册并发布模板。模板就绪后，CubeSandbox 可以用它快速创建新的沙箱；如果是历史模板或旧部署中仍保存在 CubeMaster 本地盘上的 artifact，也可以后续再用 `cubemastercli tpl merge <template-id>` 把该 rootfs 迁入 TC 管理的 artifact 存储。对**存量镜像对应的历史模板**，文档口径应统一为：**`tpl merge` 解决历史 artifact 的存储收敛问题，`tpl redo` 解决节点侧重新分发 / 必要时重建问题。** 典型场景是后续开启 `s3Backed=true`，需要将历史 artifact 从本地盘迁移到 **S3 托管存储**；若同一次运维还需要重新覆盖节点，则在 `merge` 完成后再执行 `redo`。
 
 ## 模板与镜像的关系
 

--- a/docs/zh/guide/templates.md
+++ b/docs/zh/guide/templates.md
@@ -58,7 +58,7 @@ CubeSandbox 支持两种制作方式：
 - **从 OCI 镜像制作**：准备包含系统、工具和应用依赖的 OCI 镜像，再由 CubeSandbox 将其转换为模板。这是创建可复现模板的常用方式，详见[从 OCI 镜像制作模板](./tutorials/template-from-image.md)。
 - **从运行中的沙箱制作**：先在沙箱内安装软件或调整环境，再将其当前文件系统和内存状态提交为新模板。适合交互式调试和快速固化环境，详见[将运行中的沙箱提交为模板](./tutorials/template-from-sandbox.md)。
 
-无论采用哪种方式，模板制作过程都可以概括为：准备根文件系统，启动 MicroVM 并等待环境就绪，生成快照，最后注册并发布模板。模板就绪后，CubeSandbox 可以用它快速创建新的沙箱。
+无论采用哪种方式，模板制作过程都可以概括为：准备根文件系统，启动 MicroVM 并等待环境就绪，生成快照，最后注册并发布模板。模板就绪后，CubeSandbox 可以用它快速创建新的沙箱；如果是历史模板或旧部署中仍保存在 CubeMaster 本地盘上的 artifact，也可以后续再用 `cubemastercli tpl merge <template-id>` 把该 rootfs 迁入 TC 管理的 artifact 存储。对于**存量镜像对应的历史模板**，文档里的推荐顺序是：**先 `tpl merge`，再 `tpl redo`**；如果不迁移，artifact 会继续滞留在本地盘上，后续 `redo` / 分发也仍然受这份历史 ext4 的可用性约束。
 
 ## 模板与镜像的关系
 

--- a/docs/zh/guide/tutorials/template-from-image.md
+++ b/docs/zh/guide/tutorials/template-from-image.md
@@ -1,6 +1,6 @@
 # 从 OCI 镜像制作模板
 
-本文介绍如何从标准 OCI 容器镜像出发，完成模板的创建、进度监控和删除操作。
+本文介绍如何从标准 OCI 容器镜像出发，完成模板的创建、进度监控、可选的 `tpl merge` 存储迁移，以及删除操作。
 
 建议在开始前先阅读[模板概览](../templates.md)，了解 OCI 镜像、模板快照、端口、探针和 `envd` 等相关概念。
 
@@ -172,8 +172,44 @@ cubemastercli tpl render --template-id tpl-748094d2f2374b0a8a37e6ec --json
 
 如果你更关心“应该看什么、如何一步步预览最终请求”，可继续阅读[模板检查与请求预览](../template-inspection-and-preview.md)。
 
+## 第五步 — （可选）把历史本地 artifact 迁入 TC 存储
 
-## 删除模板
+大多数**新建**的 `from-image` 模板已经沿当前数据面直接走 TC 构建，因此**不一定需要再手动执行 `tpl merge`**。`tpl merge` 主要用于以下场景：
+
+- 历史模板的 rootfs ext4 还只在 CubeMaster 本地磁盘上
+- 集群后来开启了 `s3Backed=true`，希望把旧模板收敛进 S3 / TC artifact store
+- artifact 已经迁移过，但你想再次触发幂等检查并清理遗留的本地 ext4 文件
+
+命令名叫 `merge`，对应的 API 路径是 `/cube/template/migrate`。默认会阻塞到 migrate job 结束：
+
+```bash
+cubemastercli tpl merge tpl-748094d2f2374b0a8a37e6ec
+```
+
+如果只想提交 migrate job 就返回，可使用：
+
+```bash
+cubemastercli tpl merge tpl-748094d2f2374b0a8a37e6ec --detach
+```
+
+这里的 `merge` 指的是**artifact 存储迁移**，不是 `tpl render` 里看到的 `merged_request` 请求合并。
+
+如果你在处理的是**存量镜像对应的历史模板**，推荐按下面的顺序操作：
+
+```bash
+cubemastercli tpl merge tpl-748094d2f2374b0a8a37e6ec
+cubemastercli tpl redo --template-id tpl-748094d2f2374b0a8a37e6ec
+```
+
+也就是：**先 `merge`，把旧 artifact 迁进 TC 管理的存储；再 `redo`，让后续续跑 / 分发基于迁移后的 artifact 继续执行。**
+
+> **高亮提醒**
+> 如果跳过这一步，存量模板的 rootfs artifact 仍然留在 **CubeMaster 本地磁盘**，不会自动变成 TC 托管 artifact。
+>
+> - **你会继续依赖历史本地 ext4**：后续 `redo` / 分发仍然受这份本地文件是否还在的影响。
+> - **本地文件一旦丢失，`merge` 也补不回来**：因为迁移只能上传“现存的 ext4 文件”；如果文件已经没有了，最终只能执行 `tpl redo` 重新构建。
+
+## 第六步 — 删除模板
 
 ```bash
 cubemastercli tpl delete tpl-748094d2f2374b0a8a37e6ec

--- a/docs/zh/guide/tutorials/template-from-image.md
+++ b/docs/zh/guide/tutorials/template-from-image.md
@@ -194,20 +194,20 @@ cubemastercli tpl merge tpl-748094d2f2374b0a8a37e6ec --detach
 
 这里的 `merge` 指的是**artifact 存储迁移**，不是 `tpl render` 里看到的 `merged_request` 请求合并。
 
-如果你在处理的是**存量镜像对应的历史模板**，推荐按下面的顺序操作：
+如果你在处理的是**存量镜像对应的历史模板**，文档口径应统一为：**`tpl merge` 解决历史 artifact 的存储收敛问题，`tpl redo` 解决节点侧重新分发 / 必要时重建问题。**
+
+典型场景是：模板最初的 artifact 仍保存在 `CubeMaster` 本地盘，后续集群开启了 `s3Backed=true`，需要将这批历史 artifact 从本地盘迁移到 **S3 托管存储**。如果同一次运维还需要让模板重新覆盖目标节点，可以按下面的顺序执行：
 
 ```bash
 cubemastercli tpl merge tpl-748094d2f2374b0a8a37e6ec
 cubemastercli tpl redo --template-id tpl-748094d2f2374b0a8a37e6ec
 ```
 
-也就是：**先 `merge`，把旧 artifact 迁进 TC 管理的存储；再 `redo`，让后续续跑 / 分发基于迁移后的 artifact 继续执行。**
-
 > **高亮提醒**
-> 如果跳过这一步，存量模板的 rootfs artifact 仍然留在 **CubeMaster 本地磁盘**，不会自动变成 TC 托管 artifact。
+> 在默认共盘 / 共享 PVC 部署里，即使跳过 `tpl merge`，现有 `READY` 模板通常也**仍可继续下载**；真正的问题是这些历史 artifact 仍未完成从**本地盘到 S3 托管存储**的收敛。
 >
-> - **你会继续依赖历史本地 ext4**：后续 `redo` / 分发仍然受这份本地文件是否还在的影响。
-> - **本地文件一旦丢失，`merge` 也补不回来**：因为迁移只能上传“现存的 ext4 文件”；如果文件已经没有了，最终只能执行 `tpl redo` 重新构建。
+> - **存储侧**：开启 `s3Backed=true` 后，旧模板不会自动补做迁移。
+> - **恢复侧**：如果本地 ext4 已经丢失，再补跑 `tpl merge` 也修不回来，因为已经没有可上传的文件；这时只能对可重建的 `from-image` 模板执行 `tpl redo`，回退到重建流程。
 
 ## 第六步 — 删除模板
 


### PR DESCRIPTION
## Summary
Port selected `templatecenter-v3` pieces onto `master` baseline:
- chart README updates
- `tpl migrate` workflow (submit/status API + migrate job runtime)

## Included changes
- **Chart docs**
  - update `deploy/kubernetes/chart/README.md`

- **CubeMaster migrate API & runtime**
  - add `POST/GET /cube/template/migrate`
  - add `template_migrate.go` + `template_migrate_job.go`
  - wire routes and route tests
  - add migrate operation/phase constants

- **Migrate dependency chain**
  - add `tcclient.UploadArtifact` for TC ingest
  - add `statArtifactObjectInS3` and `uploadArtifactFileToS3`
  - add TC internal `POST /tc/api/v1/artifact/upload`

## Notes
- This PR is intentionally scoped to **chart README + tpl migrate** transplant only.
- Branch is based on `master`.
