### PR TITLE
fix(templatecenter): invalidate alias mutation caches on alias write

### DIFF
--- a/CubeMaster/pkg/templatecenter/cache.go
+++ b/CubeMaster/pkg/templatecenter/cache.go
@@ -227,6 +227,17 @@ func invalidateTemplateCaches(templateID string) {
 	localcache.InvalidateImageState(templateID)
 }
 
+// invalidateTemplateAliasMutationCaches clears the query/runtime caches for an
+// alias write. Alias transfers mutate two definitions (the new holder and the
+// displaced holder), so both IDs must be invalidated after the DB transaction
+// commits; otherwise detail/list reads can keep serving the previous alias.
+func invalidateTemplateAliasMutationCaches(templateID, displacedTemplateID string) {
+	invalidateTemplateCaches(templateID)
+	if displacedTemplateID != "" && displacedTemplateID != templateID {
+		invalidateTemplateCaches(displacedTemplateID)
+	}
+}
+
 // invalidateTemplateListCache drops the aggregate list cache only. Used by
 // write paths that do not have a specific templateID in scope but still
 // mutate the list (e.g. GC deleting orphaned definitions).

--- a/CubeMaster/pkg/templatecenter/cache_query_test.go
+++ b/CubeMaster/pkg/templatecenter/cache_query_test.go
@@ -202,3 +202,50 @@ func TestInvalidateTemplateCachesClearsListAndInfo(t *testing.T) {
 		t.Fatalf("expected info cache cleared by invalidateTemplateCaches")
 	}
 }
+
+func TestInvalidateTemplateAliasMutationCachesClearsTargetAndDisplaced(t *testing.T) {
+	templateListCache.Flush()
+	templateInfoCache.Flush()
+
+	setTemplateListCache([]TemplateInfo{
+		{TemplateID: "tpl-new", DisplayName: "alias"},
+		{TemplateID: "tpl-old", DisplayName: "alias"},
+	})
+	setTemplateInfoCache("tpl-new", &TemplateInfo{TemplateID: "tpl-new", DisplayName: "alias"})
+	setTemplateInfoCache("tpl-old", &TemplateInfo{TemplateID: "tpl-old", DisplayName: "alias"})
+
+	invalidateTemplateAliasMutationCaches("tpl-new", "tpl-old")
+
+	for _, templateID := range []string{"tpl-new", "tpl-old"} {
+		if _, ok := getCachedTemplateInfo(templateID); ok {
+			t.Fatalf("expected info cache cleared for %s", templateID)
+		}
+	}
+	if _, ok := getCachedTemplateList(); ok {
+		t.Fatalf("expected list cache cleared for alias transfer")
+	}
+}
+
+func TestInvalidateTemplateAliasMutationCachesSkipsDuplicateDisplacedID(t *testing.T) {
+	templateListCache.Flush()
+	templateInfoCache.Flush()
+
+	setTemplateListCache([]TemplateInfo{{TemplateID: "tpl-same"}})
+	setTemplateInfoCache("tpl-same", &TemplateInfo{TemplateID: "tpl-same"})
+
+	// (x, x) and (x, "") clear the same cache keys, and invalidation is
+	// idempotent, so cache-state assertions cannot distinguish "cleared once"
+	// from "cleared twice" — they only assert the entry is actually cleared.
+	// Verifying the guard runs exactly once would require counting
+	// invalidateTemplateCaches calls; gomonkey-based patching replaces the real
+	// body (so the cache is never cleared under some -race builds) and panics
+	// on macOS, so we deliberately keep this as a state assertion only.
+	invalidateTemplateAliasMutationCaches("tpl-same", "tpl-same")
+
+	if _, ok := getCachedTemplateInfo("tpl-same"); ok {
+		t.Fatalf("expected info cache cleared for target")
+	}
+	if _, ok := getCachedTemplateList(); ok {
+		t.Fatalf("expected list cache cleared for target")
+	}
+}

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -1200,6 +1200,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 	expectedStatus := ""
 	claimed := false
 	displacedTemplateID := ""
+	displacedHolderDeleting := false
 	claimWarning = ""
 	var claimErr error
 	run := func() error {
@@ -1209,6 +1210,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 			expectedStatus = ""
 			claimed = false
 			displacedTemplateID = ""
+			displacedHolderDeleting = false
 			claimWarning = ""
 			claimErr = nil
 			return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -1242,6 +1244,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 					}
 					claimed = claimResult.Claimed
 					displacedTemplateID = claimResult.DisplacedTemplateID
