### PR TITLE
Validate original destinations before domain-based egress allow

### DIFF
--- a/CubeEgress/Makefile
+++ b/CubeEgress/Makefile
@@ -32,7 +32,8 @@ test-lua:
 	$(Q)LUA_BIN=$$(command -v luajit || command -v lua); \
 		test -n "$$LUA_BIN" || { echo "error: lua or luajit not installed"; exit 1; }; \
 		$$LUA_BIN tests/port_scheme_test.lua && \
-		$$LUA_BIN tests/port_scheme_extra_test.lua
+		$$LUA_BIN tests/port_scheme_extra_test.lua && \
+		$$LUA_BIN tests/dns_auth_test.lua
 
 .PHONY: build
 build:

--- a/CubeEgress/Makefile
+++ b/CubeEgress/Makefile
@@ -35,6 +35,10 @@ test-lua:
 		$$LUA_BIN tests/port_scheme_extra_test.lua && \
 		$$LUA_BIN tests/dns_auth_test.lua
 
+.PHONY: test-dns-integration
+test-dns-integration:
+	$(Q)python3 tests/dns_auth_integration.py
+
 .PHONY: build
 build:
 	$(call msg,BUILD IMAGE $(IMAGE_LOCAL):$(IMAGE_TAG)-$(ARCH))

--- a/CubeEgress/lua/access_phase.lua
+++ b/CubeEgress/lua/access_phase.lua
@@ -34,7 +34,8 @@
 --
 -- G5 is an allow-path authorization gate: if the sandbox connects to an
 -- original dst IP that proxy-side DNS does not return for the matched
--- Host/SNI, the request is denied before upstream proxying. G1/G4 stay scoped
+-- Host/SNI, the request is denied before upstream proxying. HTTPS Host rules
+-- also require Host == SNI, since upstream routing uses SNI. G1/G4 stay scoped
 -- to credential injection: a G4 mismatch on an otherwise allowed rule means we
 -- proxy the traffic upstream WITHOUT the secret, and tag the decision as a
 -- security_event.

--- a/CubeEgress/lua/access_phase.lua
+++ b/CubeEgress/lua/access_phase.lua
@@ -5,7 +5,9 @@
 --      method, path, dst_ip, scheme).
 --   2. Look up the policy for the sandbox source IP.
 --   3. Walk policy.rules in order, first-match-wins.
---   4. On allow: enforce gates G1 (scheme is http or https) and
+--   4. On allow: enforce G5 (original dst IP belongs to the matched
+--      Host/SNI according to proxy-side DNS). If the rule also injects
+--      credentials, enforce gates G1 (scheme is http or https) and
 --      G4 (HTTPS: Host == SNI; HTTP: Host present), then for each
 --      inject{header, secret, format} run
 --      ngx.req.set_header. The secret value is embedded inline in the
@@ -23,16 +25,19 @@
 --   G3 SNI matches rule — by rule_matches() above (HTTPS only; HTTP has no SNI)
 --   G4 Host == SNI      — checked here, before any inject
 --                         (HTTPS: Host==SNI; HTTP: Host present)
---   G5 dst IP authentic — implicit via G6 (proxy_ssl_verify)
+--   G5 dst IP authentic — checked here for allow rules with Host/SNI
+--                         constraints, before proxying
 --   G6 upstream cert    — Pδ; nginx proxy_ssl_verify on (already in
 --                         http {}-level config)
 --   G7 method/path      — by rule_matches()
 --   G8 policy authorise — implicit (we are inside the matched rule)
 --
--- "any G1-G8 failure → drop inject; the request continues
--- based on action.allow". That is what we do: a G4 mismatch on an
--- otherwise allowed rule means we proxy the traffic upstream WITHOUT
--- the secret, and tag the decision as a security_event.
+-- G5 is an allow-path authorization gate: if the sandbox connects to an
+-- original dst IP that proxy-side DNS does not return for the matched
+-- Host/SNI, the request is denied before upstream proxying. G1/G4 stay scoped
+-- to credential injection: a G4 mismatch on an otherwise allowed rule means we
+-- proxy the traffic upstream WITHOUT the secret, and tag the decision as a
+-- security_event.
 --
 -- Match-field semantics (all optional; missing field → matches anything):
 --   sni             string (exact or leading "*." wildcard, case-insensitive)
@@ -69,6 +74,7 @@
 
 local policy = require "policy"
 local port_scheme = require "port_scheme"
+local dns_auth = require "dns_auth"
 
 local _M = {}
 
@@ -345,6 +351,21 @@ local function deny(reason, decision)
     return ngx.exit(403)
 end
 
+local function enforce_dns_auth(match, ctx, decision)
+    local ok, reason, detail = dns_auth.verify_rule(match, ctx)
+    decision.dns_auth = detail
+    if ok then return true end
+    decision.security_event = true
+    ngx.log(ngx.NOTICE, "[access] DNS auth failed reason=", tostring(reason),
+                       " sandbox=", tostring(decision.sandbox_ip),
+                       " policy=", tostring(decision.policy_id),
+                       " rule=", tostring(decision.rule_id),
+                       " dst_ip=", tostring(decision.dst_ip),
+                       " host=", tostring(decision.host),
+                       " sni=", tostring(decision.sni))
+    return false, reason
+end
+
 local function allow(decision)
     decision.allow = true
     -- If the matched rule wants credential injection, run G1/G4
@@ -493,6 +514,10 @@ function _M.decide()
             decision.audit_level = (r.action and r.action.audit) or "metadata"
             decision.inject      = r.action and r.action.inject  -- consumed in Pγ
             if r.action and r.action.allow == true then
+                local dns_ok, dns_reason = enforce_dns_auth(r.match, ctx, decision)
+                if not dns_ok then
+                    return deny(dns_reason, decision)
+                end
                 return allow(decision)
             else
                 return deny("rule_deny", decision)

--- a/CubeEgress/lua/audit.lua
+++ b/CubeEgress/lua/audit.lua
@@ -194,6 +194,7 @@ local function build_record(event)
         },
         credentials = credentials_block(d),
         security = security,
+        dns_auth = d.dns_auth,
         -- populate these from header/body filters when
         -- audit_level == "full". For now the fields exist for schema
         -- stability but stay null.
@@ -320,6 +321,7 @@ function _M.write_security_event(reason, decision)
             inject_dropped = d.inject_dropped,
             inject_skipped = d.injected_skipped,
         },
+        dns_auth = d.dns_auth,
     }
     local line, err = cjson.encode(rec)
     if not line then

