### PR TITLE
feat(s3lvol): select reactor CPUs from scheduler affinity

### DIFF
--- a/CubeS3lvol/README.md
+++ b/CubeS3lvol/README.md
@@ -150,7 +150,7 @@ used ones:
 | `RCOW_CAPACITY_GB` | `16384` | used only at first create; thin, unused space costs nothing |
 | `RCOW_CACHE_MB` | `490496` | chunk cache on the WAL image; only matters before the first start |
 | `RCOW_LISTEN_ADDR` / `RCOW_LISTEN_PORT` | `127.0.0.1` / `4420` | |
-| `RCOW_TGT_CPUMASK` | `0x3` | |
+| `RCOW_TGT_CPUMASK` | empty (automatic) | exact SPDK mask/list override; automatic mode maps two reactors to the two highest allowed CPU IDs below `CPU_SETSIZE` |
 | `RCOW_NO_HUGE` | `1` | no hugepages by default, a deliberate choice |
 | `RCOW_RPC_SOCK` | `/var/run/s3lvol.sock` | |
 
@@ -385,12 +385,29 @@ For a local MinIO the config must also set `path_style = "true"` and
 ### Busy-polling threads and CPU affinity
 
 `s3lvol_tgt` runs SPDK reactor threads in busy-poll mode: they spin at 100% of
-the cores they are pinned to and never sleep. The current deployment starts
-with **2 reactors on 2 dedicated cores** (e.g. `-m 0x3` pins them to CPU 0 and
-CPU 1). Those two cores are fully consumed by the target, so **other
-(application/business) processes must be kept off them** — pin them elsewhere
-with `taskset`/`numactl` (or a cpuset/cgroup) so the target's request latency
-is not disturbed by scheduler contention.
+the cores they are pinned to and never sleep. Unless an explicit SPDK reactor
+mask or lcore map is supplied (`-m`, `--lcores`, or `RCOW_TGT_CPUMASK`), the
+target maps two dense SPDK lcores to the two highest-numbered logical CPUs below
+`CPU_SETSIZE` in its effective scheduler affinity at startup. Higher CPU IDs can
+still host background/CRT threads, but DPDK cannot select them as reactors.
+That affinity already reflects `taskset`, cpuset/cgroup, and container runtime
+restrictions; if only one supported CPU is available, the target starts one
+reactor, and if none is available startup fails.
+
+Background/CRT threads are restricted to the startup affinity minus the reactor
+CPUs. If the reactors consume every allowed CPU, they instead share the full
+affinity and the target logs a warning; leave at least one additional CPU allowed
+when reactor/background separation is required.
+
+The selected CPUs are fully consumed by the target, but selecting them does
+**not** isolate them from other workloads or guarantee separate physical cores;
+on SMT hosts the two highest logical CPUs may be sibling threads on one core.
+Keep other application/business processes off them with `taskset`/`numactl`
+(or a cpuset/cgroup), or set an exact
+SPDK mask/list such as `RCOW_TGT_CPUMASK=0x30` or `[4,5]` for pre-isolated
+cores. Existing one-click installations retain any persisted mask (including
+the former `0x3` default); remove or empty `RCOW_TGT_CPUMASK` before upgrading
+to opt into automatic selection.
 
 ## LIMITATIONS and TODOs
 

--- a/CubeS3lvol/app/s3lvol_tgt/Makefile
+++ b/CubeS3lvol/app/s3lvol_tgt/Makefile
@@ -8,7 +8,8 @@
 #
 #  Running (credentials are read from the environment):
 #    export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
-#    ./s3lvol_tgt -m 0x3            # needs root (DPDK)
+#    ./s3lvol_tgt                    # auto-maps two reactors to allowed CPUs
+#    ./s3lvol_tgt -m 0x30            # explicit mask overrides the default
 #
 #  === --whole-archive must cover SPDK's own libraries, not just ours ===
 #
@@ -88,9 +89,16 @@ DPDK_STATIC_LIBS = $(call dpdk_static_libs,$(SPDK_APP_LIBS))
 
 .PHONY: all clean
 
+APP_SRCS = s3lvol_tgt.c s3lvol_tgt_cpumask.c
+APP_OBJS = $(APP_SRCS:.c=.o)
+
 all: $(APP)
-$(APP): s3lvol_tgt.c $(MODULE_DIR)/libs3lvol_bdev.a $(S3BSDEV_DIR)/libs3bsdev.a
-	$(CC) $(COMMON_CFLAGS) s3lvol_tgt.c \
+
+%.o: %.c
+	$(CC) $(COMMON_CFLAGS) -c $< -o $@
+
+$(APP): $(APP_OBJS) $(MODULE_DIR)/libs3lvol_bdev.a $(S3BSDEV_DIR)/libs3bsdev.a
+	$(CC) $(COMMON_CFLAGS) $(APP_OBJS) \
 	    -Wl,--whole-archive \
 	        $(MODULE_DIR)/libs3lvol_bdev.a \
 	        $(S3BSDEV_DIR)/libs3bsdev.a \
@@ -108,8 +116,8 @@ $(APP): s3lvol_tgt.c $(MODULE_DIR)/libs3lvol_bdev.a $(S3BSDEV_DIR)/libs3bsdev.a
 
 # The build flags are not part of the dependencies, so switching
 # S3LVOL_BUILD_TYPE has to go through this stamp (see mk/). The libraries hang
-# their own copy of the dependency; this line covers s3lvol_tgt.c itself.
-$(APP): $(S3LVOL_BUILD_STAMP)
+# their own copy of the dependency; this line covers the application objects.
+$(APP_OBJS): $(S3LVOL_BUILD_STAMP)
 
 $(MODULE_DIR)/libs3lvol_bdev.a:
 	$(MAKE) --directory=$(MODULE_DIR) static
@@ -117,9 +125,8 @@ $(MODULE_DIR)/libs3lvol_bdev.a:
 $(S3BSDEV_DIR)/libs3bsdev.a:
 	$(MAKE) --directory=$(S3BSDEV_DIR) static
 
-# Header dependencies for s3lvol_tgt.c itself, recorded by -MMD. The name comes
-# from -o, so it is $(APP).d.
--include $(APP).d
+# Header dependencies recorded by -MMD (see mk/s3lvol.common.mk).
+-include $(APP_OBJS:.o=.d)
 
 clean:
 	rm -f $(APP) *.o *.d

--- a/CubeS3lvol/app/s3lvol_tgt/s3lvol_tgt.c
+++ b/CubeS3lvol/app/s3lvol_tgt/s3lvol_tgt.c
@@ -41,6 +41,25 @@
 #include "spdk/event.h"
 #include "spdk/log.h"
 
+#include "s3lvol/s3_spawner.h"
+
+#include "s3lvol_tgt_cpumask.h"
+
+static struct s3lvol_tgt_cpu_selection g_cpu_selection;
+
+static void
+s3lvol_tgt_restore_original_affinity(void)
+{
+	if (g_cpu_selection.original == NULL) {
+		return;
+	}
+	if (sched_setaffinity(0, g_cpu_selection.cpuset_size,
+			      g_cpu_selection.original) != 0) {
+		SPDK_WARNLOG("could not restore startup affinity: %s\n",
+			     strerror(errno));
+	}
+}
+
 static void
 s3lvol_tgt_started(void *arg1)
 {
@@ -53,6 +72,7 @@ int
 main(int argc, char **argv)
 {
 	struct spdk_app_opts opts = {};
+	char lcore_map[64];
 	int rc;
 
 	spdk_app_opts_init(&opts, sizeof(opts));
@@ -64,11 +84,71 @@ main(int argc, char **argv)
 		return rc == SPDK_APP_PARSE_ARGS_HELP ? 0 : 1;
 	}
 
+	if (opts.reactor_mask == NULL && opts.lcore_map == NULL) {
+		rc = s3lvol_tgt_lcore_map_from_affinity(2,
+						    lcore_map, sizeof(lcore_map),
+						    &g_cpu_selection);
+		if (rc != 0) {
+			if (rc == -ENODEV) {
+				fprintf(stderr, "process affinity contains no CPU below "
+					"CPU_SETSIZE for a DPDK reactor\n");
+			} else {
+				fprintf(stderr, "could not select reactor CPUs from process "
+					"affinity: %s\n", strerror(-rc));
+			}
+			return 1;
+		}
+		opts.lcore_map = lcore_map;
+		fprintf(stderr, "automatic reactor lcore map: %s\n", lcore_map);
+	} else {
+		size_t num_cpus;
+
+		rc = s3lvol_tgt_capture_affinity(&g_cpu_selection);
+		if (rc != 0) {
+			fprintf(stderr, "could not read process affinity: %s\n",
+				strerror(-rc));
+			return 1;
+		}
+		num_cpus = g_cpu_selection.cpuset_size * CHAR_BIT;
+		g_cpu_selection.reactors = CPU_ALLOC(num_cpus);
+		g_cpu_selection.background = CPU_ALLOC(num_cpus);
+		if (g_cpu_selection.reactors == NULL ||
+		    g_cpu_selection.background == NULL) {
+			s3lvol_tgt_cpu_selection_fini(&g_cpu_selection);
+			return 1;
+		}
+		rc = s3lvol_tgt_background_from_options(
+			g_cpu_selection.original, g_cpu_selection.cpuset_size, num_cpus,
+			opts.reactor_mask, opts.lcore_map, g_cpu_selection.reactors,
+			g_cpu_selection.background);
+		if (rc != 0) {
+			fprintf(stderr, "could not derive background CPUs from explicit "
+				"SPDK placement: %s\n", strerror(-rc));
+			s3lvol_tgt_cpu_selection_fini(&g_cpu_selection);
+			return 1;
+		}
+	}
+
+	if (s3lvol_tgt_cpu_selection_shares_reactors(&g_cpu_selection)) {
+		fprintf(stderr, "warning: reactors occupy every available CPU; "
+			"background threads will share them\n");
+	}
+	rc = s3_spawner_set_cpuset(g_cpu_selection.background,
+				   g_cpu_selection.cpuset_size);
+	if (rc != 0) {
+		fprintf(stderr, "could not preserve background CPU affinity: %s\n",
+			strerror(-rc));
+		s3lvol_tgt_cpu_selection_fini(&g_cpu_selection);
+		return 1;
+	}
+
 	rc = spdk_app_start(&opts, s3lvol_tgt_started, NULL);
 	if (rc) {
 		SPDK_ERRLOG("spdk_app_start failed: %d\n", rc);
 	}
 
+	s3lvol_tgt_restore_original_affinity();
 	spdk_app_fini();
+	s3lvol_tgt_cpu_selection_fini(&g_cpu_selection);
 	return rc;
 }

