### PR TITLE
fix(s3lvol): pin busy-poll reactors to the last two allowed CPUs

### DIFF
--- a/CubeS3lvol/README.md
+++ b/CubeS3lvol/README.md
@@ -28,6 +28,7 @@ s3lvol-<version>/
 ├── bin/s3lvol_tgt
 ├── scripts/
 │   ├── rcow_start.sh rcow_stop.sh rcow_recovery.sh rcow_common.sh
+│   ├── rcow_cpumask.sh               # default SPDK -m (last two allowed CPUs)
 │   ├── rcow_purge.sh  s3lvol_rpc.py  s3_prefix_rm.py
 │   ├── rpc.py         # this repo's launcher (3.8 argparse shim)
 │   ├── rpc_compat.py  # BooleanOptionalAction backfill for Python 3.8
@@ -150,7 +151,7 @@ used ones:
 | `RCOW_CAPACITY_GB` | `16384` | used only at first create; thin, unused space costs nothing |
 | `RCOW_CACHE_MB` | `490496` | chunk cache on the WAL image; only matters before the first start |
 | `RCOW_LISTEN_ADDR` / `RCOW_LISTEN_PORT` | `127.0.0.1` / `4420` | |
-| `RCOW_TGT_CPUMASK` | `0x3` | |
+| `RCOW_TGT_CPUMASK` | last two allowed CPUs | SPDK `-m`; override with an explicit hex mask |
 | `RCOW_NO_HUGE` | `1` | no hugepages by default, a deliberate choice |
 | `RCOW_RPC_SOCK` | `/var/run/s3lvol.sock` | |
 
@@ -386,11 +387,12 @@ For a local MinIO the config must also set `path_style = "true"` and
 
 `s3lvol_tgt` runs SPDK reactor threads in busy-poll mode: they spin at 100% of
 the cores they are pinned to and never sleep. The current deployment starts
-with **2 reactors on 2 dedicated cores** (e.g. `-m 0x3` pins them to CPU 0 and
-CPU 1). Those two cores are fully consumed by the target, so **other
-(application/business) processes must be kept off them** — pin them elsewhere
-with `taskset`/`numactl` (or a cpuset/cgroup) so the target's request latency
-is not disturbed by scheduler contention.
+with **2 reactors on the last two allowed CPUs** (for `Cpus_allowed_list: 0-7`
+that is `-m 0xc0`, CPU 6 and CPU 7). Those two cores are fully consumed by the
+target, so **other (application/business) processes must be kept off them** —
+pin them elsewhere with `taskset`/`numactl` (or a cpuset/cgroup) so the
+target's request latency is not disturbed by scheduler contention. Set
+`RCOW_TGT_CPUMASK` to an explicit hex mask when the cores are isolated.
 
 ## LIMITATIONS and TODOs
 

--- a/CubeS3lvol/make_release.sh
+++ b/CubeS3lvol/make_release.sh
@@ -28,6 +28,7 @@
 #    ├── bin/s3lvol_tgt
 #    ├── scripts/
 #    │   ├── rcow_start.sh rcow_stop.sh rcow_recovery.sh rcow_common.sh
+#    │   ├── rcow_cpumask.sh      default SPDK -m (last two allowed CPUs)
 #    │   ├── rcow_purge.sh        delete an lvstore outright (irreversible)
 #    │   ├── s3lvol_rpc.py        this repo's raw JSON-RPC client
 #    │   ├── s3_prefix_rm.py      bucket cleanup, what rcow_purge.sh deletes with
@@ -267,8 +268,8 @@ mkdir -p "${PKG_DIR}/bin" "${PKG_DIR}/scripts" || die "cannot create ${PKG_DIR}"
 log "bin/s3lvol_tgt"
 install -m 0755 "${TGT_BIN}" "${PKG_DIR}/bin/s3lvol_tgt" || die "install failed"
 