+					displacedHolderDeleting = claimResult.DisplacedHolderDeleting
 					claimWarning = claimResult.Warning
 				}
 				return tx.Table(constants.TemplateDefinitionTableName).
@@ -1259,9 +1262,17 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 		err = run()
 	}
 	if err == nil {
+		invalidateTemplateAliasMutationCaches(templateID, displacedTemplateID)
 		if claimed {
 			if displacedTemplateID != "" {
-				log.G(ctx).Warnf("alias %q transferred from template %s to newer template build %s", alias, displacedTemplateID, templateID)
+				// The DELETING branch never compares job order, so calling the
+				// released template a "newer template build" would assert an
+				// ordering that was never evaluated.
+				if displacedHolderDeleting {
+					log.G(ctx).Warnf("alias %q released from deleting template %s to template %s", alias, displacedTemplateID, templateID)
+				} else {
+					log.G(ctx).Warnf("alias %q transferred from template %s to newer template build %s", alias, displacedTemplateID, templateID)
+				}
 			}
 			return alias, claimWarning, nil
 		}
@@ -1280,6 +1291,7 @@ func publishTemplateStatusWithAlias(ctx context.Context, templateID, jobID, stat
 	if statusErr := publishTemplateStatusWithoutAlias(ctx, templateID, expectedStatus, status, lastError); statusErr != nil {
 		return "", "", statusErr
 	}
+	invalidateTemplateAliasMutationCaches(templateID, "")
 	if isDuplicateAliasError(claimErr) {
 		return "", "", nil
 	}
@@ -1324,9 +1336,10 @@ func publishTemplateStatusWithoutAlias(ctx context.Context, templateID, expected
 }
 
 type orderedAliasClaimResult struct {
-	Claimed             bool
-	DisplacedTemplateID string
-	Warning             string
+	Claimed                 bool
+	DisplacedTemplateID     string
+	DisplacedHolderDeleting bool
+	Warning                 string
 }
 
 func claimTemplateAliasByJobOrderTx(tx *gorm.DB, templateID string, claimantJobRowID uint, alias string) (orderedAliasClaimResult, error) {
@@ -1362,6 +1375,11 @@ func claimTemplateAliasByJobOrderTx(tx *gorm.DB, templateID string, claimantJobR
 		if err := syncCreateRedoImageJobAliasTx(tx, holder.TemplateID, ""); err != nil {
 			return result, err
 		}
+		// The DELETING holder's display_name and job alias were cleared above,
+		// so it is a displaced holder regardless of whether the claimant ends
+		// up claiming the alias. Report it so the caller invalidates both IDs.
+		result.DisplacedTemplateID = holder.TemplateID
+		result.DisplacedHolderDeleting = true
 		update := tx.Table(constants.TemplateDefinitionTableName).
 			Where("template_id = ? AND status <> ?", templateID, StatusDeleting).
 			Update("display_name", alias)
@@ -1421,15 +1439,41 @@ func lockTemplateDefinitionTx(tx *gorm.DB, templateID string) (*models.TemplateD
 	return def, nil
 }
 
+// getTemplateByAliasTx resolves the current alias holder, excluding DELETING
+// templates: read paths (sandbox create by alias, detail/list display) must
+// never treat a template that is being deleted as the alias holder.
 func getTemplateByAliasTx(tx *gorm.DB, alias string) (*models.TemplateDefinition, error) {
+	return getTemplateByAliasFilteredTx(tx, alias, true)
+}
+
+// getTemplateByAliasAnyStatusTx resolves the alias holder without filtering
+// DELETING rows. Alias writes release the previous holder by alias_key alone
+// (claimTemplateAliasTx matches every row whose alias_key matches, with no
+// status predicate), so callers that must invalidate the displaced holder need
+// this unfiltered view: getTemplateByAliasTx would report "not found" for a
+// DELETING holder and silently skip invalidating a row that the write did
+// mutate.
+func getTemplateByAliasAnyStatusTx(tx *gorm.DB, alias string) (*models.TemplateDefinition, error) {
+	return getTemplateByAliasFilteredTx(tx, alias, false)
+}
+
+// getTemplateByAliasFilteredTx is the shared implementation behind both alias
+// lookups. They differ only in whether DELETING rows are excluded — the
+// distinction between "who currently holds this alias" (reads) and "which rows
+// an alias write actually mutated" (cache invalidation). Rows are matched by
+// alias_key, not display_name, because alias_key is the unique constraint the
+// write path actually updates.
+func getTemplateByAliasFilteredTx(tx *gorm.DB, alias string, excludeDeleting bool) (*models.TemplateDefinition, error) {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
 		return nil, ErrTemplateNotFound
 	}
+	query := tx.Table(constants.TemplateDefinitionTableName).Where("alias_key = ?", alias)
+	if excludeDeleting {
+		query = query.Where("status <> ?", StatusDeleting)
+	}
 	def := &models.TemplateDefinition{}
-	err := tx.Table(constants.TemplateDefinitionTableName).
-		Where("alias_key = ? AND status <> ?", alias, StatusDeleting).
-		First(def).Error
+	err := query.First(def).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrTemplateNotFound
@@ -1542,7 +1586,9 @@ func setTemplateAliasLocked(ctx context.Context, templateID, alias string) error
 	if !isReady() {
 		return ErrTemplateStoreNotInitialized
 	}
-	return retryOnceOnDeadlock(func() error {
+	oldHolderToInvalidate := ""
+	err := retryOnceOnDeadlock(func() error {
+		oldHolderToInvalidate = ""
 		return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			def, err := lockTemplateDefinitionTx(tx, templateID)
 			if err != nil {
@@ -1572,7 +1618,7 @@ func setTemplateAliasLocked(ctx context.Context, templateID, alias string) error
 				return ErrTemplateNotReady
 			}
 			oldHolder := ""
-			if cur, err := getTemplateByAliasTx(tx, alias); err == nil && cur != nil && cur.TemplateID != templateID {
+			if cur, err := getTemplateByAliasAnyStatusTx(tx, alias); err == nil && cur != nil && cur.TemplateID != templateID {
 				oldHolder = cur.TemplateID
 			} else if err != nil && !errors.Is(err, ErrTemplateNotFound) {
 				return err
@@ -1587,10 +1633,16 @@ func setTemplateAliasLocked(ctx context.Context, templateID, alias string) error
 				if err := syncCreateRedoImageJobAliasTx(tx, oldHolder, ""); err != nil {
 					return err
 				}
+				oldHolderToInvalidate = oldHolder
 			}
 			return nil
 		})
 	})
+	if err != nil {
+		return err
+	}
+	invalidateTemplateAliasMutationCaches(templateID, oldHolderToInvalidate)
+	return nil
 }
 
 // applyAliasToRequestJSON returns payload with its "alias" field set to alias

--- a/CubeMaster/pkg/templatecenter/store_alias_docker_test.go
+++ b/CubeMaster/pkg/templatecenter/store_alias_docker_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,6 +78,21 @@ func runAliasStoreCases(t *testing.T, db *gorm.DB) {
 	})
 	t.Run("ClearAliasSyncsCreateRedoLeavesCommit", func(t *testing.T) {
 		testClearAliasSyncsCreateRedoLeavesCommit(t, db)
+	})
+	t.Run("SetAliasInvalidatesQueryCaches", func(t *testing.T) {
+		testSetAliasInvalidatesQueryCaches(t, db)
+	})
+	t.Run("SetAliasTransferInvalidatesBothQueryCaches", func(t *testing.T) {
+		testSetAliasTransferInvalidatesBothQueryCaches(t, db)
+	})
+	t.Run("SetAliasTransferFromDeletingHolderInvalidatesBothQueryCaches", func(t *testing.T) {
+		testSetAliasTransferFromDeletingHolderInvalidatesBothQueryCaches(t, db)
+	})
+	t.Run("PublishStatusTransferInvalidatesBothQueryCaches", func(t *testing.T) {
+		testPublishStatusTransferInvalidatesBothQueryCaches(t, db)
+	})
+	t.Run("PublishStatusClaimFailureInvalidatesQueryCaches", func(t *testing.T) {
+		testPublishStatusClaimFailureInvalidatesQueryCaches(t, db)
 	})
 }
 
@@ -510,4 +526,194 @@ func testClearAliasSyncsCreateRedoLeavesCommit(t *testing.T, db *gorm.DB) {
 	assert.NotContains(t, loadJob(createID).RequestJSON, `"alias"`)
 	assert.NotContains(t, loadJob(redoID).RequestJSON, `"alias"`)
 	assert.Equal(t, commitJSON, loadJob(commitID).RequestJSON, "COMMIT RequestJSON must be byte-identical after clear")
+}
+
+func primeTemplateQueryCaches(templateIDs ...string) {
+	infos := make([]TemplateInfo, 0, len(templateIDs))
+	for _, templateID := range templateIDs {
+		info := &TemplateInfo{TemplateID: templateID, Status: StatusReady, DisplayName: "cached-alias"}
+		setTemplateInfoCache(templateID, info)
+		infos = append(infos, *info)
+	}
+	setTemplateListCache(infos)
+}
+
+func requireTemplateQueryCachesHit(t *testing.T, templateIDs ...string) {
+	t.Helper()
+	for _, templateID := range templateIDs {
+		_, ok := getCachedTemplateInfo(templateID)
+		require.Truef(t, ok, "expected info cache hit for %s", templateID)
+	}
+	_, ok := getCachedTemplateList()
+	require.True(t, ok, "expected list cache hit")
+}
+
+func requireTemplateQueryCachesMiss(t *testing.T, templateIDs ...string) {
+	t.Helper()
+	for _, templateID := range templateIDs {
+		_, ok := getCachedTemplateInfo(templateID)
+		require.Falsef(t, ok, "expected info cache miss for %s", templateID)
+	}
+	_, ok := getCachedTemplateList()
+	require.False(t, ok, "expected list cache miss")
+}
+
+func testSetAliasInvalidatesQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	tplID := "tpl-cache-set-" + suf
+	alias := "alias-cache-set-" + suf
+	insertReadyTemplate(t, db, tplID, "")
+	cleanupTemplatesAndJobs(t, db, []string{tplID}, nil)
+	t.Cleanup(func() { invalidateTemplateCaches(tplID) })
+
+	primeTemplateQueryCaches(tplID)
+	requireTemplateQueryCachesHit(t, tplID)
+	require.NoError(t, SetTemplateAlias(context.Background(), tplID, alias))
+	requireTemplateQueryCachesMiss(t, tplID)
+
+	primeTemplateQueryCaches(tplID)
+	requireTemplateQueryCachesHit(t, tplID)
+	require.NoError(t, SetTemplateAlias(context.Background(), tplID, ""))
+	requireTemplateQueryCachesMiss(t, tplID)
+}
+
+func testSetAliasTransferInvalidatesBothQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	oldTemplateID := "tpl-cache-transfer-old-" + suf
+	newTemplateID := "tpl-cache-transfer-new-" + suf
+	alias := "alias-cache-transfer-" + suf
+	insertReadyTemplate(t, db, oldTemplateID, alias)
+	insertReadyTemplate(t, db, newTemplateID, "")
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, nil)
+	t.Cleanup(func() {
+		invalidateTemplateCaches(oldTemplateID)
+		invalidateTemplateCaches(newTemplateID)
+	})
+
+	primeTemplateQueryCaches(oldTemplateID, newTemplateID)
+	requireTemplateQueryCachesHit(t, oldTemplateID, newTemplateID)
+	require.NoError(t, SetTemplateAlias(context.Background(), newTemplateID, alias))
+	requireTemplateQueryCachesMiss(t, oldTemplateID, newTemplateID)
+
+	oldDef, err := GetDefinition(context.Background(), oldTemplateID)
+	require.NoError(t, err)
+	assert.Empty(t, oldDef.DisplayName)
+	newDef, err := GetDefinition(context.Background(), newTemplateID)
+	require.NoError(t, err)
+	assert.Equal(t, alias, newDef.DisplayName)
+}
+
+func testSetAliasTransferFromDeletingHolderInvalidatesBothQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	oldTemplateID := "tpl-cache-transfer-deleting-" + suf
+	newTemplateID := "tpl-cache-transfer-claimant-" + suf
+	oldJobID := "job-cache-transfer-deleting-" + suf
+	alias := "alias-cache-transfer-deleting-" + suf
+	// A DELETING holder is invisible to the status-filtered alias lookup, but
+	// claimTemplateAliasTx still clears it by alias_key. This pins the
+	// unfiltered holder resolution: the displaced DELETING holder's caches must
+	// be invalidated too, not just the claimant's. The job row additionally pins
+	// the behavior change that SetTemplateAlias now rewrites the deleting
+	// holder's CREATE/REDO request JSON.
+	insertTemplate(t, db, oldTemplateID, StatusDeleting, alias)
+	insertReadyTemplate(t, db, newTemplateID, "")
+	insertCreateJob(t, db, oldTemplateID, oldJobID, alias)
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, []string{oldJobID})
+	t.Cleanup(func() {
+		invalidateTemplateCaches(oldTemplateID)
+		invalidateTemplateCaches(newTemplateID)
+	})
+
+	primeTemplateQueryCaches(oldTemplateID, newTemplateID)
+	requireTemplateQueryCachesHit(t, oldTemplateID, newTemplateID)
+	require.NoError(t, SetTemplateAlias(context.Background(), newTemplateID, alias))
+	requireTemplateQueryCachesMiss(t, oldTemplateID, newTemplateID)
+
+	oldDef, err := GetDefinition(context.Background(), oldTemplateID)
+	require.NoError(t, err)
+	assert.Empty(t, oldDef.DisplayName)
+	newDef, err := GetDefinition(context.Background(), newTemplateID)
+	require.NoError(t, err)
+	assert.Equal(t, alias, newDef.DisplayName)
+
+	// With the unfiltered lookup, SetTemplateAlias now also rewrites the
+	// deleting holder's CREATE/REDO request JSON (dropping the alias).
+	var oldJob models.TemplateImageJob
+	require.NoError(t, db.Where("job_id = ?", oldJobID).First(&oldJob).Error)
+	assert.Empty(t, aliasFromRequestJSON(oldJob.RequestJSON))
+}
+
+func testPublishStatusTransferInvalidatesBothQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	oldTemplateID := "tpl-cache-publish-old-" + suf
+	newTemplateID := "tpl-cache-publish-new-" + suf
+	oldJobID := "job-cache-publish-old-" + suf
+	newJobID := "job-cache-publish-new-" + suf
+	alias := "alias-cache-publish-" + suf
+	insertReadyTemplate(t, db, oldTemplateID, alias)
+	insertTemplate(t, db, newTemplateID, StatusPending, "")
+	insertCreateJob(t, db, oldTemplateID, oldJobID, alias)
+	insertImageJob(t, db, &models.TemplateImageJob{
+		JobID:       newJobID,
+		TemplateID:  newTemplateID,
+		RequestID:   "req-" + newJobID,
+		Operation:   JobOperationCreate,
+		Status:      JobStatusRunning,
+		RequestJSON: `{"alias":"` + alias + `"}`,
+	})
+	cleanupTemplatesAndJobs(t, db, []string{oldTemplateID, newTemplateID}, []string{oldJobID, newJobID})
+	t.Cleanup(func() {
+		invalidateTemplateCaches(oldTemplateID)
+		invalidateTemplateCaches(newTemplateID)
+	})
+
+	primeTemplateQueryCaches(oldTemplateID, newTemplateID)
+	requireTemplateQueryCachesHit(t, oldTemplateID, newTemplateID)
+	displayName, warning, err := publishTemplateStatusWithAlias(context.Background(), newTemplateID, newJobID, StatusReady, "")
+	require.NoError(t, err)
+	require.Empty(t, warning)
+	require.Equal(t, alias, displayName)
+	requireTemplateQueryCachesMiss(t, oldTemplateID, newTemplateID)
+
+	holder, err := GetTemplateByAlias(context.Background(), alias)
+	require.NoError(t, err)
+	assert.Equal(t, newTemplateID, holder.TemplateID)
+	oldDef, err := GetDefinition(context.Background(), oldTemplateID)
+	require.NoError(t, err)
+	assert.Empty(t, oldDef.DisplayName)
+}
+
+func testPublishStatusClaimFailureInvalidatesQueryCaches(t *testing.T, db *gorm.DB) {
+	suf := aliasCaseSuffix()
+	templateID := "tpl-cache-claim-fail-" + suf
+	jobID := "job-cache-claim-fail-" + suf
+	// publishTemplateStatusWithAlias does not validate job aliases itself; an
+	// over-length value makes the claim fail inside the transaction, forcing
+	// the fallback status publish. This exercises its cache invalidation path
+	// against both MySQL and PostgreSQL varchar(256) display_name columns.
+	alias := strings.Repeat("a", 300)
+	insertTemplate(t, db, templateID, StatusPending, "")
+	insertImageJob(t, db, &models.TemplateImageJob{
+		JobID:       jobID,
+		TemplateID:  templateID,
+		RequestID:   "req-" + jobID,
+		Operation:   JobOperationCreate,
+		Status:      JobStatusRunning,
+		RequestJSON: `{"alias":"` + alias + `"}`,
+	})
+	cleanupTemplatesAndJobs(t, db, []string{templateID}, []string{jobID})
+	t.Cleanup(func() { invalidateTemplateCaches(templateID) })
+
+	primeTemplateQueryCaches(templateID)
+	requireTemplateQueryCachesHit(t, templateID)
+	displayName, warning, err := publishTemplateStatusWithAlias(context.Background(), templateID, jobID, StatusReady, "")
+	require.NoError(t, err)
+	assert.Empty(t, displayName)
+	assert.Contains(t, warning, "could not be claimed")
+	requireTemplateQueryCachesMiss(t, templateID)
+
+	def, err := GetDefinition(context.Background(), templateID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusReady, def.Status)
+	assert.Empty(t, def.DisplayName)
 }


