### PR TITLE
fix(clm): prevent stale auto-pause after resume

### DIFF
--- a/CubeMaster/pkg/lifecycle/schema.go
+++ b/CubeMaster/pkg/lifecycle/schema.go
@@ -26,10 +26,12 @@
 //     The CLM reconciles Redis state key + CubeProxy state dict so
 //     externally driven pause/resume calls do not desync the fleet.
 //
-// State keys (cube:v1:shared:sandbox:lifecycle:state:<id>) remain
-// exclusively written by the CLM — CubeMaster only signals intent
-// via the stream. This preserves the SETNX-based transition-lock semantics
-// (pausing / resuming) owned by the CLM's sweeper and resumer.
+// State keys (cube:v1:shared:sandbox:lifecycle:state:<id>) are normally written
+// by CLM, which owns transition markers and terminal-state reconciliation.
+// Exception: after restore, CubeMaster writes a 60s running marker under the
+// sandbox lifecycle lock, before publishing the running event and unlocking.
+// This invalidates queued auto-pauses; CLM must CAS its pausing -> paused write
+// and reconcile when the newer running marker supersedes its transition.
 package lifecycle
 
 import "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/rediskey"

--- a/CubeMaster/pkg/service/sandbox/sandbox_info.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_info.go
@@ -72,7 +72,8 @@ func SandboxInfo(ctx context.Context, req *types.GetCubeSandboxReq) (rsp *types.
 		return
 	}
 