-log "scripts/ (start, stop, recovery, purge, common)"
-for f in rcow_common.sh rcow_start.sh rcow_stop.sh rcow_recovery.sh rcow_purge.sh; do
+log "scripts/ (start, stop, recovery, purge, common, cpumask)"
+for f in rcow_common.sh rcow_cpumask.sh rcow_start.sh rcow_stop.sh rcow_recovery.sh rcow_purge.sh; do
 	[ -f "${REPO_ROOT}/scripts/${f}" ] || die "missing scripts/${f}"
 	install -m 0755 "${REPO_ROOT}/scripts/${f}" "${PKG_DIR}/scripts/${f}" ||
 		die "install failed for ${f}"

--- a/CubeS3lvol/scripts/rcow_common.sh
+++ b/CubeS3lvol/scripts/rcow_common.sh
@@ -261,7 +261,12 @@ RCOW_IOBUF_LARGE_POOL="${RCOW_IOBUF_LARGE_POOL:-512}"
 RCOW_READ_AHEAD_KB="${RCOW_READ_AHEAD_KB:-1024}"
 export S3LVOL_READ_AHEAD_KB="${RCOW_READ_AHEAD_KB}"
 
-RCOW_TGT_CPUMASK="${RCOW_TGT_CPUMASK:-0x3}"
+# Default -m: last two CPUs from this process's Cpus_allowed_list (CPU0 stays
+# free for housekeeping when the set is 0..N-1). An explicit RCOW_TGT_CPUMASK
+# always wins. See rcow_cpumask.sh.
+# shellcheck source=./rcow_cpumask.sh
+. "${RCOW_SCRIPT_DIR}/rcow_cpumask.sh"
+RCOW_TGT_CPUMASK="${RCOW_TGT_CPUMASK:-$(rcow_default_tgt_cpumask)}"
 RCOW_TGT_MEM_MB="${RCOW_TGT_MEM_MB:-16384}"
 
 # Run without hugepages, deliberately, rather than as a fallback for a node

