### PR TITLE
ci(sync): use HTTP for the apt mirror in sync-to-cnb job

### DIFF
--- a/.github/workflows/sync-to-cnb.yml
+++ b/.github/workflows/sync-to-cnb.yml
@@ -259,7 +259,10 @@ jobs:
           set -euo pipefail
           # Official archive/security HTTP is currently unreachable; this job
           # runs on a Tencent Cloud GZ runner, so use Tencent Cloud mirrors.
-          mirror="https://mirrors.tencent.com"
+          # Plain HTTP: the job container ships no CA bundle, so apt cannot
+          # verify the mirror's TLS certificate and cannot install
+          # ca-certificates to fix that.
+          mirror="http://mirrors.tencent.com"
           shopt -s nullglob
           for src in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
             sed -i \


### PR DESCRIPTION
## What

Switch the apt mirror rewritten into the `sync_to_cnb` job container from `https://` to `http://`.

## Why

#1720 pointed the container's apt sources at the Tencent Cloud mirror over HTTPS, but the `ubuntu:24.04` job container ships no CA bundle. `apt-get update` therefore failed every source with:

```
Certificate verification failed: The certificate is NOT trusted.
The certificate issuer is unknown. ... No system certificates
available. Try installing ca-certificates.
```

That is a deadlock: `ca-certificates` is the very package the step is trying to install, and the sources it would install from cannot be verified. The step aborted before installing anything, failing the whole job.

The sibling `sync_cn` job in `release-docker-images.yml` runs the same container on the same runner set and has always used `http://`, which is why it works. This change makes the two consistent.

## Testing

Reproduced by dispatching this workflow against `v0.7.1`: the `resolve_release_context` and `ensure_cnb_release` jobs passed, and `sync_release_assets` failed in `Install dependencies` on the certificate error above. Verified by the next run of this workflow.