### PR TITLE
ci(sync): use Tencent Cloud apt mirrors in sync-to-cnb job

### DIFF
--- a/.github/workflows/sync-to-cnb.yml
+++ b/.github/workflows/sync-to-cnb.yml
@@ -257,6 +257,20 @@ jobs:
       - name: Install dependencies
         run: |
           set -euo pipefail
+          # Official archive/security HTTP is currently unreachable; this job
+          # runs on a Tencent Cloud GZ runner, so use Tencent Cloud mirrors.
+          mirror="https://mirrors.tencent.com"
+          shopt -s nullglob
+          for src in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+            sed -i \
+              -e "s|http://archive.ubuntu.com/ubuntu|${mirror}/ubuntu|g" \
+              -e "s|https://archive.ubuntu.com/ubuntu|${mirror}/ubuntu|g" \
+              -e "s|http://security.ubuntu.com/ubuntu|${mirror}/ubuntu|g" \
+              -e "s|https://security.ubuntu.com/ubuntu|${mirror}/ubuntu|g" \
+              -e "s|http://ports.ubuntu.com/ubuntu-ports|${mirror}/ubuntu-ports|g" \
+              -e "s|https://ports.ubuntu.com/ubuntu-ports|${mirror}/ubuntu-ports|g" \
+              "${src}"
+          done
           apt-get update
           apt-get install -y --no-install-recommends ca-certificates curl gh python3
           rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What

Rewrite the apt sources of the `sync_to_cnb` job container to a Tencent Cloud mirror before `apt-get update`, so the job can install its dependencies.

## Why

The job runs in an `ubuntu:24.04` job container whose default apt sources point at `archive.ubuntu.com` and `security.ubuntu.com`. Those hosts are not reachable from the runner network, so `apt-get update` fails and the `Install dependencies` step never gets to install `ca-certificates` / `curl` / `gh`, failing the whole job before it can sync anything.

## How

A short shell step rewrites every apt source file in the container in place:

- `/etc/apt/sources.list`
- `/etc/apt/sources.list.d/*.list` (legacy one-line format)
- `/etc/apt/sources.list.d/*.sources` (deb822 format)

`archive`, `security` and `ports` entries are all remapped to the same mirror host, with `ports.ubuntu.com/ubuntu-ports` mapped to the ports path. `nullglob` keeps the loop safe when a given path matches nothing.

The change is scoped to this job; no other workflow or job is affected.

## Testing

The job only runs on the self-hosted runner set, so it is exercised by the next release run of this workflow.