--- a/CubeS3lvol/scripts/rcow_cpumask.sh
+++ b/CubeS3lvol/scripts/rcow_cpumask.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# CPU-list helpers for s3lvol_tgt's SPDK -m mask. Sourced by rcow_common.sh
+# (and one-click install.sh) so the default can be computed without pulling in
+# the rest of the data-plane layout. Safe to source more than once.
+
+# SPDK -m is a 64-bit core mask; ids 64 and above are not expressible.
+RCOW_SPDK_CPUMASK_MAX_ID=63
+
+# Expand a Linux CPU list ("0-3,8") into numeric IDs on stdout, one per line,
+# in the order they appear. Empty or unparseable tokens are skipped.
+rcow_expand_cpu_list() {
+	local list="${1-}"
+	local token start end id oldifs
+	list="${list// /}"
+	[ -n "${list}" ] || return 0
+	oldifs="${IFS}"
+	IFS=','
+	# shellcheck disable=SC2086
+	set -- ${list}
+	IFS="${oldifs}"
+	for token in "$@"; do
+		[ -n "${token}" ] || continue
+		case "${token}" in
+		*-*)
+			start="${token%-*}"
+			end="${token#*-}"
+			case "${start}" in
+			''|*[!0-9]*) continue ;;
+			esac
+			case "${end}" in
+			''|*[!0-9]*) continue ;;
+			esac
+			id="${start}"
+			while [ "${id}" -le "${end}" ]; do
+				printf '%s\n' "${id}"
+				id=$((id + 1))
+			done
+			;;
+		*)
+			case "${token}" in
+			''|*[!0-9]*) continue ;;
+			esac
+			printf '%s\n' "${token}"
+			;;
+		esac
+	done
+}
+
+# SPDK -m hex mask for the last two CPUs this process may run on.
+#
+# Busy-poll reactors consume those cores at 100%. Taking the high end of
+# Cpus_allowed_list keeps CPU0 (IRQs, systemd, kubelet) free when the allowed
+# set is 0..N-1. Pass a Linux CPU list to override /proc/self/status (tests).
+# CPU ids >= 64 are skipped (SPDK -m is 64-bit). One allowed CPU uses that
+# CPU. An unreadable/empty list falls back to 0x1 with a warning; a list
+# whose every id is >= 64 fails.
+rcow_default_tgt_cpumask() {
+	local list="" from_proc=0
+	local a="" b="" id mask
+	local saw_cpu=0
+	if [ "$#" -ge 1 ]; then
+		list="$1"
+	else
+		from_proc=1
+		list="$(awk -F: '/^Cpus_allowed_list:/{gsub(/^[ \t]+/, "", $2); print $2; exit}' /proc/self/status 2>/dev/null || true)"
+	fi
+	while IFS= read -r id; do
+		[ -n "${id}" ] || continue
+		saw_cpu=1
+		if [ "${id}" -gt "${RCOW_SPDK_CPUMASK_MAX_ID}" ]; then
+			continue
+		fi
+		a="${b}"
+		b="${id}"
+	done < <(rcow_expand_cpu_list "${list}")
+	if [ -z "${b}" ]; then
+		if [ "${saw_cpu}" -eq 1 ]; then
+			printf 'no CPU id <= %s in allowed list %s; SPDK -m is a 64-bit mask\n' \
+				"${RCOW_SPDK_CPUMASK_MAX_ID}" "${list}" >&2
+			return 1
+		fi
+		if [ "${from_proc}" -eq 1 ]; then
+			printf 'could not read Cpus_allowed_list from /proc/self/status; falling back to 0x1\n' >&2
+		elif [ -z "${list}" ]; then
+			printf 'empty CPU list; falling back to 0x1\n' >&2
+		else
+			printf 'could not parse CPU list %s; falling back to 0x1\n' "${list}" >&2
+		fi
+		printf '0x1\n'
+		return 0
+	fi
+	if [ -z "${a}" ]; then
+		mask=$((1 << b))
+	else
+		mask=$(( (1 << a) | (1 << b) ))
+	fi
+	printf '0x%x\n' "${mask}"
+}

--- a/CubeS3lvol/scripts/rcow_start.sh
+++ b/CubeS3lvol/scripts/rcow_start.sh
@@ -236,7 +236,7 @@ TGT_PID="$(rcow_start_target_detached "${RCOW_TGT_BIN}" -m "${RCOW_TGT_CPUMASK}"
 
 rcow_wait_rpc 60 "${TGT_PID}" ||
 	bail "the target did not start answering RPCs within 60s"
-rcow_log "target up as pid ${TGT_PID}, log ${RCOW_LOG}"
+rcow_log "target up as pid ${TGT_PID}, mask ${RCOW_TGT_CPUMASK}, log ${RCOW_LOG}"
 
 rcow_apply_startup_opts || bail "the startup options could not be applied"
 

--- a/CubeS3lvol/test/run_all.sh
+++ b/CubeS3lvol/test/run_all.sh
@@ -317,6 +317,7 @@ run_suite s3_bucket_selftest python3 ./test/tools/s3_bucket.py --self-test
 run_suite isa_baseline ./test/tools/test_isa_baseline.sh
 run_suite rpc_py38_compat ./test/tools/test_rpc_py38_compat.sh
 run_suite lvs_identity ./test/tools/test_lvs_identity.sh
+run_suite tgt_cpumask ./test/tools/test_tgt_cpumask.sh
 echo ""
 
 echo "--- integration (no S3, no root)"