--- a/CubeS3lvol/app/s3lvol_tgt/s3lvol_tgt_cpumask.c
+++ b/CubeS3lvol/app/s3lvol_tgt/s3lvol_tgt_cpumask.c
@@ -1,0 +1,501 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+#include "s3lvol_tgt_cpumask.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int
+select_reactors(const cpu_set_t *cpuset, size_t cpuset_size, size_t num_cpus,
+		size_t reactor_count, size_t *highest, size_t *second)
+{
+	int found = 0;
+
+	if (cpuset == NULL || reactor_count == 0) {
+		return -EINVAL;
+	}
+
+	if (num_cpus > CPU_SETSIZE) {
+		num_cpus = CPU_SETSIZE;
+	}
+	for (size_t cpu = num_cpus; cpu > 0; cpu--) {
+		size_t id = cpu - 1;
+
+		if (!CPU_ISSET_S(id, cpuset_size, cpuset)) {
+			continue;
+		}
+		if (found == 0) {
+			*highest = id;
+			found = 1;
+		} else if (reactor_count > 1) {
+			*second = id;
+			found = 2;
+			break;
+		}
+	}
+
+	return found == 0 ? -ENODEV : found;
+}
+
+int
+s3lvol_tgt_lcore_map_from_set(const cpu_set_t *cpuset, size_t cpuset_size,
+			     size_t num_cpus, size_t reactor_count,
+			     char *lcore_map, size_t lcore_map_size)
+{
+	size_t highest = 0, second = 0;
+	int found, written;
+
+	if (lcore_map == NULL || lcore_map_size == 0) {
+		return -EINVAL;
+	}
+
+	found = select_reactors(cpuset, cpuset_size, num_cpus, reactor_count,
+				&highest, &second);
+	if (found < 0) {
+		return found;
+	}
+
+	if (found == 1) {
+		written = snprintf(lcore_map, lcore_map_size, "0@%zu", highest);
+	} else {
+		written = snprintf(lcore_map, lcore_map_size, "0@%zu,1@%zu",
+				   second, highest);
+	}
+	if (written < 0 || (size_t)written >= lcore_map_size) {
+		return -ENOSPC;
+	}
+
+	return 0;
+}
+
+int
+s3lvol_tgt_lcore_map_from_affinity(size_t reactor_count, char *lcore_map,
+				  size_t lcore_map_size,
+				  struct s3lvol_tgt_cpu_selection *selection)
+{
+	long configured;
+	size_t num_cpus;
+
+	if (reactor_count == 0 || selection == NULL) {
+		return -EINVAL;
+	}
+
+	selection->original = NULL;
+	selection->reactors = NULL;
+	selection->background = NULL;
+	selection->cpuset_size = 0;
+	configured = sysconf(_SC_NPROCESSORS_CONF);
+	if (configured < 1) {
+		configured = CPU_SETSIZE;
+	}
+	num_cpus = (size_t)configured;
+	if (num_cpus < CPU_SETSIZE) {
+		num_cpus = CPU_SETSIZE;
+	}
+
+	for (;;) {
+		cpu_set_t *allowed;
+		size_t cpuset_size;
+		size_t highest = 0, second = 0;
+		int found, rc, saved_errno;
+
+		cpuset_size = CPU_ALLOC_SIZE(num_cpus);
+		allowed = CPU_ALLOC(num_cpus);
+		if (allowed == NULL) {
+			return -ENOMEM;
+		}
+		CPU_ZERO_S(cpuset_size, allowed);
+
+		if (sched_getaffinity(0, cpuset_size, allowed) == 0) {
+			rc = s3lvol_tgt_lcore_map_from_set(allowed, cpuset_size,
+							 num_cpus, reactor_count,
+							 lcore_map, lcore_map_size);
+			if (rc != 0) {
+				CPU_FREE(allowed);
+				return rc;
+			}
+
+			found = select_reactors(allowed, cpuset_size, num_cpus,
+						reactor_count, &highest, &second);
+			selection->original = CPU_ALLOC(num_cpus);
+			selection->reactors = CPU_ALLOC(num_cpus);
+			selection->background = CPU_ALLOC(num_cpus);
+			if (selection->original == NULL || selection->reactors == NULL ||
+			    selection->background == NULL) {
+				CPU_FREE(selection->background);
+				CPU_FREE(selection->reactors);
+				CPU_FREE(selection->original);
+				CPU_FREE(allowed);
+				selection->background = NULL;
+				selection->reactors = NULL;
+				selection->original = NULL;
+				return -ENOMEM;
+			}
+			memcpy(selection->original, allowed, cpuset_size);
+			CPU_ZERO_S(cpuset_size, selection->reactors);
+			CPU_SET_S(highest, cpuset_size, selection->reactors);
+			if (found == 2) {
+				CPU_SET_S(second, cpuset_size, selection->reactors);
+			}
+			memcpy(selection->background, allowed, cpuset_size);
+			CPU_CLR_S(highest, cpuset_size, selection->background);
+			if (found == 2) {
+				CPU_CLR_S(second, cpuset_size, selection->background);
+			}
+			if (CPU_COUNT_S(cpuset_size, selection->background) == 0) {
+				memcpy(selection->background, allowed, cpuset_size);
+			}
+			CPU_FREE(allowed);
+			selection->cpuset_size = cpuset_size;
+			return 0;
+		}
+
+		saved_errno = errno;
+		CPU_FREE(allowed);
+		if (saved_errno != EINVAL) {
+			return -saved_errno;
+		}
+		if (num_cpus > SIZE_MAX / 2) {
+			return -EOVERFLOW;
+		}
+		num_cpus *= 2;
+	}
+}
+
+int
+s3lvol_tgt_capture_affinity(struct s3lvol_tgt_cpu_selection *selection)
+{
+	long configured;
+	size_t num_cpus;
+
+	if (selection == NULL) {
+		return -EINVAL;
+	}
+	selection->original = NULL;
+	selection->reactors = NULL;
+	selection->background = NULL;
+	selection->cpuset_size = 0;
+	configured = sysconf(_SC_NPROCESSORS_CONF);
+	num_cpus = configured > 0 ? (size_t)configured : CPU_SETSIZE;
+	if (num_cpus < CPU_SETSIZE) {
+		num_cpus = CPU_SETSIZE;
+	}
+
+	for (;;) {
+		size_t cpuset_size = CPU_ALLOC_SIZE(num_cpus);
+		cpu_set_t *original = CPU_ALLOC(num_cpus);
+		int saved_errno;
+
+		if (original == NULL) {
+			return -ENOMEM;
+		}
+		CPU_ZERO_S(cpuset_size, original);
+		if (sched_getaffinity(0, cpuset_size, original) == 0) {
+			selection->original = original;
+			selection->cpuset_size = cpuset_size;
+			return 0;
+		}
+		saved_errno = errno;
+		CPU_FREE(original);
+		if (saved_errno != EINVAL) {
+			return -saved_errno;
+		}
+		if (num_cpus > SIZE_MAX / 2) {
+			return -EOVERFLOW;
+		}
+		num_cpus *= 2;
+	}
+}
+
+static int
+parse_cpu_id(const char **cursor, size_t num_cpus, size_t *cpu)
+{
+	char *end;
+	unsigned long value;
+
+	while (isspace((unsigned char)**cursor)) {
+		(*cursor)++;
+	}
+	errno = 0;
+	value = strtoul(*cursor, &end, 10);
+	if (end == *cursor || errno != 0 || value >= num_cpus) {
+		return -EINVAL;
+	}
+	*cursor = end;
+	*cpu = (size_t)value;
+	return 0;
+}
+
+static int
+parse_cpu_set(const char **cursor, size_t num_cpus, cpu_set_t *cpuset,
+	      size_t cpuset_size)
+{
+	bool parenthesized;
+
+	while (isspace((unsigned char)**cursor)) {
+		(*cursor)++;
+	}
+	parenthesized = **cursor == '(';
+	if (parenthesized) {
+		(*cursor)++;
+	}
+	for (;;) {
+		size_t first, last;
+		int rc;
+
+		rc = parse_cpu_id(cursor, num_cpus, &first);
+		if (rc != 0) {
+			return rc;
+		}
+		last = first;
+		while (isspace((unsigned char)**cursor)) {
+			(*cursor)++;
+		}
+		if (**cursor == '-') {
+			(*cursor)++;
+			rc = parse_cpu_id(cursor, num_cpus, &last);
+			if (rc != 0) {
+				return rc;
+			}
+		}
+		if (first <= last) {
+			for (size_t cpu = first; cpu <= last; cpu++) {
+				CPU_SET_S(cpu, cpuset_size, cpuset);
+			}
+		} else {
+			for (size_t cpu = last; cpu <= first; cpu++) {
+				CPU_SET_S(cpu, cpuset_size, cpuset);
+			}
+		}
+		while (isspace((unsigned char)**cursor)) {
+			(*cursor)++;
+		}
+		if (!parenthesized || **cursor == ')') {
+			if (parenthesized) {
+				(*cursor)++;
+			}
+			return 0;
+		}
+		if (**cursor != ',') {
+			return -EINVAL;
+		}
+		(*cursor)++;
+	}
+}
+
+static int
+reactors_from_lcore_map(const char *lcore_map, size_t num_cpus,
+			cpu_set_t *reactors, size_t cpuset_size)
+{
+	const char *cursor = lcore_map;
+
+	while (*cursor != '\0') {
+		cpu_set_t *lcores, *cpus;
+		int rc;
+
+		lcores = CPU_ALLOC(num_cpus);
+		cpus = CPU_ALLOC(num_cpus);
+		if (lcores == NULL || cpus == NULL) {
+			CPU_FREE(cpus);
+			CPU_FREE(lcores);
+			return -ENOMEM;
+		}
+		CPU_ZERO_S(cpuset_size, lcores);
+		CPU_ZERO_S(cpuset_size, cpus);
+		rc = parse_cpu_set(&cursor, num_cpus, lcores, cpuset_size);
+		if (rc == 0 && *cursor == '@') {
+			cursor++;
+			rc = parse_cpu_set(&cursor, num_cpus, cpus, cpuset_size);
+		} else if (rc == 0) {
+			memcpy(cpus, lcores, cpuset_size);
+		}
+		if (rc == 0) {
+			for (size_t cpu = 0; cpu < num_cpus; cpu++) {
+				if (CPU_ISSET_S(cpu, cpuset_size, cpus)) {
+					CPU_SET_S(cpu, cpuset_size, reactors);
+				}
+			}
+		}
+		CPU_FREE(cpus);
+		CPU_FREE(lcores);
+		if (rc != 0) {
+			return rc;
+		}
+		while (isspace((unsigned char)*cursor)) {
+			cursor++;
+		}
+		if (*cursor == '\0') {
+			break;
+		}
+		if (*cursor != ',') {
+			return -EINVAL;
+		}
+		cursor++;
+	}
+	return CPU_COUNT_S(cpuset_size, reactors) == 0 ? -EINVAL : 0;
+}
+
+static int
+parse_hex_mask(const char *mask, size_t num_cpus, cpu_set_t *reactors,
+	       size_t cpuset_size)
+{
+	size_t bit = 0, len;
+	bool found = false;
+
+	if (mask[0] == '0' && (mask[1] == 'x' || mask[1] == 'X')) {
+		mask += 2;
+	}
+	len = strlen(mask);
+	while (len > 0 && isspace((unsigned char)mask[len - 1])) {
+		len--;
+	}
+	for (; len > 0; len--) {
+		unsigned char ch = (unsigned char)mask[len - 1];
+		int nibble;
+
+		if (ch == ',') {
+			continue;
+		}
+		if (ch >= '0' && ch <= '9') {
+			nibble = ch - '0';
+		} else if (ch >= 'a' && ch <= 'f') {
+			nibble = ch - 'a' + 10;
+		} else if (ch >= 'A' && ch <= 'F') {
+			nibble = ch - 'A' + 10;
+		} else {
+			return -EINVAL;
+		}
+		found = true;
+		for (unsigned int offset = 0; offset < 4; offset++, bit++) {
+			if ((nibble & (1U << offset)) != 0 && bit < num_cpus) {
+				CPU_SET_S(bit, cpuset_size, reactors);
+			}
+		}
+	}
+	return found ? 0 : -EINVAL;
+}
+
+static int
+parse_mask_list(const char *mask, size_t num_cpus, cpu_set_t *reactors,
+		size_t cpuset_size)
+{
+	const char *cursor = mask + 1;
+
+	for (;;) {
+		size_t first, last;
+		int rc = parse_cpu_id(&cursor, num_cpus, &first);
+
+		if (rc != 0) {
+			return rc;
+		}
+		last = first;
+		while (isspace((unsigned char)*cursor)) {
+			cursor++;
+		}
+		if (*cursor == '-') {
+			cursor++;
+			rc = parse_cpu_id(&cursor, num_cpus, &last);
+			if (rc != 0 || last < first) {
+				return -EINVAL;
+			}
+		}
+		for (size_t cpu = first; cpu <= last; cpu++) {
+			CPU_SET_S(cpu, cpuset_size, reactors);
+		}
+		while (isspace((unsigned char)*cursor)) {
+			cursor++;
+		}
+		if (*cursor == ']') {
+			cursor++;
+			while (isspace((unsigned char)*cursor)) {
+				cursor++;
+			}
+			return *cursor == '\0' ? 0 : -EINVAL;
+		}
+		if (*cursor != ',') {
+			return -EINVAL;
+		}
+		cursor++;
+	}
+}
+
+int
+s3lvol_tgt_background_from_options(const cpu_set_t *allowed,
+				  size_t cpuset_size, size_t num_cpus,
+				  const char *reactor_mask, const char *lcore_map,
+				  cpu_set_t *reactors, cpu_set_t *background)
+{
+	int rc;
+
+	if (allowed == NULL || reactors == NULL || background == NULL ||
+	    num_cpus == 0 || (reactor_mask == NULL) == (lcore_map == NULL)) {
+		return -EINVAL;
+	}
+	CPU_ZERO_S(cpuset_size, reactors);
+	if (reactor_mask != NULL) {
+		while (isspace((unsigned char)*reactor_mask)) {
+			reactor_mask++;
+		}
+		rc = *reactor_mask == '[' ?
+		     parse_mask_list(reactor_mask, num_cpus, reactors, cpuset_size) :
+		     parse_hex_mask(reactor_mask, num_cpus, reactors, cpuset_size);
+	} else {
+		rc = reactors_from_lcore_map(lcore_map, num_cpus, reactors, cpuset_size);
+	}
+	if (rc == 0 && CPU_COUNT_S(cpuset_size, reactors) == 0) {
+		rc = -EINVAL;
+	}
+	if (rc == 0) {
+		memcpy(background, allowed, cpuset_size);
+		for (size_t cpu = 0; cpu < num_cpus; cpu++) {
+			if (CPU_ISSET_S(cpu, cpuset_size, reactors)) {
+				CPU_CLR_S(cpu, cpuset_size, background);
+			}
+		}
+		if (CPU_COUNT_S(cpuset_size, background) == 0) {
+			memcpy(background, allowed, cpuset_size);
+		}
+	}
+	return rc;
+}
+
+bool
+s3lvol_tgt_cpu_selection_shares_reactors(
+	const struct s3lvol_tgt_cpu_selection *selection)
+{
+	if (selection == NULL || selection->reactors == NULL ||
+	    selection->background == NULL) {
+		return false;
+	}
+
+	for (size_t cpu = 0; cpu < selection->cpuset_size * CHAR_BIT; cpu++) {
+		if (CPU_ISSET_S(cpu, selection->cpuset_size, selection->reactors) &&
+		    CPU_ISSET_S(cpu, selection->cpuset_size, selection->background)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void
+s3lvol_tgt_cpu_selection_fini(struct s3lvol_tgt_cpu_selection *selection)
+{
+	if (selection == NULL) {
+		return;
+	}
+
+	CPU_FREE(selection->background);
+	CPU_FREE(selection->reactors);
+	CPU_FREE(selection->original);
+	selection->background = NULL;
+	selection->reactors = NULL;
+	selection->original = NULL;
+	selection->cpuset_size = 0;
+}

--- a/CubeS3lvol/app/s3lvol_tgt/s3lvol_tgt_cpumask.h
+++ b/CubeS3lvol/app/s3lvol_tgt/s3lvol_tgt_cpumask.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef S3LVOL_TGT_CPUMASK_H
+#define S3LVOL_TGT_CPUMASK_H
+
+#include <sched.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+struct s3lvol_tgt_cpu_selection {
+	cpu_set_t *original;
+	cpu_set_t *reactors;
+	cpu_set_t *background;
+	size_t cpuset_size;
+};
+
+int s3lvol_tgt_lcore_map_from_set(const cpu_set_t *cpuset, size_t cpuset_size,
+					 size_t num_cpus, size_t reactor_count,
+					 char *lcore_map, size_t lcore_map_size);
+int s3lvol_tgt_lcore_map_from_affinity(size_t reactor_count, char *lcore_map,
+					      size_t lcore_map_size,
+					      struct s3lvol_tgt_cpu_selection *selection);
+int s3lvol_tgt_capture_affinity(struct s3lvol_tgt_cpu_selection *selection);
+int s3lvol_tgt_background_from_options(const cpu_set_t *allowed,
+				      size_t cpuset_size, size_t num_cpus,
+				      const char *reactor_mask, const char *lcore_map,
+				      cpu_set_t *reactors, cpu_set_t *background);
+bool s3lvol_tgt_cpu_selection_shares_reactors(
+	const struct s3lvol_tgt_cpu_selection *selection);
+void s3lvol_tgt_cpu_selection_fini(struct s3lvol_tgt_cpu_selection *selection);
+
+#endif /* S3LVOL_TGT_CPUMASK_H */

--- a/CubeS3lvol/include/s3lvol/s3_spawner.h
+++ b/CubeS3lvol/include/s3lvol/s3_spawner.h
@@ -37,9 +37,9 @@
  *
  *   The cpuset is **injected by the caller**; this file never calls
  *   `spdk_app_get_core_mask()` -- that is a spdk_event-layer API, and
- *   `lib/s3bsdev/` must be unit-testable outside the app framework. The logic
- *   that computes the complement of the reactor coremask lives in
- *   `module/bdev/s3lvol/`.
+ *   `lib/s3bsdev/` must be unit-testable outside the app framework. Normally
+ *   `s3lvol_tgt` injects the physical-CPU complement before DPDK narrows the
+ *   calling thread's affinity. The module layer supplies a fixed-size fallback.
  */
 
 #ifndef S3LVOL_SPAWNER_H
@@ -53,17 +53,36 @@
  * Start the spawner thread.
  *
  * \param cpuset  the set of cores background threads may run on. Typically
- *                "all cores minus the reactor cores of this process", computed
- *                by the module layer with spdk_app_get_core_mask().
- *                NULL means no affinity is set (inherits the caller's -- for
- *                unit tests only; NULL on a production path is a no-op that
- *                fixes nothing). A copy is taken internally; the caller does
- *                not need to keep it alive.
+ *                "all cores minus the reactor cores of this process". The
+ *                target normally preconfigures the physical CPU set; the module
+ *                argument is a fallback.
+ *                NULL uses a set previously supplied by
+ *                s3_spawner_set_cpuset(); without one it means no affinity is
+ *                set and the caller's affinity is inherited. A copy is taken
+ *                internally; the caller does not need to keep it alive.
  *
  * \return 0 on success; negative errno on failure. Repeated calls return 0
  *         (idempotent).
  */
 int s3_spawner_start(const cpu_set_t *cpuset);
+
+/**
+ * Preconfigure the affinity used by a later s3_spawner_start().
+ *
+ * This preserves a dynamically sized scheduler affinity before DPDK pins the
+ * calling thread. Every later start uses this set instead of its cpuset
+ * argument; stop does not discard it. A later call replaces the saved set
+ * while the spawner is stopped.
+ *
+ * \return 0 on success; -EINVAL for NULL, zero-sized, or empty sets; -ENOMEM
+ *         on allocation failure; -EBUSY once the spawner has started.
+ */
+int s3_spawner_set_cpuset(const cpu_set_t *cpuset, size_t cpuset_size);
+
+/**
+ * Whether a preconfigured set has been supplied.
+ */
+bool s3_spawner_has_cpuset(void);
 
 /**
  * Stop the spawner thread and wake/cancel every queued request.

--- a/CubeS3lvol/lib/s3bsdev/s3_spawner.c
+++ b/CubeS3lvol/lib/s3bsdev/s3_spawner.c
@@ -46,6 +46,8 @@ struct spawner_request {
 };
 
 static cpu_set_t       g_cpuset;
+static cpu_set_t       *g_preconfigured_cpuset;
+static size_t          g_preconfigured_cpuset_size;
 static bool            g_cpuset_valid = false;
 
 static pthread_t       g_spawner_thread;
@@ -72,8 +74,11 @@ spawner_thread_main(void *arg)
 
 	/* Set affinity on itself so every child it creates inherits the same set. */
 	if (g_cpuset_valid) {
-		int rc = pthread_setaffinity_np(pthread_self(),
-						sizeof(cpu_set_t), &g_cpuset);
+		const cpu_set_t *cpuset = g_preconfigured_cpuset != NULL ?
+					  g_preconfigured_cpuset : &g_cpuset;
+		size_t cpuset_size = g_preconfigured_cpuset != NULL ?
+				     g_preconfigured_cpuset_size : sizeof(g_cpuset);
+		int rc = pthread_setaffinity_np(pthread_self(), cpuset_size, cpuset);
 		if (rc != 0) {
 			/* Not fatal: falls back to inheriting the caller's affinity,
 			 * degraded performance but still functional. */
@@ -143,6 +148,46 @@ spawner_thread_main(void *arg)
 }
 
 int
+s3_spawner_set_cpuset(const cpu_set_t *cpuset, size_t cpuset_size)
+{
+	cpu_set_t *copy;
+
+	if (cpuset == NULL || cpuset_size == 0 ||
+	    CPU_COUNT_S(cpuset_size, cpuset) == 0) {
+		return -EINVAL;
+	}
+	copy = CPU_ALLOC(cpuset_size * CHAR_BIT);
+	if (copy == NULL) {
+		return -ENOMEM;
+	}
+	CPU_ZERO_S(CPU_ALLOC_SIZE(cpuset_size * CHAR_BIT), copy);
+	memcpy(copy, cpuset, cpuset_size);
+
+	pthread_mutex_lock(&g_spawner_mutex);
+	if (g_spawner_started) {
+		pthread_mutex_unlock(&g_spawner_mutex);
+		CPU_FREE(copy);
+		return -EBUSY;
+	}
+	CPU_FREE(g_preconfigured_cpuset);
+	g_preconfigured_cpuset = copy;
+	g_preconfigured_cpuset_size = cpuset_size;
+	pthread_mutex_unlock(&g_spawner_mutex);
+	return 0;
+}
+
+bool
+s3_spawner_has_cpuset(void)
+{
+	bool has_cpuset;
+
+	pthread_mutex_lock(&g_spawner_mutex);
+	has_cpuset = g_preconfigured_cpuset != NULL;
+	pthread_mutex_unlock(&g_spawner_mutex);
+	return has_cpuset;
+}
+
+int
 s3_spawner_start(const cpu_set_t *cpuset)
 {
 	int rc;
@@ -153,7 +198,10 @@ s3_spawner_start(const cpu_set_t *cpuset)
 		return 0;
 	}
 
-	if (cpuset) {
+	if (g_preconfigured_cpuset != NULL) {
+		g_cpuset_valid = CPU_COUNT_S(g_preconfigured_cpuset_size,
+						g_preconfigured_cpuset) != 0;
+	} else if (cpuset) {
 		memcpy(&g_cpuset, cpuset, sizeof(g_cpuset));
 		g_cpuset_valid = true;
 		if (CPU_COUNT(&g_cpuset) == 0) {
@@ -180,8 +228,36 @@ s3_spawner_start(const cpu_set_t *cpuset)
 	g_spawner_started = true;
 	pthread_mutex_unlock(&g_spawner_mutex);
 
-	SPDK_NOTICELOG("Thread spawner started (%d cores allowed)\n",
-		       g_cpuset_valid ? CPU_COUNT(&g_cpuset) : -1);
+	if (g_preconfigured_cpuset != NULL) {
+		char cpus[256];
+		size_t used = 0;
+
+		cpus[0] = '\0';
+		for (size_t cpu = 0; cpu < g_preconfigured_cpuset_size * CHAR_BIT; cpu++) {
+			int written;
+
+			if (!CPU_ISSET_S(cpu, g_preconfigured_cpuset_size,
+					 g_preconfigured_cpuset)) {
+				continue;
+			}
+			written = snprintf(cpus + used, sizeof(cpus) - used, "%s%zu",
+					   used == 0 ? "" : ",", cpu);
+			if (written < 0 || (size_t)written >= sizeof(cpus) - used) {
+				while (used > 0 && cpus[used - 1] != ',') {
+					used--;
+				}
+				strcpy(cpus + used, "...");
+				break;
+			}
+			used += (size_t)written;
+		}
+		SPDK_NOTICELOG("Thread spawner started (%d cores allowed: %s)\n",
+			       CPU_COUNT_S(g_preconfigured_cpuset_size,
+					   g_preconfigured_cpuset), cpus);
+	} else {
+		SPDK_NOTICELOG("Thread spawner started (%d cores allowed)\n",
+			       g_cpuset_valid ? CPU_COUNT(&g_cpuset) : -1);
+	}
 	return 0;
 }
 
@@ -214,6 +290,7 @@ s3_spawner_stop(void)
 	}
 	g_spawner_started = false;
 	g_spawner_stop = false;
+	/* Keep the preconfigured set for a later module init/start cycle. */
 	pthread_mutex_unlock(&g_spawner_mutex);
 
 	TAILQ_FOREACH_SAFE(req, &drain_list, link, tmp) {

--- a/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.c
+++ b/CubeS3lvol/module/bdev/s3lvol/vbdev_s3lvol.c
@@ -6,12 +6,11 @@
  *   This file owns two things that must happen at module init and can only
  *   happen at this layer:
  *
- *   1. **Start the thread spawner and compute its cpuset.**
- *      cpuset = all usable cores - this process's reactor cores. Computing the
- *      complement needs spdk_env_get_core_mask(), which is an env-layer API,
- *      while lib/s3bsdev must stay unit-testable outside the app framework,
- *      so the computation lives in the module layer and the cpuset is injected
- *      into s3_spawner_start().
+ *   1. **Start the thread spawner with its cpuset.**
+ *      s3lvol_tgt normally captures the physical CPU complement before DPDK
+ *      narrows the calling thread's affinity. For other applications, this
+ *      module computes a fixed-size fallback from the current affinity and
+ *      enabled SPDK cores. lib/s3bsdev stays independent of the app/env layers.
  *
  *   2. **Initialise CRT.** s3_crt_global_init() must be called after the
  *      spawner -- it pthread_creates the event loop / resolver / logger
@@ -101,21 +100,26 @@ vbdev_s3lvol_init(void)
 		return 0;
 	}
 
-	rc = s3lvol_build_spawner_cpuset(&cpuset);
-	if (rc != 0) {
-		return rc;
-	}
+	if (s3_spawner_has_cpuset()) {
+		/* s3lvol_tgt captured the real physical reactor placement before
+		 * DPDK pinned this thread; do not recompute it from lcore IDs. */
+		rc = s3_spawner_start(NULL);
+	} else {
+		rc = s3lvol_build_spawner_cpuset(&cpuset);
+		if (rc != 0) {
+			return rc;
+		}
 
-	SPDK_ENV_FOREACH_CORE(core) {
-		num_reactors++;
+		SPDK_ENV_FOREACH_CORE(core) {
+			num_reactors++;
+		}
+		SPDK_NOTICELOG("s3lvol: %d reactor cores, %d cores left for "
+			       "background threads\n", num_reactors, CPU_COUNT(&cpuset));
+		rc = s3_spawner_start(&cpuset);
 	}
-
-	SPDK_NOTICELOG("s3lvol: %d reactor cores, %d cores left for background "
-		       "threads\n", num_reactors, CPU_COUNT(&cpuset));
 
 	/* The spawner must start first: CRT init runs on it, or CRT's I/O
 	 * threads inherit the reactor's single-core affinity. */
-	rc = s3_spawner_start(&cpuset);
 	if (rc != 0) {
 		SPDK_ERRLOG("Failed to start thread spawner: %d\n", rc);
 		return rc;

--- a/CubeS3lvol/scripts/rcow_common.sh
+++ b/CubeS3lvol/scripts/rcow_common.sh
@@ -261,7 +261,10 @@ RCOW_IOBUF_LARGE_POOL="${RCOW_IOBUF_LARGE_POOL:-512}"
 RCOW_READ_AHEAD_KB="${RCOW_READ_AHEAD_KB:-1024}"
 export S3LVOL_READ_AHEAD_KB="${RCOW_READ_AHEAD_KB}"
 
-RCOW_TGT_CPUMASK="${RCOW_TGT_CPUMASK:-0x3}"
+# Empty delegates reactor selection to s3lvol_tgt, which uses the two
+# highest-numbered SPDK-supported CPUs in its effective scheduler affinity. An
+# explicit SPDK mask or CPU list is passed through unchanged by rcow_start.sh.
+RCOW_TGT_CPUMASK="${RCOW_TGT_CPUMASK:-}"
 RCOW_TGT_MEM_MB="${RCOW_TGT_MEM_MB:-16384}"
 
 # Run without hugepages, deliberately, rather than as a fallback for a node
@@ -579,6 +582,16 @@ rcow_target_pid()
 rcow_target_alive()
 {
 	rcow_target_pid >/dev/null
+}
+
+# Populate RCOW_TGT_CPUMASK_ARGS for a target launch. Keeping this as an array is
+# what makes an SPDK CPU list such as [4,9] one opaque argument.
+rcow_set_tgt_cpumask_args()
+{
+	RCOW_TGT_CPUMASK_ARGS=()
+	if [ -n "${RCOW_TGT_CPUMASK:-}" ]; then
+		RCOW_TGT_CPUMASK_ARGS=(-m "${RCOW_TGT_CPUMASK}")
+	fi
 }
 
 # Start the target detached and echo its pid.

--- a/CubeS3lvol/scripts/rcow_start.sh
+++ b/CubeS3lvol/scripts/rcow_start.sh
@@ -229,8 +229,10 @@ printf '\n==== %s: starting %s\n' "$(date -Is)" "${RCOW_TGT_BIN}" >>"${RCOW_LOG}
 # -r must match RCOW_RPC_SOCK: s3lvol_tgt defaults to /var/run/s3lvol.sock,
 # and rcow_wait_rpc below probes RCOW_RPC_SOCK -- a mismatch just times out.
 #
+rcow_set_tgt_cpumask_args
 # shellcheck disable=SC2086
-TGT_PID="$(rcow_start_target_detached "${RCOW_TGT_BIN}" -m "${RCOW_TGT_CPUMASK}" \
+TGT_PID="$(rcow_start_target_detached "${RCOW_TGT_BIN}" \
+	${RCOW_TGT_CPUMASK_ARGS[@]+"${RCOW_TGT_CPUMASK_ARGS[@]}"} \
 	-r "${RCOW_RPC_SOCK}" --wait-for-rpc ${TGT_ARGS})" ||
 	bail "the target did not come up far enough to record its pid"
 

--- a/CubeS3lvol/test/integration/Makefile
+++ b/CubeS3lvol/test/integration/Makefile
@@ -73,7 +73,7 @@ MODULE_DIR   = ../../module/bdev/s3lvol
 APPS = s3_client_test s3_spawner_test s3_thread_bounce_test s3_bs_dev_test \
        s3_journal_test s3_wal_test s3_cache_test s3_flush_test s3_export_test \
        s3_statefile_test s3_local_dev_test s3_checkpoint_test s3_export_swap_test \
-       s3_copy_xml_test s3_pending_persist_test
+       s3_copy_xml_test s3_pending_persist_test s3_tgt_cpumask_test
 
 # (a) minimal library set for the stubbed path
 STUB_SRCS      = spdk_thread_stub.c
@@ -162,6 +162,12 @@ s3_copy_xml_test: s3_copy_xml_test.c $(S3BSDEV_DIR)/s3_copy_xml.h
 # Pending-delete registry PUT coalescing. Header-only, no S3, no SPDK.
 s3_pending_persist_test: s3_pending_persist_test.c $(MODULE_DIR)/pending_persist_ctl.h
 	$(CC) $(COMMON_CFLAGS) -I$(MODULE_DIR) s3_pending_persist_test.c -o $@
+
+# Reactor selection is pure scheduler-affinity handling: no SPDK libraries.
+s3_tgt_cpumask_test: s3_tgt_cpumask_test.c \
+		../../app/s3lvol_tgt/s3lvol_tgt_cpumask.c
+	$(CC) $(COMMON_CFLAGS) -I../../app/s3lvol_tgt s3_tgt_cpumask_test.c \
+		../../app/s3lvol_tgt/s3lvol_tgt_cpumask.c -o $@
 
 # chunk map persistence check: no S3, but it does need the bdev layer.
 #
@@ -299,7 +305,7 @@ s3_checkpoint_test: s3_checkpoint_test.c $(S3BSDEV_DIR)/libs3bsdev.a
 check: s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test s3_cache_test \
        s3_flush_test s3_export_test s3_statefile_test s3_local_dev_test \
        s3_checkpoint_test s3_export_swap_test s3_copy_xml_test \
-       s3_pending_persist_test
+       s3_pending_persist_test s3_tgt_cpumask_test
 	./s3_spawner_test
 	./s3_thread_bounce_test
 	./s3_journal_test
@@ -313,6 +319,7 @@ check: s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test s3_cach
 	./s3_export_swap_test
 	./s3_copy_xml_test
 	./s3_pending_persist_test
+	./s3_tgt_cpumask_test
 
 .PHONY: $(S3BSDEV_DIR)/libs3bsdev.a
 $(S3BSDEV_DIR)/libs3bsdev.a:

--- a/CubeS3lvol/test/integration/s3_spawner_test.c
+++ b/CubeS3lvol/test/integration/s3_spawner_test.c
@@ -335,12 +335,44 @@ main(void)
 	}
 
 	printf("\n[9] repeated start/stop is idempotent\n");
+	{
+		cpu_set_t empty;
+
+		CPU_ZERO(&empty);
+		rc = s3_spawner_set_cpuset(&empty, sizeof(empty));
+		check_true("empty preconfigured cpuset is rejected", rc == -EINVAL, NULL);
+	}
 	check_true("stop is idempotent (a second call does not crash)",
 		   (s3_spawner_stop(), true), NULL);
-	rc = s3_spawner_start(&allowed);
-	check_true("start works again after stop", rc == 0, NULL);
+	rc = s3_spawner_set_cpuset(&allowed, sizeof(allowed));
+	check_true("cpuset can be preconfigured before start", rc == 0, NULL);
+	rc = s3_spawner_start(&single);
+	check_true("preconfigured start works after stop", rc == 0, NULL);
+	if (rc == 0) {
+		pthread_t t;
+		int cpus = -1;
+		rc = s3_spawner_pthread_create(&t, report_affinity, &cpus);
+		if (rc == 0) {
+			pthread_join(t, NULL);
+		}
+		check_true("preconfigured cpuset overrides start argument",
+			   rc == 0 && cpus == CPU_COUNT(&allowed), NULL);
+	}
 	rc = s3_spawner_start(&allowed);
 	check_true("repeated start returns 0", rc == 0, NULL);
+	s3_spawner_stop();
+	rc = s3_spawner_start(NULL);
+	check_true("preconfigured cpuset survives stop/start", rc == 0, NULL);
+	if (rc == 0) {
+		pthread_t t;
+		int cpus = -1;
+		rc = s3_spawner_pthread_create(&t, report_affinity, &cpus);
+		if (rc == 0) {
+			pthread_join(t, NULL);
+		}
+		check_true("restart still uses preconfigured cpuset",
+			   rc == 0 && cpus == CPU_COUNT(&allowed), NULL);
+	}
 	s3_spawner_stop();
 
 	/* Restore the main thread's affinity, to avoid affecting anything

--- a/CubeS3lvol/test/integration/s3_tgt_cpumask_test.c
+++ b/CubeS3lvol/test/integration/s3_tgt_cpumask_test.c
@@ -1,0 +1,354 @@
+/* Copyright (c) 2026 Tencent Inc.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+#include "s3lvol_tgt_cpumask.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int g_pass, g_fail;
+
+static void
+check_map(const char *what, const size_t *cpus, size_t count, size_t num_cpus,
+	  size_t reactor_count, const char *expected)
+{
+	cpu_set_t *set;
+	size_t set_size;
+	char lcore_map[64];
+	int before, rc;
+
+	set_size = CPU_ALLOC_SIZE(num_cpus);
+	set = CPU_ALLOC(num_cpus);
+	if (set == NULL) {
+		perror("CPU_ALLOC");
+		g_fail++;
+		return;
+	}
+	CPU_ZERO_S(set_size, set);
+	for (size_t i = 0; i < count; i++) {
+		CPU_SET_S(cpus[i], set_size, set);
+	}
+	before = CPU_COUNT_S(set_size, set);
+
+	rc = s3lvol_tgt_lcore_map_from_set(set, set_size, num_cpus, reactor_count,
+						 lcore_map, sizeof(lcore_map));
+	if (rc == 0 && strcmp(lcore_map, expected) == 0 &&
+	    CPU_COUNT_S(set_size, set) == before) {
+		g_pass++;
+		printf("\t[PASS] %s -> %s\n", what, lcore_map);
+	} else {
+		g_fail++;
+		printf("\t[FAIL] %s: rc=%d map='%s', expected '%s'\n",
+		       what, rc, rc == 0 ? lcore_map : "", expected);
+	}
+	CPU_FREE(set);
+}
+
+static int
+get_affinity(cpu_set_t **set_out, size_t *num_cpus_out, size_t *set_size_out)
+{
+	struct s3lvol_tgt_cpu_selection selection = {};
+	int rc;
+
+	rc = s3lvol_tgt_capture_affinity(&selection);
+	if (rc != 0) {
+		return rc;
+	}
+	*set_out = selection.original;
+	*num_cpus_out = selection.cpuset_size * CHAR_BIT;
+	*set_size_out = selection.cpuset_size;
+	selection.original = NULL;
+	s3lvol_tgt_cpu_selection_fini(&selection);
+	return 0;
+}
+
+static void
+check_affinity(void)
+{
+	cpu_set_t *original = NULL, *narrowed = NULL;
+	size_t num_cpus = 0, set_size = 0;
+	struct s3lvol_tgt_cpu_selection pair_selection = {};
+	struct s3lvol_tgt_cpu_selection single_selection = {};
+	char expected[64], lcore_map[64], single_expected[64], single_map[64];
+	ssize_t highest = -1, second = -1;
+	bool pair_sets_ok = false, single_sets_ok = false;
+	int rc, single_rc = -EINVAL;
+
+	rc = get_affinity(&original, &num_cpus, &set_size);
+	if (rc != 0) {
+		errno = -rc;
+		perror("sched_getaffinity");
+		g_fail++;
+		return;
+	}
+	for (size_t cpu = num_cpus; cpu > 0; cpu--) {
+		size_t id = cpu - 1;
+
+		if (!CPU_ISSET_S(id, set_size, original)) {
+			continue;
+		}
+		if (highest < 0) {
+			highest = (ssize_t)id;
+		} else {
+			second = (ssize_t)id;
+			break;
+		}
+	}
+	if (highest < 0) {
+		g_fail++;
+		printf("\t[FAIL] current affinity is empty\n");
+		goto out;
+	}
+
+	narrowed = CPU_ALLOC(num_cpus);
+	if (narrowed == NULL) {
+		perror("CPU_ALLOC");
+		g_fail++;
+		goto out;
+	}
+	CPU_ZERO_S(set_size, narrowed);
+	CPU_SET_S((size_t)highest, set_size, narrowed);
+	if (second >= 0) {
+		CPU_SET_S((size_t)second, set_size, narrowed);
+		snprintf(expected, sizeof(expected), "0@%zd,1@%zd", second, highest);
+	} else {
+		snprintf(expected, sizeof(expected), "0@%zd", highest);
+	}
+	if (sched_setaffinity(0, set_size, narrowed) != 0) {
+		perror("sched_setaffinity");
+		g_fail++;
+		goto out;
+	}
+
+	rc = s3lvol_tgt_lcore_map_from_affinity(2, lcore_map, sizeof(lcore_map),
+						   &pair_selection);
+	if (rc == 0) {
+		pair_sets_ok = CPU_ISSET_S((size_t)highest,
+						 pair_selection.cpuset_size,
+						 pair_selection.reactors) &&
+			       (second < 0 || CPU_ISSET_S((size_t)second,
+							 pair_selection.cpuset_size,
+							 pair_selection.reactors)) &&
+			       CPU_COUNT_S(pair_selection.cpuset_size,
+					   pair_selection.background) > 0;
+	}
+
+	CPU_ZERO_S(set_size, narrowed);
+	CPU_SET_S((size_t)highest, set_size, narrowed);
+	snprintf(single_expected, sizeof(single_expected), "0@%zd", highest);
+	if (sched_setaffinity(0, set_size, narrowed) != 0) {
+		perror("single sched_setaffinity");
+		single_rc = -errno;
+	} else {
+		single_rc = s3lvol_tgt_lcore_map_from_affinity(2, single_map,
+								 sizeof(single_map),
+								 &single_selection);
+	}
+	if (single_rc == 0) {
+		single_sets_ok = CPU_ISSET_S((size_t)highest,
+					   single_selection.cpuset_size,
+					   single_selection.reactors) &&
+				 CPU_COUNT_S(single_selection.cpuset_size,
+					     single_selection.background) == 1;
+	}
+
+	if (sched_setaffinity(0, set_size, original) != 0) {
+		perror("restore sched_setaffinity");
+		g_fail++;
+		goto out;
+	}
+	if (rc == 0 && strcmp(lcore_map, expected) == 0 && pair_sets_ok &&
+	    single_rc == 0 && strcmp(single_map, single_expected) == 0 &&
+	    single_sets_ok) {
+		g_pass++;
+		printf("\t[PASS] effective affinity -> %s and %s\n",
+		       lcore_map, single_map);
+	} else {
+		g_fail++;
+		printf("\t[FAIL] effective affinity: rc=%d map='%s', expected '%s'; "
+		       "single rc=%d map='%s', expected '%s'\n",
+		       rc, rc == 0 ? lcore_map : "", expected, single_rc,
+		       single_rc == 0 ? single_map : "", single_expected);
+	}
+
+out:
+	s3lvol_tgt_cpu_selection_fini(&single_selection);
+	s3lvol_tgt_cpu_selection_fini(&pair_selection);
+	CPU_FREE(narrowed);
+	CPU_FREE(original);
+}
+
+static void
+check_lcore_limit(void)
+{
+	const size_t pair[] = {4, 31};
+
+	check_map("one available lcore", pair, 2, 64, 1, "0@31");
+}
+
+static void
+check_explicit_options(void)
+{
+	cpu_set_t allowed, reactors, background;
+	int rc;
+
+	CPU_ZERO(&allowed);
+	CPU_SET(4, &allowed);
+	CPU_SET(9, &allowed);
+	CPU_SET(31, &allowed);
+
+	rc = s3lvol_tgt_background_from_options(&allowed, sizeof(allowed),
+						 CPU_SETSIZE, "0x210 ", NULL,
+						 &reactors, &background);
+	if (rc == 0 && CPU_COUNT(&background) == 1 && CPU_ISSET(31, &background)) {
+		g_pass++;
+		printf("\t[PASS] explicit hex mask -> background CPU 31\n");
+	} else {
+		g_fail++;
+		printf("\t[FAIL] explicit hex mask returned %d\n", rc);
+	}
+
+	rc = s3lvol_tgt_background_from_options(&allowed, sizeof(allowed),
+						 CPU_SETSIZE, "[4,9]", NULL,
+						 &reactors, &background);
+	if (rc == 0 && CPU_COUNT(&background) == 1 && CPU_ISSET(31, &background)) {
+		g_pass++;
+		printf("\t[PASS] explicit CPU list -> background CPU 31\n");
+	} else {
+		g_fail++;
+		printf("\t[FAIL] explicit CPU list returned %d\n", rc);
+	}
+
+	rc = s3lvol_tgt_background_from_options(&allowed, sizeof(allowed),
+						 CPU_SETSIZE, NULL,
+						 "0@9,1@31", &reactors, &background);
+	if (rc == 0 && CPU_COUNT(&background) == 1 && CPU_ISSET(4, &background)) {
+		g_pass++;
+		printf("\t[PASS] explicit lcore map -> background CPU 4\n");
+	} else {
+		g_fail++;
+		printf("\t[FAIL] explicit lcore map returned %d\n", rc);
+	}
+
+	rc = s3lvol_tgt_background_from_options(&allowed, sizeof(allowed),
+						 CPU_SETSIZE, NULL,
+						 " (1-0)@(9-4)", &reactors, &background);
+	if (rc == 0 && CPU_COUNT(&background) == 1 && CPU_ISSET(31, &background)) {
+		g_pass++;
+		printf("\t[PASS] grouped lcore map -> background CPU 31\n");
+	} else {
+		g_fail++;
+		printf("\t[FAIL] grouped lcore map returned %d\n", rc);
+	}
+
+	CPU_ZERO(&allowed);
+	CPU_SET(4, &allowed);
+	CPU_SET(9, &allowed);
+	rc = s3lvol_tgt_background_from_options(&allowed, sizeof(allowed),
+						 CPU_SETSIZE, "[4,9]", NULL,
+						 &reactors, &background);
+	{
+		struct s3lvol_tgt_cpu_selection selection = {
+			.reactors = &reactors,
+			.background = &background,
+			.cpuset_size = sizeof(background),
+		};
+
+		if (rc == 0 &&
+		    s3lvol_tgt_cpu_selection_shares_reactors(&selection)) {
+			g_pass++;
+			printf("\t[PASS] explicit full mask reports reactor sharing\n");
+		} else {
+			g_fail++;
+			printf("\t[FAIL] explicit full mask sharing returned %d\n", rc);
+		}
+	}
+}
+
+static void
+check_errors(void)
+{
+	cpu_set_t set;
+	char lcore_map[4];
+	int rc;
+
+	CPU_ZERO(&set);
+	if (s3lvol_tgt_lcore_map_from_set(NULL, sizeof(set), CPU_SETSIZE, 128,
+						 lcore_map, sizeof(lcore_map)) == -EINVAL &&
+	    s3lvol_tgt_lcore_map_from_set(&set, sizeof(set), CPU_SETSIZE, 0,
+						 lcore_map, sizeof(lcore_map)) == -EINVAL &&
+	    s3lvol_tgt_lcore_map_from_set(&set, sizeof(set), CPU_SETSIZE, 128,
+						 NULL, sizeof(lcore_map)) == -EINVAL &&
+	    s3lvol_tgt_lcore_map_from_set(&set, sizeof(set), CPU_SETSIZE, 128,
+						 lcore_map, 0) == -EINVAL) {
+		g_pass++;
+		printf("\t[PASS] invalid arguments are rejected\n");
+	} else {
+		g_fail++;
+		printf("\t[FAIL] invalid argument handling\n");
+	}
+
+	rc = s3lvol_tgt_lcore_map_from_set(&set, sizeof(set), CPU_SETSIZE, 128,
+						 lcore_map, sizeof(lcore_map));
+	if (rc == -ENODEV) {
+		g_pass++;
+		printf("\t[PASS] empty affinity is rejected\n");
+	} else {
+		g_fail++;
+		printf("\t[FAIL] empty affinity returned %d\n", rc);
+	}
+
+	CPU_SET(4, &set);
+	{
+		cpu_set_t reactors, background;
+
+		rc = s3lvol_tgt_background_from_options(&set, sizeof(set), CPU_SETSIZE,
+								 "0x0", NULL, &reactors,
+								 &background);
+		if (rc == -EINVAL) {
+			g_pass++;
+			printf("\t[PASS] empty reactor mask is rejected\n");
+		} else {
+			g_fail++;
+			printf("\t[FAIL] empty reactor mask returned %d\n", rc);
+		}
+	}
+
+	CPU_SET(123, &set);
+	rc = s3lvol_tgt_lcore_map_from_set(&set, sizeof(set), CPU_SETSIZE, 128,
+						 lcore_map, sizeof(lcore_map));
+	if (rc == -ENOSPC) {
+		g_pass++;
+		printf("\t[PASS] short output buffer is rejected\n");
+	} else {
+		g_fail++;
+		printf("\t[FAIL] short output buffer returned %d\n", rc);
+	}
+}
+
+int
+main(void)
+{
+	const size_t sparse[] = {1, 8, 11};
+	const size_t pair[] = {4, 31};
+	const size_t single[] = {7};
+	const size_t mixed[] = {4, 31, CPU_SETSIZE + 3, CPU_SETSIZE + 19};
+
+	check_map("sparse set", sparse, 3, 64, 128, "0@8,1@11");
+	check_map("two CPUs", pair, 2, 64, 128, "0@4,1@31");
+	check_map("one CPU", single, 1, 64, 128, "0@7");
+	check_map("IDs above CPU_SETSIZE are skipped", mixed, 4,
+		  CPU_SETSIZE + 64, 128, "0@4,1@31");
+	check_affinity();
+	check_lcore_limit();
+	check_explicit_options();
+	check_errors();
+
+	printf("\n=== %d passed, %d failed ===\n", g_pass, g_fail);
+	return g_fail ? 1 : 0;
+}

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -317,13 +317,14 @@ run_suite s3_bucket_selftest python3 ./test/tools/s3_bucket.py --self-test
 run_suite isa_baseline ./test/tools/test_isa_baseline.sh
 run_suite rpc_py38_compat ./test/tools/test_rpc_py38_compat.sh
 run_suite lvs_identity ./test/tools/test_lvs_identity.sh
+run_suite rcow_cpumask ./test/tools/test_rcow_cpumask.sh
 echo ""
 
 echo "--- integration (no S3, no root)"
 for t in s3_spawner_test s3_thread_bounce_test s3_journal_test s3_wal_test \
 	 s3_cache_test s3_flush_test s3_export_test s3_statefile_test \
 	 s3_local_dev_test s3_checkpoint_test s3_export_swap_test \
-	 s3_copy_xml_test s3_pending_persist_test; do
+	 s3_copy_xml_test s3_pending_persist_test s3_tgt_cpumask_test; do
 	run_suite "${t}" "./test/integration/${t}"
 done
 echo ""

--- a/CubeS3lvol/test/tools/test_rcow_cpumask.sh
+++ b/CubeS3lvol/test/tools/test_rcow_cpumask.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Offline tests for optional reactor-mask argument construction.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMMON="${ROOT}/scripts/rcow_common.sh"
+START="${ROOT}/scripts/rcow_start.sh"
+
+fail() {
+	echo "FAIL: $*" >&2
+	echo "result: 0 passed, 1 failed"
+	exit 1
+}
+
+[[ -f "${COMMON}" ]] || fail "missing ${COMMON}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+RCOW_LVS_NAME=cpumask-test
+RCOW_ACTIVE_FILE="${tmp}/active_lvols"
+RCOW_BSTORE_FILE="${tmp}/bstore.json"
+unset RCOW_TGT_CPUMASK
+# shellcheck source=../../scripts/rcow_common.sh
+source "${COMMON}"
+
+rcow_set_tgt_cpumask_args
+[[ "${#RCOW_TGT_CPUMASK_ARGS[@]}" -eq 0 ]] \
+	|| fail "unset mask must not add -m"
+
+RCOW_TGT_CPUMASK=""
+rcow_set_tgt_cpumask_args
+[[ "${#RCOW_TGT_CPUMASK_ARGS[@]}" -eq 0 ]] \
+	|| fail "empty mask must not add -m"
+
+RCOW_TGT_CPUMASK=0x30
+rcow_set_tgt_cpumask_args
+[[ "${#RCOW_TGT_CPUMASK_ARGS[@]}" -eq 2 ]] \
+	|| fail "hex mask must add exactly two arguments"
+[[ "${RCOW_TGT_CPUMASK_ARGS[0]}" == "-m" &&
+   "${RCOW_TGT_CPUMASK_ARGS[1]}" == "0x30" ]] \
+	|| fail "hex mask was not preserved"
+
+RCOW_TGT_CPUMASK='[4,9]'
+rcow_set_tgt_cpumask_args
+[[ "${#RCOW_TGT_CPUMASK_ARGS[@]}" -eq 2 ]] \
+	|| fail "CPU list must remain one mask argument"
+[[ "${RCOW_TGT_CPUMASK_ARGS[0]}" == "-m" &&
+   "${RCOW_TGT_CPUMASK_ARGS[1]}" == "[4,9]" ]] \
+	|| fail "CPU list was not preserved"
+
+grep -Fq '${RCOW_TGT_CPUMASK_ARGS[@]+"${RCOW_TGT_CPUMASK_ARGS[@]}"}' "${START}" \
+	|| fail "rcow_start.sh must expand the optional mask argument array safely"
+if grep -Eq -- '-m[[:space:]]+"\$\{RCOW_TGT_CPUMASK\}"' "${START}"; then
+	fail "rcow_start.sh still passes the mask unconditionally"
+fi
+
+echo "rcow CPU mask tests OK"
+echo "result: 9 passed, 0 failed"

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -668,7 +668,7 @@ When enabled, the sidecar:
 - reads S3 config from a chart Secret mounted at `/etc/s3lvol/s3.cfg`; an `existingSecret` must contain that key in s3lvol format (not `volume-s3.conf`);
 - reuses chart MinIO or `volumeS3` endpoint and credentials by default. The bucket is `cube-s3lvol` and must not be the volume plugin's `cube-volumes` (Helm fails on a shared bucket);
 - identifies the node by hashing the full Kubernetes node name (`spec.nodeName`) to `rcow-<8hex>`, so a Pod recreate is not a new machine and IP / dotted node names stay unique. `cubeS3lvol.lvsName` pins the same name on every node — do not set it when more than one node runs the sidecar;
-- uses rcow's default CPU mask (`0x3`); set `cubeS3lvol.cpuMask` when cores are isolated.
+- maps two SPDK reactors to the two highest allowed CPU IDs below `CPU_SETSIZE` in the sidecar's effective startup affinity by default (one reactor if only one supported CPU is allowed; no supported CPU is a startup error); set an exact `cubeS3lvol.cpuMask` when cores are isolated. Background threads use the remaining affinity, but share it when reactors consume every CPU, so leave at least one additional CPU for separation. Selection does not isolate CPUs from other workloads.
 
 ```yaml
 cubeS3lvol:
@@ -722,6 +722,12 @@ Override `helmTest.image` with curl+sh+awk+getent. `helmTest.dnsImage` is
 busybox for node-runtime-test only.
 
 ## Upgrade policy
+
+Upgrading from a chart release where `cubeS3lvol.cpuMask` was empty changes
+s3lvol reactor placement from the former implicit `0x3` (CPUs 0-1) to automatic
+selection. If those CPUs were isolated for the sidecar, set
+`cubeS3lvol.cpuMask: "0x3"` before upgrading; leave it empty only to opt into the
+new affinity-based placement.
 
 `cube-node` is a native `apps/v1` DaemonSet. Bumping Big Pod runtime images
 (`images.cubelet`, `images.waitNodePrep`, …) or changing the Pod template

--- a/deploy/kubernetes/chart/scripts/test-s3lvol-sidecar-guard.sh
+++ b/deploy/kubernetes/chart/scripts/test-s3lvol-sidecar-guard.sh
@@ -61,6 +61,10 @@ if grep -q 'CUBE_S3LVOL_SOCKET' "$TMP_DIR/default-node.yaml"; then
   echo "default render must not set CUBE_S3LVOL_SOCKET on cubelet" >&2
   exit 1
 fi
+if grep -q 'RCOW_TGT_CPUMASK' "$TMP_DIR/default-node.yaml"; then
+  echo "default render must not set an explicit s3lvol CPU mask" >&2
+  exit 1
+fi
 if grep -q 'app.kubernetes.io/component: cube-s3lvol' "$TMP_DIR/default.yaml"; then
   echo "default render must not create the cube-s3lvol Secret" >&2
   exit 1
@@ -104,6 +108,8 @@ if "fieldPath: spec.nodeName" not in body:
     raise SystemExit("cube-s3lvol NODE_NAME must use spec.nodeName")
 if "RCOW_LVS_NAME" in body:
     raise SystemExit("default RCOW_LVS_NAME must be derived at runtime by rcow_common, not rendered")
+if "RCOW_TGT_CPUMASK" in body:
+    raise SystemExit("default reactor CPUs must be selected at runtime, not rendered")
 if "livenessProbe:" in body:
     raise SystemExit("cube-s3lvol must not have a livenessProbe")
 if "timeoutSeconds: 8" not in body:
@@ -159,5 +165,25 @@ grep -q 'name: RCOW_LVS_NAME' "$TMP_DIR/lvs.yaml" \
 grep -q 'rcow-explicit' "$TMP_DIR/lvs.yaml" \
   || { echo "explicit lvsName must appear in the sidecar env" >&2; exit 1; }
 echo "ok: cubeS3lvol.lvsName override is rendered"
+
+helm template s3lvol-cpumask "$CHART_DIR" $COMMON_SETS \
+  --set cubeS3lvol.enabled=true \
+  --set-string 'cubeS3lvol.cpuMask=[4\,9]' \
+  > "$TMP_DIR/cpumask.yaml"
+extract_big_pod "$TMP_DIR/cpumask.yaml" "$TMP_DIR/cpumask-node.yaml"
+python3 - "$TMP_DIR/cpumask-node.yaml" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+block = re.search(r"- name: cube-s3lvol\n(.*?)(?:\n      volumes:|\Z)", text, re.S)
+if not block:
+    raise SystemExit("cube-s3lvol container block not found")
+body = block.group(1)
+if not re.search(r'name: RCOW_TGT_CPUMASK\n\s+value: "?\[4,9\]"?', body):
+    raise SystemExit("explicit cubeS3lvol.cpuMask must render unchanged")
+PY
+echo "ok: cubeS3lvol.cpuMask override is rendered unchanged"
 
 echo "cube-s3lvol sidecar guard passed"

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -1132,8 +1132,8 @@ cubeS3lvol:
   # cluster — every node would share one S3 prefix.
   lvsName: ""
   socketPath: /var/run/s3lvol/s3lvol.sock
-  # Empty: rcow default 0x3 (CPU0+1). Set when the container is pinned to
-  # isolated cores.
+  # Empty: map two SPDK reactors to the two highest allowed CPU IDs below
+  # CPU_SETSIZE. Set an exact mask/list for isolated cores.
   cpuMask: ""
   tgtMemMB: 16384
   journalMB: 1024

--- a/deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh
@@ -94,7 +94,7 @@ s3lvol_derived_lvs_name() {
 
 # An explicit RCOW_LVS_NAME (cubeS3lvol.lvsName) wins; otherwise derive
 # rcow-<hash of NODE_NAME> now, before rcow_common.sh resolves the name at
-# source time. RCOW_TGT_CPUMASK is exported only when set (rcow default 0x3).
+# source time. RCOW_TGT_CPUMASK is exported only when explicitly set.
 s3lvol_export_optional_knobs() {
   if [[ -n "${RCOW_LVS_NAME:-}" ]]; then
     export RCOW_LVS_NAME
@@ -111,7 +111,7 @@ s3lvol_export_optional_knobs() {
     export RCOW_TGT_CPUMASK
     log "RCOW_TGT_CPUMASK=${RCOW_TGT_CPUMASK} (explicit)"
   else
-    log "RCOW_TGT_CPUMASK unset; rcow_common default is 0x3"
+    log "RCOW_TGT_CPUMASK unset; s3lvol_tgt will use the two highest supported allowed CPUs"
   fi
 }
 

--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -237,7 +237,10 @@ role target:
   replaced (the new binary takes effect), then the target restarts with the
   role target. `wal_bdev.img` is **never overwritten** (created only on first
   install; its size fixes the journal/WAL layout), and the `RCOW_*` settings in
-  `.one-click.env` are merged and kept across the upgrade.
+  `.one-click.env` are merged and kept across the upgrade. This includes the
+  former generated `RCOW_TGT_CPUMASK=0x3`; remove that key before upgrading to
+  opt into mapping reactors to the two highest allowed CPU IDs below
+  `CPU_SETSIZE` automatically.
 - **Enable/disable**: preferred `ONE_CLICK_ENABLE_S3LVOL=0|1 ./install.sh`
   (honored on upgrade as well). Or put only that key in the bundle `.env`
   and re-run `install.sh`. Do not `cp env.example .env` as a full copy

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -200,7 +200,7 @@ sudo ./down.sh
 CubeS3lvol（s3lvol）作为 `cube-sandbox-*` 角色 target 的 `Wants=` 成员被统一管理：
 
 - **停止（`down.sh` / `systemctl stop cube-sandbox-{control,compute}.target`）**：s3lvol 单元会走 `cube-s3lvol-stop.sh` 的**条件卸载**——target 进程存活时完整执行 `rcow_stop.sh`（断开 initiator → 卸载 lvstore/回刷 → 终止 target），target 已崩溃时只清理 target 侧残留、绝不断开 NVMf initiator。`down.sh` 只停止服务，**不删除任何数据**（`/data/cubelet/rcow/wal_bdev.img` 与 bstore 元数据保留），再次启动走 attach/replay 恢复。
-- **升级（`install.sh` 升级模式）**：旧 `CubeS3lvol/` 目录被替换（新二进制自动生效），随后 target 随角色 target 重启。`wal_bdev.img` **永不覆盖**（仅首次安装创建，其尺寸固定 journal/WAL 布局），`.one-click.env` 中 `RCOW_*` 配置经升级合并保留。
+- **升级（`install.sh` 升级模式）**：旧 `CubeS3lvol/` 目录被替换（新二进制自动生效），随后 target 随角色 target 重启。`wal_bdev.img` **永不覆盖**（仅首次安装创建，其尺寸固定 journal/WAL 布局），`.one-click.env` 中 `RCOW_*` 配置经升级合并保留；这也包括旧版自动写入的 `RCOW_TGT_CPUMASK=0x3`。若要启用新版“自动映射 reactor 到 `CPU_SETSIZE` 以下编号最大的两个允许 CPU”的行为，请在升级前删除该项。
 - **启停开关**：推荐 `ONE_CLICK_ENABLE_S3LVOL=0|1 ./install.sh`（upgrade 同样生效）。或在包内 `.env` **只写这一项** 再重跑 `install.sh`。不要整份 `cp env.example .env` 再 upgrade，否则这个开关会被重置成 `0`。不必再手改 `.one-click.env`。也可以直接 `systemctl enable/disable cube-sandbox-s3lvol.service`。`CUBE_PVM_ENABLE` 遵循同样规则：出现在 `.env` 或进程环境中即视为显式设置（整份 `cp` 同样会把它重置为 `0`）。
 - **S3 后端**：启用后 `install.sh` 用 `CUBE_S3_*` 自动写出 `/data/cubelet/s3.cfg`（默认对接内置 MinIO；配了外部 S3 就跟外部走）。s3lvol 使用独立桶 `CUBE_S3LVOL_BUCKET`（默认 `cube-s3lvol`），与 volume 插件的 `cube-volumes` 分开。supervisor 启动前会用 stdlib SigV4 工具幂等建桶，不依赖 awscli。手写且不含 one-click sentinel 的 `s3.cfg` 不会被覆盖。开发机上旧的 `/data/cubelet/cos.cfg` **不会回落**，请改名为 `s3.cfg` 并换成新字段名。
 

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -246,10 +246,14 @@ ONE_CLICK_ENABLE_S3LVOL=0
 # RCOW_JOURNAL_MB=1024
 # Thin-provisioned capacity for newly created volumes (GiB).
 # RCOW_CAPACITY_GB=16384
-# Target process CPU affinity mask and memory (MiB). Align RCOW_TGT_CPUMASK
-# with the host's dedicated cores; 0x3 is the default mask on 4-core dev
-# boxes.
-# RCOW_TGT_CPUMASK=0x3
+# Target process CPU affinity mask and memory (MiB). When unset, the target
+# maps two SPDK reactors to the two highest allowed CPU IDs below CPU_SETSIZE
+# (or one reactor when only one such CPU is allowed; none is a startup error).
+# Set an exact SPDK mask/list when the host has dedicated cores; automatic
+# selection does not isolate those cores.
+# Existing upgrades retain a persisted mask; remove it to opt into automatic
+# selection.
+# RCOW_TGT_CPUMASK=0x30
 # RCOW_TGT_MEM_MB=16384
 # NVMe/TCP listener the target serves on (initiator connects to this).
 # Must stay on loopback: subsystems are exported with allow_any_host (-a),

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -1730,7 +1730,8 @@ case "${CUBE_EGRESS_ADMIN_PORT}" in
 esac
 
 # CubeS3lvol (s3lvol) options. Defaults mirror rcow_common.sh so the data
-# plane behaves out of the box. ONE_CLICK_ENABLE_S3LVOL only records the
+# plane behaves out of the box. An empty CPU mask delegates selection to the
+# target at each start. ONE_CLICK_ENABLE_S3LVOL only records the
 # intent here; the systemd unit wiring is done by install-units.sh when the
 # switch is 1 (the unit itself is always shipped).
 ONE_CLICK_ENABLE_S3LVOL="${ONE_CLICK_ENABLE_S3LVOL:-0}"
@@ -1746,7 +1747,7 @@ RCOW_JOURNAL_MB="${RCOW_JOURNAL_MB:-1024}"
 # total. Tuning RCOW_CACHE_MB only matters before the first start.
 RCOW_CACHE_MB="${RCOW_CACHE_MB:-490496}"
 RCOW_CAPACITY_GB="${RCOW_CAPACITY_GB:-16384}"
-RCOW_TGT_CPUMASK="${RCOW_TGT_CPUMASK:-0x3}"
+RCOW_TGT_CPUMASK="${RCOW_TGT_CPUMASK:-}"
 RCOW_TGT_MEM_MB="${RCOW_TGT_MEM_MB:-16384}"
 RCOW_LISTEN_ADDR="${RCOW_LISTEN_ADDR:-127.0.0.1}"
 RCOW_LISTEN_PORT="${RCOW_LISTEN_PORT:-4420}"
@@ -2034,9 +2035,9 @@ else
   remove_env_kv "${RUNTIME_ENV_FILE}" "CUBE_S3_S3FS_EXTRA_OPTS"
 fi
 
-# CubeS3lvol (s3lvol) runtime env: persist the resolved defaults (mirroring
-# rcow_common.sh) so the systemd unit picks them up via EnvironmentFile
-# without re-deriving them, and so `down.sh` / upgrade knows the intent.
+# CubeS3lvol (s3lvol) runtime env: persist resolved sizing and listener defaults.
+# The CPU mask is different: an absent key means that s3lvol_tgt selects from its
+# effective affinity at every start; a non-empty key records an operator override.
 upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_ENABLE_S3LVOL" "${ONE_CLICK_ENABLE_S3LVOL}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_S3LVOL_BUCKET" "${CUBE_S3LVOL_BUCKET}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_OPS_S3_BUCKET" "${CUBE_OPS_S3_BUCKET:-cube-ops}"
@@ -2049,7 +2050,11 @@ upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_WAL_MB" "${RCOW_WAL_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_JOURNAL_MB" "${RCOW_JOURNAL_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_CACHE_MB" "${RCOW_CACHE_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_CAPACITY_GB" "${RCOW_CAPACITY_GB}"
-upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_TGT_CPUMASK" "${RCOW_TGT_CPUMASK}"
+if [[ -n "${RCOW_TGT_CPUMASK}" ]]; then
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_TGT_CPUMASK" "${RCOW_TGT_CPUMASK}"
+else
+  remove_env_kv "${RUNTIME_ENV_FILE}" "RCOW_TGT_CPUMASK"
+fi
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_TGT_MEM_MB" "${RCOW_TGT_MEM_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_LISTEN_ADDR" "${RCOW_LISTEN_ADDR}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_LISTEN_PORT" "${RCOW_LISTEN_PORT}"

--- a/deploy/one-click/tests/test_env_merge.sh
+++ b/deploy/one-click/tests/test_env_merge.sh
@@ -403,11 +403,15 @@ ONE_CLICK_ENABLE_S3LVOL=0
 EOF
   cat > "${old}" <<'EOF'
 ONE_CLICK_ENABLE_S3LVOL=1
+RCOW_TGT_CPUMASK=0x3
 EOF
 
   merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
 
   assert_value "${out}" ONE_CLICK_ENABLE_S3LVOL 1
+  # The old installer generated 0x3, but it is indistinguishable from an
+  # operator override. Preserve it rather than silently moving reactor CPUs.
+  assert_value "${out}" RCOW_TGT_CPUMASK 0x3
   assert_contains "${diff}" "[preserved]"
   assert_contains "${diff}" "= ONE_CLICK_ENABLE_S3LVOL=1"
 }

--- a/deploy/one-click/tests/test_install_mode.sh
+++ b/deploy/one-click/tests/test_install_mode.sh
@@ -579,6 +579,15 @@ test_install_sh_wires_upgrade_flow() {
   assert_contains "${f}" "snapshot_one_click_toggles"
   assert_contains "${f}" "apply_one_click_toggles"
   assert_contains "${f}" "ONE_CLICK_TOGGLE_KEYS"
+  # An absent s3lvol CPU mask must reach the target as automatic selection;
+  # explicit and legacy non-empty values are still persisted unchanged.
+  assert_contains "${f}" 'RCOW_TGT_CPUMASK="${RCOW_TGT_CPUMASK:-}"'
+  assert_contains "${f}" 'if [[ -n "${RCOW_TGT_CPUMASK}" ]]; then'
+  assert_contains "${f}" 'upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_TGT_CPUMASK" "${RCOW_TGT_CPUMASK}"'
+  assert_contains "${f}" 'remove_env_kv "${RUNTIME_ENV_FILE}" "RCOW_TGT_CPUMASK"'
+  if grep -Fq 'RCOW_TGT_CPUMASK="${RCOW_TGT_CPUMASK:-0x3}"' "${f}"; then
+    fail "install.sh must not manufacture the old 0x3 CPU mask"
+  fi
   # Stop s3lvol before the target/glob stop so it can flush while MinIO is up.
   assert_contains "${f}" "systemctl stop cube-sandbox-s3lvol.service"
   # Disable must clear leftover failed state.

--- a/docs/guide/cross-node-snapshot.md
+++ b/docs/guide/cross-node-snapshot.md
@@ -140,7 +140,7 @@ Identity comes from the full Kubernetes node name, hashed to `rcow-<8hex>`. A Po
 Extra settings are only needed when:
 
 - the S3 endpoint is external and path-style — set `cubeS3lvol.s3.pathStyle: true`;
-- cores are isolated — set `cubeS3lvol.cpuMask` (default is rcow's `0x3`).
+- cores are isolated — set an exact `cubeS3lvol.cpuMask`; otherwise the target maps two SPDK reactors to the two highest allowed CPU IDs below `CPU_SETSIZE` in the sidecar's effective startup affinity (one reactor if only one supported CPU is allowed; no supported CPU is a startup error). Automatic selection honors cpusets but does not itself isolate those CPUs from other workloads.
 
 ```yaml
 cubeS3lvol:

--- a/docs/zh/guide/cross-node-snapshot.md
+++ b/docs/zh/guide/cross-node-snapshot.md
@@ -163,7 +163,7 @@ Cube 安装时默认安装 MinIO 作为 S3 服务，方便开箱体验。
 只有以下情况需要额外设置：
 
 - 外部 S3 端点为 path-style——显式设 `cubeS3lvol.s3.pathStyle: true`；
-- CPU 核做了隔离——设置 `cubeS3lvol.cpuMask`（默认 rcow 的 `0x3`）。
+- CPU 核做了隔离——设置精确的 `cubeS3lvol.cpuMask`；否则 target 默认把两个 SPDK reactor 映射到 sidecar 启动时有效 affinity 中 `CPU_SETSIZE` 以下编号最大的两个允许 CPU（仅有一个受支持 CPU 时使用一个 reactor；没有受支持 CPU 时启动失败）。自动选择会遵守 cpuset，但不会替你隔离这些 CPU 上的其他负载。
 
 ```yaml
 cubeS3lvol:


### PR DESCRIPTION
## Summary

- automatically map up to two SPDK reactors to the highest usable CPUs in the target's effective scheduler affinity when neither `-m` nor `--lcores` is supplied
- derive physical reactor CPUs for automatic placement and explicit SPDK masks/lcore maps, then keep background/CRT threads on the non-reactor affinity
- fail closed when explicit placement cannot be interpreted locally; otherwise keep background/CRT threads off reactor CPUs, warn when all allowed CPUs must be shared, and restore startup affinity during teardown
- preserve the preconfigured spawner cpuset across stop/start cycles and avoid stale module-side CPU-count logging
- make one-click and Helm CPU masks optional, preserve one-click persisted overrides, and document the Helm upgrade opt-in needed to retain the former implicit `0x3` placement
- document CPU isolation, `CPU_SETSIZE`, SMT-sibling, and upgrade caveats in English and Chinese

## Testing

- `make builder-run BUILDER_CMD='cd /workspace/CubeS3lvol && make check-offline'` — 20 suites, 759 assertions passed
- `deploy/kubernetes/chart/scripts/test-s3lvol-sidecar-guard.sh`
- `deploy/kubernetes/images/scripts/test-cube-s3lvol-entrypoint.sh`
- `deploy/one-click/tests/test_env_merge.sh`
- `deploy/one-click/tests/test_install_mode.sh`

Real-S3/dataplane startup was not run in this session; those suites remain environment-gated.

Assisted-by: Claude Code:custom-model-b6-standard

🤖 Generated with [Claude Code](https://claude.com/claude-code)







