### PR TITLE
chore(release): bump image tag to v0.7.1-rc2

### DIFF
--- a/CubeEgress/Makefile
+++ b/CubeEgress/Makefile
@@ -1,4 +1,4 @@
-IMAGE_TAG              ?= v0.7.1-rc1
+IMAGE_TAG              ?= v0.7.1-rc2
 IMAGE_LOCAL            := cube-egress
 CUBE_VERSION           ?= $(IMAGE_TAG)
 CUBE_COMMIT            ?= $(shell git rev-parse HEAD | cut -c1-8)

--- a/CubeProxy/Makefile
+++ b/CubeProxy/Makefile
@@ -1,4 +1,4 @@
-IMAGE_TAG           ?= v0.7.1-rc1
+IMAGE_TAG           ?= v0.7.1-rc2
 IMAGE_LOCAL         := cube-proxy
 
 # Base OpenResty image; overridable for private mirrors / pinned digests.

--- a/cube-lifecycle-manager/Makefile
+++ b/cube-lifecycle-manager/Makefile
@@ -1,4 +1,4 @@
-IMAGE_TAG           ?= v0.7.1-rc1
+IMAGE_TAG           ?= v0.7.1-rc2
 IMAGE_LOCAL         := cube-lifecycle-manager
 CUBE_VERSION        ?= $(IMAGE_TAG)
 CUBE_COMMIT         ?= $(shell git rev-parse HEAD | cut -c1-8)

--- a/cube-lifecycle-manager/README.md
+++ b/cube-lifecycle-manager/README.md
@@ -14,7 +14,7 @@ between CubeMaster, CubeProxy and Redis.
 
 ```sh
 make test    # go test ./...
-make build   # local image, tag: cube-lifecycle-manager:v0.7.1-rc1-<arch>
+make build   # local image, tag: cube-lifecycle-manager:v0.7.1-rc2-<arch>
 ```
 
 ## Publishing images
@@ -35,7 +35,7 @@ make manifest
 
 Overrides:
 
-- `IMAGE_TAG=<tag>` — override the release tag (default `v0.7.1-rc1`)
+- `IMAGE_TAG=<tag>` — override the release tag (default `v0.7.1-rc2`)
 - `V=1` — verbose docker commands
 
 ## Configuration

--- a/deploy/kubernetes/chart/Chart.yaml
+++ b/deploy/kubernetes/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cube
 description: CubeSandbox on Kubernetes/TKE Helm chart with separate control-plane, node, proxy, and host bootstrap images.
 type: application
-version: 0.7.1-rc1
-appVersion: "0.7.1-rc1"
+version: 0.7.1-rc2
+appVersion: "0.7.1-rc2"
 home: https://github.com/TencentCloud/CubeSandbox
 keywords:
   - cubesandbox

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -179,7 +179,7 @@ To **turn off PVM on one node**: remove the `allow-pvm-bootstrap` label. Bootstr
 ## Build and push images
 
 ```bash
-PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.7.1-rc1 ./deploy/kubernetes/images/build-cube-images.sh
+PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.7.1-rc2 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 
 Cube-owned images default to `imagePullPolicy: IfNotPresent`. To pick up a

--- a/deploy/kubernetes/chart/runtime-values.example.yaml
+++ b/deploy/kubernetes/chart/runtime-values.example.yaml
@@ -140,5 +140,5 @@ redis:
 # images:
 #   ops:
 #     repository: my-mirror.example.com/cube-sandbox/cube-ops
-#     tag: v0.7.1-rc1
+#     tag: v0.7.1-rc2
 #     pullPolicy: Always

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -19,55 +19,55 @@ images:
   # Bootstrap DaemonSet init: installs/configures PVM host kernel and may reboot the host.
   pvmHostBootstrap:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-pvm-host-bootstrap
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   # Bootstrap DaemonSet init: validates KVM/XFS, prepares host directories, checks CubeMaster reachability.
   nodeInit:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-node-init
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   # Big Pod wait-node-prep initContainer + bootstrap write-ready/hold.
   waitNodePrep:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-wait-node-prep
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   # Big Pod per-component runtime images.
   cubelet:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cubelet
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   cubeShim:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-shim
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   cubeKernel:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-kernel
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   cubeGuest:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-guest
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   cubeAgent:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-agent
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   master:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-master
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   api:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-api
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   # Standalone template build service. Built from
@@ -75,47 +75,47 @@ images:
   # because it is the process that pulls images and makes the ext4.
   templateCenter:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-templatecenter
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   ops:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-ops
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   cubemastercli:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cubemastercli
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   proxy:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-proxy
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   lifecycleManager:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   cubeEgress:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   cubeEgressNet:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress-net
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   cubeS3lvol:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-s3lvol
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   webui:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-webui
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
     pullPolicy: IfNotPresent
 
   # Used by the post-install Job that merges *.cubeProxy.domain into cluster CoreDNS.

--- a/deploy/kubernetes/images/README.md
+++ b/deploy/kubernetes/images/README.md
@@ -5,7 +5,7 @@ This directory contains image build definitions used by the Kubernetes/TKE chart
 ## Build entrypoint
 
 ```bash
-PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.7.1-rc1 ./deploy/kubernetes/images/build-cube-images.sh
+PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.7.1-rc2 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 
 Before a real release, run `scripts/bump-image.sh vX.Y.Z` so hard-coded tags
@@ -18,7 +18,7 @@ Use `NO_CACHE=1` when every Docker image layer must be rebuilt instead of
 using Docker's build cache:
 
 ```bash
-NO_CACHE=1 PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.7.1-rc1 ./deploy/kubernetes/images/build-cube-images.sh
+NO_CACHE=1 PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.7.1-rc2 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 
 The script defaults its temporary `BUILD_ROOT` to
@@ -69,7 +69,7 @@ CUBE_KERNEL_VMLINUX=/path/to/vmlinux \
 ONE_CLICK_ARCH=arm64 CUBE_KERNEL_VMLINUX=/path/to/vmlinux \
   IMAGE_TAG=dev ./deploy/kubernetes/images/build-cube-images.sh cube-kernel
 
-IMAGE_TAG=v0.7.1-rc1 ./deploy/kubernetes/images/build-cube-images.sh cube-kernel
+IMAGE_TAG=v0.7.1-rc2 ./deploy/kubernetes/images/build-cube-images.sh cube-kernel
 ```
 
 `cube-guest` does not use the one-click package. It stages guest rootfs from:
@@ -93,7 +93,7 @@ CUBE_GUEST_IMAGE_DIR=/path/to/cube-image IMAGE_TAG=dev \
 CUBE_AGENT_IMAGE_DIR=/path/to/cube-agent IMAGE_TAG=dev \
   ./deploy/kubernetes/images/build-cube-images.sh cube-agent
 
-IMAGE_TAG=v0.7.1-rc1 ./deploy/kubernetes/images/build-cube-images.sh cube-guest cube-agent
+IMAGE_TAG=v0.7.1-rc2 ./deploy/kubernetes/images/build-cube-images.sh cube-guest cube-agent
 ```
 
 ## Pinning source to a release tag
@@ -102,7 +102,7 @@ IMAGE_TAG=v0.7.1-rc1 ./deploy/kubernetes/images/build-cube-images.sh cube-guest 
 `cube-proxy`, `cube-egress`, `cube-s3lvol`, `cube-lifecycle-manager`, and `cube-webui` are
 compiled from repository source (rather than binaries in the release tarball).
 By default the script pins those source trees to `${SOURCE_REF}` (defaulting to
-`${VERSION}`, so `v0.7.1-rc1` for the default build). It exports `CubeMaster/`,
+`${VERSION}`, so `v0.7.1-rc2` for the default build). It exports `CubeMaster/`,
 `CubeAPI/`, `CubeProxy/`, `CubeEgress/`,
 `cube-lifecycle-manager/`, `web/`, and `deploy/one-click/webui/` at that git
 ref into `${BUILD_ROOT}/source-tree/` via `git archive` and points `REPO_ROOT`
@@ -174,7 +174,7 @@ entrypoint into it:
 
 ```bash
 CUBE_NODE_BASE_IMAGE=ccr.ccs.tencentyun.com/pavleli/cube-node:v0.4.0-cubevsfix-20260627 \