--- a/CubeS3lvol/test/tools/test_tgt_cpumask.sh
+++ b/CubeS3lvol/test/tools/test_tgt_cpumask.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Offline tests for the default s3lvol_tgt CPU mask (last two allowed CPUs).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="${ROOT}/scripts/rcow_cpumask.sh"
+
+fail() {
+	echo "FAIL: $*" >&2
+	echo "result: 0 passed, 1 failed"
+	exit 1
+}
+
+[[ -f "${HELPER}" ]] || fail "missing ${HELPER}"
+# shellcheck disable=SC1090
+source "${HELPER}"
+
+want_mask() {
+	local list="$1" expect="$2" got
+	got="$(rcow_default_tgt_cpumask "${list}" 2>/dev/null)" \
+		|| fail "rcow_default_tgt_cpumask ${list} failed"
+	[[ "${got}" == "${expect}" ]] \
+		|| fail "rcow_default_tgt_cpumask ${list}: got ${got}, want ${expect}"
+}
+
+want_fail() {
+	local list="$1"
+	if rcow_default_tgt_cpumask "${list}" >/dev/null 2>&1; then
+		fail "rcow_default_tgt_cpumask ${list} should fail"
+	fi
+}
+
+want_mask "0" "0x1"
+want_mask "0,1" "0x3"
+want_mask "0-1" "0x3"
+want_mask "0-3" "0xc"
+want_mask "0-7" "0xc0"
+want_mask "0-15" "0xc000"
+want_mask "6,7" "0xc0"
+want_mask "0,2,4-6" "0x60"
+want_mask "" "0x1"
+want_mask "0-127" "0xc000000000000000"
+want_mask "62-65" "0xc000000000000000"
+want_fail "64-127"
+want_fail "64,65"
+
+live="$(rcow_default_tgt_cpumask 2>/dev/null)"
+[[ "${live}" == 0x* ]] || fail "live mask must be hex, got ${live}"
+
+echo "result: 14 passed, 0 failed"

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -668,7 +668,7 @@ When enabled, the sidecar:
 - reads S3 config from a chart Secret mounted at `/etc/s3lvol/s3.cfg`; an `existingSecret` must contain that key in s3lvol format (not `volume-s3.conf`);
 - reuses chart MinIO or `volumeS3` endpoint and credentials by default. The bucket is `cube-s3lvol` and must not be the volume plugin's `cube-volumes` (Helm fails on a shared bucket);
 - identifies the node by hashing the full Kubernetes node name (`spec.nodeName`) to `rcow-<8hex>`, so a Pod recreate is not a new machine and IP / dotted node names stay unique. `cubeS3lvol.lvsName` pins the same name on every node — do not set it when more than one node runs the sidecar;