-	// Pause binding wins over Cubelet EXITED flicker / empty List: READY →
+	// Pause binding wins over Cubelet EXITED flicker / empty List, but not
+	// an explicitly running sandbox after resume: READY →
 	// paused tombstone view; FAILED → keep sandbox record with error.
 	if fillPauseBindingInfoFromMaster(ctx, req, rsp) {
 		return
@@ -245,7 +246,8 @@ func getContainerName(label map[string]string) string {
 }
 
 // fillPauseBindingInfoFromMaster synthesizes Info from the pausesnap binding
-// when present. READY → PAUSED. CREATING/FAILED prefer Cubelet PAUSING/PAUSED
+// when present. READY → PAUSED unless Cubelet confirms RUNNING.
+// CREATING/FAILED prefer Cubelet PAUSING/PAUSED
 // when the node already finished Pause (Master RPC may have timed out); otherwise
 // CREATING → PAUSING and FAILED → UNKNOWN + pause error. Overrides Cubelet
 // EXITED flicker during CoW Pause.
@@ -268,6 +270,13 @@ func fillPauseBindingInfoFromMaster(ctx context.Context, req *types.GetCubeSandb
 	var st int32
 	switch status {
 	case "READY":
+		// Resume may succeed while deleting its binding fails. An explicit
+		// running node result wins over that leftover paused tombstone.
+		for _, d := range rsp.Data {
+			if d != nil && d.SandboxID == req.SandboxID && d.Status == int32(cubebox.ContainerState_CONTAINER_RUNNING) {
+				return false
+			}
+		}
 		st = int32(cubebox.ContainerState_CONTAINER_PAUSED)
 	case pausesnap.StatusFailed:
 		// Master timed out / failed, but Cubelet may still have reached PAUSED.

--- a/CubeMaster/pkg/service/sandbox/sandbox_info_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_info_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sandbox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	basetypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/types"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/pausesnap"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/pkgs/proto/services/cubebox/v1"
+)
+
+func TestReadyPauseBindingPreservesRunningNodeState(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(localcache.GetSandboxProxyMap, func(context.Context, string) (*basetypes.SandboxProxyMap, bool) {
+		return &basetypes.SandboxProxyMap{}, true
+	})
+	// A successful resume is allowed to leave this record when Delete fails.
+	patches.ApplyFunc(pausesnap.GetBySandbox, func(context.Context, string) (*pausesnap.Record, error) {
+		return &pausesnap.Record{SnapshotID: "snap", Status: "READY"}, nil
+	})
+	for _, tc := range []struct {
+		name       string
+		state      cubebox.ContainerState
+		empty      bool
+		synthesize bool
+	}{
+		{"resumed with leftover binding", cubebox.ContainerState_CONTAINER_RUNNING, false, false},
+		{"paused", cubebox.ContainerState_CONTAINER_PAUSED, false, true},
+		{"exited flicker", cubebox.ContainerState_CONTAINER_EXITED, false, true},
+		{"empty node response", 0, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rsp := &types.GetCubeSandboxRes{Ret: &types.Ret{}}
+			if !tc.empty {
+				rsp.Data = []*types.SandboxData{{SandboxID: "sbx", Status: int32(tc.state)}}
+			}
+			got := fillPauseBindingInfoFromMaster(context.Background(), &types.GetCubeSandboxReq{SandboxID: "sbx"}, rsp)
+			if got != tc.synthesize {
+				t.Fatalf("synthesized=%v want %v", got, tc.synthesize)
+			}
+			want := int32(cubebox.ContainerState_CONTAINER_PAUSED)
+			if !tc.synthesize {
+				want = int32(cubebox.ContainerState_CONTAINER_RUNNING)
+			}
+			if len(rsp.Data) != 1 || rsp.Data[0].Status != want {
+				t.Fatalf("unexpected Info: %+v", rsp.Data)
+			}
+		})
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_lifecycle_state.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_lifecycle_state.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sandbox
+
+import (
+	"errors"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/rediskey"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/wrapredis"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxlock"
+)
+
+// Wire contract with CLM internal/cubemasterclient: paired with
+// ErrorCode_Conflict (130409). Keep both sides and their literal contract
+// tests in sync; this message distinguishes stale intent from lock contention.
+const pauseSupersededMessage = "auto-pause superseded by lifecycle state change"
+
+var errPauseSuperseded = errors.New(pauseSupersededMessage)
+
+// resumedLifecycleStateTTL protects a completed resume until CLM processes its
+// running event. It matches CLM's default StateLockTTL, but is independent of
+// that configurable TTL and of the Master lifecycle operation lock lifetime.
+const resumedLifecycleStateTTL = 60 * time.Second
+
+func checkPauseLifecycleState(sandboxID, expected string) error {
+	r := wrapredis.GetRedis()
+	if r == nil || r.RedisConnPool == nil {
+		return sandboxlock.ErrRedisUnavailable
+	}
+	state, err := redis.String(r.Do("GET", rediskey.SandboxLifecycleState(sandboxID)))
+	if err != nil && !errors.Is(err, redis.ErrNil) {
+		return err
+	}
+	if state != expected {
+		return errPauseSuperseded
+	}
+	return nil
+}
+
+// Called while the Master resume lock is held. The short-lived running marker
+// rejects pending auto-pauses until the existing running event refreshes CLM's
+// activity timestamp. It uses the same default 60s marker lifetime as CLM.
+func markResumedLifecycleState(sandboxID string) error {
+	r := wrapredis.GetRedis()
+	if r == nil || r.RedisConnPool == nil {
+		return sandboxlock.ErrRedisUnavailable
+	}
+	_, err := r.Do("SET", rediskey.SandboxLifecycleState(sandboxID), "running", "EX", int(resumedLifecycleStateTTL.Seconds()))
+	return err
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_lifecycle_state_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_lifecycle_state_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/gomodule/redigo/redis"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/wrapredis"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxlock"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestCompletedResumeReportsAllSynchronizationFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name                            string
+		stateErr, purgeErr, proxyMapErr error
+	}{
+		{name: "success"},
+		{name: "state", stateErr: errors.New("marker write failed")},
+		{name: "proxy", purgeErr: errors.New("cache purge failed")},
+		{name: "both", stateErr: errors.New("marker write failed"), purgeErr: errors.New("cache purge failed")},
+		{name: "mapping", proxyMapErr: errors.New("mapping write failed")},
+		{name: "all", proxyMapErr: errors.New("mapping write failed"), stateErr: errors.New("marker write failed"), purgeErr: errors.New("cache purge failed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			patches.ApplyFunc(markResumedLifecycleState, func(string) error { return tc.stateErr })
+			hookCalled := false
+			patches.ApplyFunc(runAfterUpdateSandboxSuccessHook, func(context.Context, string, string, string, string) {
+				hookCalled = true
+			})
+			rsp := &types.Res{Ret: &types.Ret{RetCode: int(errorcode.ErrorCode_Success)}}
+			completeResumeSynchronization(context.Background(), &types.UpdateRequest{SandboxID: "sbx"}, rsp, "127.0.0.1", tc.proxyMapErr, tc.purgeErr)
+			if !rsp.ResumeCompleted || !hookCalled {
+				t.Fatal("completed restore lost bookkeeping")
+			}
+			wantCode := int(errorcode.ErrorCode_Success)
+			for _, err := range []error{tc.stateErr, tc.purgeErr, tc.proxyMapErr} {
+				if err != nil {
+					wantCode = int(errorcode.ErrorCode_MasterInternalError)
+					if !strings.Contains(rsp.Ret.RetMsg, err.Error()) {
+						t.Fatalf("lost synchronization error %v: %+v", err, rsp.Ret)
+					}
+				}
+			}
+			if tc.proxyMapErr != nil {
+				wantCode = int(errorcode.ErrorCode_DBError)
+			}
+			if rsp.Ret.RetCode != wantCode {
+				t.Fatalf("ret_code=%d want %d", rsp.Ret.RetCode, wantCode)
+			}
+		})
+	}
+}
+
+func TestAutoPauseChecksStateAfterQueuedResume(t *testing.T) {
+	const sid = "sb-queued-auto-pause"
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	var stateMu, lifecycleMu sync.Mutex
+	state := "pausing" // sweeper already acquired its marker
+	r := &wrapredis.RedisWrap{RedisConnPool: &redis.Pool{}}
+	patches.ApplyFunc(wrapredis.GetRedis, func() *wrapredis.RedisWrap { return r })
+	patches.ApplyMethod(r, "Do", func(_ *wrapredis.RedisWrap, cmd string, args ...interface{}) (interface{}, error) {
+		stateMu.Lock()
+		defer stateMu.Unlock()
+		if cmd == "SET" {
+			state = args[1].(string)
+			return "OK", nil
+		}
+		return []byte(state), nil
+	})
+	patches.ApplyFunc(config.GetConfig, func() *config.Config { return &config.Config{Common: &config.CommonConf{}} })
+	localcache.SetSandboxCache(sid, &localcache.SandboxCache{SandboxID: sid, HostIP: "127.0.0.1"})
+	defer localcache.DeleteSandboxCache(sid)
+	var pauses atomic.Int32
+	patches.ApplyFunc(pauseSandbox, func(context.Context, *types.UpdateRequest, string) *types.Res {
+		pauses.Add(1)
+		return successResumeRes()
+	})
+	queued := make(chan struct{})
+	patches.ApplyFunc(sandboxlock.WithLock, func(ctx context.Context, _ string, opts sandboxlock.Options, fn func(context.Context) error) error {
+		if opts.Value == "pause" {
+			close(queued)
+		}
+		lifecycleMu.Lock()
+		defer lifecycleMu.Unlock()
+		return fn(ctx)
+	})
+	// Model the real resume lock while Cubelet is restoring. The pending pause
+	// must not inspect pausing until after the resume has published running.
+	lifecycleMu.Lock()
+	done := make(chan *types.Res, 1)
+	go func() {
+		done <- Update(context.Background(), &types.UpdateRequest{SandboxID: sid, InstanceType: "cubebox", Action: "pause", ExpectedLifecycleState: "pausing"})
+	}()
+	select {
+	case <-queued:
+	case <-time.After(time.Second):
+		lifecycleMu.Unlock()
+		t.Fatal("pause did not reach lock")
+	}
+	if err := markResumedLifecycleState(sid); err != nil {
+		lifecycleMu.Unlock()
+		t.Fatal(err)
+	}
+	lifecycleMu.Unlock()
+	rsp := <-done
+	// Pin the wire literals, not the production constants: changing Master's
+	// wording must not silently break CLM's superseded-pause classification.
+	if rsp.Ret.RetCode != 130409 || rsp.Ret.RetMsg != "auto-pause superseded by lifecycle state change" || pauses.Load() != 0 {
+		t.Fatalf("stale pause ran after resume: ret=%+v pauses=%d", rsp.Ret, pauses.Load())
+	}
+}
+
+func TestAutoPauseStatePrecondition(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	r := &wrapredis.RedisWrap{RedisConnPool: &redis.Pool{}}
+	patches.ApplyFunc(wrapredis.GetRedis, func() *wrapredis.RedisWrap { return r })
+	var state string
+	var readErr error
+	patches.ApplyMethod(r, "Do", func(_ *wrapredis.RedisWrap, _ string, _ ...interface{}) (interface{}, error) {
+		return []byte(state), readErr
+	})
+	for _, value := range []string{"pausing", "running", "paused", "resuming", ""} {
+		state = value
+		err := checkPauseLifecycleState("sbx", "pausing")
+		if (err == nil) != (value == "pausing") {
+			t.Fatalf("state=%q err=%v", value, err)
+		}
+	}
+	readErr = errors.New("Redis unavailable")
+	if err := checkPauseLifecycleState("sbx", "pausing"); !errors.Is(err, readErr) {
+		t.Fatalf("lost Redis error: %v", err)
+	}
+	if err := markResumedLifecycleState("sbx"); !errors.Is(err, readErr) {
+		t.Fatalf("resume synchronization silently failed: %v", err)
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_resume_pause.go
@@ -434,11 +434,9 @@ func resumeFromPauseSnapshot(ctx context.Context, req *types.UpdateRequest, host
 	// Resume recreates the guest NIC / host ports. Normal Create writes Redis
 	// proxy metadata in dealSuccResult; thin resume Create must rewrite it or
 	// CubeProxy keeps routing to the pre-pause SandboxIP (same-node 504).
-	if err := refreshProxyMapAfterResume(ctx, req.SandboxID, targetIP, cubeRsp); err != nil {
-		rsp.Ret.RetCode = int(errorcode.ErrorCode_DBError)
-		rsp.Ret.RetMsg = fmt.Sprintf("refreshSandboxProxyMap after resume fail:%s", err.Error())
-		return rsp
-	}
+	// The guest is already running. A routing write failure must still reach
+	// the completed-resume bookkeeping below, while remaining an API error.
+	proxyMapErr := refreshProxyMapAfterResume(ctx, req.SandboxID, targetIP, cubeRsp)
 	// Drop CubeProxy local_cache so the new SandboxIP is used immediately
 	// (cache hits renew TTL and would otherwise keep routing to the old NIC).
 	// A purge that fails leaves the sandbox unreachable for good, so it has
@@ -470,16 +468,36 @@ func resumeFromPauseSnapshot(ctx context.Context, req *types.UpdateRequest, host
 	if err := pausesnap.Delete(ctx, snapID); err != nil {
 		log.G(ctx).Warnf("resume: delete pause snap meta %s: %v", snapID, err)
 	}
+	completeResumeSynchronization(ctx, req, rsp, targetIP, proxyMapErr, purgeErr)
+	return rsp
+}
+
+func completeResumeSynchronization(ctx context.Context, req *types.UpdateRequest, rsp *types.Res, targetIP string, proxyMapErr, purgeErr error) {
+	// Invalidate queued CLM auto-pauses before releasing the Master lock and
+	// before publishing running (StateSync must not observe an old pausing key).
+	stateErr := markResumedLifecycleState(req.SandboxID)
+	rsp.ResumeCompleted = true
 	runAfterUpdateSandboxSuccessHook(ctx, req.SandboxID, req.InstanceType, "resume", req.RequestID)
+	if stateErr != nil {
+		stateErr = fmt.Errorf("sandbox resumed but lifecycle state synchronization failed: %w", stateErr)
+	}
 
 	if purgeErr != nil {
-		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterInternalError)
-		rsp.Ret.RetMsg = fmt.Sprintf(
-			"sandbox %s resumed on %s but CubeProxy kept its pre-pause route and will not reach it: %v",
+		purgeErr = fmt.Errorf(
+			"sandbox %s resumed on %s but CubeProxy kept its pre-pause route and will not reach it: %w",
 			req.SandboxID, targetIP, purgeErr)
+	}
+	if proxyMapErr != nil {
+		proxyMapErr = fmt.Errorf("refreshSandboxProxyMap after resume fail:%w", proxyMapErr)
+	}
+	if err := errors.Join(proxyMapErr, stateErr, purgeErr); err != nil {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterInternalError)
+		if proxyMapErr != nil {
+			rsp.Ret.RetCode = int(errorcode.ErrorCode_DBError)
+		}
+		rsp.Ret.RetMsg = err.Error()
 		log.G(ctx).Errorf("resume: %s", rsp.Ret.RetMsg)
 	}
-	return rsp
 }
 
 // loadResumeSandboxSpec is the single sandboxspec.Get on the Resume path.
@@ -521,6 +539,12 @@ func refreshProxyMapAfterResume(ctx context.Context, sandboxID, hostIP string, c
 	if sandboxID == "" || hostIP == "" || cubeRsp == nil {
 		return fmt.Errorf("missing sandboxID/hostIP/create response")
 	}
+	// Create already confirmed placement. Keep local lifecycle/Info calls on
+	// the restored node even if persisting its proxy mapping fails.
+	localcache.SetSandboxCache(sandboxID, &localcache.SandboxCache{
+		SandboxID: sandboxID,
+		HostIP:    hostIP,
+	})
 
 	proxy := &proxytypes.SandboxProxyMap{
 		HostIP:             hostIP,
@@ -562,10 +586,6 @@ func refreshProxyMapAfterResume(ctx context.Context, sandboxID, hostIP string, c
 	if err := setSandboxProxyMapFn(ctx, proxy); err != nil {
 		return err
 	}
-	localcache.SetSandboxCache(sandboxID, &localcache.SandboxCache{
-		SandboxID: sandboxID,
-		HostIP:    hostIP,
-	})
 	log.G(ctx).Infof("resume: refreshed proxy map sandbox=%s host=%s sandboxIP=%s ports=%v",
 		sandboxID, hostIP, proxy.SandboxIP, proxy.ContainerToHostPorts)
 	return nil

--- a/CubeMaster/pkg/service/sandbox/sandbox_resume_proxy_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_resume_proxy_test.go
@@ -5,12 +5,86 @@ package sandbox
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	proxytypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/types"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubeproxy"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/pausesnap"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/restoreplace"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	cubebox "github.com/tencentcloud/CubeSandbox/pkgs/proto/services/cubebox/v1"
+	protoret "github.com/tencentcloud/CubeSandbox/pkgs/proto/services/errorcode/v1"
 )
+
+func TestResumeProxyMapFailureStillCompletesBookkeeping(t *testing.T) {
+	for _, target := range []string{"10.0.0.1", "10.0.0.2"} {
+		t.Run(target, func(t *testing.T) {
+			const sid = "sb-resume-map-failure"
+			const origin = "10.0.0.1"
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			localcache.SetSandboxCache(sid, &localcache.SandboxCache{SandboxID: sid, HostIP: origin})
+			defer localcache.DeleteSandboxCache(sid)
+			patches.ApplyFunc(pausesnap.GetBySandbox, func(context.Context, string) (*pausesnap.Record, error) {
+				return &pausesnap.Record{SnapshotID: "snap", Status: "READY", NodeIP: origin}, nil
+			})
+			patches.ApplyFunc(loadResumeSandboxSpec, func(context.Context, string) *types.CreateCubeSandboxReq { return nil })
+			patches.ApplyFunc(resumePlacement, func(context.Context, *pausesnap.Record, string, *types.CreateCubeSandboxReq) (*restoreplace.Placement, error) {
+				return &restoreplace.Placement{NodeIP: target, CrossNode: target != origin}, nil
+			})
+			patches.ApplyFunc(cubelet.Create, func(_ context.Context, endpoint string, _ *cubebox.RunCubeSandboxRequest) (*cubebox.RunCubeSandboxResponse, error) {
+				if !strings.Contains(endpoint, target) {
+					t.Fatalf("restore sent to wrong node: %s", endpoint)
+				}
+				return &cubebox.RunCubeSandboxResponse{SandboxID: sid, SandboxIP: "192.168.1.62", Ret: &protoret.Ret{RetCode: 200}}, nil
+			})
+			origGet, origSet := getSandboxProxyMapFn, setSandboxProxyMapFn
+			defer func() { getSandboxProxyMapFn, setSandboxProxyMapFn = origGet, origSet }()
+			getSandboxProxyMapFn = func(context.Context, string) (*proxytypes.SandboxProxyMap, bool) { return nil, false }
+			setSandboxProxyMapFn = func(_ context.Context, proxy *proxytypes.SandboxProxyMap) error {
+				if proxy.HostIP != target {
+					t.Fatalf("wrong mapping target: %s", proxy.HostIP)
+				}
+				return errors.New("injected mapping write failure")
+			}
+			var purged, cleaned, deleted, marked, published bool
+			patches.ApplyFunc(cubeproxy.InvalidateBackendCache, func(_ context.Context, id, host string) error {
+				purged = id == sid && host == target
+				return nil
+			})
+			patches.ApplyFunc(pausesnap.DropOriginTombstone, func(_ context.Context, _, id, host, _, _ string) error {
+				cleaned = target != origin && id == sid && host == origin
+				return nil
+			})
+			patches.ApplyFunc(pausesnap.CleanupPauseSnapshot, func(_ context.Context, _, host, _, _ string) error {
+				cleaned = target == origin && host == target
+				return nil
+			})
+			patches.ApplyFunc(pausesnap.Delete, func(_ context.Context, id string) error { deleted = id == "snap"; return nil })
+			patches.ApplyFunc(markResumedLifecycleState, func(id string) error { marked = id == sid; return nil })
+			patches.ApplyFunc(runAfterUpdateSandboxSuccessHook, func(_ context.Context, id, _, action, _ string) {
+				published = marked && id == sid && action == "resume"
+			})
+			rsp := resumeFromPauseSnapshot(context.Background(), &types.UpdateRequest{SandboxID: sid, InstanceType: "cubebox", Action: "resume"}, origin)
+			if !rsp.ResumeCompleted || rsp.Ret.RetCode != int(errorcode.ErrorCode_DBError) || !strings.Contains(rsp.Ret.RetMsg, "injected mapping write failure") {
+				t.Fatalf("lost partial completion or mapping error: %+v ret=%+v", rsp, rsp.Ret)
+			}
+			if !purged || !cleaned || !deleted || !marked || !published {
+				t.Fatalf("bookkeeping skipped: purge=%v cleanup=%v delete=%v marker=%v event=%v", purged, cleaned, deleted, marked, published)
+			}
+			if cache := localcache.GetSandboxCache(sid); cache == nil || cache.HostIP != target {
+				t.Fatalf("local placement still points at pre-resume node: %+v", cache)
+			}
+		})
+	}
+}
 
 func TestRefreshProxyMapAfterResumeRewritesSandboxIP(t *testing.T) {
 	origGet := getSandboxProxyMapFn

--- a/CubeMaster/pkg/service/sandbox/sandbox_update.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_update.go
@@ -73,6 +73,19 @@ func Update(ctx context.Context, req *types.UpdateRequest) (rsp *types.Res) {
 		// Client/HTTP cancel must not abort bookkeeping or release the lock
 		// while SAVE/Create/Destroy is still in flight on Cubelet.
 		ctx = context.WithoutCancel(ctx)
+		// Check after acquiring the Master lifecycle lock: a resume may have
+		// completed while this auto-pause RPC was queued behind it.
+		if req.Action == "pause" && req.ExpectedLifecycleState != "" {
+			if err := checkPauseLifecycleState(req.SandboxID, req.ExpectedLifecycleState); err != nil {
+				if errors.Is(err, errPauseSuperseded) {
+					rsp.Ret.RetCode = int(errorcode.ErrorCode_Conflict)
+				} else {
+					rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterInternalError)
+				}
+				rsp.Ret.RetMsg = err.Error()
+				return nil
+			}
+		}
 		var hostIP string
 		if v := localcache.GetSandboxCache(req.SandboxID); v != nil {
 			hostIP = v.HostIP
@@ -96,7 +109,7 @@ func Update(ctx context.Context, req *types.UpdateRequest) (rsp *types.Res) {
 			*rsp = *pauseSandbox(ctx, req, hostIP)
 		case "resume":
 			*rsp = *resumeFromPauseSnapshot(ctx, req, hostIP)
-			if rsp.Ret.RetCode == int(errorcode.ErrorCode_Success) {
+			if rsp.Ret.RetCode == int(errorcode.ErrorCode_Success) || rsp.ResumeCompleted {
 				publishUpdateTimeout(ctx, req)
 			}
 		}

--- a/CubeMaster/pkg/service/sandbox/sandbox_update_timeout_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_update_timeout_test.go
@@ -7,6 +7,7 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -192,6 +193,28 @@ func TestUpdateResumeSucceedsWhenTimeoutProviderFails(t *testing.T) {
 	}
 	if !provider.called {
 		t.Fatal("expected RefreshTimeout to be attempted")
+	}
+}
+
+func TestUpdateCompletedResumeStillPublishesTimeoutOnSyncFailure(t *testing.T) {
+	const sid = "sb-resume-sync-pending"
+	localcache.SetSandboxCache(sid, &localcache.SandboxCache{SandboxID: sid, HostIP: "127.0.0.1"})
+	defer localcache.DeleteSandboxCache(sid)
+	provider := &mockTimeoutProvider{}
+	SetTimeoutProvider(provider)
+	defer SetTimeoutProvider(nil)
+	for _, timeout := range []int{300, types.NeverTimeout} {
+		t.Run(fmt.Sprint(timeout), func(t *testing.T) {
+			provider.called = false
+			stubResumeUpdate(t, &types.Res{ResumeCompleted: true, Ret: &types.Ret{RetCode: int(errorcode.ErrorCode_MasterInternalError), RetMsg: "resume completed; Redis synchronization failed"}})
+			rsp := Update(context.Background(), resumeTimeoutReq(sid, timeout))
+			if !rsp.ResumeCompleted || rsp.Ret.RetCode != int(errorcode.ErrorCode_MasterInternalError) {
+				t.Fatal("partial success was lost or incorrectly reported as full success")
+			}
+			if !provider.called || provider.lastTimeoutSeconds != timeout {
+				t.Fatal("completed restore lost timeout update")
+			}
+		})
 	}
 }
 

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -29,6 +29,9 @@ type Request struct {
 type Res struct {
 	RequestID string `json:"requestID,omitempty"`
 	Ret       *Ret   `json:"ret,omitempty"`
+	// ResumeCompleted distinguishes a completed restore with failed follow-up
+	// synchronization from a restore that never completed.
+	ResumeCompleted bool `json:"resume_completed,omitempty"`
 }
 
 type Ret struct {
@@ -826,6 +829,9 @@ type UpdateRequest struct {
 	SandboxID    string `json:"sandbox_id"`
 	InstanceType string `json:"instance_type"`
 	Action       string `json:"action"`
+	// CLM auto-pause is conditional on still owning the shared pausing marker.
+	// Explicit API pauses omit this precondition.
+	ExpectedLifecycleState string `json:"expected_lifecycle_state,omitempty"`
 	// Timeout is the optional idle TTL for resume. nil or 0 keeps the stored
 	// timeout; -1 (NeverTimeout) disables expiry; N>0 opens an N-second
 	// window from now. Values below -1 are rejected. Immediate expiry is

--- a/cube-lifecycle-manager/internal/cubemasterclient/client.go
+++ b/cube-lifecycle-manager/internal/cubemasterclient/client.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -64,8 +65,9 @@ const (
 // non-success ret_code. Callers can errors.As-extract it to react to
 // specific conditions (e.g. "sandbox already paused" → treat as success).
 type APIError struct {
-	RetCode int
-	RetMsg  string
+	RetCode         int
+	RetMsg          string
+	ResumeCompleted bool
 }
 
 func (e *APIError) Error() string {
@@ -78,6 +80,28 @@ func (e *APIError) Error() string {
 func (e *APIError) IsNotFound() bool {
 	return e != nil && e.RetCode == RetCodeInvalidParamFormat
 }
+
+// IsPauseSuperseded means Master rejected a queued auto-pause after a resume
+// changed the shared state. It is not a successful pause.
+func (e *APIError) IsPauseSuperseded() bool {
+	return e != nil && e.RetCode == retCodeConflict && e.RetMsg == pauseSupersededMessage
+}
+
+// Wire contract mirrored from CubeMaster's ErrorCode_Conflict and
+// pkg/service/sandbox/sandbox_lifecycle_state.go. Keep both sides and their
+// literal contract tests in sync: the code also represents lock contention,
+// so the message is part of the protocol, not freely editable display text.
+const (
+	retCodeConflict        = 130409
+	pauseSupersededMessage = "auto-pause superseded by lifecycle state change"
+)
+
+// Info status values mirror ContainerState in
+// pkgs/proto/services/cubebox/v1/cubebox.proto without importing the proto module.
+const (
+	statusRunning = 1 // CONTAINER_RUNNING
+	statusPaused  = 5 // CONTAINER_PAUSED
+)
 
 // alreadyHasPauseSnapshotMarker is the pausesnap.Begin message CubeMaster
 // wraps as 130400. Other 130400 Begin failures must not be treated as success.
@@ -112,14 +136,16 @@ func New(baseURL string, timeout time.Duration) *Client {
 
 // updateRequest mirrors CubeMaster pkg/service/sandbox/types.UpdateRequest.
 type updateRequest struct {
-	RequestID    string `json:"requestID"`
-	SandboxID    string `json:"sandbox_id"`
-	InstanceType string `json:"instance_type"`
-	Action       string `json:"action"` // "pause" | "resume"
+	RequestID              string `json:"requestID"`
+	SandboxID              string `json:"sandbox_id"`
+	InstanceType           string `json:"instance_type"`
+	Action                 string `json:"action"` // "pause" | "resume"
+	ExpectedLifecycleState string `json:"expected_lifecycle_state,omitempty"`
 }
 
 type updateResponse struct {
-	Ret struct {
+	ResumeCompleted bool `json:"resume_completed"`
+	Ret             struct {
 		RetCode int    `json:"ret_code"`
 		RetMsg  string `json:"ret_msg"`
 	} `json:"ret"`
@@ -133,12 +159,12 @@ type killRequest struct {
 	KillReason   string `json:"kill_reason,omitempty"`
 }
 
-// Pause asks CubeMaster to pause the given sandbox. instanceType is required
-// by the master; for the cubebox runtime that's "cubebox".
+// Pause asks CubeMaster to auto-pause the given sandbox. The caller must first
+// acquire CLM's pausing marker; Master revalidates it under the lifecycle lock.
+// instanceType is required; for the cubebox runtime that's "cubebox".
 //
-// Returns nil on success or when the sandbox is already paused. Returns an
-// *APIError for any non-success ret_code; use APIError.IsNotFound /
-// IsAlreadyInState to classify.
+// Returns nil on success, or an *APIError for any non-success ret_code; use
+// IsNotFound, IsAlreadyInState, or IsPauseSuperseded to classify it.
 func (c *Client) Pause(ctx context.Context, sandboxID, instanceType string) error {
 	return c.update(ctx, sandboxID, instanceType, "pause")
 }
@@ -147,6 +173,49 @@ func (c *Client) Pause(ctx context.Context, sandboxID, instanceType string) erro
 // as Pause.
 func (c *Client) Resume(ctx context.Context, sandboxID, instanceType string) error {
 	return c.update(ctx, sandboxID, instanceType, "resume")
+}
+
+// SandboxState provides an authoritative fallback when a reconciliation task
+// outlives the short-lived Redis state marker.
+func (c *Client) SandboxState(ctx context.Context, sandboxID, instanceType string) (string, error) {
+	query := url.Values{"sandbox_id": {sandboxID}, "instance_type": {instanceType}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/cube/sandbox/info?"+query.Encode(), nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.httpc.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("sandbox state: http %d", resp.StatusCode)
+	}
+	var body struct {
+		updateResponse
+		Data []struct {
+			SandboxID string `json:"sandbox_id"`
+			Status    int    `json:"status"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return "", err
+	}
+	if body.Ret.RetCode != RetCodeSuccess {
+		return "", &APIError{RetCode: body.Ret.RetCode, RetMsg: body.Ret.RetMsg}
+	}
+	for _, item := range body.Data {
+		if item.SandboxID != sandboxID {
+			continue
+		}
+		switch item.Status {
+		case statusRunning:
+			return "running", nil
+		case statusPaused:
+			return "paused", nil
+		}
+	}
+	return "", errors.New("sandbox has no confirmed running/paused state")
 }
 
 // Kill asks CubeMaster to destroy the given sandbox.
@@ -202,11 +271,16 @@ func (c *Client) update(ctx context.Context, sandboxID, instanceType, action str
 		return errors.New("sandbox_id and instance_type are required")
 	}
 
+	var expectedState string
+	if action == "pause" {
+		expectedState = "pausing"
+	}
 	body, err := json.Marshal(updateRequest{
-		RequestID:    uuid.NewString(),
-		SandboxID:    sandboxID,
-		InstanceType: instanceType,
-		Action:       action,
+		RequestID:              uuid.NewString(),
+		SandboxID:              sandboxID,
+		InstanceType:           instanceType,
+		Action:                 action,
+		ExpectedLifecycleState: expectedState,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
@@ -240,5 +314,5 @@ func (c *Client) update(ctx context.Context, sandboxID, instanceType, action str
 	if ur.Ret.RetCode == RetCodeSuccess {
 		return nil
 	}
-	return &APIError{RetCode: ur.Ret.RetCode, RetMsg: ur.Ret.RetMsg}
+	return &APIError{RetCode: ur.Ret.RetCode, RetMsg: ur.Ret.RetMsg, ResumeCompleted: action == "resume" && ur.ResumeCompleted}
 }

--- a/cube-lifecycle-manager/internal/cubemasterclient/client_test.go
+++ b/cube-lifecycle-manager/internal/cubemasterclient/client_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -46,6 +47,92 @@ func TestKill_Success(t *testing.T) {
 	}
 	if capturedBody.KillReason != KillReasonTimeout {
 		t.Fatalf("kill_reason should be propagated, got %q", capturedBody.KillReason)
+	}
+}
+
+func TestPauseSupersededWireContract(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"superseded", `{"ret":{"ret_code":130409,"ret_msg":"auto-pause superseded by lifecycle state change"}}`, true},
+		{"lock contention", `{"ret":{"ret_code":130409,"ret_msg":"sandbox lifecycle operation in progress; retry later"}}`, false},
+		{"wrong code", `{"ret":{"ret_code":130500,"ret_msg":"auto-pause superseded by lifecycle state change"}}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer server.Close()
+			err := New(server.URL, time.Second).Pause(context.Background(), "sbx", "cubebox")
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) || apiErr.IsPauseSuperseded() != tc.want {
+				t.Fatalf("unexpected classification: err=%v wantSuperseded=%v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestOnlyAutoPauseCarriesLifecyclePrecondition(t *testing.T) {
+	for _, action := range []string{"pause", "resume"} {
+		t.Run(action, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Error(err)
+				}
+				expected, exists := body["expected_lifecycle_state"]
+				if action == "pause" && expected != "pausing" {
+					t.Error("auto-pause lost precondition")
+				}
+				if action == "resume" && exists {
+					t.Error("resume must not carry pause precondition")
+				}
+				_, _ = w.Write([]byte(`{"ret":{"ret_code":200}}`))
+			}))
+			defer server.Close()
+			if err := New(server.URL, time.Second).update(context.Background(), "sbx", "cubebox", action); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestResumeCompletedSurvivesErrorDecoding(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ret":{"ret_code":130500,"ret_msg":"state synchronization failed"},"resume_completed":true}`))
+	}))
+	defer server.Close()
+	client := New(server.URL, time.Second)
+	var apiErr *APIError
+	if err := client.Resume(context.Background(), "sbx", "cubebox"); !errors.As(err, &apiErr) || !apiErr.ResumeCompleted {
+		t.Fatalf("partial result lost: %v", err)
+	}
+	if err := client.Pause(context.Background(), "sbx", "cubebox"); !errors.As(err, &apiErr) || apiErr.ResumeCompleted {
+		t.Fatalf("pause misclassified as completed resume: %v", err)
+	}
+}
+
+func TestSandboxStateRequiresConfirmedTerminalState(t *testing.T) {
+	for _, status := range []int{1, 5, 4} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("sandbox_id") != "sbx" || r.URL.Query().Get("instance_type") != "cubebox" {
+				t.Error("missing sandbox identity")
+			}
+			_, _ = fmt.Fprintf(w, `{"ret":{"ret_code":200},"data":[{"sandbox_id":"sbx","status":%d}]}`, status)
+		}))
+		state, err := New(server.URL, time.Second).SandboxState(context.Background(), "sbx", "cubebox")
+		server.Close()
+		if status == 4 {
+			if err == nil {
+				t.Fatal("unconfirmed state accepted")
+			}
+			continue
+		}
+		if err != nil || (status == 1 && state != "running") || (status == 5 && state != "paused") {
+			t.Fatalf("state=%s err=%v", state, err)
+		}
 	}
 }
 

--- a/cube-lifecycle-manager/internal/lifecycle/schema.go
+++ b/cube-lifecycle-manager/internal/lifecycle/schema.go
@@ -4,7 +4,11 @@
 
 // Package lifecycle is the CLM-local mirror of
 // CubeMaster/pkg/lifecycle. The two MUST stay byte-compatible: CubeMaster is
-// the single writer, CLM is a pure consumer.
+// the writer of lifecycle metadata/events, CLM consumes them.
+// State keys are normally written by CLM. After restore, CubeMaster writes a
+// 60s running marker under its sandbox lifecycle lock before publishing the
+// running event and unlocking. This invalidates queued auto-pauses; CLM must
+// CAS pausing -> paused and reconcile when running supersedes its transition.
 //
 // We do not import the CubeMaster module directly because it would drag in
 // MySQL, gRPC, scheduler, and a host of other heavy dependencies that have no

--- a/cube-lifecycle-manager/internal/resumer/resumer.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer.go
@@ -110,6 +110,7 @@ func (r *Resumer) Resume(ctx context.Context, sandboxID string) error {
 
 func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 	start := time.Now()
+	var completionErr error
 	entry := r.o.Registry.Get(sandboxID)
 	if entry == nil {
 		return errors.New("sandbox not in registry")
@@ -142,7 +143,11 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 			return errors.New("auto_resume not enabled for sandbox")
 		}
 		if err := r.callCubeMasterResume(ctx, sandboxID, entry.Meta.InstanceType); err != nil {
-			return err
+			var apiErr *cubemasterclient.APIError
+			if !errors.As(err, &apiErr) || !apiErr.ResumeCompleted {
+				return err
+			}
+			completionErr = err // Restore completed; still perform all bookkeeping.
 		}
 	case errors.Is(ownErr, errAlreadyRunning):
 		// Sandbox is already running per Redis. Skip the RPC and run the
@@ -192,7 +197,7 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 	r.o.Log.Info("auto-resumed sandbox",
 		zap.String("sandbox_id", sandboxID),
 		zap.Duration("duration", time.Since(start)))
-	return nil
+	return completionErr
 }
 
 func (r *Resumer) pushRunningState(sandboxID string) {
@@ -224,8 +229,9 @@ func (r *Resumer) pushRunningState(sandboxID string) {
 // callCubeMasterResume issues the resume RPC and maps the three classes
 // of CubeMaster response (success / not-found / already-running / real
 // failure) onto the appropriate caller-side cleanup. Returns nil when the
-// caller should proceed to the success-bookkeeping path; non-nil when the
-// caller should bail with an error.
+// caller should proceed to the success-bookkeeping path. A ResumeCompleted
+// APIError also requires bookkeeping, followed by returning the original error;
+// other errors stop the operation.
 func (r *Resumer) callCubeMasterResume(ctx context.Context, sandboxID, instanceType string) error {
 	resumeErr := r.o.CubeMaster.Resume(ctx, sandboxID, instanceType)
 	if resumeErr == nil {
@@ -233,6 +239,10 @@ func (r *Resumer) callCubeMasterResume(ctx context.Context, sandboxID, instanceT
 	}
 	var apiErr *cubemasterclient.APIError
 	switch {
+	case errors.As(resumeErr, &apiErr) && apiErr.ResumeCompleted:
+		// Do not clear ownership as if the VM were still paused. The caller
+		// refreshes activity and state, but preserves the partial-failure error.
+		return apiErr
 	case errors.As(resumeErr, &apiErr) && apiErr.IsNotFound():
 		// CubeMaster doesn't know this sandbox anymore — deleted out
 		// from under us. Evict everywhere and surface as an error to

--- a/cube-lifecycle-manager/internal/resumer/resumer_test.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer_test.go
@@ -225,6 +225,33 @@ func newTestResumer(reg *registry.Registry, store *fakeStore, master *fakeMaster
 	})
 }
 
+func TestCompletedResumeErrorStillRefreshesStateAndActivity(t *testing.T) {
+	reg := registry.New()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: "sbx", InstanceType: "cubebox", AutoResume: true})
+	reg.SetRuntimeState("sbx", "paused")
+	store, push := newFakeStore(), &fakePush{}
+	partial := &cubemasterclient.APIError{RetCode: 130500, RetMsg: "running synchronization failed", ResumeCompleted: true}
+	master := &fakeMaster{failNext: true, failError: partial}
+	r := newTestResumer(reg, store, master, push)
+	before := time.Now().UnixMilli()
+	// No running event will be replayed: it was skipped while resuming.
+	err := r.Resume(context.Background(), "sbx")
+	if !errors.Is(err, partial) {
+		t.Fatalf("partial error lost: %v", err)
+	}
+	entry := reg.Get("sbx")
+	if store.state("sbx") != "running" || entry.RuntimeState != "running" || entry.LastActiveMs < before {
+		t.Fatalf("completed resume was rolled back: %+v state=%s", entry, store.state("sbx"))
+	}
+	if !pollUntil(time.Second, func() bool {
+		push.mu.Lock()
+		defer push.mu.Unlock()
+		return len(push.pushed) > 0 && push.pushed[len(push.pushed)-1] == "running"
+	}) {
+		t.Fatal("proxy not reconciled")
+	}
+}
+
 func TestResumer_HappyPath(t *testing.T) {
 	reg := registry.New()
 	reg.Upsert(lifecycle.SandboxLifecycleMeta{

--- a/cube-lifecycle-manager/internal/statesync/handler.go
+++ b/cube-lifecycle-manager/internal/statesync/handler.go
@@ -5,11 +5,9 @@
 // Package statesync reconciles the CLM's view of a sandbox's runtime
 // state with pause / resume actions driven externally through CubeMaster.
 //
-// CubeMaster is a stateless proxy: when the SDK calls Sandbox.connect() to
-// resume a paused sandbox, CubeMaster forwards the RPC to Cubelet but does
-// not touch the CLM's state key or CubeProxy's per-worker state dict.
-// Without a nudge from CubeMaster the CLM would keep thinking the
-// sandbox is paused and reject the next request from the dataplane.
+// When the SDK calls Sandbox.connect(), CubeMaster restores through Cubelet
+// and writes a short-lived running marker under its lifecycle lock. The state
+// event then updates CLM's registry, activity timestamp and CubeProxy state.
 //
 // CubeMaster now emits an OpState event on the lifecycle events stream after
 // every successful pause / resume RPC (see CubeMaster/pkg/lifecycle/store.go
@@ -21,12 +19,11 @@
 //     (mirrors resumer.doResume: avoids the sweeper re-pausing a sandbox
 //     that just came back).
 //
-// The event source (CubeMaster) is stateless with respect to the CLM's
-// SETNX-based transition locks ("pausing", "resuming"). To avoid a state
-// event racing an in-flight sweeper.tryPause or resumer.doResume, Handle
-// skips reconciliation whenever the current state key holds a transition
-// marker; the CLM's own flow will write the terminal state moments
-// later, so the event is redundant.
+// Handle skips events while a pausing/resuming marker is present to avoid
+// overwriting an in-flight CLM transition. A completed Master resume replaces
+// that marker with running before publishing its event, allowing reconciliation
+// here. CLM's sweeper uses CAS and retained repairs for superseded pauses; its
+// resumer also completes bookkeeping on a resume_completed partial failure.
 package statesync
 
 import (

--- a/cube-lifecycle-manager/internal/sweeper/iface.go
+++ b/cube-lifecycle-manager/internal/sweeper/iface.go
@@ -21,12 +21,14 @@ type stateStore interface {
 	// WriteState / ClearStateNotify are the notify-emitting equivalents.
 	// See internal/resumer/iface.go for the same contract.
 	WriteState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
+	WriteStateCAS(ctx context.Context, sandboxID, expected, state string, ttl time.Duration) (bool, error)
 	ClearStateNotify(ctx context.Context, sandboxID string) error
 }
 
 // pauseKiller is the subset of cubemasterclient.Client that the sweeper needs.
 // Pause + Kill are the two terminal transitions the sweeper can trigger.
 type pauseKiller interface {
+	SandboxState(ctx context.Context, sandboxID, instanceType string) (string, error)
 	Pause(ctx context.Context, sandboxID, instanceType string) error
 	Kill(ctx context.Context, sandboxID, instanceType, reason string) error
 }

--- a/cube-lifecycle-manager/internal/sweeper/sweeper.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper.go
@@ -65,6 +65,11 @@ type Options struct {
 // its own goroutine; Run returns when ctx is cancelled.
 type Sweeper struct {
 	o Options
+	// Owned by the sweep goroutine. Failed repairs survive individual action
+	// deadlines and are retried before the paused fast path on later ticks.
+	pending map[string]struct{}
+	// Notification retries never gate lifecycle decisions or extend activity.
+	notifications map[string]struct{}
 	// metrics — exposed for testing rather than via Prometheus for now.
 	pauseTriggered atomic.Int64
 	pauseFailed    atomic.Int64
@@ -79,7 +84,7 @@ func New(o Options) *Sweeper {
 	if o.StartedAt.IsZero() {
 		o.StartedAt = o.Now()
 	}
-	return &Sweeper{o: o}
+	return &Sweeper{o: o, pending: make(map[string]struct{}), notifications: make(map[string]struct{})}
 }
 
 // Run blocks until ctx is cancelled, sweeping every Interval.
@@ -104,6 +109,45 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 	if s.o.Leader != nil && !s.o.Leader.IsLeader() {
 		return
 	}
+	// Bound the whole retry phase, not just each RPC, so a slow fleet cannot
+	// delay idle decisions in proportion to the number of pending sandboxes.
+	// Separate budgets prevent either queue from starving the other, while
+	// preserving the time previously allowed for an individual attempt.
+	retryCtx, retryCancel := context.WithTimeout(ctx, advisoryPushTimeout)
+	remaining := retryBatchLimit
+	for sid := range s.notifications {
+		if retryCtx.Err() != nil || remaining == 0 {
+			break
+		}
+		if _, repairing := s.pending[sid]; repairing {
+			continue
+		}
+		if ctx.Err() != nil || (s.o.Leader != nil && !s.o.Leader.IsLeader()) {
+			retryCancel()
+			return
+		}
+		remaining--
+		if err := s.retryNotification(retryCtx, sid); err != nil {
+			s.o.Log.Warn("state notification pending", zap.String("sandbox_id", sid), zap.Error(err))
+		}
+	}
+	retryCancel()
+	retryCtx, retryCancel = context.WithTimeout(ctx, reconciliationTimeout)
+	remaining = retryBatchLimit
+	for sid := range s.pending {
+		if retryCtx.Err() != nil || remaining == 0 {
+			break
+		}
+		if ctx.Err() != nil || (s.o.Leader != nil && !s.o.Leader.IsLeader()) {
+			retryCancel()
+			return
+		}
+		remaining--
+		if err := s.reconcilePause(retryCtx, sid); err != nil {
+			s.o.Log.Warn("pause reconciliation pending", zap.String("sandbox_id", sid), zap.Error(err))
+		}
+	}
+	retryCancel()
 
 	now := s.o.Now()
 	nowMs := now.UnixMilli()
@@ -122,6 +166,9 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 	withinWarmup := now.Sub(s.o.StartedAt) < s.o.BootstrapWarmup
 
 	for _, e := range s.o.Registry.Snapshot() {
+		if _, pending := s.pending[e.Meta.SandboxID]; pending {
+			continue
+		}
 		// Bootstrap entries during warmup → skip. `FirstSeenAt <= StartedAt`
 		// (we backdate FirstSeenAt during bootstrap, so equality means
 		// "loaded from HGETALL", inequality means "new event").
@@ -217,8 +264,10 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 }
 
 const (
-	advisoryPushTimeout  = time.Second
-	terminalWriteReserve = 2 * time.Second
+	advisoryPushTimeout   = time.Second
+	reconciliationTimeout = 3 * time.Second
+	retryBatchLimit       = 16
+	terminalWriteReserve  = 2 * time.Second
 )
 
 // rpcContext carves the CubeMaster call out of the action budget, holding
@@ -279,6 +328,9 @@ func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 	if pauseErr != nil {
 		var apiErr *cubemasterclient.APIError
 		switch {
+		case errors.As(pauseErr, &apiErr) && apiErr.IsPauseSuperseded():
+			s.pending[sid] = struct{}{}
+			return s.reconcileSupersededPause(ctx, sid)
 		case errors.As(pauseErr, &apiErr) && apiErr.IsNotFound():
 			// Sandbox doesn't exist on CubeMaster anymore. Clean up local
 			// state and stop chasing it.
@@ -318,20 +370,128 @@ func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 		}
 	}
 
-	if err := s.o.Redis.WriteState(ctx, sid, "paused", s.o.StateLockTTL); err != nil {
-		s.o.Log.Warn("write paused state failed",
-			zap.String("sandbox_id", sid), zap.Error(err))
-	}
+	s.pending[sid] = struct{}{}
 	s.o.Registry.SetRuntimeState(sid, lifecycle.StatePaused)
+	var pushErr error
 	if err := s.o.ProxyPush.SetState(ctx, sid, "paused"); err != nil {
+		pushErr = err
 		s.o.Log.Warn("push paused state failed",
 			zap.String("sandbox_id", sid), zap.Error(err))
+	}
+	// A resume may complete after the pause RPC but before this bookkeeping.
+	// Finish proxy writes before the CAS so a failed CAS can repair them, and
+	// never overwrite the newer running marker with this stale paused result.
+	updated, err := s.o.Redis.WriteStateCAS(ctx, sid, "pausing", "paused", s.o.StateLockTTL)
+	if err != nil {
+		return err
+	}
+	if !updated {
+		return s.reconcileSupersededPause(ctx, sid)
+	}
+	delete(s.pending, sid)
+	if pushErr != nil {
+		s.notifications[sid] = struct{}{}
+	} else {
+		delete(s.notifications, sid)
 	}
 
 	s.pauseTriggered.Add(1)
 	s.o.Log.Info("auto-paused sandbox",
 		zap.String("sandbox_id", sid),
 		zap.Intp("timeout_seconds", e.Meta.TimeoutSeconds))
+	return nil
+}
+
+func (s *Sweeper) reconcileSupersededPause(ctx context.Context, sid string) error {
+	// The pause's action context may already have expired. Bound each repair
+	// independently; retain unresolved state repairs across Redis failures.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), reconciliationTimeout)
+	defer cancel()
+	return s.reconcilePause(ctx, sid)
+}
+
+// Scheduled retries inherit the sweep's shared budget; immediate post-RPC
+// repairs use the independent context above when the action has expired.
+func (s *Sweeper) reconcilePause(ctx context.Context, sid string) error {
+	entry := s.o.Registry.Get(sid)
+	if entry == nil {
+		delete(s.pending, sid)
+		return nil
+	}
+	state, _, err := s.o.Redis.GetState(ctx, sid)
+	if err != nil {
+		return err
+	}
+	if state == "" {
+		state, err = s.o.CubeMaster.SandboxState(ctx, sid, entry.Meta.InstanceType)
+		if err != nil {
+			return err
+		}
+		updated, err := s.o.Redis.WriteStateCAS(ctx, sid, "", state, s.o.StateLockTTL)
+		if err != nil {
+			return err
+		}
+		if !updated {
+			return errors.New("lifecycle state changed during reconciliation")
+		}
+	}
+	if state != lifecycle.StateRunning && state != lifecycle.StatePaused {
+		return errors.New("lifecycle transition still in progress")
+	}
+	if state == lifecycle.StateRunning && entry.RuntimeState != lifecycle.StateRunning {
+		s.o.Registry.MergeLastActive(sid, s.o.Now().UnixMilli())
+	}
+	s.o.Registry.SetRuntimeState(sid, state)
+	current, _, err := s.o.Redis.GetState(ctx, sid)
+	if err != nil {
+		return err
+	}
+	if current != state {
+		return errors.New("lifecycle state changed during reconciliation")
+	}
+	delete(s.pending, sid)
+	s.notifications[sid] = struct{}{}
+	return s.retryNotification(ctx, sid)
+}
+
+// Resolve the latest state on every attempt; a queued notification must not
+// replay running after a subsequent pause or extend the Redis ownership TTL.
+func (s *Sweeper) retryNotification(ctx context.Context, sid string) error {
+	ctx, cancel := context.WithTimeout(ctx, advisoryPushTimeout)
+	defer cancel()
+	currentState := func() (string, error) {
+		entry := s.o.Registry.Get(sid)
+		if entry == nil {
+			return "", nil
+		}
+		state, _, err := s.o.Redis.GetState(ctx, sid)
+		if err == nil && state == "" {
+			state = entry.RuntimeState
+		}
+		return state, err
+	}
+	state, err := currentState()
+	if err != nil {
+		return err
+	}
+	if state == "" {
+		if s.o.Registry.Get(sid) != nil {
+			return errors.New("sandbox state not yet known")
+		}
+		delete(s.notifications, sid)
+		return nil
+	}
+	if err := s.o.ProxyPush.SetState(ctx, sid, state); err != nil {
+		return err
+	}
+	current, err := currentState()
+	if err != nil {
+		return err
+	}
+	if current != state {
+		return errors.New("lifecycle state changed during proxy notification")
+	}
+	delete(s.notifications, sid)
 	return nil
 }
 

--- a/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
@@ -7,6 +7,8 @@ package sweeper
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -17,6 +19,70 @@ import (
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/registry"
 )
+
+type slowRetryPush struct {
+	*fakePush
+	calls int
+}
+
+func (p *slowRetryPush) SetState(ctx context.Context, sid, state string) error {
+	if strings.HasPrefix(sid, "notify-") {
+		p.calls++
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return p.fakePush.SetState(ctx, sid, state)
+}
+
+type slowRepairStore struct {
+	stateStore
+	calls int
+}
+
+func (s *slowRepairStore) GetState(ctx context.Context, sid string) (string, bool, error) {
+	if strings.HasPrefix(sid, "repair-") {
+		s.calls++
+		<-ctx.Done()
+		return "", false, ctx.Err()
+	}
+	return s.stateStore.GetState(ctx, sid)
+}
+
+func TestSlowRetryBacklogLeavesTimeForIdleScan(t *testing.T) {
+	reg, store, push := registry.New(), newFakeStore(), newFakePush()
+	now := time.Now()
+	master := &fakeMaster{}
+	s := newTestSweeper(reg, store, master, push, now)
+	slowPush := &slowRetryPush{fakePush: push}
+	slowStore := &slowRepairStore{stateStore: store}
+	s.o.ProxyPush, s.o.Redis = slowPush, slowStore
+	for i := 0; i < 4; i++ {
+		for _, prefix := range []string{"notify-", "repair-"} {
+			sid := fmt.Sprintf("%s%d", prefix, i)
+			reg.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: sid, CreatedAt: now.UnixMilli()})
+			reg.SetRuntimeState(sid, "paused")
+			if prefix == "notify-" {
+				s.notifications[sid] = struct{}{}
+			} else {
+				s.pending[sid] = struct{}{}
+			}
+		}
+	}
+	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{SandboxID: "idle", InstanceType: "cubebox", AutoPause: true}, now.Add(-time.Hour).UnixMilli())
+	s.sweepOnce(context.Background())
+	// A deadline-consuming retry must stop its queue, while both queues and
+	// the idle scan still get a turn. Count attempts instead of wall-clock
+	// timing so this remains stable on slow CI machines.
+	if slowPush.calls != 1 || slowStore.calls != 1 {
+		t.Fatalf("unbounded or starved retry queue: notifications=%d repairs=%d", slowPush.calls, slowStore.calls)
+	}
+	if len(s.notifications) != 4 || len(s.pending) != 4 {
+		t.Fatal("unfinished retry tasks were lost")
+	}
+	if len(master.calls) != 1 || master.calls[0] != "idle" {
+		t.Fatalf("idle scan did not pause the unrelated sandbox: %v", master.calls)
+	}
+}
 
 // fakeStore implements stateStore. It uses simple maps; lock contention isn't
 // the focus of these tests, atomicity of state transitions is.
@@ -76,6 +142,16 @@ func (f *fakeStore) WriteState(ctx context.Context, sid, state string, ttl time.
 	return f.SetState(ctx, sid, state, ttl)
 }
 
+func (f *fakeStore) WriteStateCAS(_ context.Context, sid, expected, state string, _ time.Duration) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.states[sid] != expected {
+		return false, nil
+	}
+	f.states[sid] = state
+	return true, nil
+}
+
 func (f *fakeStore) ClearStateNotify(ctx context.Context, sid string) error {
 	return f.ClearState(ctx, sid)
 }
@@ -90,6 +166,7 @@ func (f *fakeStore) state(sid string) string {
 // The same struct serves both paths so a single sweeper can drive either; the
 // pause-* tests assert on `calls`, the kill-* tests on `killCalls`.
 type fakeMaster struct {
+	state     string
 	mu        sync.Mutex
 	calls     []string
 	failNext  bool
@@ -99,6 +176,13 @@ type fakeMaster struct {
 	killReasons  []string
 	failNextKill bool
 	failKillErr  error
+}
+
+func (f *fakeMaster) SandboxState(context.Context, string, string) (string, error) {
+	if f.state == "" {
+		return "running", nil
+	}
+	return f.state, nil
 }
 
 func (f *fakeMaster) Pause(_ context.Context, sid, _ string) error {
@@ -135,6 +219,150 @@ type fakePush struct {
 
 func newFakePush() *fakePush {
 	return &fakePush{pushed: make(map[string][]string)}
+}
+
+type resumeDuringPausePush struct {
+	*fakePush
+	store *fakeStore
+}
+
+func (p resumeDuringPausePush) SetState(ctx context.Context, sid, state string) error {
+	if state == "pausing" || state == "paused" {
+		// Master resumes either while the pause RPC is queued or before its
+		// successful result is reconciled by CLM.
+		_ = p.store.SetState(ctx, sid, "running", time.Minute)
+	}
+	return p.fakePush.SetState(ctx, sid, state)
+}
+
+func TestResumeSupersedesQueuedPauseAndLateBookkeeping(t *testing.T) {
+	for _, superseded := range []bool{true, false} {
+		reg, store, push := registry.New(), newFakeStore(), newFakePush()
+		reg.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: "sbx", InstanceType: "cubebox", AutoPause: true})
+		master := &fakeMaster{}
+		if superseded {
+			master.failNext = true
+			master.failError = &cubemasterclient.APIError{RetCode: 130409, RetMsg: "auto-pause superseded by lifecycle state change"}
+		}
+		now := time.Now()
+		s := newTestSweeper(reg, store, master, push, now)
+		s.o.ProxyPush = resumeDuringPausePush{push, store}
+		if err := s.tryPause(context.Background(), *reg.Get("sbx")); err != nil {
+			t.Fatal(err)
+		}
+		entry := reg.Get("sbx")
+		if store.state("sbx") != "running" || entry.RuntimeState != "running" || entry.LastActiveMs != now.UnixMilli() {
+			t.Fatalf("stale pause overwrote resume: superseded=%v entry=%+v state=%s", superseded, entry, store.state("sbx"))
+		}
+		states := push.states("sbx")
+		if states[len(states)-1] != "running" {
+			t.Fatalf("proxy retained stale pause: %v", states)
+		}
+		triggered, _ := s.Stats()
+		if triggered != 0 {
+			t.Fatal("superseded pause counted as auto-paused")
+		}
+	}
+}
+
+type flakyReconcileStore struct {
+	stateStore
+	casFailures, readFailures int
+}
+
+func (f *flakyReconcileStore) WriteStateCAS(ctx context.Context, sid, expected, state string, ttl time.Duration) (bool, error) {
+	if f.casFailures > 0 {
+		f.casFailures--
+		return false, errors.New("CAS unavailable")
+	}
+	return f.stateStore.WriteStateCAS(ctx, sid, expected, state, ttl)
+}
+
+func (f *flakyReconcileStore) GetState(ctx context.Context, sid string) (string, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return "", false, err
+	}
+	if f.readFailures > 0 {
+		f.readFailures--
+		return "", false, errors.New("GET unavailable")
+	}
+	return f.stateStore.GetState(ctx, sid)
+}
+
+type flakyRunningPush struct {
+	*fakePush
+	failures  int
+	allStates bool
+}
+
+func (p *flakyRunningPush) SetState(ctx context.Context, sid, state string) error {
+	if (state == "running" || p.allStates) && p.failures > 0 {
+		p.failures--
+		return errors.New("proxy unavailable")
+	}
+	return p.fakePush.SetState(ctx, sid, state)
+}
+
+func TestPauseCASFailureRetriedBeforeParkedSkip(t *testing.T) {
+	reg, store, push := registry.New(), newFakeStore(), newFakePush()
+	now := time.Now()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: "sbx", InstanceType: "cubebox", AutoPause: true, CreatedAt: now.Add(-time.Hour).UnixMilli()})
+	// The running event has already been consumed, so there is no later event
+	// available to repair an obsolete paused write after a failed CAS.
+	reg.SetRuntimeState("sbx", "running")
+	reg.MergeLastActive("sbx", now.UnixMilli())
+	master := &fakeMaster{state: "running"}
+	s := newTestSweeper(reg, store, master, push, now)
+	flaky := &flakyReconcileStore{stateStore: store, casFailures: 1}
+	s.o.Redis = flaky
+	s.o.ProxyPush = resumeDuringPausePush{push, store}
+	if err := s.tryPause(context.Background(), *reg.Get("sbx")); err == nil {
+		t.Fatal("expected CAS error")
+	}
+	if reg.Get("sbx").RuntimeState != "paused" || len(s.pending) != 1 {
+		t.Fatal("failed paused write was not retained for repair")
+	}
+	flaky.readFailures = 1
+	s.sweepOnce(context.Background())
+	if len(s.pending) != 1 {
+		t.Fatal("lost repair after Redis read failure")
+	}
+	// An unresolved repair outlives the Redis key: query Master for a
+	// confirmed terminal state before repairing the Registry.
+	_ = store.ClearState(context.Background(), "sbx")
+	s.o.ProxyPush = &flakyRunningPush{fakePush: push, failures: 1}
+	s.sweepOnce(context.Background())
+	if len(s.pending) != 0 || len(s.notifications) != 1 {
+		t.Fatal("notification failure must not retain lifecycle repair")
+	}
+	// Notification retries use the already repaired Registry after expiry,
+	// without recreating a Redis ownership marker.
+	_ = store.ClearState(context.Background(), "sbx")
+	s.sweepOnce(context.Background())
+	if len(s.pending) != 0 || len(s.notifications) != 0 || reg.Get("sbx").RuntimeState != "running" || store.state("sbx") != "" {
+		t.Fatal("repair did not converge")
+	}
+	states := push.states("sbx")
+	if states[len(states)-1] != "running" || len(master.calls) != 1 {
+		t.Fatalf("repair issued another pause or left proxy stale: %v", states)
+	}
+}
+
+func TestPauseReconciliationUsesFreshContext(t *testing.T) {
+	reg, store, push := registry.New(), newFakeStore(), newFakePush()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: "sbx", InstanceType: "cubebox"})
+	_ = store.SetState(context.Background(), "sbx", "running", time.Minute)
+	s := newTestSweeper(reg, store, &fakeMaster{}, push, time.Now())
+	s.o.Redis = &flakyReconcileStore{stateStore: store}
+	s.pending["sbx"] = struct{}{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := s.reconcileSupersededPause(ctx, "sbx"); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.pending) != 0 {
+		t.Fatal("expired action context prevented repair")
+	}
 }
 
 func (f *fakePush) SetState(_ context.Context, sid, state string) error {
@@ -907,5 +1135,64 @@ func TestSweeper_AlreadyPausedReconcilesAsSuccess(t *testing.T) {
 	if triggered != 1 || failed != 0 {
 		t.Fatalf("already-paused should count as triggered, not failed: triggered=%d failed=%d",
 			triggered, failed)
+	}
+}
+
+// Failed notifications must neither refresh activity nor prevent a later
+// timeout action, and must send the new paused state when delivery recovers.
+func TestNotificationOutageDoesNotExtendIdleTimeout(t *testing.T) {
+	ctx := context.Background()
+	reg, store, push := registry.New(), newFakeStore(), newFakePush()
+	now := time.Now()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: "sbx", InstanceType: "cubebox", AutoPause: true, CreatedAt: now.Add(-time.Hour).UnixMilli()})
+	reg.SetRuntimeState("sbx", "paused")
+	_ = store.SetState(ctx, "sbx", "running", time.Minute)
+	master := &fakeMaster{}
+	s := newTestSweeper(reg, store, master, push, now)
+	s.o.Now = func() time.Time { return now }
+	s.o.ProxyPush = &flakyRunningPush{fakePush: push, failures: 100, allStates: true}
+	s.pending["sbx"] = struct{}{}
+	s.sweepOnce(ctx)
+	resumedAt := reg.Get("sbx").LastActiveMs
+	if len(s.pending) != 0 || len(s.notifications) != 1 || resumedAt != now.UnixMilli() {
+		t.Fatal("running repair did not finish independently of notification")
+	}
+	_ = store.ClearState(ctx, "sbx") // simulate TTL expiry
+	for i := 0; i < 4; i++ {
+		now = now.Add(time.Minute)
+		s.sweepOnce(ctx)
+		if reg.Get("sbx").LastActiveMs != resumedAt || len(master.calls) != 0 || store.state("sbx") != "" {
+			t.Fatal("notification retry changed activity or ownership")
+		}
+	}
+	now = now.Add(2 * time.Minute)
+	s.sweepOnce(ctx)
+	if len(master.calls) != 1 || reg.Get("sbx").RuntimeState != "paused" || len(s.notifications) != 1 || len(s.pending) != 0 {
+		t.Fatal("notification outage prevented idle pause or retained lifecycle repair")
+	}
+	s.o.ProxyPush = push
+	s.sweepOnce(ctx)
+	states := push.states("sbx")
+	if states[len(states)-1] != "paused" || reg.Get("sbx").LastActiveMs != resumedAt {
+		t.Fatalf("stale running notification replayed: %v", states)
+	}
+}
+
+func TestReconciliationDoesNotRefreshAlreadyAppliedResume(t *testing.T) {
+	ctx := context.Background()
+	reg, store, push := registry.New(), newFakeStore(), newFakePush()
+	now := time.Now()
+	active := now.Add(-time.Minute).UnixMilli()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: "sbx"})
+	reg.SetRuntimeState("sbx", "running")
+	reg.MergeLastActive("sbx", active)
+	_ = store.SetState(ctx, "sbx", "running", time.Minute)
+	s := newTestSweeper(reg, store, &fakeMaster{}, push, now)
+	s.pending["sbx"] = struct{}{}
+	if err := s.reconcileSupersededPause(ctx, "sbx"); err != nil {
+		t.Fatal(err)
+	}
+	if reg.Get("sbx").LastActiveMs != active {
+		t.Fatal("already applied resume was counted as new activity")
 	}
 }

--- a/docs/dev/redis-key-spec.md
+++ b/docs/dev/redis-key-spec.md
@@ -63,7 +63,7 @@ The following are the standard keys currently registered in the system (`v1`). N
 | Instance metadata (reserved) | `cube:v1:master:instance:meta:{...}` | string / list | master | CubeMaster | CubeMaster | none |
 | Sandbox lifecycle registry | `cube:v1:shared:sandbox:lifecycle:meta` | Hash | shared | CubeMaster | cube-lifecycle-manager | none (lifecycle via `HDEL`) |
 | Sandbox lifecycle events | `cube:v1:shared:sandbox:lifecycle:events` | Stream | shared | CubeMaster | cube-lifecycle-manager | MAXLEN ~ 100000 |
-| Sandbox lifecycle state | `cube:v1:shared:sandbox:lifecycle:state:{sandboxID}` | String | shared | cube-lifecycle-manager | cube-lifecycle-manager | SET TTL (default 60s); plain-text state (`paused` / `running` / transition markers) |
+| Sandbox lifecycle state | `cube:v1:shared:sandbox:lifecycle:state:{sandboxID}` | String | shared | cube-lifecycle-manager; CubeMaster (post-restore `running`) | cube-lifecycle-manager; CubeMaster (auto-pause precondition) | SET TTL (CLM configurable, default 60s; Master running marker fixed 60s); plain-text state (`paused` / `running` / transition markers) |
 | Sandbox lifecycle wakeup | `cube:v1:shared:sandbox:lifecycle:notify` | Pub/Sub channel | shared | cube-lifecycle-manager | cube-lifecycle-manager | n/a (best-effort hint) |
 | CLM leader lease | `cube:v1:shared:lock:lifecycle-manager:leader` | String | shared | cube-lifecycle-manager | cube-lifecycle-manager | SET NX PX, default 10s; single-key WATCH transaction for renew/release |
 | Sandbox op lock (pause/resume/delete) | `cube:v1:master:lock:sandbox:{sandboxID}` | String | master | CubeMaster | CubeMaster | SET NX EX by op: pause **180s**, resume/delete **120s**, other **60s**; unlock = token-matched Lua GET+DEL (no renew) |
@@ -134,7 +134,7 @@ See the `redis` tags on `InstanceInfoMap` in [`CubeMaster/pkg/base/types/redis.g
 | `instance:info` / `instance:meta` | No TTL | Managed per instance lifecycle; may be augmented later |
 | `sandbox:lifecycle:meta` | No TTL | Written on sandbox create, `HDEL` on destroy |
 | `sandbox:lifecycle:events` | MAXLEN ~ | Stream trimmed on each `XADD` (default ~100000) |
-| `sandbox:lifecycle:state` | SET TTL | `EX` on each write (cube-lifecycle-manager default 60s); released on rollback or sandbox delete |
+| `sandbox:lifecycle:state` | SET TTL | CLM: configurable `StateLockTTL` (default 60s); Master post-restore `running`: fixed 60s; released on rollback or sandbox delete |
 | `lock:lifecycle-manager:leader` | Renewable lease | Acquired with `SET NX PX` (default 10s); renewed and released with a token-checked, single-key `WATCH`/`MULTI`/`EXEC` transaction; no Lua/EVAL |
 | `lock:sandbox` | SET NX EX (op-specific) | Crash/leak safety net only; normal unlock is token-safe Lua (`GET` must match holder token before `DEL`). TTLs: pause **180s**, resume/delete **120s**, default **60s** (`CubeMaster/pkg/sandboxlock`). No renew. |
 | `cube_proxy:registry` | No TTL (heartbeat-derived) | Written by each CubeProxy replica on startup; entries are `HDEL`'d by cube-lifecycle-manager once the corresponding heartbeat expires |

--- a/docs/zh/dev/redis-key-spec.md
+++ b/docs/zh/dev/redis-key-spec.md
@@ -63,7 +63,7 @@ cube:{ver}:{scope}:{resource}[:{sub}...]:{id}
 | 实例 metadata（预留） | `cube:v1:master:instance:meta:{...}` | string / list | master | CubeMaster | CubeMaster | 无 |
 | 沙箱 lifecycle 注册表 | `cube:v1:shared:sandbox:lifecycle:meta` | Hash | shared | CubeMaster | cube-lifecycle-manager | 无（生命周期由 `HDEL` 管理） |
 | 沙箱 lifecycle 事件流 | `cube:v1:shared:sandbox:lifecycle:events` | Stream | shared | CubeMaster | cube-lifecycle-manager | MAXLEN ~ 100000 |
-| 沙箱 lifecycle 状态 | `cube:v1:shared:sandbox:lifecycle:state:{sandboxID}` | String | shared | cube-lifecycle-manager | cube-lifecycle-manager | SET TTL（默认 60s）；纯文本状态（`paused` / `running` / 过渡标记） |
+| 沙箱 lifecycle 状态 | `cube:v1:shared:sandbox:lifecycle:state:{sandboxID}` | String | shared | cube-lifecycle-manager；CubeMaster（恢复后的 `running`） | cube-lifecycle-manager；CubeMaster（自动暂停前置条件） | SET TTL（CLM 可配置，默认 60s；Master 的 running 标记固定为 60s）；纯文本状态（`paused` / `running` / 过渡标记） |
 | 沙箱 lifecycle 唤醒通知 | `cube:v1:shared:sandbox:lifecycle:notify` | Pub/Sub channel | shared | cube-lifecycle-manager | cube-lifecycle-manager | 不适用（best-effort 提示） |
 | CLM leader 租约 | `cube:v1:shared:lock:lifecycle-manager:leader` | String | shared | cube-lifecycle-manager | cube-lifecycle-manager | SET NX PX，默认 10s；续租/释放使用单 key WATCH 事务 |
 | 沙箱操作锁（pause/resume/delete） | `cube:v1:master:lock:sandbox:{sandboxID}` | String | master | CubeMaster | CubeMaster | 按操作 SET NX EX：pause **180s**，resume/delete **120s**，其它 **60s**；解锁为 token 匹配的 Lua GET+DEL（不续期） |
@@ -134,7 +134,7 @@ cube:{ver}:{scope}:{resource}[:{sub}...]:{id}
 | `instance:info` / `instance:meta` | 无 TTL | 随实例生命周期管理；后续可按需补充 |
 | `sandbox:lifecycle:meta` | 无 TTL | 沙箱创建时写入，销毁时 `HDEL` |
 | `sandbox:lifecycle:events` | MAXLEN ~ | 每次 `XADD` 时裁剪（默认 ~100000） |
-| `sandbox:lifecycle:state` | SET TTL | 每次写入带 `EX`（cube-lifecycle-manager 默认 60s）；回滚或沙箱删除时释放 |
+| `sandbox:lifecycle:state` | SET TTL | CLM：可配置的 `StateLockTTL`（默认 60s）；Master 恢复后的 `running`：固定 60s；回滚或沙箱删除时释放 |
 | `lock:lifecycle-manager:leader` | 可续期租约 | 通过 `SET NX PX` 获取（默认 10s）；使用 token 校验的单 key `WATCH`/`MULTI`/`EXEC` 事务续租和释放；不使用 Lua/EVAL |
 | `lock:sandbox` | SET NX EX（按操作） | 仅作崩溃／泄漏兜底；正常解锁为 token 安全的 Lua（`GET` 匹配持锁 token 后才 `DEL`）。TTL：pause **180s**，resume/delete **120s**，默认 **60s**（见 `CubeMaster/pkg/sandboxlock`）。不续期。 |
 | `cube_proxy:registry` | 无 TTL（依赖心跳） | 每个 CubeProxy 副本启动时写入；对应心跳过期后由 cube-lifecycle-manager 通过 `HDEL` 清理 |


### PR DESCRIPTION
## Problem

Ref #1683

An explicit `connect` could race with CLM auto-pause. CLM could decide that a sandbox was idle, mark it as `pausing`, and queue a pause request while CubeMaster was restoring the same sandbox. The CubeMaster lifecycle lock serialized both operations, but it did not invalidate a pause request whose idle decision became stale while waiting for the lock.

The `running` event from resume could then be skipped while CLM still observed the `pausing` transition, and the queued pause could run immediately afterwards. A successful `connect` could therefore return a sandbox that became `paused` again within milliseconds. Delayed bookkeeping and synchronization failures could also leave Redis, CLM's registry, and CubeProxy out of sync with the actual sandbox.

## Solution

- CLM includes `expected_lifecycle_state=pausing` in auto-pause requests. CubeMaster revalidates this precondition after acquiring the sandbox lifecycle lock, rejecting a pause that was superseded while queued before it reaches Cubelet.
- CubeMaster records a short-lived `running` lifecycle marker immediately after restore succeeds and before releasing the lock or publishing the event. This makes the completed resume visible to queued auto-pause work.
- CLM commits the final `pausing -> paused` transition with CAS. If resume changed the state while the pause RPC was running, CLM reconciles Redis, its in-memory registry, and CubeProxy instead of overwriting the newer `running` state.
- Failed reconciliation is retained and retried with a bounded context. CubeProxy notification retries are handled separately, do not block idle-timeout decisions or refresh activity timestamps, and resolve the latest state before sending it.
- CubeMaster reports when restore completed even if lifecycle synchronization failed. CLM can then finish running-state bookkeeping and apply the requested timeout while preserving the partial-failure error.
- The Info fallback preserves an explicit Cubelet `running` result when a completed resume leaves behind a stale READY pause binding.