--- a/CubeEgress/lua/dns_auth.lua
+++ b/CubeEgress/lua/dns_auth.lua
@@ -1,0 +1,263 @@
+-- CubeSandbox cube-egress - bind L7 domain identity to original dst IP.
+--
+-- Host/SNI policy matches prove only what name the sandbox presented to the
+-- proxy. For transparent proxying we must also prove that the original
+-- destination IP belongs to that name according to proxy-side DNS, otherwise a
+-- sandbox can forge Host/SNI while connecting to an unrelated IP.
+
+local _M = {}
+
+local RESOLV_CONF = "/etc/resolv.conf"
+local CACHE_TTL_MIN = 5
+local CACHE_TTL_MAX = 300
+
+local test_resolver
+
+local function lower(s)
+    if type(s) ~= "string" then return nil end
+    return string.lower(s)
+end
+
+local function trim(s)
+    if type(s) ~= "string" then return nil end
+    return (string.gsub(s, "^%s*(.-)%s*$", "%1"))
+end
+
+local IPV4_PATTERN = "^([0-9]+)%.([0-9]+)%.([0-9]+)%.([0-9]+)$"
+
+local function parse_ipv4(s)
+    if type(s) ~= "string" then return nil end
+    local a, b, c, d = string.match(s, IPV4_PATTERN)
+    if not a then return nil end
+    local out = {}
+    for _, octet in ipairs({a, b, c, d}) do
+        if #octet > 1 and string.sub(octet, 1, 1) == "0" then return nil end
+        local n = tonumber(octet)
+        if not n or n < 0 or n > 255 then return nil end
+        out[#out + 1] = tostring(n)
+    end
+    return table.concat(out, ".")
+end
+
+local function normalize_domain(name)
+    name = trim(name)
+    if not name or name == "" then return nil end
+    return string.gsub(lower(name), "%.$", "")
+end
+
+local function normalize_resolver_address(addr)
+    addr = trim(addr)
+    if not addr or addr == "" then return nil end
+    local ip, port = string.match(addr, "^([^:]+):([0-9]+)$")
+    if ip then
+        ip = parse_ipv4(ip)
+        port = tonumber(port)
+        if ip and port and port > 0 and port <= 65535 then return {ip, port} end
+        return nil
+    end
+    addr = parse_ipv4(addr)
+    if not addr then return nil end
+    return addr
+end
+
+local function resolver_key(ns)
+    if type(ns) == "table" then return tostring(ns[1]) .. ":" .. tostring(ns[2]) end
+    return tostring(ns)
+end
+
+local function append_nameserver(out, seen, ns)
+    local normalized = normalize_resolver_address(ns)
+    if not normalized then return end
+    local key = resolver_key(normalized)
+    if seen[key] then return end
+    seen[key] = true
+    out[#out + 1] = normalized
+end
+
+local function nameservers_from_env()
+    local raw = os.getenv("CUBE_EGRESS_DNS_RESOLVER_ADDRS")
+    if not raw or raw == "" then return nil end
+    local out, seen = {}, {}
+    for token in string.gmatch(raw, "[^,%s]+") do
+        append_nameserver(out, seen, token)
+    end
+    if #out == 0 then return nil end
+    return out
+end
+
+local function nameservers_from_resolv_conf(path)
+    local f = io.open(path or RESOLV_CONF, "r")
+    if not f then return nil end
+    local out, seen = {}, {}
+    for line in f:lines() do
+        local ns = string.match(line, "^%s*nameserver%s+([^%s#;]+)")
+        if ns then append_nameserver(out, seen, ns) end
+    end
+    f:close()
+    if #out == 0 then return nil end
+    return out
+end
+
+local function cache()
+    return ngx and ngx.shared and ngx.shared.dns_auth_cache or nil
+end
+
+local function clamp_ttl(ttl)
+    ttl = tonumber(ttl) or CACHE_TTL_MIN
+    if ttl < CACHE_TTL_MIN then return CACHE_TTL_MIN end
+    if ttl > CACHE_TTL_MAX then return CACHE_TTL_MAX end
+    return math.floor(ttl)
+end
+
+local function resolve_ipv4s_uncached(name)
+    if test_resolver then return test_resolver(name) end
+
+    local ok_lib, resolver_lib = pcall(require, "resty.dns.resolver")
+    if not ok_lib or not resolver_lib then
+        return nil, "resolver_module_unavailable:" .. tostring(resolver_lib)
+    end
+    local nameservers = nameservers_from_env() or nameservers_from_resolv_conf()
+    if not nameservers then return nil, "no_proxy_dns_resolver" end
+    local resolver, err = resolver_lib:new({
+        nameservers = nameservers,
+        retrans = 2,
+        timeout = 2000,
+    })
+    if not resolver then return nil, "resolver_init_failed:" .. tostring(err) end
+
+    local qname = name
+    local out, seen = {}, {}
+    local min_ttl = CACHE_TTL_MAX
+    for _ = 1, 5 do
+        local answers, qerr = resolver:query(qname, {qtype = resolver.TYPE_A})
+        if not answers then return nil, "dns_query_failed:" .. tostring(qerr) end
+        if answers.errcode then return nil, "dns_rcode_" .. tostring(answers.errcode) end
+
+        local cname
+        for _, ans in ipairs(answers) do
+            if ans.address then
+                local ip = parse_ipv4(ans.address)
+                if ip and not seen[ip] then
+                    seen[ip] = true
+                    out[#out + 1] = ip
+                end
+                if ans.ttl then min_ttl = math.min(min_ttl, clamp_ttl(ans.ttl)) end
+            elseif ans.cname and not cname then
+                cname = normalize_domain(ans.cname)
+                if ans.ttl then min_ttl = math.min(min_ttl, clamp_ttl(ans.ttl)) end
+            end
+        end
+        if #out > 0 or not cname or cname == qname then break end
+        qname = cname
+    end
+    return out, nil, clamp_ttl(min_ttl)
+end
+
+local function resolve_ipv4s(name)
+    local c = cache()
+    local list_key = "name:" .. name
+    if c then
+        local cached = c:get(list_key)
+        if cached and cached ~= "" then
+            local out = {}
+            for ip in string.gmatch(cached, "[^,]+") do
+                out[#out + 1] = ip
+            end
+            return out
+        end
+    end
+
+    local ips, err, ttl = resolve_ipv4s_uncached(name)
+    if not ips then return nil, err end
+    if c and #ips > 0 then
+        c:set(list_key, table.concat(ips, ","), ttl or CACHE_TTL_MIN)
+    end
+    return ips
+end
+
+local function list_contains(list, value)
+    for _, item in ipairs(list or {}) do
+        if item == value then return true end
+    end
+    return false
+end
+
+local function verify_name(name, dst_ip)
+    dst_ip = parse_ipv4(dst_ip)
+    if not dst_ip then return false, "g5_missing_original_dst", {name = name} end
+
+    local literal = parse_ipv4(name)
+    if literal then
+        if literal == dst_ip then return true, nil, {name = name, ips = {literal}} end
+        return false, "g5_ip_literal_mismatch", {
+            name = name,
+            dst_ip = dst_ip,
+            resolved_ips = {literal},
+        }
+    end
+
+    local domain = normalize_domain(name)
+    if not domain then return false, "g5_missing_domain_identity", {name = name} end
+    local ips, err = resolve_ipv4s(domain)
+    if not ips then
+        return false, "g5_dns_resolve_failed", {
+            name = domain,
+            dst_ip = dst_ip,
+            resolver_error = err,
+        }
+    end
+    if not list_contains(ips, dst_ip) then
+        return false, "g5_dst_ip_not_in_dns", {
+            name = domain,
+            dst_ip = dst_ip,
+            resolved_ips = ips,
+        }
+    end
+    return true, nil, {name = domain, dst_ip = dst_ip, resolved_ips = ips}
+end
+
+function _M.verify_rule(match, ctx)
+    if type(match) ~= "table" then return true end
+    local names = {}
+    if match.host ~= nil then
+        if not ctx.host or ctx.host == "" then
+            return false, "g5_missing_host_for_dns_auth", {field = "host"}
+        end
+        names[#names + 1] = {field = "host", value = ctx.host}
+    end
+    if match.sni ~= nil then
+        if not ctx.sni or ctx.sni == "" then
+            return false, "g5_missing_sni_for_dns_auth", {field = "sni"}
+        end
+        names[#names + 1] = {field = "sni", value = ctx.sni}
+    end
+    if #names == 0 then return true end
+
+    local checked, seen = {}, {}
+    for _, entry in ipairs(names) do
+        local key = normalize_domain(entry.value) or entry.value
+        if not seen[key] then
+            seen[key] = true
+            local ok, reason, detail = verify_name(entry.value, ctx.dst_ip)
+            detail = detail or {}
+            detail.field = entry.field
+            checked[#checked + 1] = detail
+            if not ok then return false, reason, {checks = checked} end
+        end
+    end
+    return true, nil, {checks = checked}
+end
+
+function _M._set_test_resolver(fn)
+    test_resolver = fn
+end
+
+function _M._parse_ipv4(s)
+    return parse_ipv4(s)
+end
+
+function _M._nameservers_from_resolv_conf(path)
+    return nameservers_from_resolv_conf(path)
+end
+
+return _M

--- a/CubeEgress/lua/dns_auth.lua
+++ b/CubeEgress/lua/dns_auth.lua
@@ -8,10 +8,14 @@
 local _M = {}
 
 local RESOLV_CONF = "/etc/resolv.conf"
-local CACHE_TTL_MIN = 5
 local CACHE_TTL_MAX = 300
-
-local test_resolver
+local MAX_CNAME_HOPS = 5
+local LOOKUP_TIMEOUT = 5
+local MAX_INFLIGHT = 16
+local MAX_WAITERS = 256
+local configured_nameservers, configuration_error
+local cache_prefix
+local inflight, active_lookups = {}, 0
 
 local function lower(s)
     if type(s) ~= "string" then return nil end
@@ -40,9 +44,16 @@ local function parse_ipv4(s)
 end
 
 local function normalize_domain(name)
-    name = trim(name)
-    if not name or name == "" then return nil end
-    return string.gsub(lower(name), "%.$", "")
+    if type(name) ~= "string" then return nil end
+    name = string.gsub(lower(name), "%.$", "")
+    if #name == 0 or #name > 253 or string.find(name, "[^a-z0-9.%-]")
+        or string.find(name, "..", 1, true) then return nil end
+    for label in string.gmatch(name, "[^.]+") do
+        if #label > 63 or not string.match(label, "^[a-z0-9]")
+            or not string.match(label, "[a-z0-9]$") then return nil end
+    end
+    if string.sub(name, 1, 1) == "." or string.sub(name, -1) == "." then return nil end
+    return name
 end
 
 local function normalize_resolver_address(addr)
@@ -67,11 +78,12 @@ end
 
 local function append_nameserver(out, seen, ns)
     local normalized = normalize_resolver_address(ns)
-    if not normalized then return end
+    if not normalized then return false end
     local key = resolver_key(normalized)
-    if seen[key] then return end
+    if seen[key] then return true end
     seen[key] = true
     out[#out + 1] = normalized
+    return true
 end
 
 local function nameservers_from_env()
@@ -79,9 +91,11 @@ local function nameservers_from_env()
     if not raw or raw == "" then return nil end
     local out, seen = {}, {}
     for token in string.gmatch(raw, "[^,%s]+") do
-        append_nameserver(out, seen, token)
+        if not append_nameserver(out, seen, token) then
+            return nil, "invalid_proxy_dns_resolver"
+        end
     end
-    if #out == 0 then return nil end
+    if #out == 0 then return nil, "invalid_proxy_dns_resolver" end
     return out
 end
 
@@ -102,60 +116,101 @@ local function cache()
     return ngx and ngx.shared and ngx.shared.dns_auth_cache or nil
 end
 
+local function nameservers()
+    if not configured_nameservers and not configuration_error then
+        configured_nameservers, configuration_error = nameservers_from_env()
+        if not configured_nameservers and not configuration_error then
+            configured_nameservers = nameservers_from_resolv_conf()
+        end
+        if not configured_nameservers and not configuration_error then
+            configuration_error = "no_proxy_dns_resolver"
+        end
+        if configured_nameservers then
+            local keys = {}
+            for _, ns in ipairs(configured_nameservers) do keys[#keys + 1] = resolver_key(ns) end
+            -- Shared dictionaries survive reloads. A changed resolver view
+            -- must not inherit entries from the previous configuration.
+            cache_prefix = "dns-v2:" .. table.concat(keys, ",") .. ":"
+        end
+    end
+    return configured_nameservers, configuration_error
+end
+
 local function clamp_ttl(ttl)
-    ttl = tonumber(ttl) or CACHE_TTL_MIN
-    if ttl < CACHE_TTL_MIN then return CACHE_TTL_MIN end
+    ttl = tonumber(ttl) or 0
+    if ttl < 0 then return 0 end
     if ttl > CACHE_TTL_MAX then return CACHE_TTL_MAX end
     return math.floor(ttl)
 end
 
 local function resolve_ipv4s_uncached(name)
-    if test_resolver then return test_resolver(name) end
-
     local ok_lib, resolver_lib = pcall(require, "resty.dns.resolver")
     if not ok_lib or not resolver_lib then
         return nil, "resolver_module_unavailable:" .. tostring(resolver_lib)
     end
-    local nameservers = nameservers_from_env() or nameservers_from_resolv_conf()
-    if not nameservers then return nil, "no_proxy_dns_resolver" end
+    -- Resolver configuration is process-owned and read once per worker.
+    local servers, config_err = nameservers()
+    if not servers then return nil, config_err end
     local resolver, err = resolver_lib:new({
-        nameservers = nameservers,
+        nameservers = servers,
         retrans = 2,
         timeout = 2000,
     })
     if not resolver then return nil, "resolver_init_failed:" .. tostring(err) end
 
     local qname = name
-    local out, seen = {}, {}
+    local visited = {[name] = true}
     local min_ttl = CACHE_TTL_MAX
-    for _ = 1, 5 do
+    local hops = 0
+    while true do
         local answers, qerr = resolver:query(qname, {qtype = resolver.TYPE_A})
         if not answers then return nil, "dns_query_failed:" .. tostring(qerr) end
         if answers.errcode then return nil, "dns_rcode_" .. tostring(answers.errcode) end
 
-        local cname
-        for _, ans in ipairs(answers) do
-            if ans.address then
-                local ip = parse_ipv4(ans.address)
-                if ip and not seen[ip] then
-                    seen[ip] = true
-                    out[#out + 1] = ip
+        -- Accept only IN records owned by the queried name or its CNAME
+        -- chain. Unrelated answers must never authorize a destination.
+        while true do
+            local out, seen, cname = {}, {}, nil
+            for _, ans in ipairs(answers) do
+                if ans.section == 1 and ans.class == 1 and normalize_domain(ans.name) == qname then
+                    if ans.type == resolver.TYPE_A then
+                        local ip = parse_ipv4(ans.address)
+                        if not ip then return nil, "invalid_dns_address" end
+                        if not seen[ip] then out[#out + 1] = ip; seen[ip] = true end
+                        min_ttl = math.min(min_ttl, clamp_ttl(ans.ttl))
+                    elseif ans.type == resolver.TYPE_CNAME then
+                        local target = normalize_domain(ans.cname)
+                        if not target or (cname and cname ~= target) then
+                            return nil, "invalid_dns_cname"
+                        end
+                        cname = target
+                        min_ttl = math.min(min_ttl, clamp_ttl(ans.ttl))
+                    end
                 end
-                if ans.ttl then min_ttl = math.min(min_ttl, clamp_ttl(ans.ttl)) end
-            elseif ans.cname and not cname then
-                cname = normalize_domain(ans.cname)
-                if ans.ttl then min_ttl = math.min(min_ttl, clamp_ttl(ans.ttl)) end
             end
+            if #out > 0 then
+                if cname then return nil, "conflicting_dns_cname" end
+                return out, nil, min_ttl
+            end
+            if not cname then
+                if qname == name or visited[qname] == "queried" then
+                    return nil, "dns_no_a_records"
+                end
+                break
+            end
+            hops = hops + 1
+            if visited[cname] then return nil, "dns_cname_loop" end
+            if hops > MAX_CNAME_HOPS then return nil, "dns_cname_limit" end
+            visited[cname] = true
+            qname = cname
         end
-        if #out > 0 or not cname or cname == qname then break end
-        qname = cname
+        visited[qname] = "queried"
     end
-    return out, nil, clamp_ttl(min_ttl)
 end
 
-local function resolve_ipv4s(name)
+local function cached_ipv4s(name)
     local c = cache()
-    local list_key = "name:" .. name
+    local list_key = cache_prefix .. name
     if c then
         local cached = c:get(list_key)
         if cached and cached ~= "" then
@@ -166,13 +221,96 @@ local function resolve_ipv4s(name)
             return out
         end
     end
+end
 
-    local ips, err, ttl = resolve_ipv4s_uncached(name)
-    if not ips then return nil, err end
-    if c and #ips > 0 then
-        c:set(list_key, table.concat(ips, ","), ttl or CACHE_TTL_MIN)
+local function run_lookup(name, deadline)
+    -- The watchdog covers the entire CNAME chain, retries and TCP fallback,
+    -- not just one socket read. Cancelling the query releases its cosockets.
+    local started = ngx.now()
+    local query = ngx.thread.spawn(resolve_ipv4s_uncached, name)
+    local watchdog = ngx.thread.spawn(function()
+        ngx.sleep(math.max(0, deadline - ngx.now()))
+        return nil, "dns_deadline_exceeded"
+    end)
+    local ran, ips, err, ttl = ngx.thread.wait(query, watchdog)
+    ngx.thread.kill(query)
+    ngx.thread.kill(watchdog)
+    if not ran then ips, err = nil, "dns_query_exception" end
+
+    if ttl then ttl = math.max(0, ttl - (ngx.now() - started)) end
+    return ips, err, ttl
+end
+
+local function finish_lookup(name, pending, ips, err)
+    if inflight[name] ~= pending then return end
+    pending.ips, pending.err = ips, err
+    inflight[name] = nil
+    active_lookups = active_lookups - 1
+    if pending.waiters > 0 then pending.ready:post(pending.waiters) end
+end
+
+local function complete_lookup(premature, name, pending)
+    if inflight[name] ~= pending then return end
+    if premature or ngx.now() >= pending.deadline then
+        return finish_lookup(name, pending, nil, "dns_deadline_exceeded")
     end
-    return ips
+    local ran, ips, err, ttl
+    ran, ips, err, ttl = pcall(run_lookup, name, pending.deadline)
+    if not ran then ips, err = nil, "dns_query_exception" end
+    if inflight[name] ~= pending then return end
+    if ngx.now() >= pending.deadline then ips, err = nil, "dns_deadline_exceeded" end
+    local c = cache()
+    -- shared_dict uses millisecond expiry; a sub-millisecond TTL can round
+    -- down to its special "never expire" value.
+    if c and ips and #ips > 0 and ttl and ttl >= 0.001 then
+        c:set(cache_prefix .. name, table.concat(ips, ","), ttl)
+    end
+    finish_lookup(name, pending, ips, err)
+end
+
+local function resolve_ipv4s(name)
+    local servers, config_err = nameservers()
+    if not servers then return nil, config_err end
+    local cached = cached_ipv4s(name)
+    if cached then return cached end
+
+    -- A successfully registered timer can still be dropped if nginx cannot
+    -- allocate its fake connection. Reap independently of callback execution.
+    local now = ngx.now()
+    for key, item in pairs(inflight) do
+        if now >= item.deadline then
+            finish_lookup(key, item, nil, "dns_deadline_exceeded")
+        end
+    end
+
+    -- Timer ownership keeps shared work and slot cleanup alive even if the
+    -- initiating client disconnects. Results are retained only while in flight.
+    local pending = inflight[name]
+    if not pending then
+        if active_lookups >= MAX_INFLIGHT then return nil, "dns_concurrency_limit" end
+        local ready, sem_err = require("ngx.semaphore").new()
+        if not ready then return nil, "dns_semaphore_failed:" .. tostring(sem_err) end
+        pending = {ready = ready, waiters = 0, deadline = now + LOOKUP_TIMEOUT}
+        inflight[name] = pending
+        active_lookups = active_lookups + 1
+        local ok = ngx.timer.at(0, complete_lookup, name, pending)
+        if not ok then
+            inflight[name] = nil
+            active_lookups = active_lookups - 1
+            return nil, "dns_timer_unavailable"
+        end
+    end
+    if pending.waiters >= MAX_WAITERS then return nil, "dns_waiter_limit" end
+    pending.waiters = pending.waiters + 1
+    local ok = pending.ready:wait(math.max(0, pending.deadline - ngx.now()))
+    pending.waiters = pending.waiters - 1
+    if not ok then
+        if ngx.now() >= pending.deadline then
+            finish_lookup(name, pending, nil, "dns_deadline_exceeded")
+        end
+        return nil, "dns_deadline_exceeded"
+    end
+    return pending.ips, pending.err
 end
 
 local function list_contains(list, value)
@@ -186,7 +324,9 @@ local function verify_name(name, dst_ip)
     dst_ip = parse_ipv4(dst_ip)
     if not dst_ip then return false, "g5_missing_original_dst", {name = name} end
 
-    local literal = parse_ipv4(name)
+    local domain = normalize_domain(name)
+    if not domain then return false, "g5_missing_domain_identity", {name = name} end
+    local literal = parse_ipv4(domain)
     if literal then
         if literal == dst_ip then return true, nil, {name = name, ips = {literal}} end
         return false, "g5_ip_literal_mismatch", {
@@ -196,8 +336,6 @@ local function verify_name(name, dst_ip)
         }
     end
 
-    local domain = normalize_domain(name)
-    if not domain then return false, "g5_missing_domain_identity", {name = name} end
     local ips, err = resolve_ipv4s(domain)
     if not ips then
         return false, "g5_dns_resolve_failed", {
@@ -218,6 +356,15 @@ end
 
 function _M.verify_rule(match, ctx)
     if type(match) ~= "table" then return true end
+    -- HTTPS forwards SNI as Host and uses SNI for upstream verification.
+    -- A Host-constrained allow must authorize that same routing identity,
+    -- including on shared hosting where unrelated names resolve to one IP.
+    if ctx.scheme == "https" and match.host ~= nil then
+        local host, sni = normalize_domain(ctx.host), normalize_domain(ctx.sni)
+        if not host or not sni or host ~= sni then
+            return false, "g5_host_sni_mismatch", {host = ctx.host, sni = ctx.sni}
+        end
+    end
     local names = {}
     if match.host ~= nil then
         if not ctx.host or ctx.host == "" then
@@ -246,18 +393,6 @@ function _M.verify_rule(match, ctx)
         end
     end
     return true, nil, {checks = checked}
-end
-
-function _M._set_test_resolver(fn)
-    test_resolver = fn
-end
-
-function _M._parse_ipv4(s)
-    return parse_ipv4(s)
-end
-
-function _M._nameservers_from_resolv_conf(path)
-    return nameservers_from_resolv_conf(path)
 end
 
 return _M

--- a/CubeEgress/nginx.conf
+++ b/CubeEgress/nginx.conf
@@ -10,6 +10,7 @@ worker_rlimit_nofile 65535;
 
 env CUBE_EGRESS_BOOTSTRAP_URL;
 env CUBE_EGRESS_DEBUG_DUMP;
+env CUBE_EGRESS_DNS_RESOLVER_ADDRS;
 
 events {
     worker_connections 16384;
@@ -26,6 +27,7 @@ http {
     # 1000 sandboxes × 10 inject rules × 2048-byte secrets, plus JSON/slab overhead.
     lua_shared_dict policy_store 128m;
     lua_shared_dict meta_store 1m;
+    lua_shared_dict dns_auth_cache 16m;
     # ---- Lua ----
     lua_package_path "/usr/local/openresty/site/lualib/?.lua;/usr/local/openresty/nginx/lua/?.lua;;";
 

--- a/CubeEgress/tests/dns_auth_integration.py
+++ b/CubeEgress/tests/dns_auth_integration.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Exercise production access/audit/proxy locations with real DNS and TLS.
+
+Requires Docker, Python 3 and openssl on the host. No target environment is
+modified. Policy storage and certificate issuance are fixture adapters; packet
+steering is replaced by direct sockets preserving distinct destination IPs.
+"""
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import http.client
+import http.server
+import json
+import os
+from pathlib import Path
+import socket
+import socketserver
+import ssl
+import struct
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+
+
+def block(text, marker):
+    start = text.index(marker)
+    opening = text.index("{", start)
+    depth = 1
+    end = opening + 1
+    while depth:
+        depth += (text[end] == "{") - (text[end] == "}")
+        end += 1
+    return text[start:end]
+
+
+def fixture_config(source):
+    config = source.replace("user cube-proxy cube-proxy;", "user root;")
+    config = config.replace("worker_processes 2;", "worker_processes 1;")
+    config = config.replace("http {", "http {\n    lua_check_client_abort on;", 1)
+    config = config.replace("/var/run/openresty", "/tmp")
+    config = config.replace("/usr/local/openresty/nginx/lua/?.lua", "/fixture/?.lua;/repo/lua/?.lua")
+    config = config.replace("192.168.0.1:8080 transparent reuseport", "0.0.0.0:80")
+    config = config.replace("192.168.0.1:8443 ssl transparent reuseport", "0.0.0.0:443 ssl")
+    config = config.replace("http://$server_addr:$server_port", "http://$server_addr:18080")
+    config = config.replace("https://$server_addr:$server_port", "https://$server_addr:18443")
+    config = config.replace("/etc/cube/ca/placeholder.crt", "/fixture/cert.pem")
+    config = config.replace("/etc/cube/ca/placeholder.key", "/fixture/key.pem")
+    config = config.replace("/etc/ssl/certs/ca-certificates.crt", "/fixture/cert.pem")
+    config = config.replace(block(config, "init_by_lua_block"), '''init_by_lua_block {
+        audit = require("audit")
+        audit.bootstrap({file_path = "/tmp/audit.jsonl"})
+        package.preload["policy"] = function()
+            return {get = function()
+                return require("cjson.safe").decode(ngx.shared.policy_store:get("fixture") or "null")
+            end}
+        end
+    }''')
+    config = config.replace(block(config, "init_worker_by_lua_block"), '''init_worker_by_lua_block {
+        audit.init_worker()
+        ngx.shared.meta_store:set("bootstrap_status", "ready")
+    }''')
+    config = config.replace(block(config, "ssl_certificate_by_lua_block"), "")
+    config = config.replace('require("admin").dispatch()', '''ngx.req.read_body()
+                ngx.shared.policy_store:set("fixture", ngx.req.get_body_data())
+                ngx.say("ok")''')
+    return config
+
+
+def host_run(args):
+    repo = Path(__file__).resolve().parents[1]
+    name = "egress-dns-test-" + uuid.uuid4().hex[:10]
+    with tempfile.TemporaryDirectory(prefix="egress-dns-") as directory:
+        fixture = Path(directory)
+        fixture.chmod(0o755)
+        (fixture / "hosts").write_text("127.0.0.1 localhost\n127.0.0.3 allowed.example.test\n")
+        (fixture / "nginx.conf").write_text(fixture_config((repo / "nginx.conf").read_text()))
+        if args.baseline_ref:
+            old = subprocess.check_output(["git", "show", args.baseline_ref + ":CubeEgress/lua/access_phase.lua"], cwd=repo)
+            (fixture / "access_phase.lua").write_bytes(old)
+        subprocess.run(["openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+                        "-days", "1", "-subj", "/CN=allowed.example.test",
+                        "-addext", "subjectAltName=DNS:*.example.test",
+                        "-keyout", str(fixture / "key.pem"), "-out", str(fixture / "cert.pem")],
+                       check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        mount = ["-v", str(repo) + ":/repo:ro", "-v", directory + ":/fixture:ro"]
+        try:
+            subprocess.run(["docker", "run", "-d", "--name", name, *mount,
+                            "-e", "CUBE_EGRESS_DNS_RESOLVER_ADDRS=127.0.0.1:15353",
+                            args.openresty_image, "openresty", "-c", "/fixture/nginx.conf",
+                            "-g", "daemon off;"], check=True, stdout=subprocess.DEVNULL)
+            command = ["docker", "run", "--rm", "--network", "container:" + name, *mount,
+                       args.python_image, "python", "/repo/tests/dns_auth_integration.py", "--inside"]
+            if args.baseline_ref:
+                command += ["--baseline-ref", args.baseline_ref]
+            subprocess.run(command, check=True, timeout=120)
+            service_name = name + "-fixtures"
+            try:
+                subprocess.run(["docker", "run", "-d", "--name", service_name,
+                                "--network", "container:" + name, *mount,
+                                args.python_image, "python", "/repo/tests/dns_auth_integration.py",
+                                "--inside", "--serve-only"], check=True, stdout=subprocess.DEVNULL)
+                for _ in range(30):
+                    ready = subprocess.run(["docker", "exec", service_name, "test", "-f", "/tmp/ready"],
+                                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    if ready.returncode == 0:
+                        break
+                    time.sleep(0.1)
+                else:
+                    raise AssertionError("curl fixtures did not start")
+                for scheme, port in [("http", 80), ("https", 443)]:
+                    for method in ["hosts", "resolve"]:
+                        curl = ["docker", "run", "--rm", "--network", "container:" + name,
+                                "-v", str(fixture / "hosts") + ":/etc/hosts:ro", *mount,
+                                args.curl_image, "--silent", "--show-error", "--max-time", "10",
+                                "--noproxy", "*", "--cacert", "/fixture/cert.pem",
+                                "-o", "/dev/null", "-w", "%{http_code}"]
+                        if method == "resolve":
+                            curl += ["--resolve", "allowed.example.test:%d:127.0.0.3" % port]
+                        curl += [scheme + "://allowed.example.test/"]
+                        status = subprocess.check_output(curl, text=True).strip()
+                        expected = "200" if args.baseline_ref else "403"
+                        assert status == expected, (scheme, method, status)
+                        print("curl %s via container %s override: %s" % (scheme, method, status))
+            finally:
+                subprocess.run(["docker", "rm", "-f", service_name], check=False, stdout=subprocess.DEVNULL)
+            audit_text = subprocess.check_output(["docker", "exec", name, "cat", "/tmp/audit.jsonl"], text=True)
+            rows = [json.loads(line) for line in audit_text.splitlines()]
+            if not args.baseline_ref:
+                events = [r for r in rows if r.get("event") == "security_event"]
+                assert any(r.get("dns_auth") for r in events), "missing DNS security audit"
+                assert "fixture-secret" not in audit_text, "audit leaked injected value"
+                print("audit: PASS (structured records, DNS denial details, secret redaction)")
+            else:
+                print("baseline audit: structured records parsed")
+        except Exception:
+            subprocess.run(["docker", "logs", "--tail", "60", name], check=False)
+            raise
+        finally:
+            subprocess.run(["docker", "rm", "-f", name], check=False, stdout=subprocess.DEVNULL)
+
+
+def wire_name(name):
+    return b"".join(bytes([len(part)]) + part.encode("ascii") for part in name.split(".")) + b"\0"
+
+
+class DNS(socketserver.BaseRequestHandler):
+    records = {}
+    delays = {}
+    queries = []
+
+    def handle(self):
+        data, sock = self.request
+        offset, labels = 12, []
+        while data[offset]:
+            size = data[offset]
+            labels.append(data[offset + 1:offset + 1 + size].decode("ascii"))
+            offset += size + 1
+        name = ".".join(labels).lower()
+        self.queries.append(name)
+        time.sleep(self.delays.get(name, 0))
+        question = data[12:offset + 5]
+        records = self.records.get(name)
+        if records == "timeout":
+            return
+        rcode = 3 if records is None else 0
+        answers = []
+        for owner, kind, value, ttl in records or []:
+            payload = socket.inet_aton(value) if kind == 1 else wire_name(value)
+            answers.append(wire_name(owner) + struct.pack("!HHIH", kind, 1, ttl, len(payload)) + payload)
+        header = data[:2] + struct.pack("!HHHHH", 0x8180 | rcode, 1, len(answers), 0, 0)
+        sock.sendto(header + question + b"".join(answers), self.client_address)
+
+
+class Upstream(http.server.BaseHTTPRequestHandler):
+    hits = []
+
+    def do_GET(self):
+        self.hits.append((self.server.server_address, dict(self.headers)))
+        payload = json.dumps({"host": self.headers.get("Host"),
+                              "injected": self.headers.get("X-Test-Secret")}).encode()
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):
+        pass
+
+
+def inside_run(args):
+    dns = socketserver.ThreadingUDPServer(("127.0.0.1", 15353), DNS)
+    threading.Thread(target=dns.serve_forever, daemon=True).start()
+    cert = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    cert.load_cert_chain("/fixture/cert.pem", "/fixture/key.pem")
+    for ip in ["127.0.0.2", "127.0.0.3"]:
+        for port in [18080, 18443]:
+            server = http.server.ThreadingHTTPServer((ip, port), Upstream)
+            if port == 18443:
+                server.socket = cert.wrap_socket(server.socket, server_side=True)
+            threading.Thread(target=server.serve_forever, daemon=True).start()
+    client_tls = ssl.create_default_context(cafile="/fixture/cert.pem")
+
+    def policy(match, inject=False, allow=True):
+        action = {"allow": allow, "audit": "metadata"}
+        if inject:
+            action["inject"] = [{"header": "X-Test-Secret", "secret": "fixture-secret",
+                                 "secret_ref_synthetic": "test-fixture"}]
+        body = json.dumps({"policy_id": "integration", "rules": [
+            {"id": "tested", "match": match, "action": action},
+            {"id": "fallback", "match": {}, "action": {"allow": True}}]})
+        connection = http.client.HTTPConnection("127.0.0.1", 9091, timeout=5)
+        connection.request("PUT", "/admin/v1/policies/fixture", body, {"Content-Type": "application/json"})
+        assert connection.getresponse().status == 200
+        connection.close()
+
+    def request(label, ip="127.0.0.2", host="allowed.example.test", tls=False,
+                sni=None, expected=200, injected=None, quiet=False):
+        before = len(Upstream.hits)
+        sock = socket.create_connection((ip, 443 if tls else 80), timeout=15)
+        if tls:
+            sock = client_tls.wrap_socket(sock, server_hostname=sni or host)
+        sock.sendall(("GET / HTTP/1.1\r\nHost: " + host + "\r\nConnection: close\r\n\r\n").encode())
+        response = http.client.HTTPResponse(sock)
+        response.begin()
+        body = response.read()
+        assert response.status == expected, (label, response.status, expected, body)
+        if expected == 403:
+            assert len(Upstream.hits) == before, label + ": denied request reached upstream"
+        elif expected == 200:
+            assert json.loads(body)["injected"] == injected, (label, body)
+        sock.close()
+        if not quiet:
+            print(label + ": " + str(expected))
+
+    for _ in range(50):
+        try:
+            policy({"host": "*.example.test"})
+            break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        raise AssertionError("nginx did not start")
+
+    DNS.records["allowed.example.test"] = [("allowed.example.test", 1, "127.0.0.2", 30)]
+    if args.serve_only:
+        Path("/tmp/ready").touch()
+        threading.Event().wait()
+    bypass_status = 200 if args.baseline_ref else 403
+    request("normal HTTP")
+    request("forged HTTP destination", ip="127.0.0.3", expected=bypass_status)
+    request("normal HTTPS", tls=True)
+    request("forged HTTPS destination with valid certificate", tls=True, ip="127.0.0.3", expected=bypass_status)
+    request("Host-only HTTPS policy with other SNI on shared IP", tls=True,
+            sni="blocked.example.test", expected=bypass_status)
+    if args.baseline_ref:
+        print("BASELINE: HTTP and HTTPS bypass reproduced in socket fixture")
+        return
+
+    policy({"sni": "*.example.test", "scheme": "https"})
+    request("SNI-only normal", tls=True)
+    request("SNI-only forged destination", tls=True, ip="127.0.0.3", expected=403)
+    policy({"host": "*.example.test"}, inject=True)
+    request("HTTP credential injection", injected="fixture-secret")
+    request("HTTPS credential injection", tls=True, injected="fixture-secret")
+    request("deny before credential injection", ip="127.0.0.3", expected=403)
+    policy({"host": "*.example.test"})
+    DNS.records["alias.example.test"] = [("alias.example.test", 5, "target.example.test", 1),
+                                         ("target.example.test", 1, "127.0.0.2", 30)]
+    request("inline CNAME", host="alias.example.test")
+    DNS.records["alias.example.test"] = [("alias.example.test", 1, "127.0.0.3", 30)]
+    time.sleep(1.2)
+    request("CNAME TTL expiry", host="alias.example.test", expected=403)
+    DNS.records["zero.example.test"] = [("zero.example.test", 1, "127.0.0.2", 0)]
+    request("TTL zero first answer", host="zero.example.test")
+    DNS.records["zero.example.test"] = [("zero.example.test", 1, "127.0.0.3", 0)]
+    request("TTL zero refreshed", host="zero.example.test", expected=403)
+    DNS.records["poison.example.test"] = [("unrelated.example.test", 1, "127.0.0.2", 30)]
+    request("unrelated DNS owner", host="poison.example.test", expected=403)
+    request("NXDOMAIN", host="missing.example.test", expected=403)
+    DNS.records["timeout.example.test"] = "timeout"
+    request("DNS timeout", host="timeout.example.test", expected=403)
+
+    DNS.records["parallel.example.test"] = [("parallel.example.test", 1, "127.0.0.2", 0)]
+    DNS.delays["parallel.example.test"] = 0.5
+    with ThreadPoolExecutor(max_workers=32) as pool:
+        list(pool.map(lambda _: request("coalesced", host="parallel.example.test", quiet=True), range(32)))
+    assert DNS.queries.count("parallel.example.test") == 1, DNS.queries
+    print("32 overlapping TTL-zero requests: one DNS query")
+
+    DNS.delays["parallel-failure.example.test"] = 0.5
+    with ThreadPoolExecutor(max_workers=32) as pool:
+        list(pool.map(lambda _: request("coalesced failure", host="parallel-failure.example.test",
+                                       expected=403, quiet=True), range(32)))
+    assert DNS.queries.count("parallel-failure.example.test") == 1
+    print("32 overlapping NXDOMAIN requests: one DNS query, all denied")
+
+    DNS.records["abort.example.test"] = [("abort.example.test", 1, "127.0.0.2", 0)]
+    DNS.delays["abort.example.test"] = 0.5
+    abandoned = socket.create_connection(("127.0.0.2", 80))
+    abandoned.sendall(b"GET / HTTP/1.1\r\nHost: abort.example.test\r\n\r\n")
+    time.sleep(0.1)
+    abandoned.close()
+    request("initiating client disconnected", host="abort.example.test")
+    assert DNS.queries.count("abort.example.test") == 1
+
+    names = ["cap" + str(i) + ".example.test" for i in range(40)]
+    for name in names:
+        DNS.records[name] = "timeout"
+    with ThreadPoolExecutor(max_workers=40) as pool:
+        list(pool.map(lambda name: request("bounded", host=name, expected=403, quiet=True), names))
+    queried_names = set(DNS.queries).intersection(names)
+    assert len(queried_names) <= 16, len(queried_names)
+    print("40 distinct concurrent misses: at most 16 active names per worker, all denied")
+
+    for i in range(7):
+        name = "slow" + str(i) + ".example.test"
+        DNS.records[name] = [(name, 5, "slow" + str(i + 1) + ".example.test", 30)]
+        DNS.delays[name] = 1.2
+    started = time.monotonic()
+    request("total CNAME deadline", host="slow0.example.test", expected=403)
+    elapsed = time.monotonic() - started
+    assert 4.5 <= elapsed < 6.5, elapsed
+    print("whole-chain timeout: %.2fs (5s budget)" % elapsed)
+    DNS.records["recovery.example.test"] = [("recovery.example.test", 1, "127.0.0.2", 30)]
+    request("DNS slots recovered after timeout", host="recovery.example.test")
+    policy({"host": "127.0.0.2"})
+    request("IP literal", host="127.0.0.2")
+    request("forged IP literal", host="127.0.0.2", ip="127.0.0.3", expected=403)
+    policy({"host": "*.example.test"}, allow=False)
+    request("explicit deny takes precedence", expected=403)
+    policy({})
+    request("unconstrained rule retains behavior", ip="127.0.0.3")
+    print("FIXED: all integration cases passed; every 403 left upstream hit count unchanged")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inside", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--serve-only", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--baseline-ref", help="reproduce using an older access_phase.lua git ref")
+    parser.add_argument("--openresty-image", default=os.environ.get("OPENRESTY_TEST_IMAGE", "openresty/openresty:alpine"))
+    parser.add_argument("--python-image", default=os.environ.get("PYTHON_TEST_IMAGE", "python:3.12-alpine"))
+    parser.add_argument("--curl-image", default=os.environ.get("CURL_TEST_IMAGE", "curlimages/curl:8.16.0"))
+    arguments = parser.parse_args()
+    if arguments.inside:
+        inside_run(arguments)
+    else:
+        host_run(arguments)

--- a/CubeEgress/tests/dns_auth_test.lua
+++ b/CubeEgress/tests/dns_auth_test.lua
@@ -1,0 +1,83 @@
+package.path = "lua/?.lua;" .. package.path
+
+local dns_auth = require "dns_auth"
+
+local function assert_true(value, message)
+    if not value then error(message or "expected true") end
+end
+
+local function assert_false(value, message)
+    if value then error(message or "expected false") end
+end
+
+local function assert_eq(got, want, message)
+    if got ~= want then
+        error((message or "unexpected value") .. ": got=" .. tostring(got) .. " want=" .. tostring(want))
+    end
+end
+
+local records = {
+    ["bypass.blob.core.windows.net"] = {"20.42.1.7"},
+    ["api.example.com"] = {"198.51.100.9"},
+    ["sni.example.com"] = {"198.51.100.10"},
+}
+
+dns_auth._set_test_resolver(function(name)
+    local ips = records[name]
+    if not ips then return nil, "test_nxdomain" end
+    return ips, nil, 30
+end)
+
+local ok, reason = dns_auth.verify_rule(
+    {host = "*.blob.core.windows.net", scheme = "http"},
+    {
+        host = "bypass.blob.core.windows.net",
+        dst_ip = "203.0.113.66",
+    })
+assert_false(ok, "forged HTTP Host should not authorize an unrelated original dst")
+assert_eq(reason, "g5_dst_ip_not_in_dns")
+
+ok, reason = dns_auth.verify_rule(
+    {host = "*.blob.core.windows.net", scheme = "http"},
+    {
+        host = "bypass.blob.core.windows.net",
+        dst_ip = "20.42.1.7",
+    })
+assert_true(ok, reason)
+
+ok, reason = dns_auth.verify_rule(
+    {sni = "*.example.com", scheme = "https"},
+    {
+        sni = "sni.example.com",
+        dst_ip = "203.0.113.66",
+    })
+assert_false(ok, "forged TLS SNI should not authorize an unrelated original dst")
+assert_eq(reason, "g5_dst_ip_not_in_dns")
+
+ok, reason = dns_auth.verify_rule(
+    {host = "api.example.com", sni = "api.example.com", scheme = "https"},
+    {
+        host = "api.example.com",
+        sni = "api.example.com",
+        dst_ip = "198.51.100.9",
+    })
+assert_true(ok, reason)
+
+ok, reason = dns_auth.verify_rule(
+    {host = "198.51.100.20", scheme = "http"},
+    {
+        host = "198.51.100.20",
+        dst_ip = "198.51.100.21",
+    })
+assert_false(ok, "IP-literal Host must match the original destination exactly")
+assert_eq(reason, "g5_ip_literal_mismatch")
+
+ok, reason = dns_auth.verify_rule(
+    {method = {"GET"}, scheme = "http"},
+    {
+        host = "anything.example.com",
+        dst_ip = "203.0.113.66",
+    })
+assert_true(ok, reason)
+
+print("dns_auth_test: PASS")

--- a/CubeEgress/tests/dns_auth_test.lua
+++ b/CubeEgress/tests/dns_auth_test.lua
@@ -1,83 +1,157 @@
 package.path = "lua/?.lua;" .. package.path
 
+local records, queries, entries, clock = {}, {}, {}, 0
+local query_delays = {}
+ngx = {shared = {dns_auth_cache = {
+    get = function(_, key)
+        local item = entries[key]
+        if item and item.expires > clock then return item.value end
+    end,
+    set = function(_, key, value, ttl)
+        assert(ttl > 0, "zero TTL must never become an immortal cache entry")
+        entries[key] = {value = value, expires = clock + ttl}
+    end,
+}}}
+-- Deterministic scheduling for response-parser tests; actual scheduling and
+-- concurrent lookup limits are exercised by dns_auth_integration.py.
+ngx.now = function() return clock end
+ngx.sleep = function() end
+ngx.thread = {
+    spawn = function(fn, ...) return {pcall(fn, ...)} end,
+    wait = function(thread) return unpack(thread, 1, 4) end,
+    kill = function() end,
+}
+local scheduled, dropped, drop_timer
+ngx.timer = {at = function(_, fn, ...)
+    if drop_timer then dropped = {fn, ...}; return true end
+    scheduled = {fn, ...}
+    return true
+end}
+package.loaded["ngx.semaphore"] = {new = function() return {
+    post = function() end,
+    wait = function()
+        if not scheduled then clock = clock + 5; return false end
+        if dropped then
+            local old = dropped
+            dropped = nil
+            old[1](false, unpack(old, 2))
+        end
+        local job = scheduled
+        scheduled = nil
+        job[1](false, unpack(job, 2))
+        return true
+    end,
+} end}
+package.loaded["resty.dns.resolver"] = {
+    new = function(_, opts)
+        assert(#opts.nameservers > 0)
+        return {TYPE_A = 1, TYPE_CNAME = 5, query = function(_, name)
+            queries[#queries + 1] = name
+            clock = clock + (query_delays[name] or 0)
+            local response = records[name]
+            if response == "timeout" then return nil, "timeout" end
+            return response or {errcode = 3}
+        end}
+    end,
+}
 local dns_auth = require "dns_auth"
-
-local function assert_true(value, message)
-    if not value then error(message or "expected true") end
-end
-
-local function assert_false(value, message)
-    if value then error(message or "expected false") end
-end
-
-local function assert_eq(got, want, message)
-    if got ~= want then
-        error((message or "unexpected value") .. ": got=" .. tostring(got) .. " want=" .. tostring(want))
+local function entry(name)
+    for key, value in pairs(entries) do
+        if string.sub(key, -#name - 1) == ":" .. name then return value end
     end
 end
+local function a(name, ip, ttl)
+    return {name = name, address = ip, ttl = ttl or 30, class = 1, type = 1, section = 1}
+end
+local function cname(name, target, ttl)
+    return {name = name, cname = target, ttl = ttl or 30, class = 1, type = 5, section = 1}
+end
+local function verify(name, ip, expected, reason, match, ctx)
+    ctx = ctx or {host = name, dst_ip = ip, scheme = "http"}
+    local ok, why = dns_auth.verify_rule(match or {host = "*.example.com"}, ctx)
+    assert(ok == expected, name .. ": " .. tostring(why))
+    if reason then assert(why == reason, tostring(why)) end
+end
 
-local records = {
-    ["bypass.blob.core.windows.net"] = {"20.42.1.7"},
-    ["api.example.com"] = {"198.51.100.9"},
-    ["sni.example.com"] = {"198.51.100.10"},
-}
+records["allowed.example.com"] = {a("allowed.example.com", "198.51.100.9"),
+    a("allowed.example.com", "198.51.100.10")}
+verify("allowed.example.com", "203.0.113.66", false, "g5_dst_ip_not_in_dns")
+verify("ALLOWED.EXAMPLE.COM.", "198.51.100.10", true)
+verify("198.51.100.9", "198.51.100.9", true)
+verify("198.51.100.9", "198.51.100.10", false, "g5_ip_literal_mismatch")
+verify("missing.example.com", "198.51.100.9", false, "g5_dns_resolve_failed")
+records["timeout.example.com"] = "timeout"
+verify("timeout.example.com", "198.51.100.9", false, "g5_dns_resolve_failed")
+verify("bad..example.com", "198.51.100.9", false, "g5_missing_domain_identity")
+verify("allowed.example.com", "::1", false, "g5_missing_original_dst")
 
-dns_auth._set_test_resolver(function(name)
-    local ips = records[name]
-    if not ips then return nil, "test_nxdomain" end
-    return ips, nil, 30
-end)
+records["poison.example.com"] = {a("unrelated.example.com", "203.0.113.66")}
+verify("poison.example.com", "203.0.113.66", false, "g5_dns_resolve_failed")
+local additional = a("additional.example.com", "203.0.113.66")
+additional.section = 3
+records["additional.example.com"] = {additional}
+verify("additional.example.com", "203.0.113.66", false, "g5_dns_resolve_failed")
+records["alias.example.com"] = {cname("alias.example.com", "target.example.net", 2),
+    a("target.example.net", "198.51.100.9"), a("unrelated.example.com", "203.0.113.66")}
+verify("alias.example.com", "203.0.113.66", false, "g5_dst_ip_not_in_dns")
+verify("alias.example.com", "198.51.100.9", true)
+assert(entry("alias.example.com").expires == 2)
+clock = 3
+records["alias.example.com"] = {a("alias.example.com", "198.51.100.10")}
+verify("alias.example.com", "198.51.100.9", false, "g5_dst_ip_not_in_dns")
 
-local ok, reason = dns_auth.verify_rule(
-    {host = "*.blob.core.windows.net", scheme = "http"},
-    {
-        host = "bypass.blob.core.windows.net",
-        dst_ip = "203.0.113.66",
-    })
-assert_false(ok, "forged HTTP Host should not authorize an unrelated original dst")
-assert_eq(reason, "g5_dst_ip_not_in_dns")
+records["split.example.com"] = {cname("split.example.com", "target.example.net")}
+records["target.example.net"] = {a("target.example.net", "198.51.100.9")}
+verify("split.example.com", "198.51.100.9", true)
+assert(queries[#queries] == "target.example.net")
+records["loop.example.com"] = {cname("loop.example.com", "loop.example.com")}
+verify("loop.example.com", "198.51.100.9", false, "g5_dns_resolve_failed")
+for i = 1, 7 do
+    records["hop" .. i .. ".example.com"] = {
+        cname("hop" .. i .. ".example.com", "hop" .. (i + 1) .. ".example.com")}
+end
+verify("hop1.example.com", "198.51.100.9", false, "g5_dns_resolve_failed")
+records["zero.example.com"] = {a("zero.example.com", "198.51.100.9", 0)}
+verify("zero.example.com", "198.51.100.9", true)
+assert(entry("zero.example.com") == nil)
+records["zero.example.com"] = {a("zero.example.com", "198.51.100.10", 0)}
+verify("zero.example.com", "198.51.100.9", false, "g5_dst_ip_not_in_dns")
+records["tiny.example.com"] = {a("tiny.example.com", "198.51.100.9", 1)}
+query_delays["tiny.example.com"] = 0.9999
+verify("tiny.example.com", "198.51.100.9", true)
+assert(entry("tiny.example.com") == nil, "sub-millisecond TTL must not become permanent")
 
-ok, reason = dns_auth.verify_rule(
-    {host = "*.blob.core.windows.net", scheme = "http"},
-    {
-        host = "bypass.blob.core.windows.net",
-        dst_ip = "20.42.1.7",
-    })
-assert_true(ok, reason)
+verify("allowed.example.com", nil, false, "g5_host_sni_mismatch", {host = "allowed.example.com"},
+    {host = "allowed.example.com", sni = "blocked.example.com", dst_ip = "198.51.100.9", scheme = "https"})
+verify("allowed.example.com", nil, true, nil, {host = "allowed.example.com"},
+    {host = "allowed.example.com", sni = "ALLOWED.EXAMPLE.COM", dst_ip = "198.51.100.9", scheme = "https"})
+verify("allowed.example.com", nil, false, "g5_dst_ip_not_in_dns", {sni = "*.example.com"},
+    {sni = "allowed.example.com", dst_ip = "203.0.113.66", scheme = "https"})
+verify("anything.example.com", "203.0.113.66", true, nil, {})
 
-ok, reason = dns_auth.verify_rule(
-    {sni = "*.example.com", scheme = "https"},
-    {
-        sni = "sni.example.com",
-        dst_ip = "203.0.113.66",
-    })
-assert_false(ok, "forged TLS SNI should not authorize an unrelated original dst")
-assert_eq(reason, "g5_dst_ip_not_in_dns")
+drop_timer = true
+for i = 1, 20 do
+    verify("dropped" .. i .. ".example.com", "198.51.100.9", false, "g5_dns_resolve_failed")
+end
+drop_timer = false
+records["dropped20.example.com"] = {a("dropped20.example.com", "198.51.100.9")}
+verify("dropped20.example.com", "198.51.100.9", true)
 
-ok, reason = dns_auth.verify_rule(
-    {host = "api.example.com", sni = "api.example.com", scheme = "https"},
-    {
-        host = "api.example.com",
-        sni = "api.example.com",
-        dst_ip = "198.51.100.9",
-    })
-assert_true(ok, reason)
-
-ok, reason = dns_auth.verify_rule(
-    {host = "198.51.100.20", scheme = "http"},
-    {
-        host = "198.51.100.20",
-        dst_ip = "198.51.100.21",
-    })
-assert_false(ok, "IP-literal Host must match the original destination exactly")
-assert_eq(reason, "g5_ip_literal_mismatch")
-
-ok, reason = dns_auth.verify_rule(
-    {method = {"GET"}, scheme = "http"},
-    {
-        host = "anything.example.com",
-        dst_ip = "203.0.113.66",
-    })
-assert_true(ok, reason)
-
-print("dns_auth_test: PASS")
+local original_getenv = os.getenv
+os.getenv = function(key)
+    if key == "CUBE_EGRESS_DNS_RESOLVER_ADDRS" then return "invalid-resolver" end
+    return original_getenv(key)
+end
+package.loaded.dns_auth = nil
+dns_auth = require "dns_auth"
+verify("allowed.example.com", "198.51.100.9", false, "g5_dns_resolve_failed")
+os.getenv = function(key)
+    if key == "CUBE_EGRESS_DNS_RESOLVER_ADDRS" then return "127.0.0.9:5300" end
+    return original_getenv(key)
+end
+package.loaded.dns_auth = nil
+dns_auth = require "dns_auth"
+records["allowed.example.com"] = {a("allowed.example.com", "203.0.113.66")}
+verify("allowed.example.com", "198.51.100.9", false, "g5_dst_ip_not_in_dns")
+os.getenv = original_getenv
+print("dns_auth_test: PASS (resolver responses, CNAME ownership, expiry, failure and routing boundaries)")

--- a/docs/guide/security-proxy.md
+++ b/docs/guide/security-proxy.md
@@ -123,10 +123,57 @@ remains an additional upstream authenticity check, not the only guard.
 DNS-auth failures return 403 and write a `security_event` reason such as
 `g5_dst_ip_not_in_dns` with `dns_auth` details in the audit record.
 
+This check applies to traffic steered into CubeEgress. CubeVS first classifies
+the original IP/port: traffic rejected there never reaches this check, and
+ordinary SNAT flows do not enter the L7 proxy.
+
 By default CubeEgress reads resolver addresses from its own
 `/etc/resolv.conf`. Operators can override them with
 `CUBE_EGRESS_DNS_RESOLVER_ADDRS` (comma or whitespace separated IPv4
 addresses, optionally with `:port`).
+
+Use trusted resolvers reachable from the proxy container, with the same DNS
+view as the sandbox. An invalid explicit resolver setting fails closed; reload
+workers after changing resolver configuration. Resolution uses asynchronous
+OpenResty cosockets, not a shell process, guest `/etc/hosts`, NSS or DNS search
+suffixes. The current data plane and this check support IPv4 only.
+
+Only A records owned by the queried name or its validated CNAME chain are
+accepted. Chains are limited to five aliases and the whole lookup to five
+seconds. Each worker permits at most 16 active DNS lookups and shares an active
+lookup among at most 256 overlapping requests for the same name. A timer owns
+the lookup so client disconnection cannot strand its slot. Positive results are
+cached across workers for the shortest A/CNAME TTL, capped at 300 seconds with
+lookup time deducted; zero-TTL results are not cached. Cache hits do not issue
+DNS queries. Failures and saturation return 403; they never fall through to a
+later allow rule. In-flight coalescing is per worker, so simultaneous cold
+misses in different workers can still issue one query each.
+
+For HTTPS rules constrained by `host`, Host and SNI must also name the same
+domain (`g5_host_sni_mismatch` otherwise). This applies even without credential
+injection: the HTTPS proxy uses SNI for both upstream TLS and its forwarded
+Host header. SNI-only rules continue to authorize that upstream identity.
+Rules with neither `host` nor `sni` retain their existing behavior.
+
+The proxy keeps the original destination IP and port. Replacing them with a
+newly resolved address would require reapplying the destination's L4/CIDR
+policy. This choice can reject legitimate CDN or split-DNS requests when guest
+and proxy receive different address sets, including during DNS rotation.
+DNS membership is not a certificate, tenant-ownership or private-IP check:
+shared hosting and attacker-controlled domains inside an allowed wildcard
+remain within that wildcard's authority. Keep upstream TLS verification and
+the appropriate destination restrictions enabled.
+
+Run `make -C CubeEgress test-lua` and `make -C CubeEgress test-dns-integration`
+for repository verification. The integration suite requires Docker, Python 3
+and host `openssl`; override image sources with `OPENRESTY_TEST_IMAGE`,
+`PYTHON_TEST_IMAGE` and `CURL_TEST_IMAGE`. It exercises production access/audit
+modules and proxy locations with real DNS, TLS, curl `/etc/hosts` and
+`--resolve` overrides, TTL and concurrency checks. Policy storage and
+certificate issuance are fixtures; direct sockets replace TPROXY and backends
+use different ports. It does not verify a deployed guest, CubeVS/eBPF
+interception or the patched production image. Reproduce the old behavior with
+`python3 CubeEgress/tests/dns_auth_integration.py --baseline-ref <pre-fix-ref>`.
 
 ### Custom L7 ports
 

--- a/docs/guide/security-proxy.md
+++ b/docs/guide/security-proxy.md
@@ -105,6 +105,29 @@ Match fields (all optional, AND'd together):
 A request must match every present field; absent fields are
 wildcarded.
 
+Before an allow rule with `host` or `sni` is proxied, CubeEgress
+resolves the presented identity from the proxy side and verifies that
+the transparent proxy's original destination IP is one of the DNS A
+records for that identity. This blocks forged-name flows such as:
+
+```bash
+curl --resolve bypass.blob.core.windows.net:80:203.0.113.66 \
+  http://bypass.blob.core.windows.net/
+```
+
+Even if a policy allows `*.blob.core.windows.net`, the request above is
+denied unless proxy-side DNS for `bypass.blob.core.windows.net` returns
+`203.0.113.66`. The same check runs for TLS SNI based allow rules before
+the upstream connection is attempted; HTTPS certificate verification
+remains an additional upstream authenticity check, not the only guard.
+DNS-auth failures return 403 and write a `security_event` reason such as
+`g5_dst_ip_not_in_dns` with `dns_auth` details in the audit record.
+
+By default CubeEgress reads resolver addresses from its own
+`/etc/resolv.conf`. Operators can override them with
+`CUBE_EGRESS_DNS_RESOLVER_ADDRS` (comma or whitespace separated IPv4
+addresses, optionally with `:port`).
+
 ### Custom L7 ports
 
 By default a rule intercepts the classic `{80/http, 443/https}`

--- a/docs/zh/guide/security-proxy.md
+++ b/docs/zh/guide/security-proxy.md
@@ -93,6 +93,27 @@ with Sandbox.create(network={"rules": rules}) as sb:
 
 请求要同时满足所有出现的字段；未出现的字段视作通配。
 
+带 `host` 或 `sni` 的 allow 规则在真正转发前，还会由 CubeEgress 在
+代理侧解析请求中呈现的域名，并校验透明代理拿到的原始目的 IP 是否
+属于该域名的 DNS A 记录。这样可以阻断伪造域名的流量，例如：
+
+```bash
+curl --resolve bypass.blob.core.windows.net:80:203.0.113.66 \
+  http://bypass.blob.core.windows.net/
+```
+
+即使策略放行 `*.blob.core.windows.net`，只要代理侧 DNS 解析
+`bypass.blob.core.windows.net` 时没有返回 `203.0.113.66`，该请求
+就会被 403 拒绝。同样的校验也作用于基于 TLS SNI 的 allow 规则，
+并且发生在连接上游之前；HTTPS 的证书校验仍然保留，但只是额外的
+上游真实性检查，不再是唯一兜底。DNS 绑定失败会写入
+`security_event`，reason 例如 `g5_dst_ip_not_in_dns`，审计记录中
+也会包含 `dns_auth` 细节。
+
+默认情况下，CubeEgress 使用代理容器自己的 `/etc/resolv.conf`
+发现 resolver。运维侧也可以通过 `CUBE_EGRESS_DNS_RESOLVER_ADDRS`
+显式指定，格式为逗号或空白分隔的 IPv4 地址，可选 `:port`。
+
 ### 自定义 L7 端口
 
 默认情况下，一条规则拦截经典的 `{80/http, 443/https}` 集合。可选

--- a/docs/zh/guide/security-proxy.md
+++ b/docs/zh/guide/security-proxy.md
@@ -110,9 +110,47 @@ curl --resolve bypass.blob.core.windows.net:80:203.0.113.66 \
 `security_event`，reason 例如 `g5_dst_ip_not_in_dns`，审计记录中
 也会包含 `dns_auth` 细节。
 
+此校验作用于已被导入 CubeEgress 的流量。CubeVS 先按原始 IP/端口
+分类，被其拒绝的连接不会到达此处，普通 SNAT 流量也不进入 L7 代理。
+
 默认情况下，CubeEgress 使用代理容器自己的 `/etc/resolv.conf`
 发现 resolver。运维侧也可以通过 `CUBE_EGRESS_DNS_RESOLVER_ADDRS`
 显式指定，格式为逗号或空白分隔的 IPv4 地址，可选 `:port`。
+
+resolver 必须由运维控制、在代理容器中可达，并与 sandbox 使用一致的
+DNS 视图。显式配置非法时拒绝请求；修改配置后需重载 worker。解析使用
+OpenResty cosocket 异步完成，不启动 shell，也不使用 guest 的
+`/etc/hosts`、NSS 或 DNS search suffix。目前数据平面与此校验只支持 IPv4。
+
+仅接受查询域名或其合法 CNAME 链所属的 A 记录，最多跟随 5 个别名，
+整个解析操作限时 5 秒。每个 worker 最多同时执行 16 个解析，相同域名
+的重叠请求（最多 256 个）共享一次解析，包括失败和 TTL=0 的结果。
+解析由 timer 持有，客户端断开不会导致解析槽无法释放。成功结果在 worker
+间共享缓存，采用 A/CNAME 链最短 TTL，上限 300 秒并扣除解析耗时；
+TTL=0 不缓存。缓存命中不发 DNS 请求。解析失败或并发容量耗尽均返回
+403，不继续匹配后面的 allow 规则。同域并发合并限于单个 worker，
+不同 worker 同时发生冷缓存未命中时仍可能各发起一次查询。
+
+HTTPS 规则只要包含 `host` 约束，就要求 Host 与 SNI 指向同一域名，
+否则以 `g5_host_sni_mismatch` 拒绝，即使该规则不注入凭据也一样。
+这是因为 HTTPS 上游 TLS 和转发的 Host 都使用 SNI。只约束 SNI 的规则
+仍以此上游身份授权；不含 `host` 或 `sni` 的规则保持原有行为。
+
+代理保留原始目的 IP 和端口，不将其替换为新解析出来的地址，否则必须
+重新执行新目的地的 L4/CIDR 策略。因此，CDN、分区 DNS 或 DNS 轮换时，
+guest 与代理获取不同 IP 集合可能导致正常请求被拒绝。DNS 归属不是
+证书、租户归属或私网 IP 校验：共享 IP、放行通配符范围内的攻击者可控
+子域名仍属于该通配符的授权范围，应保留上游 TLS 验证及相应目的地限制。
+
+仓库验证入口为 `make -C CubeEgress test-lua` 和
+`make -C CubeEgress test-dns-integration`。集成测试需要 Docker、
+Python 3 和宿主机 `openssl`，可通过 `OPENRESTY_TEST_IMAGE`、
+`PYTHON_TEST_IMAGE`、`CURL_TEST_IMAGE` 选择镜像来源。测试运行真实的
+access/audit 模块与代理 location，覆盖 DNS、TLS、curl 的
+`/etc/hosts` 和 `--resolve` 覆盖、TTL 与并发边界。策略存储和证书签发
+使用测试适配，直接 socket 代替 TPROXY，上游使用不同测试端口；因此
+不代表真实 guest、CubeVS/eBPF 拦截或生产补丁镜像验证完成。
+旧行为可通过 `python3 CubeEgress/tests/dns_auth_integration.py --baseline-ref <修复前提交>` 复现。
 
 ### 自定义 L7 端口
 


### PR DESCRIPTION
CubeEgress previously matched only the presented Host/SNI before forwarding to the original destination. For traffic reaching the L7 proxy, client hosts or `curl --resolve` overrides could therefore authorize an unrelated IP. Host-only HTTPS rules could also match one Host while forwarding another SNI on a shared IP.

Bind domain-constrained allow rules to trusted proxy-side DNS A records before connecting upstream or injecting credentials. Validate answer owner/class/section and CNAME chains; require HTTPS Host constraints to agree with SNI. Preserve the original IP/port and behavior for rules without domain constraints.

Asynchronous lookups have a five-second whole-operation deadline, five-alias limit, 16 active lookups per worker, and up to 256 coalesced same-name waiters. Shared positive caching uses the shortest A/CNAME TTL with a 300-second cap and elapsed lookup time deducted; zero and sub-millisecond TTLs are not cached. Timer-owned work and independent deadline cleanup handle client disconnects and callbacks dropped under resource pressure. Cache keys distinguish resolver configurations.

## Validation

- Lua port/scheme and DNS suites, Lua bytecode compilation, and `git diff --check` passed.
- Real curl HTTP/HTTPS with container `/etc/hosts` and `--resolve` overrides: all four forged-destination cases returned 200 on baseline `62da0187`, and 403 with the fix. Normal HTTP/HTTPS requests returned 200.
- Real DNS/OpenResty/TLS fixture tests cover injection, redacted audit, Host/SNI mismatch, CNAME ownership and expiry, TTL zero, NXDOMAIN, timeouts, IP literals, and explicit deny precedence. Denied requests did not increase upstream hit counts.
- 32 overlapping TTL-zero requests used one DNS query; 32 NXDOMAIN requests also used one query. Forty distinct concurrent misses used at most 16 active names. A slow CNAME chain was denied at approximately 5.02 seconds, with subsequent recovery. Initiator disconnection, dropped timers, late callbacks, and sub-millisecond TTLs have regression coverage.

Run `make -C CubeEgress test-lua` and `make -C CubeEgress test-dns-integration`. Reproduce the baseline with `python3 CubeEgress/tests/dns_auth_integration.py --baseline-ref 62da0187`.

## Scope and limitations

The container harness uses production access/audit modules and proxy locations, but fixture policy storage, static test certificates, direct sockets instead of TPROXY, and separate backend ports. It does not verify a deployed CubeSandbox guest, CubeVS/eBPF interception, or the patched production image. Test OpenResty is 1.31.1.1; the production base is 1.29.2.5 and was not rebuilt here.

CDN/split-DNS views and rotation may reject legitimate destinations. DNS membership does not establish tenant ownership or replace private-IP policy and TLS verification. IPv4 only; positive cache is shared across workers, while in-flight coalescing is per worker. English and Chinese guides document these boundaries.