-- uses rcow's default CPU mask (`0x3`); set `cubeS3lvol.cpuMask` when cores are isolated.
+- uses the last two allowed CPUs by default; set `cubeS3lvol.cpuMask` when cores are isolated.
 
 ```yaml
 cubeS3lvol:

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -1132,8 +1132,8 @@ cubeS3lvol:
   # cluster — every node would share one S3 prefix.
   lvsName: ""
   socketPath: /var/run/s3lvol/s3lvol.sock
-  # Empty: rcow default 0x3 (CPU0+1). Set when the container is pinned to
-  # isolated cores.
+  # Empty: last two CPUs from Cpus_allowed_list (keeps CPU0 free when the
+  # set is 0..N-1). Set a hex mask when the container is pinned to isolated cores.
   cpuMask: ""
   tgtMemMB: 16384
   journalMB: 1024

--- a/deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/cube-s3lvol-entrypoint.sh
@@ -94,7 +94,8 @@ s3lvol_derived_lvs_name() {
 
 # An explicit RCOW_LVS_NAME (cubeS3lvol.lvsName) wins; otherwise derive
 # rcow-<hash of NODE_NAME> now, before rcow_common.sh resolves the name at
-# source time. RCOW_TGT_CPUMASK is exported only when set (rcow default 0x3).
+# source time. RCOW_TGT_CPUMASK is exported only when set (rcow default:
+# last two allowed CPUs).
 s3lvol_export_optional_knobs() {
   if [[ -n "${RCOW_LVS_NAME:-}" ]]; then
     export RCOW_LVS_NAME
@@ -111,7 +112,7 @@ s3lvol_export_optional_knobs() {
     export RCOW_TGT_CPUMASK
     log "RCOW_TGT_CPUMASK=${RCOW_TGT_CPUMASK} (explicit)"
   else
-    log "RCOW_TGT_CPUMASK unset; rcow_common default is 0x3"
+    log "RCOW_TGT_CPUMASK unset; rcow_common pins the last two allowed CPUs"
   fi
 }
 

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -246,10 +246,12 @@ ONE_CLICK_ENABLE_S3LVOL=0
 # RCOW_JOURNAL_MB=1024
 # Thin-provisioned capacity for newly created volumes (GiB).
 # RCOW_CAPACITY_GB=16384
-# Target process CPU affinity mask and memory (MiB). Align RCOW_TGT_CPUMASK
-# with the host's dedicated cores; 0x3 is the default mask on 4-core dev
-# boxes.
-# RCOW_TGT_CPUMASK=0x3
+# Target process CPU affinity mask and memory (MiB). Default is unset: the
+# s3lvol service derives the last two CPUs from its own Cpus_allowed_list
+# at start. Set an explicit hex mask to pin elsewhere. A persisted
+# RCOW_TGT_CPUMASK=0x3 from an older install is CPU0+CPU1; remove that key
+# to pick the new default.
+# RCOW_TGT_CPUMASK=0xc
 # RCOW_TGT_MEM_MB=16384
 # NVMe/TCP listener the target serves on (initiator connects to this).
 # Must stay on loopback: subsystems are exported with allow_any_host (-a),

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -1746,7 +1746,10 @@ RCOW_JOURNAL_MB="${RCOW_JOURNAL_MB:-1024}"
 # total. Tuning RCOW_CACHE_MB only matters before the first start.
 RCOW_CACHE_MB="${RCOW_CACHE_MB:-490496}"
 RCOW_CAPACITY_GB="${RCOW_CAPACITY_GB:-16384}"
-RCOW_TGT_CPUMASK="${RCOW_TGT_CPUMASK:-0x3}"
+# Leave RCOW_TGT_CPUMASK unset unless the operator (or a previous
+# .one-click.env) set it. rcow_common.sh derives last-two at service start
+# from the service's own affinity; freezing the installer's mask would be
+# wrong under taskset/cgroup and would abort bundles that omit CubeS3lvol.
 RCOW_TGT_MEM_MB="${RCOW_TGT_MEM_MB:-16384}"
 RCOW_LISTEN_ADDR="${RCOW_LISTEN_ADDR:-127.0.0.1}"
 RCOW_LISTEN_PORT="${RCOW_LISTEN_PORT:-4420}"
@@ -2049,7 +2052,9 @@ upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_WAL_MB" "${RCOW_WAL_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_JOURNAL_MB" "${RCOW_JOURNAL_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_CACHE_MB" "${RCOW_CACHE_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_CAPACITY_GB" "${RCOW_CAPACITY_GB}"
-upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_TGT_CPUMASK" "${RCOW_TGT_CPUMASK}"
+if [[ -n "${RCOW_TGT_CPUMASK:-}" ]]; then
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_TGT_CPUMASK" "${RCOW_TGT_CPUMASK}"
+fi
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_TGT_MEM_MB" "${RCOW_TGT_MEM_MB}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_LISTEN_ADDR" "${RCOW_LISTEN_ADDR}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "RCOW_LISTEN_PORT" "${RCOW_LISTEN_PORT}"

--- a/deploy/one-click/tests/test_package_layout.sh
+++ b/deploy/one-click/tests/test_package_layout.sh
@@ -381,7 +381,12 @@ test_s3lvol_rpc_launcher_is_packaged() {
   require_file "${ROOT_DIR}/CubeS3lvol/scripts/rpc.py" "s3lvol rpc.py launcher"
   require_file "${ROOT_DIR}/CubeS3lvol/scripts/rpc_compat.py" \
     "s3lvol rpc.py 3.8 compat shim"
+  require_file "${ROOT_DIR}/CubeS3lvol/scripts/rcow_cpumask.sh" \
+    "s3lvol default CPU mask helper"
   require_file "${ROOT_DIR}/CubeS3lvol/make_release.sh" "s3lvol make_release.sh"
+  if ! grep -q -F 'rcow_cpumask.sh' "${ROOT_DIR}/CubeS3lvol/make_release.sh"; then
+    fail "make_release.sh must install scripts/rcow_cpumask.sh"
+  fi
   if ! grep -q -F 'scripts/spdk_rpc.py' "${ROOT_DIR}/CubeS3lvol/make_release.sh"; then
     fail "make_release.sh must install SPDK rpc.py as scripts/spdk_rpc.py"
   fi

--- a/docs/guide/cross-node-snapshot.md
+++ b/docs/guide/cross-node-snapshot.md
@@ -140,7 +140,7 @@ Identity comes from the full Kubernetes node name, hashed to `rcow-<8hex>`. A Po
 Extra settings are only needed when:
 
 - the S3 endpoint is external and path-style — set `cubeS3lvol.s3.pathStyle: true`;
-- cores are isolated — set `cubeS3lvol.cpuMask` (default is rcow's `0x3`).
+- cores are isolated — set `cubeS3lvol.cpuMask` (default is the last two allowed CPUs).
 
 ```yaml
 cubeS3lvol:

