### PR TITLE
      fix(cubemaster): classify postgres alias errors by sqlstate

### DIFF
--- a/CubeMaster/pkg/service/httpservice/cube/template_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
@@ -510,12 +511,9 @@ func TestSetTemplateAliasHandler_409_OnDuplicateAlias(t *testing.T) {
 	resolveTemplateIdentifierFn = func(ctx context.Context, identifier string) (string, error) {
 		return identifier, nil
 	}
-	// Simulate a duplicate-key error by returning an error that the real
-	// IsDuplicateAliasError recognises. The detector keys on
-	// *mysql.MySQLError(1062) or "23505"/"unique_constraint" in the message;
-	// we use the message form so the test does not import the mysql driver.
+	// Simulate the structured MySQL duplicate-key error returned by the driver.
 	setTemplateAliasFn = func(ctx context.Context, templateID, alias string) error {
-		return errors.New("Error 1062 (23000): Duplicate entry 'my-alias' for key 'alias_key' unique_constraint")
+		return &mysql.MySQLError{Number: 1062, Message: "Duplicate entry 'my-alias' for key 'alias_key'"}
 	}
 
 	req := httptest.NewRequest(http.MethodPut, "/cube/template/tpl-1/alias",

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db"
@@ -1498,25 +1499,24 @@ func isDuplicateAliasError(err error) bool {
 	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
 		return true
 	}
-	// pgconn.PgError has Code == "23505" for unique_violation. We check via
-	// string matching on the error message as a fallback because the pgx
-	// driver may not be imported in all build configurations.
-	s := err.Error()
-	return strings.Contains(s, "23505") || strings.Contains(s, "unique_constraint")
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }
 
 // isDeadlockError reports transient lock errors worth one retry in the alias
 // release+claim transaction: InnoDB deadlock (1213) / lock-wait-timeout (1205),
 // and the PostgreSQL equivalents 40P01 (deadlock_detected) / 55P03
-// (lock_not_available). PG codes are string-matched like isDuplicateAliasError
-// because pgx may not be imported in all build configurations.
+// (lock_not_available).
 func isDeadlockError(err error) bool {
 	var mysqlErr *mysql.MySQLError
 	if errors.As(err, &mysqlErr) && (mysqlErr.Number == 1205 || mysqlErr.Number == 1213) {
 		return true
 	}
-	s := err.Error()
-	return strings.Contains(s, "40P01") || strings.Contains(s, "55P03")
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == "40P01" || pgErr.Code == "55P03"
 }
 
 func retryOnceOnDeadlock(run func() error) error {

--- a/CubeMaster/pkg/templatecenter/store_test.go
+++ b/CubeMaster/pkg/templatecenter/store_test.go
@@ -794,8 +794,8 @@ func TestIsDeadlockError(t *testing.T) {
 	assert.True(t, isDeadlockError(&mysql.MySQLError{Number: 1205, Message: "Lock wait timeout exceeded"}))
 	assert.True(t, isDeadlockError(&mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}))
 	assert.True(t, isDeadlockError(fmt.Errorf("claim fail: %w", &mysql.MySQLError{Number: 1213, Message: "Deadlock found"})))
-	assert.True(t, isDeadlockError(errors.New("ERROR: deadlock detected; SQLSTATE 40P01")))
-	assert.True(t, isDeadlockError(errors.New("ERROR: lock not available; SQLSTATE 55P03")))
+	assert.True(t, isDeadlockError(&pgconn.PgError{Code: "40P01", Message: "deadlock detected"}))
+	assert.True(t, isDeadlockError(fmt.Errorf("wrapped: %w", &pgconn.PgError{Code: "55P03", Message: "lock not available"})))
 	assert.False(t, isDeadlockError(&mysql.MySQLError{Number: 1062, Message: "Duplicate entry"}))
 	assert.False(t, isDeadlockError(errors.New("Error 1062 (23000): Duplicate entry for key 'alias_key'")))
 	assert.False(t, isDeadlockError(errors.New("connection reset by peer")))
@@ -963,6 +963,36 @@ func TestIsDuplicateAliasError_WrappedPostgres23505(t *testing.T) {
 	}
 	wrapped := fmt.Errorf("claim alias %q for template %s fail: %w", "shared", "tpl-1", inner)
 	assert.True(t, isDuplicateAliasError(wrapped), "23505 must remain detectable after %%w wrap")
+}
+
+func TestIsDuplicateAliasErrorRejectsMisleadingText(t *testing.T) {
+	wrappedLengthError := fmt.Errorf(
+		"claim alias for template tpl-cache-claim-fail-23505 fail: %w",
+		&pgconn.PgError{Code: "22001", Message: "value too long"},
+	)
+	for _, err := range []error{
+		wrappedLengthError,
+		errors.New("claim alias for template tpl-cache-claim-fail-23505 failed: SQLSTATE 22001"),
+		errors.New("unique_constraint mentioned in diagnostic text"),
+		errors.New("ERROR: value too long for type character varying(256) (SQLSTATE 22001)"),
+	} {
+		assert.False(t, isDuplicateAliasError(err))
+	}
+}
+
+func TestIsDuplicateAliasErrorPostgresSQLState(t *testing.T) {
+	for _, code := range []string{"23505"} {
+		inner := &pgconn.PgError{Code: code, Message: "duplicate key"}
+		assert.True(t, isDuplicateAliasError(inner))
+		assert.True(t, isDuplicateAliasError(fmt.Errorf("wrapped: %w", inner)))
+	}
+	assert.False(t, isDuplicateAliasError(&pgconn.PgError{Code: "22001", Message: "value too long"}))
+}
+
+func TestIsDuplicateAliasErrorMySQLCodes(t *testing.T) {
+	assert.True(t, isDuplicateAliasError(&mysql.MySQLError{Number: 1062, Message: "Duplicate entry"}))
+	assert.True(t, isDuplicateAliasError(fmt.Errorf("wrapped: %w", &mysql.MySQLError{Number: 1062, Message: "Duplicate entry"})))
+	assert.False(t, isDuplicateAliasError(&mysql.MySQLError{Number: 1406, Message: "Data too long"}))
 }
 
 func TestSyncCreateRedoImageJobAliasTx_NoJobsSucceeds(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix intermittent PostgreSQL CI failures when publishing template status with an alias.

## Root Cause

`isDuplicateAliasError` detected PostgreSQL duplicate key errors by searching arbitrary error text for `23505` or `unique_constraint`.

When a wrapped PostgreSQL `22001` error included a template ID containing `23505`, it was incorrectly classified as a duplicate alias error. The fallback path then suppressed the expected alias claim warning.

## Changes

- Classify MySQL duplicate aliases using structured error code `1062`.
- Classify PostgreSQL duplicate aliases using `pgconn.PgError.Code == "23505"`.
- Classify PostgreSQL deadlocks using SQLSTATE `40P01` and `55P03`.
- Preserve wrapped error handling through `errors.As`.
- Add regression tests for:
  - Wrapped PostgreSQL `22001` errors with template IDs containing `23505`.
  - Direct and wrapped PostgreSQL `23505` errors.
  - MySQL `1062` and non-duplicate errors.
  - Misleading error text containing `23505` or `unique_constraint`.

## Validation

- Templatecenter classification unit tests passed.
- PostgreSQL Docker test `TestAliasStorePostgreSQL` passed.
- Verified alias claim failure returns the warning, leaves the template in `READY`, and invalidates query caches.
- Changes are limited to CubeMaster error classification logic and tests.