### PR TITLE
fix(clm): timeout-kill paused sandboxes under on_timeout=kill

### DIFF
--- a/cube-lifecycle-manager/internal/redisstream/stream.go
+++ b/cube-lifecycle-manager/internal/redisstream/stream.go
@@ -245,17 +245,43 @@ func (c *Client) AcquireState(ctx context.Context, sandboxID, state string, ttl 
 }
 
 // AcquireResume atomically changes an absent or paused state to resuming using
-// a single-key WATCH transaction. It returns acquired=true for the owner;
-// otherwise state is the value observed atomically before deciding to wait or
-// reconcile. Transactions avoid Lua/EVAL and remain single-slot safe.
+// a single-key WATCH transaction. acquired=true means this caller owns the
+// transition. state is always the value observed before the write: paused or
+// empty when acquired, otherwise the blocking marker a waiter should reconcile
+// against. Transactions avoid Lua/EVAL and remain single-slot safe.
 func (c *Client) AcquireResume(ctx context.Context, sandboxID string, ttl time.Duration) (state string, acquired bool, err error) {
+	return c.acquireIf(ctx, sandboxID, "resuming", ttl, allowEmptyOrPaused)
+}
+
+// AcquireKill atomically changes an absent or paused state to killing. It is
+// the timeout-kill counterpart of AcquireResume: the two CAS transitions
+// are mutually exclusive, so a concurrent resume wins or this kill does,
+// but neither overwrites an in-flight resuming / pausing / running lock.
+// state is the pre-CAS observation (paused or empty when acquired) so a
+// failed kill can restore the proxy to the right prior state.
+func (c *Client) AcquireKill(ctx context.Context, sandboxID string, ttl time.Duration) (state string, acquired bool, err error) {
+	return c.acquireIf(ctx, sandboxID, "killing", ttl, allowEmptyOrPaused)
+}
+
+func allowEmptyOrPaused(current string) bool {
+	return current == "" || current == lifecycle.StatePaused
+}
+
+// acquireIf CAS-writes dest when allow(current) still holds under WATCH.
+// The returned state is always the pre-write observation, including when acquired.
+func (c *Client) acquireIf(
+	ctx context.Context,
+	sandboxID, dest string,
+	ttl time.Duration,
+	allow func(current string) bool,
+) (string, bool, error) {
 	const maxAttempts = 3
 	key := lifecycle.StateKey(sandboxID)
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		state = ""
-		acquired = false
-		err = c.rdb.Watch(ctx, func(tx *redis.Tx) error {
+		var state string
+		acquired := false
+		err := c.rdb.Watch(ctx, func(tx *redis.Tx) error {
 			current, getErr := tx.Get(ctx, key).Result()
 			if errors.Is(getErr, redis.Nil) {
 				current = ""
@@ -264,16 +290,15 @@ func (c *Client) AcquireResume(ctx context.Context, sandboxID string, ttl time.D
 			}
 
 			state = current
-			if current != "" && current != lifecycle.StatePaused {
+			if !allow(current) {
 				return nil
 			}
 
 			_, txErr := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-				pipe.Set(ctx, key, "resuming", ttl)
+				pipe.Set(ctx, key, dest, ttl)
 				return nil
 			})
 			if txErr == nil {
-				state = "resuming"
 				acquired = true
 			}
 			return txErr
@@ -282,11 +307,11 @@ func (c *Client) AcquireResume(ctx context.Context, sandboxID string, ttl time.D
 			continue
 		}
 		if err != nil {
-			return "", false, fmt.Errorf("acquire resume %s: %w", key, err)
+			return "", false, fmt.Errorf("acquire %s %s: %w", dest, key, err)
 		}
 		return state, acquired, nil
 	}
-	return "", false, fmt.Errorf("acquire resume %s: transaction conflicted after %d attempts", key, maxAttempts)
+	return "", false, fmt.Errorf("acquire %s %s: transaction conflicted after %d attempts", dest, key, maxAttempts)
 }
 
 // SetState forces the state value (overwriting any existing). Used to

--- a/cube-lifecycle-manager/internal/redisstream/transactions_redis_test.go
+++ b/cube-lifecycle-manager/internal/redisstream/transactions_redis_test.go
@@ -15,18 +15,23 @@ import (
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
 )
 
-func TestRedisTransactionsProtectResumeOwnership(t *testing.T) {
+func newTestClient(t *testing.T) (*Client, *redis.Client) {
+	t.Helper()
 	server := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: server.Addr()})
 	t.Cleanup(func() { _ = rdb.Close() })
-	client := New(rdb, zap.NewNop())
+	return New(rdb, zap.NewNop()), rdb
+}
+
+func TestRedisTransactionsProtectResumeOwnership(t *testing.T) {
+	client, rdb := newTestClient(t)
 	ctx := context.Background()
 
 	if err := client.SetState(ctx, "sbx", lifecycle.StatePaused, time.Minute); err != nil {
 		t.Fatal(err)
 	}
 	state, acquired, err := client.AcquireResume(ctx, "sbx", 10*time.Second)
-	if err != nil || !acquired || state != "resuming" {
+	if err != nil || !acquired || state != lifecycle.StatePaused {
 		t.Fatalf("AcquireResume() = (%q, %v, %v)", state, acquired, err)
 	}
 
@@ -59,11 +64,53 @@ func TestRedisTransactionsProtectResumeOwnership(t *testing.T) {
 	}
 }
 
+func TestRedisTransactionsProtectKillOwnership(t *testing.T) {
+	client, _ := newTestClient(t)
+	ctx := context.Background()
+
+	if err := client.SetState(ctx, "sbx", lifecycle.StatePaused, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	state, acquired, err := client.AcquireKill(ctx, "sbx", 10*time.Second)
+	if err != nil || !acquired || state != lifecycle.StatePaused {
+		t.Fatalf("AcquireKill() = (%q, %v, %v)", state, acquired, err)
+	}
+
+	state, acquired, err = client.AcquireKill(ctx, "sbx", 10*time.Second)
+	if err != nil || acquired || state != "killing" {
+		t.Fatalf("second AcquireKill() = (%q, %v, %v)", state, acquired, err)
+	}
+
+	state, acquired, err = client.AcquireResume(ctx, "sbx", 10*time.Second)
+	if err != nil || acquired || state != "killing" {
+		t.Fatalf("AcquireResume must not overwrite killing: (%q, %v, %v)", state, acquired, err)
+	}
+}
+
+func TestAcquireKillAndResumeAreMutuallyExclusive(t *testing.T) {
+	client, _ := newTestClient(t)
+	ctx := context.Background()
+
+	if err := client.SetState(ctx, "sbx-resume-first", lifecycle.StatePaused, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	state, acquired, err := client.AcquireResume(ctx, "sbx-resume-first", 10*time.Second)
+	if err != nil || !acquired || state != lifecycle.StatePaused {
+		t.Fatalf("AcquireResume() = (%q, %v, %v)", state, acquired, err)
+	}
+	state, acquired, err = client.AcquireKill(ctx, "sbx-resume-first", 10*time.Second)
+	if err != nil || acquired || state != "resuming" {
+		t.Fatalf("AcquireKill must not overwrite resuming: (%q, %v, %v)", state, acquired, err)
+	}
+
+	state, acquired, err = client.AcquireKill(ctx, "sbx-empty", 10*time.Second)
+	if err != nil || !acquired || state != "" {
+		t.Fatalf("AcquireKill(empty) = (%q, %v, %v)", state, acquired, err)
+	}
+}
+
 func TestGetStatesReturnsPresentKeys(t *testing.T) {
-	server := miniredis.RunT(t)
-	rdb := redis.NewClient(&redis.Options{Addr: server.Addr()})
-	t.Cleanup(func() { _ = rdb.Close() })
-	client := New(rdb, zap.NewNop())
+	client, _ := newTestClient(t)
 	ctx := context.Background()
 
 	if err := client.SetState(ctx, "a", lifecycle.StatePaused, time.Minute); err != nil {
@@ -85,10 +132,7 @@ func TestGetStatesReturnsPresentKeys(t *testing.T) {
 }
 
 func TestCursorValidDetectsTrimmedHistory(t *testing.T) {
-	server := miniredis.RunT(t)
-	rdb := redis.NewClient(&redis.Options{Addr: server.Addr()})
-	t.Cleanup(func() { _ = rdb.Close() })
-	client := New(rdb, zap.NewNop())
+	client, rdb := newTestClient(t)
 	ctx := context.Background()
 
 	if err := rdb.XAdd(ctx, &redis.XAddArgs{

--- a/cube-lifecycle-manager/internal/resumer/resumer.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer.go
@@ -317,15 +317,17 @@ func (r *Resumer) acquireResumeOwnership(ctx context.Context, sandboxID string) 
 		return nil
 	}
 
-	switch {
-	case cur == "running":
+	switch cur {
+	case "running":
 		// Sandbox is already running on Redis's view. No-op resume; the
 		// caller's success path will re-push running to the proxy in case
 		// the local dict drifted.
 		r.o.Log.Info("resume requested but sandbox already running; reconciling",
 			zap.String("sandbox_id", sandboxID))
 		return errAlreadyRunning
-	case cur == "pausing" || cur == "resuming":
+	case "killing", lifecycle.StateKilled:
+		return errSandboxKilled
+	case "pausing", "resuming":
 		// Active transition by a peer → wait it out. waitForRunning
 		// returning nil means the peer transitioned to "running"; treat
 		// that as a no-op resume from our perspective so we DON'T issue
@@ -335,7 +337,7 @@ func (r *Resumer) acquireResumeOwnership(ctx context.Context, sandboxID string) 
 			return err
 		}
 		return errAlreadyRunning
-	case cur == "", cur == "paused":
+	case "", "paused":
 		// AcquireResume only returns these values when its WATCH transaction
 		// repeatedly conflicted, which is surfaced as an error. Keep this
 		// defensive branch for alternate stateStore implementations.
@@ -357,6 +359,11 @@ func (r *Resumer) acquireResumeOwnership(ctx context.Context, sandboxID string) 
 // as a successful no-op (state will be re-asserted into the proxy dict).
 var errAlreadyRunning = errors.New("sandbox already running")
 
+// errSandboxKilled is returned when a racing timeout-kill owns the sandbox.
+// CubeProxy maps killing/killed to 410; CLM must fail the resume RPC the
+// same way instead of waiting out the caller's deadline.
+var errSandboxKilled = errors.New("peer killed sandbox during resume")
+
 // waitForRunning is invoked when acquireResumeOwnership observed a peer's
 // transition lock ("pausing" or "resuming") and we must not fire our own
 // duplicate RPC. It resolves the peer's outcome when:
@@ -365,7 +372,7 @@ var errAlreadyRunning = errors.New("sandbox already running")
 //   - state == "paused"     → peer gave up; bail with an error so
 //     CubeProxy returns 503 and the next request
 //     gets a fresh resume attempt.
-//   - state == "killed"     → peer (sweeper) destroyed the sandbox.
+//   - state == "killed" / "killing" → peer (sweeper) destroyed the sandbox.
 //   - key expired (!ok)     → peer crashed mid-flight; return an error so
 //     the caller re-enters Resume() cleanly.
 //
@@ -406,17 +413,18 @@ func (r *Resumer) waitForRunningLegacy(ctx context.Context, sandboxID string) er
 // classifyState maps a GetState (state, ok) pair onto a wait decision.
 // done=true means the waiter should return (err is nil on success).
 // done=false means the state is still in-flight ("pausing" / "resuming" /
-// "killing" / unknown) and the caller should keep waiting.
+// unknown) and the caller should keep waiting.
 func classifyState(state string, ok bool) (err error, done bool) {
-	switch {
-	case !ok:
+	if !ok {
 		return errors.New("peer resume lock expired without resolution"), true
-	case state == "running":
+	}
+	switch state {
+	case "running":
 		return nil, true
-	case state == "paused":
+	case "paused":
 		return errors.New("peer resume left sandbox paused"), true
-	case state == lifecycle.StateKilled:
-		return errors.New("peer killed sandbox during resume"), true
+	case "killing", lifecycle.StateKilled:
+		return errSandboxKilled, true
 	default:
 		// "pausing" / "resuming" / anything else — keep waiting.
 		return nil, false

--- a/cube-lifecycle-manager/internal/resumer/resumer_test.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer_test.go
@@ -530,6 +530,36 @@ func TestResumer_NoOpWhenStateIsAlreadyRunning(t *testing.T) {
 	}
 }
 
+func TestResumer_FailsFastWhenStateIsKilling(t *testing.T) {
+	for _, state := range []string{"killing", lifecycle.StateKilled} {
+		t.Run(state, func(t *testing.T) {
+			reg := registry.New()
+			reg.Upsert(lifecycle.SandboxLifecycleMeta{
+				SandboxID: "sbx", InstanceType: "cubebox", AutoResume: true,
+			})
+			store := newFakeStore()
+			store.states["sbx"] = state
+			master := &fakeMaster{}
+			r := newTestResumer(reg, store, master, &fakePush{})
+
+			start := time.Now()
+			err := r.Resume(context.Background(), "sbx")
+			if err == nil {
+				t.Fatal("resume must fail when the sweeper owns killing/killed")
+			}
+			if !errors.Is(err, errSandboxKilled) {
+				t.Fatalf("got %v, want errSandboxKilled", err)
+			}
+			if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+				t.Fatalf("must fail fast, took %s", elapsed)
+			}
+			if got := atomic.LoadInt32(&master.calls); got != 0 {
+				t.Fatalf("must not call master.Resume, got %d", got)
+			}
+		})
+	}
+}
+
 func TestResumer_RunningStatePushRetriesAsynchronously(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -774,6 +804,7 @@ func TestClassifyState(t *testing.T) {
 		{name: "running", state: "running", ok: true, done: true},
 		{name: "paused", state: "paused", ok: true, wantErr: true, done: true},
 		{name: "killed", state: lifecycle.StateKilled, ok: true, wantErr: true, done: true},
+		{name: "killing", state: "killing", ok: true, wantErr: true, done: true},
 		{name: "missing", ok: false, wantErr: true, done: true},
 		{name: "resuming", state: "resuming", ok: true},
 		{name: "pausing", state: "pausing", ok: true},

--- a/cube-lifecycle-manager/internal/sweeper/iface.go
+++ b/cube-lifecycle-manager/internal/sweeper/iface.go
@@ -15,6 +15,9 @@ import (
 // satisfies this interface implicitly.
 type stateStore interface {
 	AcquireState(ctx context.Context, sandboxID, state string, ttl time.Duration) (bool, error)
+	// AcquireKill CAS-claims killing from empty or paused. state is the
+	// pre-CAS observation (paused or empty when acquired).
+	AcquireKill(ctx context.Context, sandboxID string, ttl time.Duration) (state string, acquired bool, err error)
 	SetState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
 	ClearState(ctx context.Context, sandboxID string) error
 	GetState(ctx context.Context, sandboxID string) (string, bool, error)

--- a/cube-lifecycle-manager/internal/sweeper/sweeper.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper.go
@@ -158,13 +158,10 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 			continue
 		}
 
-		// Already-terminal fast path: Redis or the in-memory RuntimeState
-		// may already say the sandbox is parked at paused/pausing/killing/
-		// killed. Redis alone is not enough — the state-key TTL
-		// (StateLockTTL=60s) expires, GetState goes empty, and idle keeps
-		// growing because LastActive is frozen after pause. Without the
-		// RuntimeState check we re-issue Pause every Interval.
-		if isParkedSweepState(e.RuntimeState) {
+		// Redis state-key TTL expires while RuntimeState stays paused and
+		// LastActive is frozen, so idle keeps growing. Without this check
+		// an AutoPause sandbox would be Pause'd every Interval.
+		if skipSweepState(e.RuntimeState, e.Meta.AutoPause) {
 			continue
 		}
 		curState, _, stateErr := s.o.Redis.GetState(ctx, e.Meta.SandboxID)
@@ -172,22 +169,15 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 			s.o.Log.Warn("get state failed; will attempt action anyway",
 				zap.String("sandbox_id", e.Meta.SandboxID),
 				zap.Error(stateErr))
-		} else if isParkedSweepState(curState) {
-			// Nothing to do. "pausing" / "killing" mean a peer (or our own
-			// previous invocation) is mid-flight; let it finish.
+		} else if skipSweepState(curState, e.Meta.AutoPause) {
 			continue
 		}
 
-		switch {
-		case e.Meta.AutoPause:
-			if s.o.Leader != nil && !s.o.Leader.IsLeader() {
-				return
-			}
+		if e.Meta.AutoPause {
 			s.o.Log.Info("idle threshold exceeded; pausing",
 				zap.String("sandbox_id", e.Meta.SandboxID),
 				zap.Duration("idle_for", idleFor),
 				zap.Intp("timeout_seconds", e.Meta.TimeoutSeconds))
-
 			if err := s.tryPause(ctx, e); err != nil {
 				s.pauseFailed.Add(1)
 				s.o.Log.Warn("auto-pause failed",
@@ -195,23 +185,19 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 					zap.Duration("idle_for", idleFor),
 					zap.Error(err))
 			}
-		default:
-			if s.o.Leader != nil && !s.o.Leader.IsLeader() {
-				return
-			}
-			s.o.Log.Info("idle threshold exceeded; killing",
+			continue
+		}
+		s.o.Log.Info("idle threshold exceeded; killing",
+			zap.String("sandbox_id", e.Meta.SandboxID),
+			zap.Duration("idle_for", idleFor),
+			zap.Intp("timeout_seconds", e.Meta.TimeoutSeconds),
+			zap.String("kill_reason", cubemasterclient.KillReasonTimeout))
+		if err := s.tryKill(ctx, e); err != nil {
+			s.killFailed.Add(1)
+			s.o.Log.Warn("timeout-kill failed",
 				zap.String("sandbox_id", e.Meta.SandboxID),
 				zap.Duration("idle_for", idleFor),
-				zap.Intp("timeout_seconds", e.Meta.TimeoutSeconds),
-				zap.String("kill_reason", cubemasterclient.KillReasonTimeout))
-
-			if err := s.tryKill(ctx, e); err != nil {
-				s.killFailed.Add(1)
-				s.o.Log.Warn("timeout-kill failed",
-					zap.String("sandbox_id", e.Meta.SandboxID),
-					zap.Duration("idle_for", idleFor),
-					zap.Error(err))
-			}
+				zap.Error(err))
 		}
 	}
 }
@@ -347,24 +333,25 @@ func (s *Sweeper) KillStats() (triggered, failed int64) {
 	return s.killTriggered.Load(), s.killFailed.Load()
 }
 
-// tryKill is the kill-path counterpart of tryPause. Same coordination
-// pattern (SETNX → notify proxy → RPC → finalise), but the terminal state is
-// non-recoverable: on success we evict the registry entry and tell every
-// CubeProxy replica to forget the sandbox. The Lua gate maps `killing` /
-// `killed` to 410 Gone so any in-flight client request fails fast instead of
-// hanging on a doomed retry.
+// tryKill is the kill-path counterpart of tryPause. Coordination is
+// AcquireKill (empty/paused → killing) → notify proxy → RPC → finalise.
+// The terminal state is non-recoverable: on success we evict the registry
+// entry and tell every CubeProxy replica to forget the sandbox. The Lua
+// gate maps `killing` / `killed` to 410 Gone so any in-flight client
+// request fails fast instead of hanging on a doomed retry.
 func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 	ctx, cancel := context.WithTimeout(ctx, s.o.ActionTimeout)
 	defer cancel()
 
 	sid := e.Meta.SandboxID
-	got, err := s.o.Redis.AcquireState(ctx, sid, "killing", s.o.StateLockTTL)
+	prior, got, err := s.o.Redis.AcquireKill(ctx, sid, s.o.StateLockTTL)
 	if err != nil {
 		return err
 	}
 	if !got {
-		// A peer CLM replica (or our own resume / pause path) holds the state.
-		// Skip — the holder will drive the transition.
+		// A peer holds resuming / pausing / killing / killed / running.
+		// Skip — the holder will drive the transition (or the next sweep
+		// will retry after idle is still overdue).
 		return nil
 	}
 
@@ -380,27 +367,25 @@ func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 	rpcCancel()
 	if killErr != nil {
 		var apiErr *cubemasterclient.APIError
-		switch {
-		case errors.As(killErr, &apiErr) && apiErr.IsNotFound():
-			s.o.Log.Info("sandbox not found on cubemaster during kill; evicting from registry",
-				zap.String("sandbox_id", sid),
-				zap.Int("ret_code", apiErr.RetCode),
-				zap.String("ret_msg", apiErr.RetMsg))
-		case errors.As(killErr, &apiErr) && apiErr.IsAlreadyInState():
-			s.o.Log.Info("sandbox already in terminal state on cubemaster; reconciling",
-				zap.String("sandbox_id", sid),
-				zap.Int("ret_code", apiErr.RetCode))
-		default:
-			// A transport or timeout error has an unknown server-side result.
-			// Do NOT clear state and broadcast "running". Retain "killing"
-			// marker so proxy continues to reject requests and sweeper does not flap.
-			if !errors.As(killErr, &apiErr) {
-				return errors.New("cubemaster kill result unknown: " + killErr.Error())
-			}
+		if !errors.As(killErr, &apiErr) {
+			// Transport/timeout: unknown server-side result. Keep "killing"
+			// so the proxy keeps rejecting and the next sweep does not flap.
+			return errors.New("cubemaster kill result unknown: " + killErr.Error())
+		}
+		if !apiErr.IsNotFound() {
+			// 130490 / TaskStateInvalid is not a kill no-op: CubeMaster uses
+			// it both for "already in the desired state" and for "another
+			// lifecycle operation holds the sandbox". Evicting here would
+			// drop a live sandbox that lost a race with resume. Treat every
+			// structured non-NotFound error as retryable rollback.
 			_ = s.o.Redis.ClearStateNotify(ctx, sid)
-			_ = s.o.ProxyPush.SetState(ctx, sid, "running")
+			_ = s.o.ProxyPush.SetState(ctx, sid, killRollbackProxyState(prior))
 			return errors.New("cubemaster kill: " + killErr.Error())
 		}
+		s.o.Log.Info("sandbox not found on cubemaster during kill; evicting from registry",
+			zap.String("sandbox_id", sid),
+			zap.Int("ret_code", apiErr.RetCode),
+			zap.String("ret_msg", apiErr.RetMsg))
 	}
 
 	if err := s.o.Redis.WriteState(ctx, sid, "killed", s.o.StateLockTTL); err != nil {
@@ -421,11 +406,28 @@ func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 	return nil
 }
 
-func isParkedSweepState(state string) bool {
+// skipSweepState reports whether this sweep should leave the sandbox alone.
+// Transition markers are always skipped so we do not pile onto an in-flight
+// pause / resume / kill. `paused` is skipped only when AutoPause is set:
+// that is the desired terminal state for on_timeout=pause. For
+// on_timeout=kill a paused sandbox is not finished work.
+func skipSweepState(state string, autoPause bool) bool {
 	switch state {
-	case lifecycle.StatePaused, "pausing", "killing", lifecycle.StateKilled:
+	case "pausing", "resuming", "killing", lifecycle.StateKilled:
 		return true
+	case lifecycle.StatePaused:
+		return autoPause
 	default:
 		return false
 	}
+}
+
+// killRollbackProxyState is the CubeProxy state to restore when a kill RPC
+// fails after AcquireKill succeeded. paused must go back to paused so the
+// Lua gate still asks CLM to resume; empty/running rolls back to running.
+func killRollbackProxyState(prior string) string {
+	if prior == lifecycle.StatePaused {
+		return lifecycle.StatePaused
+	}
+	return lifecycle.StateRunning
 }

--- a/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
@@ -48,6 +48,20 @@ func (f *fakeStore) AcquireState(_ context.Context, sid, state string, _ time.Du
 	return true, nil
 }
 
+func (f *fakeStore) AcquireKill(_ context.Context, sid string, _ time.Duration) (string, bool, error) {
+	if f.failAcquire {
+		return "", false, errors.New("redis down")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cur := f.states[sid]
+	if cur != "" && cur != lifecycle.StatePaused {
+		return cur, false, nil
+	}
+	f.states[sid] = "killing"
+	return cur, true, nil
+}
+
 func (f *fakeStore) SetState(_ context.Context, sid, state string, _ time.Duration) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -336,6 +350,81 @@ func TestSweeper_KillRollsBackOnFailure(t *testing.T) {
 	}
 }
 
+func TestSweeper_KillPausedRollsBackToPausedOnFailure(t *testing.T) {
+	reg := registry.New()
+	store := newFakeStore()
+	const sid = "sbx-paused-killfail"
+	store.states[sid] = lifecycle.StatePaused
+	master := &fakeMaster{failNextKill: true, failKillErr: &cubemasterclient.APIError{
+		RetCode: 130500,
+		RetMsg:  "definitive failure",
+	}}
+	push := newFakePush()
+
+	now := time.Now()
+	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
+		SandboxID: sid, InstanceType: "cubebox",
+		AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
+	}, now.Add(-10*time.Minute).UnixMilli())
+
+	s := newTestSweeper(reg, store, master, push, now)
+	s.sweepOnce(context.Background())
+
+	if got := store.state(sid); got != "" {
+		t.Fatalf("redis state should be cleared after rollback, got %q", got)
+	}
+	pushed := push.states(sid)
+	if len(pushed) == 0 || pushed[len(pushed)-1] != lifecycle.StatePaused {
+		t.Fatalf("rollback should restore proxy to paused, got %v", pushed)
+	}
+	if reg.Get(sid) == nil {
+		t.Fatal("registry entry should NOT be evicted on kill failure")
+	}
+	_, failed := s.KillStats()
+	if failed != 1 {
+		t.Fatalf("expected kill failed=1, got %d", failed)
+	}
+}
+
+func TestSweeper_KillPausedDoesNotEvictOnTaskStateInvalid(t *testing.T) {
+	reg := registry.New()
+	store := newFakeStore()
+	const sid = "sbx-paused-busy"
+	store.states[sid] = lifecycle.StatePaused
+	master := &fakeMaster{failNextKill: true, failKillErr: &cubemasterclient.APIError{
+		RetCode: cubemasterclient.RetCodeTaskStateInvalid,
+		RetMsg:  "sandbox lifecycle operation is in progress",
+	}}
+	push := newFakePush()
+
+	now := time.Now()
+	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
+		SandboxID: sid, InstanceType: "cubebox",
+		AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
+	}, now.Add(-10*time.Minute).UnixMilli())
+
+	s := newTestSweeper(reg, store, master, push, now)
+	s.sweepOnce(context.Background())
+
+	if reg.Get(sid) == nil {
+		t.Fatal("130490 must not evict a live paused sandbox")
+	}
+	if got := store.state(sid); got != "" {
+		t.Fatalf("must not write killed; redis should be cleared for retry, got %q", got)
+	}
+	if got := push.deletedIDs(); len(got) != 0 {
+		t.Fatalf("DeleteMeta must not fire on 130490, got %v", got)
+	}
+	pushed := push.states(sid)
+	if len(pushed) == 0 || pushed[len(pushed)-1] != lifecycle.StatePaused {
+		t.Fatalf("proxy must roll back to paused, got %v", pushed)
+	}
+	triggered, failed := s.KillStats()
+	if triggered != 0 || failed != 1 {
+		t.Fatalf("130490 is a retryable failure: triggered=%d failed=%d", triggered, failed)
+	}
+}
+
 func TestSweeper_KillPreservesOwnershipOnUnknownError(t *testing.T) {
 	reg := registry.New()
 	store := newFakeStore()
@@ -400,25 +489,84 @@ func TestSweeper_KillNotFoundEvictsRegistry(t *testing.T) {
 	}
 }
 
-func TestSweeper_KillSkipsAlreadyKillingSandbox(t *testing.T) {
-	reg := registry.New()
-	store := newFakeStore()
-	store.states["sbx-killmid"] = "killing"
+func TestSweeper_KillsPausedSandboxWhenAutoPauseFalse(t *testing.T) {
+	// on_timeout=kill + a prior manual pause must still timeout-kill,
+	// whether Redis still holds "paused" or only RuntimeState does.
+	const sid = "sbx-paused-kill"
+	cases := []struct {
+		name          string
+		redisPaused   bool
+		runtimePaused bool
+	}{
+		{name: "redis_paused", redisPaused: true},
+		{name: "runtime_paused_redis_empty", runtimePaused: true},
+		{name: "both_paused", redisPaused: true, runtimePaused: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := registry.New()
+			store := newFakeStore()
+			master := &fakeMaster{}
+			push := newFakePush()
+			now := time.Now()
+			seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
+				SandboxID: sid, InstanceType: "cubebox",
+				AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
+			}, now.Add(-1*time.Hour).UnixMilli())
+			if tc.redisPaused {
+				store.states[sid] = lifecycle.StatePaused
+			}
+			if tc.runtimePaused {
+				if !reg.SetRuntimeState(sid, lifecycle.StatePaused) {
+					t.Fatal("SetRuntimeState")
+				}
+			}
 
-	master := &fakeMaster{}
-	push := newFakePush()
+			s := newTestSweeper(reg, store, master, push, now)
+			s.sweepOnce(context.Background())
 
-	now := time.Now()
-	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
-		SandboxID: "sbx-killmid", InstanceType: "cubebox",
-		AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
-	}, now.Add(-1*time.Hour).UnixMilli())
+			if len(master.killCalls) != 1 || master.killCalls[0] != sid {
+				t.Fatalf("expected timeout Kill, got %v", master.killCalls)
+			}
+			if len(master.killReasons) != 1 || master.killReasons[0] != cubemasterclient.KillReasonTimeout {
+				t.Fatalf("kill reason = %v, want [timeout]", master.killReasons)
+			}
+			if reg.Get(sid) != nil {
+				t.Fatal("registry entry should have been evicted after kill")
+			}
+			if got := store.state(sid); got != "killed" {
+				t.Fatalf("expected redis state=killed, got %q", got)
+			}
+			triggered, failed := s.KillStats()
+			if triggered != 1 || failed != 0 {
+				t.Fatalf("kill stats: triggered=%d failed=%d", triggered, failed)
+			}
+		})
+	}
+}
 
-	s := newTestSweeper(reg, store, master, push, now)
-	s.sweepOnce(context.Background())
+func TestSweeper_SkipsInFlightSandboxWhenAutoPauseFalse(t *testing.T) {
+	for _, state := range []string{"resuming", "killing"} {
+		t.Run(state, func(t *testing.T) {
+			reg := registry.New()
+			store := newFakeStore()
+			sid := "sbx-" + state
+			store.states[sid] = state
+			master := &fakeMaster{}
+			push := newFakePush()
+			now := time.Now()
+			seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
+				SandboxID: sid, InstanceType: "cubebox",
+				AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
+			}, now.Add(-1*time.Hour).UnixMilli())
 
-	if len(master.killCalls) != 0 {
-		t.Fatalf("sweeper must NOT call Kill when peer is mid-flight: %v", master.killCalls)
+			s := newTestSweeper(reg, store, master, push, now)
+			s.sweepOnce(context.Background())
+
+			if len(master.killCalls) != 0 {
+				t.Fatalf("sweeper must NOT call Kill while state=%s: %v", state, master.killCalls)
+			}
+		})
 	}
 }
 

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -38,14 +38,17 @@ Go: `cubesandbox.NeverTimeout`; Python: `from cubesandbox import NEVER_TIMEOUT`.
    create()       ┌────▼────┐   timeout & on_timeout=pause   ┌─────────┐
   ───────────────►│ running │ ──────────────────────────────►│ paused  │
                   │         │◄──────── connect() or          │         │
-                  └─┬─────┬─┘    auto_resume-triggered req   └────┬────┘
-                    │     │                                       │
-        kill()      │     │ timeout & on_timeout=kill             │ kill()
-        ────────────┘     └─────────────────┐                     │
-                                            ▼                     ▼
-                                      ┌────────────┐
-                                      │ terminated │
-                                      └────────────┘
+                  └──┬────┬─┘    auto_resume-triggered req   └──┬────┬─┘
+                     │    │                                     │    │
+                     │    │ timeout & on_timeout=kill           │    │ timeout & on_timeout=kill
+                     │    └────────────────┐                    │    └──────────────┐
+                     │                     ▼                    │                   ▼
+                     │               ┌────────────┐◄────────────┘
+                     │               │ terminated │
+                     │               └──────▲─────┘
+                     │                      │
+                     │ kill()               │ kill()
+                     └──────────────────────┘
 ```
 
 ## Create
@@ -138,6 +141,8 @@ sandbox.connect()                     # restore from snapshot
 sandbox.run_code("print('back!')")    # carry on as if never paused
 ```
 
+`pause()` does **not** cancel idle reclamation. With the default `on_timeout="kill"`, a later-paused sandbox is still destroyed once idle exceeds `timeout`. To keep a paused sandbox, pass `timeout=NEVER_TIMEOUT`, omit `timeout` (with no positive server default), or set a high `timeout` — see [Behaviour](#behaviour) below.
+
 `connect()` does not change the sandbox's idle timeout — the value set at create (or later via `set_timeout`) is preserved across pause/resume. To change it at resume time, use the deprecated `resume(timeout=...)`:
 
 | `resume(timeout=...)` | Effect |
@@ -194,7 +199,7 @@ Any of these resets the idle clock:
 - SDK calls: `sandbox.run_code(...)`, `sandbox.commands.run(...)`, `sandbox.files.read(...)` / `write(...)`.
 - Direct HTTP traffic to a service inside the sandbox (e.g. via the URL returned by `getHost()`).
 
-Sandboxes that don't opt in (no `lifecycle` argument) default to `on_timeout="kill"`: once they sit idle for the effective `timeout` the platform destroys them. This matches e2b's `lifecycle.on_timeout="kill"` semantic. To avoid automatic reclamation, pass `timeout=NEVER_TIMEOUT`, omit `timeout` (with no positive server default), set a high `timeout`, or send periodic activity to reset the idle clock.
+Sandboxes that don't opt in (no `lifecycle` argument) default to `on_timeout="kill"`: once they sit idle for the effective `timeout` the platform destroys them. This matches e2b's `lifecycle.on_timeout="kill"` semantic. Manual `pause()` does **not** cancel that kill: a later-paused sandbox is still destroyed when idle exceeds `timeout`. To keep a paused sandbox, pass `timeout=NEVER_TIMEOUT`, omit `timeout` (with no positive server default), set a high `timeout`, or send periodic activity to reset the idle clock.
 
 ### End-to-end examples
 

--- a/docs/zh/guide/lifecycle.md
+++ b/docs/zh/guide/lifecycle.md
@@ -38,14 +38,17 @@ Go：`cubesandbox.NeverTimeout`；Python：`from cubesandbox import NEVER_TIMEOU
    create()       ┌────▼────┐   timeout & on_timeout=pause   ┌─────────┐
   ───────────────►│ running │ ──────────────────────────────►│ paused  │
                   │         │◄──────── connect() 或          │         │
-                  └─┬─────┬─┘     auto_resume 触发的请求      └────┬────┘
-                    │     │                                       │
-        kill()      │     │ timeout & on_timeout=kill             │ kill()
-        ────────────┘     └─────────────────┐                     │
-                                            ▼                     ▼
-                                      ┌────────────┐
-                                      │ terminated │
-                                      └────────────┘
+                  └──┬────┬─┘     auto_resume 触发的请求      └──┬────┬─┘
+                     │    │                                     │    │
+                     │    │ timeout & on_timeout=kill           │    │ timeout & on_timeout=kill
+                     │    └────────────────┐                    │    └──────────────┐
+                     │                     ▼                    │                   ▼
+                     │               ┌────────────┐◄────────────┘
+                     │               │ terminated │
+                     │               └──────▲─────┘
+                     │                      │
+                     │ kill()               │ kill()
+                     └──────────────────────┘
 ```
 
 ## 创建沙箱
@@ -138,6 +141,8 @@ sandbox.connect()                     # 从快照恢复
 sandbox.run_code("print('back!')")    # 像没暂停过一样继续用
 ```
 
+`pause()` **不会取消**空闲回收。默认 `on_timeout="kill"` 时，之后被暂停的沙箱空闲仍超过 `timeout` 一样会被销毁。若要保住暂停中的沙箱，请传 `timeout=NEVER_TIMEOUT`、省略 `timeout`（且服务端未设正数默认）、或把 `timeout` 设得足够大——见下文 [行为说明](#行为说明)。
+
 `connect()` 不会改变沙箱的空闲超时——创建时设置的值（或之后用 `set_timeout` 改的值）在暂停/恢复过程中保持不变。若要在恢复时改超时，用已弃用的 `resume(timeout=...)`：
 
 | `resume(timeout=...)` | 效果 |
@@ -194,7 +199,7 @@ sandbox = Sandbox.create(
 - 通过 SDK 调用：`sandbox.run_code(...)`、`sandbox.commands.run(...)`、`sandbox.files.read(...)` / `write(...)`。
 - 通过 HTTP 直连沙箱内的服务（例如 `getHost()` 返回的 URL）。
 
-未配置 `auto_pause` / 不传 `lifecycle` 的沙箱默认行为是 `on_timeout="kill"`：空闲超过 `timeout` 秒后，平台会主动销毁该沙箱。这与 e2b `lifecycle.on_timeout="kill"` 语义一致。若不希望被自动回收，可传 `timeout=NEVER_TIMEOUT`、省略 `timeout`（且服务端未设正数默认）、把 `timeout` 设得足够大，或通过定期活动刷新空闲计时。
+未配置 `auto_pause` / 不传 `lifecycle` 的沙箱默认行为是 `on_timeout="kill"`：空闲超过 `timeout` 秒后，平台会主动销毁该沙箱。这与 e2b `lifecycle.on_timeout="kill"` 语义一致。手动 `pause()` **不会取消** auto-kill：之后被暂停的沙箱，空闲仍超过 `timeout` 时一样会被销毁。若要保住暂停中的沙箱，请传 `timeout=NEVER_TIMEOUT`、省略 `timeout`（且服务端未设正数默认）、把 `timeout` 设得足够大，或通过定期活动刷新空闲计时。
 
 ### 端到端示例
 


### PR DESCRIPTION
## Problem

A sandbox created with `on_timeout="kill"` that gets paused — by a manual `pause()` or by any path that lands it in `paused` — was never reclaimed. The sweeper treated `paused` as a terminal state for every policy, so the entry stayed in the registry with `LastActive` frozen and the idle deadline past, and no action was ever taken. The sandbox leaked until deleted by hand.

## Root cause

`sweepOnce` gated on `isParkedSweepState`, which unconditionally returned true for `paused`. That is correct only for `on_timeout="pause"`, where `paused` is the desired outcome. It is wrong for `on_timeout="kill"`, where `paused` is not finished work.

A second issue sat in the kill path. `tryKill` used the unconditional `AcquireState(…, "killing", …)`, so it could overwrite a peer replica's in-flight `resuming` marker and strand the sandbox.

## Changes

**`internal/sweeper/sweeper.go`**
- `isParkedSweepState` becomes `skipSweepState(state, autoPause)`. Transition markers (`pausing`, `resuming`, `killing`, `killed`) are always skipped so the sweep does not pile onto an in-flight transition. `paused` is skipped only when `AutoPause` is set.
- The `switch` on `AutoPause` collapses into an early `continue` for the pause branch; the kill branch falls through. The duplicated leader check is hoisted above the branch.

**`internal/redisstream/stream.go`**
- New `AcquireKill`, the timeout-kill counterpart of `AcquireResume`. Both are CAS transitions over the same allow-set (absent or `paused`). A concurrent resume and kill are therefore mutually exclusive: whichever wins the transaction owns the transition, and neither clobbers an in-flight `resuming` / `pausing` / `running` lock.
- The shared CAS body is factored into `acquireIf`; `AcquireResume` becomes a thin wrapper.

**`internal/sweeper/iface.go`** — `stateStore` gains `AcquireKill`.

**Docs** (`docs/guide/lifecycle.md`, `docs/zh/guide/lifecycle.md`)
- State diagram now shows the `paused → terminated` path under `on_timeout=kill` and `kill()`.
- The default-behavior section notes that a manual `pause()` does **not** cancel the auto-kill: a later-paused sandbox is still destroyed once idle exceeds `timeout`.

## Tests

- `TestSweeper_KillsPausedSandboxWhenAutoPauseFalse` — table over `redis_paused`, `runtime_paused_redis_empty`, `both_paused`; asserts exactly one `Kill` with reason `timeout`, registry eviction, `killed` state, and kill stats. Covers the case where the Redis state-key TTL has expired (`StateLockTTL=60s`) and only `RuntimeState` still says paused.
- `TestSweeper_SkipsInFlightSandboxWhenAutoPauseFalse` — replaces `TestSweeper_KillSkipsAlreadyKillingSandbox`; covers `resuming` and `killing`.
- `TestRedisTransactionsProtectKillOwnership` and `TestAcquireKillAndResumeAreMutuallyExclusive` — pin the CAS semantics both ways: `AcquireKill` does not overwrite `resuming`, `AcquireResume` does not overwrite `killing`.
- `newTestClient` helper deduplicates client setup in the redisstream tests.

## Verification

```
go build ./...
go test -count=1 ./internal/sweeper/... ./internal/redisstream/...
```

Both packages pass; `gofmt` clean.

## Note for reviewers

The behavior change is deliberate and bounded: sandboxes on `on_timeout="kill"` that are paused and idle past `timeout` now get destroyed. Sandboxes that must survive should set `timeout=NEVER_TIMEOUT`, omit `timeout`, or send periodic activity — the docs call this out explicitly.