--- a/docs/zh/guide/cross-node-snapshot.md
+++ b/docs/zh/guide/cross-node-snapshot.md
@@ -163,7 +163,7 @@ Cube 安装时默认安装 MinIO 作为 S3 服务，方便开箱体验。
 只有以下情况需要额外设置：
 
 - 外部 S3 端点为 path-style——显式设 `cubeS3lvol.s3.pathStyle: true`；
-- CPU 核做了隔离——设置 `cubeS3lvol.cpuMask`（默认 rcow 的 `0x3`）。
+- CPU 核做了隔离——设置 `cubeS3lvol.cpuMask`（默认绑本进程 `Cpus_allowed_list` 里的最后两核）。
 
 ```yaml
 cubeS3lvol:


### PR DESCRIPTION
## Summary
- Default `RCOW_TGT_CPUMASK` is no longer hardcoded to `0x3` (CPU0+CPU1). When unset, s3lvol derives an SPDK `-m` mask from this process's `Cpus_allowed_list` and pins the two busy-poll reactors to the last two allowed CPUs, leaving CPU0 free for housekeeping on a `0..N-1` set.
- One-click install and Helm (`cubeS3lvol.cpuMask` empty) pick up the same default. An explicit mask still wins. A persisted `RCOW_TGT_CPUMASK=0x3` from an older one-click install is kept; delete that key to adopt the new default.
- Adds `rcow_cpumask.sh` plus an offline unit test; bilingual cross-node snapshot docs and chart/one-click comments are updated.

## Test plan
- [x] `CubeS3lvol/test/tools/test_tgt_cpumask.sh` (range, sparse list, single CPU, empty list)
- [x] `deploy/kubernetes/images/scripts/test-cube-s3lvol-entrypoint.sh`
- [x] `deploy/one-click/tests/test_package_layout.sh`
- [ ] On a node with `Cpus_allowed_list: 0-7`, start s3lvol and confirm logs show `mask 0xc0` and reactors on CPU 6+7
- [ ] Confirm `RCOW_TGT_CPUMASK=0x3` / `cubeS3lvol.cpuMask` still override the computed default
- [ ] Confirm a one-click upgrade that already has `RCOW_TGT_CPUMASK=0x3` in `.one-click.env` does not rewrite it

