### PR TITLE
ci(workflows): use provider-prefixed model id for Claude Code action

### DIFF
--- a/.github/workflows/claude-response.yml
+++ b/.github/workflows/claude-response.yml
@@ -45,8 +45,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
             ANTHROPIC_BASE_URL: https://tokenhub.tencentmaas.com
-            ANTHROPIC_MODEL: deepseek-v4-flash-202605
-            ANTHROPIC_SMALL_FAST_MODEL: deepseek-v4-flash-202605
+            ANTHROPIC_MODEL: deepseek/deepseek-v4-flash
+            ANTHROPIC_SMALL_FAST_MODEL: deepseek/deepseek-v4-flash
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -80,8 +80,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: https://tokenhub.tencentmaas.com
-          ANTHROPIC_MODEL: deepseek-v4-flash-202605
-          ANTHROPIC_SMALL_FAST_MODEL: deepseek-v4-flash-202605
+          ANTHROPIC_MODEL: deepseek/deepseek-v4-flash
+          ANTHROPIC_SMALL_FAST_MODEL: deepseek/deepseek-v4-flash
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
             ANTHROPIC_BASE_URL: https://tokenhub.tencentmaas.com
-            ANTHROPIC_MODEL: deepseek-v4-flash-202605
-            ANTHROPIC_SMALL_FAST_MODEL: deepseek-v4-flash-202605
+            ANTHROPIC_MODEL: deepseek/deepseek-v4-flash
+            ANTHROPIC_SMALL_FAST_MODEL: deepseek/deepseek-v4-flash
             CLAUDE_CODE_SCRIPT_CAPS: '{"edit-issue-labels.sh":2}'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
             ANTHROPIC_BASE_URL: https://tokenhub.tencentmaas.com
-            ANTHROPIC_MODEL: deepseek-v4-flash-202605
-            ANTHROPIC_SMALL_FAST_MODEL: deepseek-v4-flash-202605
+            ANTHROPIC_MODEL: deepseek/deepseek-v4-flash
+            ANTHROPIC_SMALL_FAST_MODEL: deepseek/deepseek-v4-flash
             CLAUDE_CODE_SCRIPT_CAPS: '{"edit-issue-labels.sh":2}'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Background

The Claude Code action workflows set `ANTHROPIC_MODEL` and
`ANTHROPIC_SMALL_FAST_MODEL` to a bare model name (`deepseek-v4-flash-202605`).
The gateway expects a provider-prefixed identifier, so the bare name no longer
resolves to the intended model.

## Change

Switch both variables to `deepseek/deepseek-v4-flash` in the four workflows
that use the Claude Code action:

- `.github/workflows/claude-response.yml`
- `.github/workflows/code-review.yml`
- `.github/workflows/duplicate-issues.yml`
- `.github/workflows/issue-triage.yml`

## Scope

Configuration-only change; 4 files, 8 lines. All four workflows now resolve the
same model through the same identifier, so behavior is consistent across
comment responses, code review, duplicate detection and issue triage.

## Validation

- `git diff` confirms only the two env vars per file are touched.
- No functional, credential or endpoint changes.

Signed-off-by: jinlong <jinlong@tencent.com>