-  PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.7.1-rc1 \
+  PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.7.1-rc2 \
   ./deploy/kubernetes/images/build-cube-images.sh
 ```
 

--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -15,7 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 WORKTREE_ROOT="${REPO_ROOT}"
 
-VERSION="${VERSION:-v0.7.1-rc1}"
+VERSION="${VERSION:-v0.7.1-rc2}"
 IMAGE_TAG="${IMAGE_TAG:-${VERSION}}"
 REGISTRY="${REGISTRY:-cube-sandbox-int.tencentcloudcr.com/cube-sandbox}"
 # SOURCE_REF pins the CubeMaster / CubeAPI / CubeOps / pkgs/cubedb / CubeProxy /
@@ -233,9 +233,9 @@ Examples:
   SOURCE_REF="" IMAGE_TAG=dev $0 cube-shim
   CUBE_KERNEL_VMLINUX=/path/vmlinux CUBE_KERNEL_PVM_VMLINUX=/path/vmlinux-pvm \\
     IMAGE_TAG=dev $0 cube-kernel
-  IMAGE_TAG=v0.7.1-rc1 $0 cube-kernel
+  IMAGE_TAG=v0.7.1-rc2 $0 cube-kernel
   CUBE_GUEST_IMAGE_DIR=/path/to/cube-image IMAGE_TAG=dev $0 cube-guest
-  IMAGE_TAG=v0.7.1-rc1 $0 cube-guest
+  IMAGE_TAG=v0.7.1-rc2 $0 cube-guest
   SOURCE_REF="" IMAGE_TAG=dev $0 cube-api
   SOURCE_REF="" IMAGE_TAG=dev $0 cube-ops
 

--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -736,7 +736,7 @@ export TENCENTCLOUD_TKE_NODE_COUNT=2              # TKE worker nodes (default 2)
 export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                 # default: public pre-built images
 export TENCENTCLOUD_USE_CFS=false                 # default: no CFS, cubemaster single replica
-export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.7.1-rc1
+export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.7.1-rc2
 ```
 
 For non-interactive / CI runs, also set these (without a TTY the interactive

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -640,7 +640,7 @@ export TENCENTCLOUD_TKE_NODE_COUNT=2              # TKE worker 节点数（默�
 export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                 # 默认使用公网预置镜像
 export TENCENTCLOUD_USE_CFS=false                 # 默认无 CFS，cubemaster 单副本
-export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.7.1-rc1
+export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.7.1-rc2
 ```
 
 非交互 / CI 运行时建议显式设置以下变量（没有 TTY 时交互菜单会回退到默认值，显式设置可避免意外）。密码变量是例外：非交互运行会拒绝使用仓库中公开可见的内置演示密码并要求显式设置；如需在临时沙箱中使用不安全的默认密码，可设置 `TENCENTCLOUD_ALLOW_INSECURE_DEFAULTS=1`。

--- a/deploy/one-click/build-agent-ext4.sh
+++ b/deploy/one-click/build-agent-ext4.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   OUTPUT_DIR=/path/to/cube-agent [ONE_CLICK_CUBE_AGENT_BIN=/path/to/cube-agent] \
-#     CUBE_VERSION=v0.7.1-rc1 ./deploy/one-click/build-agent-ext4.sh
+#     CUBE_VERSION=v0.7.1-rc2 ./deploy/one-click/build-agent-ext4.sh
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/deploy/one-click/build-guest-image.sh
+++ b/deploy/one-click/build-guest-image.sh
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   OUTPUT_DIR=/path/to/cube-image [ONE_CLICK_CUBE_INIT_BIN=/path/to/cube-init] \
-#     CUBE_VERSION=v0.7.1-rc1 ./deploy/one-click/build-guest-image.sh
+#     CUBE_VERSION=v0.7.1-rc2 ./deploy/one-click/build-guest-image.sh
 #
 # When ONE_CLICK_CUBE_INIT_BIN is unset, cube-init is built locally (or via
 # ONE_CLICK_CUBE_INIT_BUILD_MODE=docker).

--- a/deploy/one-click/scripts/one-click/up-cube-lifecycle-manager.sh
+++ b/deploy/one-click/scripts/one-click/up-cube-lifecycle-manager.sh
@@ -31,10 +31,10 @@ COMPOSE_FILE="${CUBE_LCM_DIR}/docker-compose.yaml"
 #   3. default    → int.tencentcloudcr.com (overseas/international)
 #
 # The image is published by cube-lifecycle-manager/Makefile's `make push`
-# to both registries under the same :v0.7.1-rc1 tag; either default resolves
+# to both registries under the same :v0.7.1-rc2 tag; either default resolves
 # to whatever the operator most recently published.
-CUBE_LCM_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.7.1-rc1"
-CUBE_LCM_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.7.1-rc1"
+CUBE_LCM_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.7.1-rc2"
+CUBE_LCM_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.7.1-rc2"
 if [[ -n "${CUBE_SANDBOX_CUBE_LCM_IMAGE:-}" ]]; then
   CUBE_LCM_IMAGE="${CUBE_SANDBOX_CUBE_LCM_IMAGE}"
 elif [[ "${MIRROR:-}" == "cn" ]]; then

--- a/deploy/one-click/scripts/one-click/up-cube-proxy.sh
+++ b/deploy/one-click/scripts/one-click/up-cube-proxy.sh
@@ -35,14 +35,14 @@ COMPOSE_FILE="${PROXY_DIR}/docker-compose.yaml"
 #   3. default    → int.tencentcloudcr.com (overseas/international)
 #
 # The image is published by CubeProxy/Makefile's `make push` to both
-# registries under the same :v0.7.1-rc1 tag; either default resolves
+# registries under the same :v0.7.1-rc2 tag; either default resolves
 # to whatever the operator most recently published.
 #
 # Compatibility: CUBE_PROXY_IMAGE_TAG is deprecated (local compose build era).
 # A non-default leftover value is honored once with a warning; the old default
 # cube-proxy:one-click is ignored so upgrades adopt the pre-published image.
-CUBE_PROXY_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.7.1-rc1"
-CUBE_PROXY_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.7.1-rc1"
+CUBE_PROXY_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.7.1-rc2"
+CUBE_PROXY_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.7.1-rc2"
 if [[ -z "${CUBE_SANDBOX_CUBE_PROXY_IMAGE:-}" && -n "${CUBE_PROXY_IMAGE_TAG:-}" ]]; then
   if [[ "${CUBE_PROXY_IMAGE_TAG}" == "cube-proxy:one-click" ]]; then
     log "CUBE_PROXY_IMAGE_TAG=cube-proxy:one-click is deprecated and ignored; set CUBE_SANDBOX_CUBE_PROXY_IMAGE or MIRROR to select the pre-published cube-proxy image"

--- a/deploy/one-click/scripts/systemd/cube-egress-start.sh
+++ b/deploy/one-click/scripts/systemd/cube-egress-start.sh
@@ -27,10 +27,10 @@ require_cmd docker
 #   3. default    → int.tencentcloudcr.com (overseas/international)
 #
 # Production-pushed by CubeEgress/Makefile's `make push` to BOTH repos
-# under the :v0.7.1-rc1 tag, so either default resolves to the same digest
+# under the :v0.7.1-rc2 tag, so either default resolves to the same digest
 # the operator most recently published.
-CUBE_EGRESS_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress:v0.7.1-rc1"
-CUBE_EGRESS_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress:v0.7.1-rc1"
+CUBE_EGRESS_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress:v0.7.1-rc2"
+CUBE_EGRESS_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress:v0.7.1-rc2"
 if [[ -n "${CUBE_SANDBOX_CUBE_EGRESS_IMAGE:-}" ]]; then
   CUBE_EGRESS_IMAGE="${CUBE_SANDBOX_CUBE_EGRESS_IMAGE}"
 elif [[ "${MIRROR:-}" == "cn" ]]; then

--- a/deploy/one-click/terraform/tencentcloud/build_images.sh
+++ b/deploy/one-click/terraform/tencentcloud/build_images.sh
@@ -72,7 +72,7 @@ NAMESPACE="${NAMESPACE:-cube-sandbox}"
 # One shared, externally overridable tag for all component images. Keep in
 # sync with terraform/tencentcloud (var.image_tag) so the default TKE deployment
 # consumes exactly what this script builds.
-TAG="${TAG:-v0.7.1-rc1}"
+TAG="${TAG:-v0.7.1-rc2}"
 
 CUBE_API_IMAGE="${CUBE_API_IMAGE:-${REGISTRY}/${NAMESPACE}/cube-api:${TAG}}"
 CUBE_OPS_IMAGE="${CUBE_OPS_IMAGE:-${REGISTRY}/${NAMESPACE}/cube-ops:${TAG}}"

--- a/deploy/one-click/terraform/tencentcloud/create.sh
+++ b/deploy/one-click/terraform/tencentcloud/create.sh
@@ -889,7 +889,7 @@ setup_env() {
 	TENCENTCLOUD_USE_CFS="${TENCENTCLOUD_USE_CFS:-false}"
 	export TF_VAR_use_tcr="$TENCENTCLOUD_USE_TCR"
 	export TF_VAR_use_cfs="$TENCENTCLOUD_USE_CFS"
-	CUBE_IMAGE_TAG="${TENCENTCLOUD_CUBE_IMAGE_TAG:-v0.7.1-rc1}"
+	CUBE_IMAGE_TAG="${TENCENTCLOUD_CUBE_IMAGE_TAG:-v0.7.1-rc2}"
 	export TF_VAR_image_tag="$CUBE_IMAGE_TAG"
 	export TF_VAR_image_registry="${TENCENTCLOUD_IMAGE_REGISTRY:-cube-sandbox-cn.tencentcloudcr.com}"
 	export TF_VAR_image_namespace="${TENCENTCLOUD_IMAGE_NAMESPACE:-cube-sandbox}"
@@ -1588,7 +1588,7 @@ build_and_push_images() {
 	reg=$(terraform output -raw tcr_registry_name 2>/dev/null || echo "")
 	ns=$(terraform output -raw tcr_namespace 2>/dev/null || echo "")
 	user=$(terraform output -raw tcr_token_user 2>/dev/null || echo "")
-	tag="${CUBE_IMAGE_TAG:-v0.7.1-rc1}"
+	tag="${CUBE_IMAGE_TAG:-v0.7.1-rc2}"
 
 	if [ -z "$js_pub_ip" ] || [ -z "$reg" ] || [ -z "$ns" ]; then
 		echo -e "  ${RED}✗ Missing jumpserver / TCR info; cannot build images${NC}"
@@ -1699,7 +1699,7 @@ tcr_build_and_push() {
 	# The image tag was already resolved earlier (env / saved selection /
 	# prompt_deployment_env / default), so don't ask again — just remind which tag
 	# will be built & pushed.
-	echo -e "  ${GREEN}✓ Image tag to build & push: ${CUBE_IMAGE_TAG:-v0.7.1-rc1}${NC}"
+	echo -e "  ${GREEN}✓ Image tag to build & push: ${CUBE_IMAGE_TAG:-v0.7.1-rc2}${NC}"
 	echo ""
 
 	# Pre-pull the base images the build needs from the in-VPC TCR mirror first
@@ -1952,7 +1952,7 @@ prompt_deployment_env() {
 	select_env TENCENTCLOUD_CUBE_DB "Cube database name" "cube_mvp"
 	select_env TENCENTCLOUD_CUBE_USER "Cube database user" "cube"
 	select_env_secret TENCENTCLOUD_CUBE_PASSWORD "Cube database password" "cube_pass"
-	select_env TENCENTCLOUD_CUBE_IMAGE_TAG "Cube component image tag" "v0.7.1-rc1" "dev"
+	select_env TENCENTCLOUD_CUBE_IMAGE_TAG "Cube component image tag" "v0.7.1-rc2" "dev"
 
 	# Ask whether to print verbose terraform logs (defaults to off). Runs before
 	# setup_env so the resolved value feeds VERBOSE. An explicit
@@ -4385,7 +4385,7 @@ TENCENTCLOUD_CUBE_DB='${TENCENTCLOUD_CUBE_DB:-cube_mvp}'
 TENCENTCLOUD_CUBE_USER='${TENCENTCLOUD_CUBE_USER:-cube}'
 TENCENTCLOUD_CUBE_PASSWORD='${TENCENTCLOUD_CUBE_PASSWORD:-}'
 TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY='${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}}'
-TENCENTCLOUD_CUBE_IMAGE_TAG='${TENCENTCLOUD_CUBE_IMAGE_TAG:-v0.7.1-rc1}'
+TENCENTCLOUD_CUBE_IMAGE_TAG='${TENCENTCLOUD_CUBE_IMAGE_TAG:-v0.7.1-rc2}'
 TENCENTCLOUD_IMAGE_REGISTRY='${TF_VAR_image_registry:-${TENCENTCLOUD_IMAGE_REGISTRY:-cube-sandbox-cn.tencentcloudcr.com}}'
 TENCENTCLOUD_IMAGE_NAMESPACE='${TF_VAR_image_namespace:-${TENCENTCLOUD_IMAGE_NAMESPACE:-cube-sandbox}}'
 TENCENTCLOUD_CUBEMASTER_IMAGE='${TF_VAR_cubemaster_image:-${TENCENTCLOUD_CUBEMASTER_IMAGE:-}}'
@@ -4608,7 +4608,7 @@ write_resolved_tfvars_file() {
 		--argjson enable_public_network "$(_bool_json "${TF_VAR_enable_public_network:-${TENCENTCLOUD_ENABLE_PUBLIC_NETWORK:-false}}")" \
 		--argjson use_tcr "$(_bool_json "${TF_VAR_use_tcr:-${TENCENTCLOUD_USE_TCR:-false}}")" \
 		--argjson use_cfs "$(_bool_json "${TF_VAR_use_cfs:-${TENCENTCLOUD_USE_CFS:-false}}")" \
-		--arg image_tag "${TF_VAR_image_tag:-${CUBE_IMAGE_TAG:-${TENCENTCLOUD_CUBE_IMAGE_TAG:-v0.7.1-rc1}}}" \
+		--arg image_tag "${TF_VAR_image_tag:-${CUBE_IMAGE_TAG:-${TENCENTCLOUD_CUBE_IMAGE_TAG:-v0.7.1-rc2}}}" \
 		--arg image_registry "${TF_VAR_image_registry:-${TENCENTCLOUD_IMAGE_REGISTRY:-cube-sandbox-cn.tencentcloudcr.com}}" \
 		--arg image_namespace "${TF_VAR_image_namespace:-${TENCENTCLOUD_IMAGE_NAMESPACE:-cube-sandbox}}" \
 		--arg cubemaster_image "${TF_VAR_cubemaster_image:-${TENCENTCLOUD_CUBEMASTER_IMAGE:-}}" \

--- a/deploy/one-click/terraform/tencentcloud/env.example
+++ b/deploy/one-click/terraform/tencentcloud/env.example
@@ -42,20 +42,20 @@ TENCENTCLOUD_CUBE_PASSWORD='CHANGEME_CUBE_PASSWORD'
 # --- TKE / images
 TENCENTCLOUD_USE_TCR='false'
 TENCENTCLOUD_USE_CFS='false'
-TENCENTCLOUD_CUBE_IMAGE_TAG='v0.7.1-rc1'
+TENCENTCLOUD_CUBE_IMAGE_TAG='v0.7.1-rc2'
 TENCENTCLOUD_IMAGE_REGISTRY='cube-sandbox-cn.tencentcloudcr.com'
 TENCENTCLOUD_IMAGE_NAMESPACE='cube-sandbox'
-TENCENTCLOUD_CUBEMASTER_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-master:v0.7.1-rc1'
+TENCENTCLOUD_CUBEMASTER_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-master:v0.7.1-rc2'
 # CubeTemplateCenter (template build worker). Mandatory: CubeMaster no longer
 # builds templates in-process, so this image must exist in the registry.
 # build_images.sh (TENCENTCLOUD_BUILD_IMAGES=1, the default) builds+pushes it
 # from the bundle together with the other component images.
-TENCENTCLOUD_CUBETEMPLATECENTER_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-templatecenter:v0.7.1-rc1'
-TENCENTCLOUD_CUBEAPI_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-api:v0.7.1-rc1'
-TENCENTCLOUD_CUBEOPS_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-ops:v0.7.1-rc1'
-TENCENTCLOUD_CUBEPROXY_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.7.1-rc1'
-TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.7.1-rc1'
-TENCENTCLOUD_WEBUI_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-webui:v0.7.1-rc1'
+TENCENTCLOUD_CUBETEMPLATECENTER_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-templatecenter:v0.7.1-rc2'
+TENCENTCLOUD_CUBEAPI_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-api:v0.7.1-rc2'
+TENCENTCLOUD_CUBEOPS_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-ops:v0.7.1-rc2'
+TENCENTCLOUD_CUBEPROXY_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.7.1-rc2'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.7.1-rc2'
+TENCENTCLOUD_WEBUI_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-webui:v0.7.1-rc2'
 TENCENTCLOUD_TKE_CLUSTER_VERSION='1.34.1'
 TENCENTCLOUD_TKE_NODE_COUNT='2'
 # Optional: TKE worker node instance type (defaults to SA9.LARGE8; leave unset to use the default).

--- a/deploy/one-click/terraform/tencentcloud/variables.tf
+++ b/deploy/one-click/terraform/tencentcloud/variables.tf
@@ -272,7 +272,7 @@ variable "use_cfs" {
 variable "image_tag" {
   description = "Shared image tag for the Cube components when per-component image overrides are empty"
   type        = string
-  default     = "v0.7.1-rc1"
+  default     = "v0.7.1-rc2"
 }
 
 variable "image_registry" {
@@ -290,43 +290,43 @@ variable "image_namespace" {
 variable "cubemaster_image" {
   description = "Full cubemaster image override."
   type        = string
-  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-master:v0.7.1-rc1"
+  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-master:v0.7.1-rc2"
 }
 
 variable "cubeapi_image" {
   description = "Full cube-api image override."
   type        = string
-  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-api:v0.7.1-rc1"
+  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-api:v0.7.1-rc2"
 }
 
 variable "cubeops_image" {
   description = "Full cube-ops image override."
   type        = string
-  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-ops:v0.7.1-rc1"
+  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-ops:v0.7.1-rc2"
 }
 
 variable "cubeproxy_image" {
   description = "Full cube-proxy image override."
   type        = string
-  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.7.1-rc1"
+  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.7.1-rc2"
 }
 
 variable "webui_image" {
   description = "Full cube-webui image override."
   type        = string
-  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-webui:v0.7.1-rc1"
+  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-webui:v0.7.1-rc2"
 }
 
 variable "cube_lifecycle_manager_image" {
   description = "Full cube-lifecycle-manager image override."
   type        = string
-  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.7.1-rc1"
+  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.7.1-rc2"
 }
 
 variable "templatecenter_image" {
   description = "Full cube-templatecenter image override."
   type        = string
-  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-templatecenter:v0.7.1-rc1"
+  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-templatecenter:v0.7.1-rc2"
 }
 
 variable "templatecenter_enabled" {

--- a/docs/guide/kubernetes/faq.md
+++ b/docs/guide/kubernetes/faq.md
@@ -444,7 +444,7 @@ Whether PVC/PV are deleted depends on the StorageClass `reclaimPolicy` (TKE’s 
 
 ```bash
 ONE_CLICK_ARCH=arm64 \
-PUSH=1 REGISTRY=<your-registry> IMAGE_TAG=v0.7.1-rc1 \
+PUSH=1 REGISTRY=<your-registry> IMAGE_TAG=v0.7.1-rc2 \
 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 

--- a/docs/guide/kubernetes/upgrade.md
+++ b/docs/guide/kubernetes/upgrade.md
@@ -50,10 +50,10 @@ Upgrade PVM kernel swap     →  only change images.pvmHostBootstrap.tag
 ```yaml
 images:
   cubelet:
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
   # Add others only if you need them together, e.g.:
   # cubeShim:
-  #   tag: v0.7.1-rc1
+  #   tag: v0.7.1-rc2
 ```
 
 Only change the keys you truly need to bump; leave other images alone. Full key names are in the [appendix](#appendix-image-key-cheat-sheet) at the end.

--- a/docs/guide/tencentcloud-terraform-deploy.md
+++ b/docs/guide/tencentcloud-terraform-deploy.md
@@ -292,7 +292,7 @@ export TENCENTCLOUD_TKE_NODE_COUNT=2                 # TKE worker nodes (control
 export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                    # default: public pre-built images
 export TENCENTCLOUD_USE_CFS=false                    # default: no CFS
-export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.7.1-rc1
+export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.7.1-rc2
 export TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS=2
 ```
 

--- a/docs/zh/guide/kubernetes/faq.md
+++ b/docs/zh/guide/kubernetes/faq.md
@@ -444,7 +444,7 @@ PVC/PV 是否删除取决于实际 StorageClass 的 `reclaimPolicy`（TKE 的 `c
 
 ```bash
 ONE_CLICK_ARCH=arm64 \
-PUSH=1 REGISTRY=<your-registry> IMAGE_TAG=v0.7.1-rc1 \
+PUSH=1 REGISTRY=<your-registry> IMAGE_TAG=v0.7.1-rc2 \
 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 

--- a/docs/zh/guide/kubernetes/upgrade.md
+++ b/docs/zh/guide/kubernetes/upgrade.md
@@ -50,10 +50,10 @@ CubeSandbox 的网络（cubevs）钩子挂在 Pod 的网卡上，沙箱的 tap �
 ```yaml
 images:
   cubelet:
-    tag: v0.7.1-rc1
+    tag: v0.7.1-rc2
   # 需要一起升再写上，例如：
   # cubeShim:
-  #   tag: v0.7.1-rc1
+  #   tag: v0.7.1-rc2
 ```
 
 只改你真正要升的键；其它镜像保持不动即可。完整键名见文末[附录](#附录-镜像键速查)。

--- a/docs/zh/guide/tencentcloud-terraform-deploy.md
+++ b/docs/zh/guide/tencentcloud-terraform-deploy.md
@@ -291,7 +291,7 @@ export TENCENTCLOUD_TKE_NODE_COUNT=2                 # TKE worker 节点数（�
 export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                    # 默认：公网预置镜像
 export TENCENTCLOUD_USE_CFS=false                    # 默认：无 CFS
-export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.7.1-rc1
+export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.7.1-rc2
 export TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS=2
 ```
 


### PR DESCRIPTION
## Summary

Bump the shared Cube component image tag from `v0.7.1-rc1` to `v0.7.1-rc2` across deployment manifests, scripts, one-click Terraform defaults, and docs.

Tag-only change; no behavior change.

## Changes

- **Makefiles**: `CubeEgress`, `CubeProxy`, `cube-lifecycle-manager` (`IMAGE_TAG` default) and the lifecycle-manager README
- **Helm chart**: `Chart.yaml` (`version` / `appVersion`), `values.yaml` (all component `tag`s), `runtime-values.example.yaml`, chart README
- **Image build**: `deploy/kubernetes/images/build-cube-images.sh` (`VERSION` default) and its README
- **One-click**: proxy / egress / lifecycle-manager launch scripts, guest and agent image build scripts, `README` / `README_zh`
- **Terraform (tencentcloud)**: `variables.tf` defaults, `build_images.sh`, `create.sh`, `env.example`
- **Docs**: `docs/guide/*` and `docs/zh/guide/*` (Kubernetes FAQ, upgrade, Tencent Cloud Terraform deploy)

## Notes

- The mirrored `int` / `cn` registry defaults in the one-click scripts stay in lockstep under the same tag.
- Text replacement is exhaustive: every occurrence of `v0.7.1-rc1` in the touched files now reads `v0.7.1-rc2`.

## Test plan

- [ ] `git grep -n v0.7.1-rc1` returns no matches in the touched directories
- [ ] Helm chart renders on the new tag (`helm template` / chart lint)
- [ ] One-click and Terraform deployment paths resolve the bumped default