### PR DESCRIPTION
## Problem

Alias transfers mutate two template definitions (the new holder and the displaced holder), but the query/runtime caches were not invalidated for both IDs after the write committed.

**Scope of the staleness** (corrected — an earlier version of this text said 6h, which conflated two different caches):

| Cache | TTL | Affects alias display? |
|-------|-----|------------------------|
| `templateInfoCache` / `templateListCache` | **1 min** (`templateQueryCacheTTL`), refreshed every **30s** | **Yes** — this is what this PR fixes |
| `templateDefinitionCache` / kind / locality | 6h (`templateCacheTTL`) | No — keyed by template ID, not alias |

After an alias transfer, list/detail reads on the **CubeMaster replica that performed the write** are invalidated immediately. Other replicas still rely on the 1-minute query cache and the 30-second refresh backstop (up to ~30–60s staleness). **Sandbox create by alias is unaffected** — `GetTemplateByAlias` always hits the DB.

Split out from #1693 per review feedback — this is an intentional v3 carry-over, independent of the tpl migrate workflow.

## Fix

- Add `invalidateTemplateAliasMutationCaches(templateID, displacedTemplateID)` which clears both the target and the displaced holder (deduping when they are the same ID).
- Call it after the alias claim/transfer transaction commits in `publishTemplateStatusWithAlias` and `setTemplateAliasLocked`.
- Report the displaced holder on the `DELETING` path of `claimTemplateAliasByJobOrderTx`: `claimTemplateAliasTx` clears by `alias_key` with **no status filter**, so a DELETING holder is mutated even though it is invisible to the status-filtered lookup. `setTemplateAliasLocked` now resolves the previous holder without the `status <> DELETING` filter, so the invalidated ID matches the rows actually written.
- Branch the transfer log on the holder status: the DELETING path never compares job order, so calling the released template a "newer template build" asserted an ordering that was never evaluated.

**Behavior change worth calling out:** with the unfiltered lookup, `SetTemplateAlias` now also acts on a DELETING holder — its CREATE/REDO `RequestJSON` alias is rewritten via `syncCreateRedoImageJobAliasTx`, where previously the holder was invisible and that step was skipped. This matches what the publish path already does (`testBuildClearsDeletingHolderJobAlias`) and is intentional. The consequence is that a malformed job payload on a DELETING holder now fails the operator's alias transfer instead of silently skipping it; we consider failing loudly the correct behavior here.

## Tests

- `cache_query_test.go`: both-IDs-cleared and same-ID dedup behavior.
- `store_alias_docker_test.go`: alias store cases (get-by-alias excludes snapshots, newer build transfers alias, older build cannot reclaim, concurrent claims converge, etc.).
- `store_alias_docker_test.go`: `SetAliasTransferFromDeletingHolderInvalidatesBothQueryCaches` — primes the query caches, transfers an alias whose current holder is `DELETING` via `SetTemplateAlias`, then asserts (a) both IDs' info/list caches are cleared and (b) the DELETING holder's `display_name` is cleared. This is the case that pins the new unfiltered lookup; the existing READY-holder transfer test passes either way.
