### PR TITLE
ci(release): use Tencent Cloud apt mirrors in sync_cn job

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -848,6 +848,20 @@ jobs:
       - name: Install dependencies
         run: |
           set -euo pipefail
+          # Official archive/security HTTP is currently unreachable; this job
+          # runs on a Tencent Cloud GZ runner, so use Tencent Cloud mirrors.
+          mirror="http://mirrors.tencent.com"
+          shopt -s nullglob
+          for src in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+            sed -i \
+              -e "s|http://archive.ubuntu.com/ubuntu|${mirror}/ubuntu|g" \
+              -e "s|https://archive.ubuntu.com/ubuntu|${mirror}/ubuntu|g" \
+              -e "s|http://security.ubuntu.com/ubuntu|${mirror}/ubuntu|g" \
+              -e "s|https://security.ubuntu.com/ubuntu|${mirror}/ubuntu|g" \
+              -e "s|http://ports.ubuntu.com/ubuntu-ports|${mirror}/ubuntu-ports|g" \
+              -e "s|https://ports.ubuntu.com/ubuntu-ports|${mirror}/ubuntu-ports|g" \
+              "${src}"
+          done
           apt-get update
           apt-get install -y --no-install-recommends curl ca-certificates
           rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What

Rewrite the apt sources of the `sync_cn` job container to a Tencent Cloud mirror before `apt-get update`, so the job can install its dependencies.

## Why

The `sync_cn` job runs in an `ubuntu:24.04` job container whose default apt sources point at `archive.ubuntu.com` and `security.ubuntu.com`. Those hosts are not reachable from the runner network, so `apt-get update` fails and the `Install dependencies` step never gets to install `curl` / `ca-certificates`, failing the whole job before it can sync images.

## How

A short shell step rewrites every apt source file in the container in place:

- `/etc/apt/sources.list`
- `/etc/apt/sources.list.d/*.list` (legacy one-line format)
- `/etc/apt/sources.list.d/*.sources` (deb822 format)

`archive`, `security` and `ports` entries are all remapped to the same mirror host, with `ports.ubuntu.com/ubuntu-ports` mapped to the ports path. `nullglob` keeps the loop safe when a given path matches nothing.

The change is scoped to this job; no other workflow or job is affected.

## Testing

The `sync_cn` job only runs on the self-hosted runner set, so it is exercised by the next release run of this workflow.